### PR TITLE
Features/sanitize schema names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,7 @@ dependencies = [
  "anyhow",
  "arrow",
  "indexmap",
+ "regex",
  "thiserror 2.0.12",
 ]
 
@@ -689,6 +690,7 @@ dependencies = [
  "indexmap",
  "nd-arrow-array",
  "object_store",
+ "regex",
  "serde",
  "tokio",
  "tracing",

--- a/beacon-common/Cargo.toml
+++ b/beacon-common/Cargo.toml
@@ -8,3 +8,4 @@ arrow = { workspace=true }
 anyhow = { workspace=true }
 indexmap = { workspace = true }
 thiserror = { workspace=true }
+regex = "1.11.1"

--- a/beacon-common/src/lib.rs
+++ b/beacon-common/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod schema_sanitizer;
 pub mod super_typing;

--- a/beacon-common/src/schema_sanitizer.rs
+++ b/beacon-common/src/schema_sanitizer.rs
@@ -1,0 +1,4 @@
+use arrow::datatypes::{Field, Schema};
+use regex::Regex;
+
+

--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -23,6 +23,8 @@ pub struct Config {
     pub default_table: String,
     #[envconfig(from = "BEACON_ENABLE_SQL", default = "false")]
     pub enable_sql: bool,
+    #[envconfig(from = "BEACON_SANITIZE_SCHEMA", default = "false")]
+    pub sanitize_schema: bool,
 }
 
 impl Config {

--- a/beacon-sources/Cargo.toml
+++ b/beacon-sources/Cargo.toml
@@ -19,6 +19,7 @@ nd-arrow-array = { git = "https://github.com/robinskil/nd-arrow-array.git", bran
 tracing = { workspace=true }
 serde = { workspace=true}
 utoipa = { workspace=true}
+regex = "1.11.1"
 
 # Local dependencies
 beacon-config = { path = "../beacon-config" }

--- a/beacon-sources/src/lib.rs
+++ b/beacon-sources/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{any::Any, borrow::Cow, sync::Arc};
 
-use arrow::datatypes::SchemaRef;
+use arrow::datatypes::{Field, Schema, SchemaRef};
 use datafusion::{
     catalog::{Session, TableProvider},
     common::{Constraints, Statistics},
@@ -11,11 +11,14 @@ use datafusion::{
     },
     execution::SessionState,
     logical_expr::{dml::InsertOp, LogicalPlan, TableProviderFilterPushDown},
-    physical_plan::ExecutionPlan,
+    physical_expr::EquivalenceProperties,
+    physical_plan::{DisplayAs, ExecutionPlan, PlanProperties},
     prelude::Expr,
 };
 
 use beacon_common::super_typing::super_type_schema;
+use futures::StreamExt;
+use regex::Regex;
 
 pub mod arrow_format;
 pub mod csv_format;
@@ -28,6 +31,7 @@ pub mod sql;
 #[derive(Debug)]
 pub struct DataSource {
     inner_table: ListingTable,
+    sanitized_schema: Option<SchemaRef>,
 }
 
 impl DataSource {
@@ -40,12 +44,16 @@ impl DataSource {
         let listing_options = ListingOptions::new(file_format).with_file_extension("");
 
         let mut schemas = vec![];
+        let mut sanitized_schemas = vec![];
+
         for table_url in &table_urls {
             tracing::debug!("Infer schema for table: {}", table_url);
             let schema = listing_options
                 .infer_schema(&session_state, table_url)
                 .await?;
-            schemas.push(schema);
+
+            schemas.push(schema.clone());
+            sanitized_schemas.push(Arc::new(Self::sanitize_schema(&schema)));
         }
 
         let super_schema = Arc::new(
@@ -53,12 +61,53 @@ impl DataSource {
                 .map_err(|e| anyhow::anyhow!("Failed to super type schema: {}", e))?,
         );
 
+        //Sanitize the schema
+        let sanitized_schema = Arc::new(super_type_schema(&sanitized_schemas).unwrap());
+
         let config = ListingTableConfig::new_with_multi_paths(table_urls)
             .with_listing_options(listing_options)
             .with_schema(super_schema);
 
         let table = ListingTable::try_new(config)?;
-        Ok(Self { inner_table: table })
+        Ok(Self {
+            inner_table: table,
+            sanitized_schema: Some(sanitized_schema),
+        })
+    }
+
+    fn sanitize_column_name(name: &str) -> String {
+        let name = name.to_lowercase();
+        let re = Regex::new(r"[^\w]").unwrap(); // Matches anything except [a-zA-Z0-9_]
+        let mut sanitized = re.replace_all(&name, "_").to_string();
+
+        // If name starts with a digit, prefix it with an underscore
+        if sanitized
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(false)
+        {
+            sanitized = format!("_{}", sanitized);
+        }
+
+        sanitized
+    }
+
+    fn sanitize_schema(schema: &Schema) -> Schema {
+        let fields: Vec<Field> = schema
+            .fields()
+            .iter()
+            .map(|field| {
+                let sanitized_name = Self::sanitize_column_name(field.name());
+                Field::new(
+                    &sanitized_name,
+                    field.data_type().clone(),
+                    field.is_nullable(),
+                )
+            })
+            .collect();
+
+        Schema::new(fields)
     }
 }
 
@@ -69,7 +118,7 @@ impl TableProvider for DataSource {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.inner_table.schema()
+        self.sanitized_schema.as_ref().unwrap().clone()
     }
 
     fn constraints(&self) -> Option<&Constraints> {
@@ -99,9 +148,12 @@ impl TableProvider for DataSource {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        self.inner_table
+        let plan = self
+            .inner_table
             .scan(state, projection, filters, limit)
-            .await
+            .await?;
+
+        Ok(plan)
     }
 
     fn supports_filters_pushdown(
@@ -124,5 +176,109 @@ impl TableProvider for DataSource {
         self.inner_table
             .insert_into(_state, _input, _insert_op)
             .await
+    }
+}
+
+#[derive(Debug)]
+struct SanitationPlan {
+    unsanitized_schema: SchemaRef,
+    sanitized_schema: SchemaRef,
+    sub_plan: Arc<dyn ExecutionPlan>,
+    plan_properties: PlanProperties,
+}
+
+impl SanitationPlan {
+    fn new(
+        unsanitized_schema: SchemaRef,
+        sanitized_schema: SchemaRef,
+        sub_plan: Arc<dyn ExecutionPlan>,
+    ) -> Self {
+        let original_plan_props = sub_plan.properties().clone();
+        let eq_props = original_plan_props
+            .eq_properties
+            .clone()
+            .with_new_schema(sanitized_schema.clone())
+            .unwrap();
+        let plan_properties = original_plan_props.with_eq_properties(eq_props);
+
+        Self {
+            unsanitized_schema,
+            sanitized_schema,
+            sub_plan,
+            plan_properties,
+        }
+    }
+}
+
+impl DisplayAs for SanitationPlan {
+    fn fmt_as(
+        &self,
+        t: datafusion::physical_plan::DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        match t {
+            datafusion::physical_plan::DisplayFormatType::Default => {
+                write!(f, "SanitationPlan: {}", self.unsanitized_schema)
+            }
+            datafusion::physical_plan::DisplayFormatType::Verbose => {
+                write!(
+                    f,
+                    "SanitationPlan: unsanitized schema: {}, sanitized schema: {}",
+                    self.unsanitized_schema, self.sanitized_schema
+                )
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ExecutionPlan for SanitationPlan {
+    fn name(&self) -> &str {
+        "SanitationPlan"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
+        &self.plan_properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        if children.is_empty() {
+            Ok(self.clone())
+        } else {
+            Err(datafusion::error::DataFusionError::Internal(
+                "SanitationPlan does not have children".to_string(),
+            ))
+        }
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<datafusion::execution::TaskContext>,
+    ) -> datafusion::error::Result<datafusion::execution::SendableRecordBatchStream> {
+        let stream = self.sub_plan.execute(partition, context.clone())?;
+
+        let schema = self.sanitized_schema.clone();
+        let stream = async_stream::stream! {
+            while let Some(batch) = stream.next().await {
+                let batch = batch.map_err(|e| {
+                    datafusion::error::DataFusionError::Execution(format!("Failed to read batch: {}", e))
+                })?;
+                yield Ok(batch);
+            }
+        };
+
+        Ok(Box::pin(stream))
     }
 }


### PR DESCRIPTION
This pull request introduces a new schema sanitization feature to the `beacon` project. The changes span multiple files and include the addition of a new module, updates to configuration, and modifications to the data source processing to support schema sanitization.

### Schema Sanitization Feature:

* **Configuration:**
  - Added `sanitize_schema` configuration option to `Config` struct in `beacon-config/src/lib.rs`.

* **New Module:**
  - Introduced `schema_sanitizer` module in `beacon-common/src/lib.rs`.
  - Implemented schema sanitization logic in `beacon-common/src/schema_sanitizer.rs`.

* **Dependency Updates:**
  - Added `regex` dependency to `beacon-common/Cargo.toml` and `beacon-sources/Cargo.toml`. [[1]](diffhunk://#diff-e2eefc56e949ae7fb8c362641e0288704fec7597ae6bf45a76fb3464c8cbd403R11) [[2]](diffhunk://#diff-33bede9265ffcaa6dde23befcb9c4a3e41f7df9f49391701a0bcace3103ecfbeR22)

* **Data Source Modifications:**
  - Updated `DataSource` struct in `beacon-sources/src/lib.rs` to include `sanitized_schema` field.
  - Enhanced `DataSource` to sanitize schema based on configuration and apply sanitized schema during data scan. [[1]](diffhunk://#diff-b03584eb222ad065295d205c63ea58178e96eda48db1cf6f654ee4ec445c9822R49-R127) [[2]](diffhunk://#diff-b03584eb222ad065295d205c63ea58178e96eda48db1cf6f654ee4ec445c9822L102-R208)
  - Added `SanitizedPlan` struct to handle execution plans with sanitized schemas.

* **Subproject Update:**
  - Updated subproject commit for `beacon-py`.