### PR TITLE
Improve cora mappings

### DIFF
--- a/beacon-functions/src/blue_cloud/cora/map_platform_l06.rs
+++ b/beacon-functions/src/blue_cloud/cora/map_platform_l06.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use arrow::array::StringArray;
 use datafusion::{
@@ -6,25 +6,14 @@ use datafusion::{
     prelude::create_udf,
     scalar::ScalarValue,
 };
-use lazy_static::lazy_static;
-
-lazy_static! {
-    static ref L06_MAP: HashMap<String, String> = {
-        let mut map = HashMap::new();
-        map.insert("FB".to_string(), "SDN:L06::35".to_string());
-        map.insert("MO".to_string(), "SDN:L06::48".to_string());
-        map.insert("PF".to_string(), "SDN:L06::46".to_string());
-        map.insert("SM".to_string(), "SDN:L06::70".to_string());
-        map.insert("XX".to_string(), "SDN:L06::0".to_string());
-
-        map
-    };
-}
 
 pub fn map_cora_platform_l06() -> ScalarUDF {
     create_udf(
         "map_cora_platform_l06",
-        vec![datafusion::arrow::datatypes::DataType::Utf8],
+        vec![
+            datafusion::arrow::datatypes::DataType::Utf8,
+            datafusion::arrow::datatypes::DataType::Utf8,
+        ],
         datafusion::arrow::datatypes::DataType::Utf8,
         datafusion::logical_expr::Volatility::Immutable,
         Arc::new(map_cora_platform_l06_impl),
@@ -34,36 +23,99 @@ pub fn map_cora_platform_l06() -> ScalarUDF {
 fn map_cora_platform_l06_impl(
     parameters: &[ColumnarValue],
 ) -> datafusion::error::Result<ColumnarValue> {
-    match &parameters[0] {
-        ColumnarValue::Array(flag) => {
-            let flag_array = flag
+    if parameters.len() != 2 {
+        return Err(datafusion::error::DataFusionError::Execution(
+            "map_cora_platform_l06 function requires 2 parameters. The Bigram and WMO_INST_TYPE"
+                .to_string(),
+        ));
+    }
+
+    match (&parameters[0], &parameters[1]) {
+        (ColumnarValue::Array(array), ColumnarValue::Array(wmo_inst_type)) => {
+            let bigram_array = array.as_any().downcast_ref::<StringArray>().unwrap();
+            let wmo_inst_type_array = wmo_inst_type
                 .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
+                .downcast_ref::<StringArray>()
                 .unwrap();
 
-            let array = flag_array.iter().map(|flag| {
-                flag.map(|value| L06_MAP.get(value).map(|s| s).cloned())
-                    .flatten()
-            });
-
-            let array = StringArray::from_iter(array);
-
-            Ok(ColumnarValue::Array(Arc::new(array)))
+            Ok(ColumnarValue::Array(Arc::new(StringArray::from_iter(
+                bigram_array.iter().zip(wmo_inst_type_array.iter()).map(
+                    |(bigram, wmo_inst_type)| map_cora_platform_func_impl(bigram, wmo_inst_type),
+                ),
+            ))))
         }
-        ColumnarValue::Scalar(ScalarValue::Utf8(value)) => {
-            let sdn_flag = value
-                .as_ref()
-                .map(|value| L06_MAP.get(value.as_str()).map(|s| s.to_string()))
-                .flatten();
+        (
+            ColumnarValue::Array(bigram_arr),
+            ColumnarValue::Scalar(ScalarValue::Utf8(wmo_inst_type)),
+        ) => {
+            let bigram_array = bigram_arr.as_any().downcast_ref::<StringArray>().unwrap();
 
-            Ok(ColumnarValue::Scalar(
-                datafusion::scalar::ScalarValue::Utf8(sdn_flag),
-            ))
+            Ok(ColumnarValue::Array(Arc::new(StringArray::from_iter(
+                bigram_array
+                    .iter()
+                    .map(|bigram| map_cora_platform_func_impl(bigram, wmo_inst_type.as_deref())),
+            ))))
         }
-        _ => {
-            return Err(datafusion::error::DataFusionError::Execution(
-                "Invalid input type".to_string(),
-            ))
+        (
+            ColumnarValue::Scalar(ScalarValue::Utf8(bigram)),
+            ColumnarValue::Array(wmo_inst_type_arr),
+        ) => {
+            let wmo_inst_type_array = wmo_inst_type_arr
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+
+            Ok(ColumnarValue::Array(Arc::new(StringArray::from_iter(
+                wmo_inst_type_array.iter().map(|wmo_inst_type| {
+                    map_cora_platform_func_impl(bigram.as_deref(), wmo_inst_type)
+                }),
+            ))))
         }
+        (
+            ColumnarValue::Scalar(ScalarValue::Utf8(bigram)),
+            ColumnarValue::Scalar(ScalarValue::Utf8(wmo_inst_type)),
+        ) => {
+            let platform_code = map_cora_platform_func_impl(
+                bigram.as_ref().map(|s| s.as_str()),
+                wmo_inst_type.as_ref().map(|s| s.as_str()),
+            );
+
+            if let Some(code) = platform_code {
+                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(
+                    code.to_string(),
+                ))))
+            } else {
+                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None)))
+            }
+        }
+        _ => Err(datafusion::error::DataFusionError::Execution(
+            "map_cora_platform_l06 function requires 2 parameters. The Bigram and WMO_INST_TYPE"
+                .to_string(),
+        )),
+    }
+}
+
+fn map_cora_platform_func_impl(
+    platform_bigram: Option<&str>,
+    wmo_inst_type: Option<&str>,
+) -> Option<&'static str> {
+    match (platform_bigram, wmo_inst_type) {
+        (Some("BO"), _) => Some("SDN:L06::30"),
+        (Some("CT"), Some("995")) => Some("SDN:L06::30"),
+        (Some("CT"), _) => Some("SDN:L06::30"),
+        (Some("DB"), _) => Some("SDN:L06::42"),
+        (Some("FB"), _) => Some("SDN:L06::35"),
+        (Some("GL"), _) => Some("SDN:L06::27"),
+        (Some("ML"), _) => Some("SDN:L06::36"),
+        (Some("MO"), _) => Some("SDN:L06::48"),
+        (Some("PF"), _) => Some("SDN:L06::46"),
+        (Some("SD"), _) => Some("SDN:L06::3B"),
+        (Some("SF"), _) => Some("SDN:L06::23"),
+        (Some("SM"), _) => Some("SDN:L06::70"),
+        (Some("TS"), _) => Some("SDN:L06::30"),
+        (Some("TX"), _) => Some("SDN:L06::48"),
+        (Some("XB"), _) => Some("SDN:L06::30"),
+        (Some("XX"), _) => Some("SDN:L06::0"),
+        _ => None,
     }
 }


### PR DESCRIPTION
Closing #55 

This pull request refactors the `map_cora_platform_l06` function in `map_platform_l06.rs` to improve flexibility and maintainability. The changes include replacing the static `L06_MAP` with a new `map_cora_platform_func_impl` function for dynamic mapping logic, enhancing the function to support two parameters, and adding comprehensive error handling for invalid inputs.

### Refactoring and Code Simplification:
* Removed the static `L06_MAP` `lazy_static!` block in favor of a new `map_cora_platform_func_impl` function, which dynamically handles the mapping of platform codes based on the provided `Bigram` and `WMO_INST_TYPE`. This change reduces memory usage and improves flexibility. [[1]](diffhunk://#diff-cd62a83a195204eda25c59eea7e316a8c7613dad760906bb2eb1dc84a3e61d3bL1-R16) [[2]](diffhunk://#diff-cd62a83a195204eda25c59eea7e316a8c7613dad760906bb2eb1dc84a3e61d3bL37-R119)

### Enhanced Functionality:
* Updated the `map_cora_platform_l06` function to accept two parameters (`Bigram` and `WMO_INST_TYPE`) instead of one, enabling more complex and accurate mapping logic.

### Improved Error Handling:
* Added validation to ensure the function receives exactly two parameters, returning a descriptive error message if the input is invalid.
* Enhanced error handling for unsupported input types, providing clearer feedback to users. 

### Code Readability:
* Consolidated mapping logic into the `map_cora_platform_func_impl` helper function, improving readability and making it easier to modify or extend the mapping rules in the future.