### PR TITLE
Fix Preset Table Aliasing

### DIFF
--- a/beacon-tables/src/preset_table.rs
+++ b/beacon-tables/src/preset_table.rs
@@ -124,10 +124,10 @@ impl PresetTable {
                     exposed_fields.push(field.clone());
                 }
             } else {
-                panic!(
-                    "Column '{}' not found in the current schema",
+                return Err(TableError::TableError(format!(
+                    "Data column '{}' not found in the current schema",
                     column.column_name
-                );
+                )));
             }
         }
 
@@ -140,10 +140,10 @@ impl PresetTable {
                     exposed_fields.push(field.clone());
                 }
             } else {
-                panic!(
+                return Err(TableError::TableError(format!(
                     "Metadata column '{}' not found in the current schema",
                     column.column_name
-                );
+                )));
             }
         }
 


### PR DESCRIPTION
This pull request refactors the `PresetTable` implementation in `beacon-tables/src/preset_table.rs` to improve schema handling and error reporting. The most significant changes include replacing `HashMap` with `IndexMap` for deterministic ordering, adding explicit error handling for missing columns, and enhancing the projection logic for better schema alignment.

### Schema Handling Improvements:
* Replaced `HashMap` with `IndexMap` for `renames` in `PresetTable` and `PresetTableProvider` to ensure deterministic ordering of column mappings.
* Enhanced projection logic to translate indices to actual column names, ensuring alignment between exposed and source schemas. Added error handling for missing columns in the source schema during projection.

### Code Quality Improvements:
* Added debug logging in the projection logic to trace column mappings and aliases, aiding in debugging and transparency.