### PR TITLE
Fix Array Length Result of SeaDataNet Units Mapping

### DIFF
--- a/beacon-functions/src/blue_cloud/map_units_sdn.rs
+++ b/beacon-functions/src/blue_cloud/map_units_sdn.rs
@@ -153,10 +153,46 @@ impl ScalarUDFImpl for MapUnitsSeaDataNet {
                         //apply the conversion function
                         conversion_fn.map(|f| f(value))
                     })
-                })
-                .flatten(),
+                    .unwrap_or(None)
+                }),
         );
 
         Ok(ColumnarValue::Array(Arc::new(array)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::scalar::ScalarValue;
+
+    use super::*;
+
+    #[test]
+    fn test_unit_conversion_function_input_output() {
+        let function_args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("SDN:P06::UPOX".to_string()))),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("SDN:P06::KGUM".to_string()))),
+                ColumnarValue::Array(Arc::new(PrimitiveArray::<Float64Type>::from_iter([
+                    Some(1.0),
+                    None,
+                    Some(3.0),
+                ]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::Float64,
+        };
+
+        let function = map_units_seadatanet();
+
+        let result = function.invoke_with_args(function_args).unwrap();
+
+        //Assert length = 3
+        match result {
+            ColumnarValue::Array(array) => {
+                assert_eq!(array.len(), 3);
+            }
+            _ => panic!("Expected an array"),
+        }
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `ScalarUDFImpl` implementation for `MapUnitsSeaDataNet` in the `beacon-functions/src/blue_cloud/map_units_sdn.rs` file. The main changes involve modifying the conversion function handling and adding a new test module.

Improvements and additions:

* Modified the conversion function to use `unwrap_or(None)` instead of `flatten()` so to not remove null values from function.
* Added a new test module to verify the unit conversion function's input and output. This includes a test case `test_unit_conversion_function_input_output` that checks the function's behavior with specific inputs and asserts the length of the resulting array.