### PR TITLE
Improve the performance of `st_within_point`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrow",
+ "beacon-config",
  "csv",
  "datafusion",
  "geo",
@@ -636,6 +637,8 @@ dependencies = [
  "gsw",
  "inventory",
  "lazy_static",
+ "lru",
+ "ordered-float 5.0.0",
  "serde",
  "wkt 0.12.0",
 ]
@@ -2733,6 +2736,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
+name = "lru"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,6 +3092,15 @@ name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
 ]
@@ -3943,7 +3964,7 @@ checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "ordered-float",
+ "ordered-float 2.10.1",
 ]
 
 [[package]]

--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -25,6 +25,8 @@ pub struct Config {
     pub enable_sql: bool,
     #[envconfig(from = "BEACON_SANITIZE_SCHEMA", default = "false")]
     pub sanitize_schema: bool,
+    #[envconfig(from = "BEACON_ST_WITHIN_POINT_CACHE_SIZE", default = "10000")]
+    pub st_within_point_cache_size: usize,
 }
 
 impl Config {

--- a/beacon-functions/Cargo.toml
+++ b/beacon-functions/Cargo.toml
@@ -16,3 +16,7 @@ csv = "1.3.1"
 
 lazy_static = "1.5.0"
 gsw = "0.2.2"
+lru = "0.14.0"
+ordered-float = "5.0.0"
+
+beacon-config = { path = "../beacon-config" }

--- a/beacon-functions/src/geo/st_within_point.rs
+++ b/beacon-functions/src/geo/st_within_point.rs
@@ -1,12 +1,17 @@
-use std::{str::FromStr, sync::Arc};
+use std::{cell::RefCell, num::NonZero, str::FromStr, sync::Arc};
 
 use arrow::{array::AsArray, datatypes::Float64Type};
 use datafusion::{
     logical_expr::{ColumnarValue, ScalarUDFImpl, Signature},
     scalar::ScalarValue,
 };
-use geo::{Contains, Geometry};
+use geo::{BoundingRect, Contains, Geometry, Point, Rect};
+use ordered_float::OrderedFloat;
 use wkt::Wkt;
+
+thread_local! {
+    static POINT_LOOKUP_CACHE: RefCell<lru::LruCache<Point<OrderedFloat<f64>>, bool>> = RefCell::new(lru::LruCache::new(NonZero::new(beacon_config::CONFIG.st_within_point_cache_size).expect("Cache size must be non-zero")));
+}
 
 #[derive(Debug)]
 pub struct WithinPointUdf {
@@ -52,27 +57,6 @@ impl ScalarUDFImpl for WithinPointUdf {
         &self,
         args: datafusion::logical_expr::ScalarFunctionArgs,
     ) -> datafusion::error::Result<datafusion::logical_expr::ColumnarValue> {
-        let mut geom_iter: Box<dyn Iterator<Item = Option<&str>>> = match &args.args[0] {
-            datafusion::logical_expr::ColumnarValue::Array(array) => {
-                if let Some(array) = array.as_string_opt::<i32>() {
-                    Box::new(array.iter())
-                } else {
-                    return Err(datafusion::error::DataFusionError::Internal(
-                        "st_within_point expects a string array as its first argument".to_string(),
-                    ));
-                }
-            }
-            datafusion::logical_expr::ColumnarValue::Scalar(scalar_value) => {
-                if let ScalarValue::Utf8(wkt) = scalar_value {
-                    Box::new(std::iter::repeat_n(wkt.as_deref(), args.number_rows))
-                } else {
-                    return Err(datafusion::error::DataFusionError::Internal(
-                        "st_within_point expects a string as its first argument".to_string(),
-                    ));
-                }
-            }
-        };
-
         let resized_lon_array = args.args[1].to_array(args.number_rows).unwrap();
         let mut lon_iter = resized_lon_array
             .as_primitive_opt::<Float64Type>()
@@ -88,6 +72,44 @@ impl ScalarUDFImpl for WithinPointUdf {
             .ok_or(datafusion::error::DataFusionError::Internal(
                 "st_within_point expects a float64 array as its third argument".to_string(),
             ))?;
+
+        let mut geom_iter: Box<dyn Iterator<Item = Option<&str>>> = match &args.args[0] {
+            datafusion::logical_expr::ColumnarValue::Array(array) => {
+                if let Some(array) = array.as_string_opt::<i32>() {
+                    Box::new(array.iter())
+                } else {
+                    return Err(datafusion::error::DataFusionError::Internal(
+                        "st_within_point expects a string array as its first argument".to_string(),
+                    ));
+                }
+            }
+            datafusion::logical_expr::ColumnarValue::Scalar(scalar_value) => {
+                if let ScalarValue::Utf8(wkt) = scalar_value {
+                    if true {
+                        if let Some(wkt) = wkt {
+                            let wkt = Wkt::from_str(wkt).map_err(|e| anyhow::anyhow!(e)).map_err(
+                                |e| datafusion::error::DataFusionError::Execution(e.to_string()),
+                            )?;
+                            let geometry: Geometry = wkt.try_into().unwrap();
+                            let result =
+                                st_within_point_fast(geometry, &mut lon_iter, &mut lat_iter)
+                                    .map_err(|e| {
+                                        datafusion::error::DataFusionError::Execution(e.to_string())
+                                    })?;
+                            return Ok(ColumnarValue::Array(Arc::new(
+                                arrow::array::BooleanArray::from(result),
+                            )));
+                        }
+                    }
+
+                    Box::new(std::iter::repeat_n(wkt.as_deref(), args.number_rows))
+                } else {
+                    return Err(datafusion::error::DataFusionError::Internal(
+                        "st_within_point expects a string as its first argument".to_string(),
+                    ));
+                }
+            }
+        };
 
         let result = st_within_point(&mut geom_iter, &mut lon_iter, &mut lat_iter)
             .map_err(|e| datafusion::error::DataFusionError::Internal(e.to_string()))?;
@@ -118,8 +140,66 @@ fn st_within_point_impl(
             // ST_WithinPoint implementation
             let wkt = Wkt::from_str(geom).map_err(|e| anyhow::anyhow!(e))?;
             let geometry: Geometry = wkt.try_into().unwrap();
+
             let point = geo::Point::new(lon, lat);
             Ok(geometry.contains(&point))
+        }
+        _ => Ok(false),
+    }
+}
+
+fn st_within_point_fast(
+    geom: Geometry,
+    lon: &mut dyn Iterator<Item = Option<f64>>,
+    lat: &mut dyn Iterator<Item = Option<f64>>,
+) -> anyhow::Result<Vec<bool>> {
+    let bounding_rect = geom.bounding_rect();
+    lon.zip(lat)
+        .map(|(lon, lat)| st_within_point_fast_impl(&geom, bounding_rect, lon, lat))
+        .collect()
+}
+
+fn st_within_point_fast_impl(
+    geometry: &Geometry,
+    bounding_rect: Option<Rect>,
+    lon: Option<f64>,
+    lat: Option<f64>,
+) -> anyhow::Result<bool> {
+    match (geometry, lon, lat) {
+        (geometry, Some(lon), Some(lat)) => {
+            // ST_WithinPoint implementation
+            let point = geo::Point::new(lon, lat);
+            let ordered_point = geo::Point::new(OrderedFloat(lon), OrderedFloat(lat));
+
+            // If the point is outside the bounding rectangle, it cannot be within the geometry
+            if let Some(rect) = bounding_rect {
+                if !rect.contains(&point) {
+                    return Ok(false);
+                }
+            }
+
+            // If the bounding rectangle is not available, we proceed with the full geometry check
+            // First, check the cache
+            let result = POINT_LOOKUP_CACHE.with(|cache| {
+                if let Some(result) = cache.borrow_mut().get(&ordered_point) {
+                    return Some(*result);
+                }
+                None
+            });
+
+            if let Some(result) = result {
+                return Ok(result);
+            }
+
+            // If not found in cache, perform the geometry check
+            let result = geometry.contains(&point);
+
+            // Store the result in the cache
+            POINT_LOOKUP_CACHE.with(|cache| {
+                cache.borrow_mut().put(ordered_point, result);
+            });
+
+            Ok(result)
         }
         _ => Ok(false),
     }


### PR DESCRIPTION
Fixes #68

This pull request introduces a caching mechanism to optimize the `st_within_point` function in the `beacon-functions` crate, along with associated configuration and dependency updates. The primary focus is on improving performance by reducing redundant geometry computations using an in-memory LRU cache. Below are the most important changes grouped by theme:

### Caching Optimization for `st_within_point`:

* Added a new helper function, `st_within_point_fast`, and its implementation, `st_within_point_fast_impl`, to perform optimized geometry checks with caching and bounding rectangle optimizations. (`beacon-functions/src/geo/st_within_point.rs`)

### Configuration Updates:

* Added a new configuration field, `st_within_point_cache_size`, to control the size of the LRU cache, with a default value of 10,000. (`beacon-config/src/lib.rs`)

### Dependency Additions:

* Updated `Cargo.toml` to include the `lru` crate for caching and the `ordered-float` crate for handling floating-point comparisons. Also added a dependency on `beacon-config` for shared configuration. (`beacon-functions/Cargo.toml`)

These changes enhance the performance of spatial queries while maintaining flexibility through configurable parameters.