### PR TITLE
Add pagination to Query

### DIFF
--- a/beacon-query/src/lib.rs
+++ b/beacon-query/src/lib.rs
@@ -53,6 +53,8 @@ pub struct QueryBody {
     from: Option<From>,
     sort_by: Option<Vec<Sort>>,
     distinct: Option<Vec<String>>,
+    offset: Option<usize>,
+    limit: Option<usize>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, ToSchema)]

--- a/beacon-query/src/parser.rs
+++ b/beacon-query/src/parser.rs
@@ -94,6 +94,9 @@ impl Parser {
             builder = builder.sort(sort_by.iter().map(|s| s.to_expr()))?;
         }
 
+        let offset = query_body.offset.unwrap_or(0);
+        builder = builder.limit(offset, query_body.limit)?;
+
         let plan = builder.build()?;
         Ok(plan)
     }


### PR DESCRIPTION
This pull request enhances the `beacon-query` module by adding support for pagination in query handling. The changes introduce `offset` and `limit` parameters to the query structure and update the query parsing logic to utilize these parameters.

### Pagination support:

* **Added `offset` and `limit` fields to `QueryBody`**: These new fields allow specifying the starting point and maximum number of records to return in a query. (`beacon-query/src/lib.rs`, 
* **Updated `Parser` implementation to handle pagination**: The `Parser` now applies the `offset` and `limit` values when constructing the query plan, defaulting `offset` to `0` if not provided. 