### PR TITLE
NetCDF fill value default encoder fix

### DIFF
--- a/beacon-arrow-netcdf/src/encoders/default.rs
+++ b/beacon-arrow-netcdf/src/encoders/default.rs
@@ -30,7 +30,7 @@ macro_rules! downcast_and_put_values {
 
         let temp_buffer = array
             .iter()
-            .map(|x| x.unwrap_or(<$native_type>::MIN))
+            .map(|x| x.unwrap_or(<$native_type>::MAX))
             .collect::<Vec<_>>();
 
         $variable.put_values::<$native_type, _>(&temp_buffer, $extents)?;


### PR DESCRIPTION
Fixes: #45

This pull request includes a single change to the `beacon-arrow-netcdf/src/encoders/default.rs` file. The change modifies the `downcast_and_put_values` macro to use `<$native_type>::MAX` as the default value instead of `<$native_type>::MIN` when unwrapping optional values. 