### PR TITLE
Features/physical tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "beacon-config",
+ "beacon-query",
  "beacon-sources",
  "datafusion",
  "indexmap",

--- a/beacon-query/src/lib.rs
+++ b/beacon-query/src/lib.rs
@@ -55,6 +55,7 @@ pub struct QueryBody {
 #[serde(untagged)]
 pub enum Select {
     TryCast {
+        #[serde(skip_serializing)]
         #[serde(flatten)]
         select: Box<Select>,
         #[schema(value_type = String)]

--- a/beacon-tables/Cargo.toml
+++ b/beacon-tables/Cargo.toml
@@ -19,3 +19,4 @@ tracing = { workspace = true }
 
 beacon-sources = { path = "../beacon-sources" }
 beacon-config = { path = "../beacon-config" }
+beacon-query = { path = "../beacon-query" }

--- a/beacon-tables/src/error.rs
+++ b/beacon-tables/src/error.rs
@@ -1,4 +1,4 @@
-use crate::logical_table::LogicalTableError;
+use crate::{logical_table::LogicalTableError, physical_table};
 
 #[derive(Debug, thiserror::Error)]
 pub enum TableError {
@@ -32,4 +32,6 @@ pub enum TableError {
     FailedToCreateBaseTableDirectory(std::io::Error),
     #[error("Failed to create table directory: {0} for table: {1}")]
     FailedToCreateTableDirectory(std::io::Error, String),
+    #[error("Physical table error: {0}")]
+    PhysicalTableError(#[from] physical_table::error::PhysicalTableError),
 }

--- a/beacon-tables/src/lib.rs
+++ b/beacon-tables/src/lib.rs
@@ -7,6 +7,7 @@ pub mod empty_table;
 pub mod error;
 pub mod file_format;
 pub mod logical_table;
+pub mod physical_table;
 pub mod schema_provider;
 pub mod table;
 

--- a/beacon-tables/src/physical_table/error.rs
+++ b/beacon-tables/src/physical_table/error.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, thiserror::Error)]
+pub enum PhysicalTableError {}

--- a/beacon-tables/src/physical_table/error.rs
+++ b/beacon-tables/src/physical_table/error.rs
@@ -1,2 +1,9 @@
+use super::table_engine::error::TableEngineError;
+
 #[derive(Debug, thiserror::Error)]
-pub enum PhysicalTableError {}
+pub enum PhysicalTableError {
+    #[error("Table Creation Error: {0}")]
+    TableCreationError(Box<PhysicalTableError>),
+    #[error("Table Engine Error: {0}")]
+    TableEngineError(#[from] TableEngineError),
+}

--- a/beacon-tables/src/physical_table/mod.rs
+++ b/beacon-tables/src/physical_table/mod.rs
@@ -1,0 +1,92 @@
+use std::{path::PathBuf, sync::Arc};
+
+use beacon_query::{parser::Parser, InnerQuery};
+use datafusion::{
+    catalog::TableProvider,
+    prelude::{DataFrame, SessionContext},
+};
+use error::PhysicalTableError;
+use table_engine::TableEngine;
+
+use crate::error::TableError;
+
+pub mod error;
+pub mod table_engine;
+#[async_trait::async_trait]
+#[typetag::serde]
+pub trait PhysicalTableProvider: std::fmt::Debug + Send + Sync {
+    /// Creates a new table provider.
+    ///
+    /// # Arguments
+    ///
+    /// * `session_ctx` - A shared session context to be used during provider creation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `TableError` if there is an issue retrieving the table provider.
+    async fn create(
+        &self,
+        table_directory: PathBuf,
+        session_ctx: Arc<SessionContext>,
+    ) -> Result<(), PhysicalTableError>;
+
+    /// Returns the table provider.
+    ///
+    /// # Arguments
+    ///     
+    /// * `session_ctx` - A shared session context to be used during provider retrieval.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `TableError` if there is an issue retrieving the table provider.
+    async fn table_provider(
+        &self,
+        table_directory: PathBuf,
+        session_ctx: Arc<SessionContext>,
+    ) -> Result<Arc<dyn TableProvider>, PhysicalTableError>;
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct PhysicalTable {
+    pub table_name: String,
+    pub table_generation_query: InnerQuery,
+    pub engine: Arc<dyn TableEngine>,
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "physical_table")]
+impl PhysicalTableProvider for PhysicalTable {
+    async fn create(
+        &self,
+        table_directory: PathBuf,
+        session_ctx: Arc<SessionContext>,
+    ) -> Result<(), PhysicalTableError> {
+        //Parse the query
+        let logical_plan =
+            Parser::parse_to_logical_plan(&session_ctx, self.table_generation_query.clone())
+                .await
+                .unwrap();
+
+        let dataframe = DataFrame::new(session_ctx.state(), logical_plan);
+
+        //Run the query against the engine
+        self.engine
+            .create(table_directory, dataframe)
+            .await
+            .unwrap();
+
+        Ok(())
+    }
+
+    async fn table_provider(
+        &self,
+        table_directory: PathBuf,
+        session_ctx: Arc<SessionContext>,
+    ) -> Result<Arc<dyn TableProvider>, PhysicalTableError> {
+        Ok(self
+            .engine
+            .table_provider(table_directory, session_ctx)
+            .await
+            .unwrap())
+    }
+}

--- a/beacon-tables/src/physical_table/table_engine/error.rs
+++ b/beacon-tables/src/physical_table/table_engine/error.rs
@@ -1,0 +1,11 @@
+#[derive(Debug, thiserror::Error)]
+pub enum TableEngineError {
+    #[error("Datafusion Error: {0}")]
+    DatafusionError(#[from] datafusion::error::DataFusionError),
+    #[error("IO Error: {0}")]
+    IOError(#[from] std::io::Error),
+    #[error("Invalid Path.")]
+    InvalidPath,
+    #[error("Failed to create table provider: {0}")]
+    TableProviderError(anyhow::Error),
+}

--- a/beacon-tables/src/physical_table/table_engine/mod.rs
+++ b/beacon-tables/src/physical_table/table_engine/mod.rs
@@ -4,24 +4,37 @@ use datafusion::{
     catalog::TableProvider,
     prelude::{DataFrame, SessionContext},
 };
+use error::TableEngineError;
 
+pub mod error;
 pub mod parquet;
-
 #[async_trait::async_trait]
 #[typetag::serde]
 pub trait TableEngine: std::fmt::Debug + Send + Sync {
-    async fn create(&self, table_directory: PathBuf, dataframe: DataFrame) -> Result<(), String>;
+    async fn create(
+        &self,
+        table_directory: PathBuf,
+        dataframe: DataFrame,
+    ) -> Result<(), TableEngineError>;
 
-    async fn insert(&self, table_directory: PathBuf, dataframe: DataFrame) -> Result<(), String> {
-        return Err("Insert operation not supported".to_string());
+    async fn insert(
+        &self,
+        table_directory: PathBuf,
+        dataframe: DataFrame,
+    ) -> Result<(), TableEngineError> {
+        unimplemented!()
     }
-    async fn delete(&self, table_directory: PathBuf, dataframe: DataFrame) -> Result<(), String> {
-        return Err("Delete operation not supported".to_string());
+    async fn delete(
+        &self,
+        table_directory: PathBuf,
+        dataframe: DataFrame,
+    ) -> Result<(), TableEngineError> {
+        unimplemented!()
     }
 
     async fn table_provider(
         &self,
         table_directory: PathBuf,
         session_ctx: Arc<SessionContext>,
-    ) -> Result<Arc<dyn TableProvider>, String>;
+    ) -> Result<Arc<dyn TableProvider>, TableEngineError>;
 }

--- a/beacon-tables/src/physical_table/table_engine/mod.rs
+++ b/beacon-tables/src/physical_table/table_engine/mod.rs
@@ -1,0 +1,27 @@
+use std::{path::PathBuf, sync::Arc};
+
+use datafusion::{
+    catalog::TableProvider,
+    prelude::{DataFrame, SessionContext},
+};
+
+pub mod parquet;
+
+#[async_trait::async_trait]
+#[typetag::serde]
+pub trait TableEngine: std::fmt::Debug + Send + Sync {
+    async fn create(&self, table_directory: PathBuf, dataframe: DataFrame) -> Result<(), String>;
+
+    async fn insert(&self, table_directory: PathBuf, dataframe: DataFrame) -> Result<(), String> {
+        return Err("Insert operation not supported".to_string());
+    }
+    async fn delete(&self, table_directory: PathBuf, dataframe: DataFrame) -> Result<(), String> {
+        return Err("Delete operation not supported".to_string());
+    }
+
+    async fn table_provider(
+        &self,
+        table_directory: PathBuf,
+        session_ctx: Arc<SessionContext>,
+    ) -> Result<Arc<dyn TableProvider>, String>;
+}

--- a/beacon-tables/src/physical_table/table_engine/parquet.rs
+++ b/beacon-tables/src/physical_table/table_engine/parquet.rs
@@ -1,0 +1,77 @@
+use std::{path::PathBuf, sync::Arc};
+
+use beacon_sources::{
+    formats_factory::Formats, parquet_format::SuperParquetFormatFactory, DataSource,
+};
+use datafusion::{
+    catalog::TableProvider,
+    dataframe::DataFrameWriteOptions,
+    datasource::{
+        file_format::{parquet::ParquetFormatFactory, FileFormatFactory},
+        listing::ListingTableUrl,
+    },
+    prelude::{DataFrame, SessionContext},
+};
+
+use super::{error::TableEngineError, TableEngine};
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct ParquetTable {}
+
+impl ParquetTable {}
+
+#[typetag::serde]
+#[async_trait::async_trait]
+impl TableEngine for ParquetTable {
+    async fn create(
+        &self,
+        table_directory: PathBuf,
+        dataframe: DataFrame,
+    ) -> Result<(), TableEngineError> {
+        // Implement the logic to create a Parquet table
+
+        // Directory name
+        let directory_name = table_directory
+            .file_name()
+            .ok_or(TableEngineError::InvalidPath)?;
+
+        //Path if relative to the object store filesystem root
+        let path = format!(
+            "{}/{}/{}",
+            beacon_config::TABLES_DIR_PREFIX.to_string(),
+            directory_name.to_string_lossy(),
+            "table.parquet"
+        );
+
+        dataframe
+            .write_parquet(&path, DataFrameWriteOptions::new(), None)
+            .await
+            .map_err(|e| TableEngineError::DatafusionError(e))?;
+
+        Ok(())
+    }
+
+    async fn table_provider(
+        &self,
+        table_directory: PathBuf,
+        session_ctx: Arc<SessionContext>,
+    ) -> Result<Arc<dyn TableProvider>, TableEngineError> {
+        //Table url
+        let table_url = ListingTableUrl::parse(&format!(
+            "{}/{}/{}",
+            beacon_config::TABLES_DIR_PREFIX.to_string(),
+            table_directory.file_name().unwrap().to_string_lossy(),
+            "table.parquet"
+        ))?;
+
+        let session_state = session_ctx.state();
+
+        let file_format = SuperParquetFormatFactory.default();
+
+        Ok(Arc::new(
+            DataSource::new(&session_state, file_format, vec![table_url])
+                .await
+                .map_err(|e| TableEngineError::TableProviderError(e))?,
+        ))
+    }
+}


### PR DESCRIPTION
This pull request introduces several significant changes to the `beacon-tables` and `beacon-query` modules, focusing on integrating physical table support and improving error handling. The most important changes include adding a new `PhysicalTableProvider` trait, updating the `Table` and `TableError` enums, and modifying the `BeaconSchemaProvider` to handle physical tables.

### Physical Table Support:

* **Addition of `PhysicalTableProvider` trait**: Introduced in `beacon-tables/src/physical_table/mod.rs`, this trait defines methods for creating and retrieving physical table providers.
* **Implementation of `TableEngine` for Parquet tables**: Added in `beacon-tables/src/physical_table/table_engine/parquet.rs`, this implementation provides the logic for creating and retrieving Parquet table providers.

### Error Handling:

* **New error types**: Added `PhysicalTableError` in `beacon-tables/src/physical_table/error.rs` and `TableEngineError` in `beacon-tables/src/physical_table/table_engine/error.rs` to handle errors specific to physical tables and table engines.

### Enum and Struct Updates:

* **Update to `Table` and `TableError` enums**: The `Table` enum now includes a `Physical` variant, and `TableError` includes a `PhysicalTableError` variant to handle errors from physical tables.
* **Introduction of `TableInfo` struct**: This struct, defined in `beacon-tables/src/table.rs`, encapsulates a `Table` instance and its directory path, aiding in managing table metadata.

### Schema Provider Modifications:

* **Modifications to `BeaconSchemaProvider`**: Updated to handle `TableInfo` instead of `Table`, and to support physical tables in methods such as `load_tables` and `table_provider`.

These changes collectively enhance the system's capability to manage both logical and physical tables, improve error handling, and streamline schema management.