### PR TITLE
Fix ODV Timestamp Type & Schema Projection

### DIFF
--- a/beacon-sources/src/odv_format.rs
+++ b/beacon-sources/src/odv_format.rs
@@ -149,7 +149,6 @@ impl OdvExec {
         let schema_adapter = self
             .schema_adapter_factory
             .create(projected_table_schema.clone(), self.table_schema.clone());
-        let projection = self.projection.clone();
 
         let stream = try_stream! {
             for sub_partition in partition {
@@ -168,7 +167,7 @@ impl OdvExec {
                     .map_schema(&file_schema)
                     .expect("map_schema failed");
 
-                while let Some(batch)= reader.read(projection.as_deref()) {
+                while let Some(batch)= reader.read(Some(&adapted_projection)) {
                     let batch = batch.map_err(|e| {
                         datafusion::error::DataFusionError::Execution(format!("Failed to read ODV batch: {}", e))
                     })?;


### PR DESCRIPTION
This pull request includes several updates to the `beacon-arrow-odv` and `beacon-sources` crates, focusing on improving the handling of timestamp fields and schema adaptation. The most important changes include updating the data type for timestamp fields, conditionally modifying schema fields based on field names, and refining the projection handling in the ODV execution.

### Improvements to timestamp handling:

* [`beacon-arrow-odv/src/reader.rs`](diffhunk://#diff-1b917b17c8d227e3f8fe6e44cc61132de2dc65cd861c52c55e50fd336e0739f7L106-R110): Updated the data type for the `yyyy-mm-ddThh:mm:ss.sss` field to `Timestamp` with millisecond precision.
* [`beacon-arrow-odv/src/reader.rs`](diffhunk://#diff-1b917b17c8d227e3f8fe6e44cc61132de2dc65cd861c52c55e50fd336e0739f7R235-R242): Added conditional logic to set the data type to `Timestamp` for fields named `time_iso8601`.

### Codebase simplification and cleanup:

* [`beacon-arrow-odv/src/reader.rs`](diffhunk://#diff-1b917b17c8d227e3f8fe6e44cc61132de2dc65cd861c52c55e50fd336e0739f7R276): Removed an unnecessary blank line to improve code readability.
* [`beacon-arrow-odv/src/reader.rs`](diffhunk://#diff-1b917b17c8d227e3f8fe6e44cc61132de2dc65cd861c52c55e50fd336e0739f7L317): Removed an unnecessary blank line in the `impl OdvDecoder` block.

### Refinements in schema adaptation:

* [`beacon-sources/src/odv_format.rs`](diffhunk://#diff-ec843190812e46cdbda54c314e05e98085ccd72219862ad36a6b181e161a2daeL152): Removed the unused `projection` variable in the `impl OdvExec` block.
* [`beacon-sources/src/odv_format.rs`](diffhunk://#diff-ec843190812e46cdbda54c314e05e98085ccd72219862ad36a6b181e161a2daeL171-R170): Updated the `reader.read` method to use `adapted_projection` instead of `projection`.