### PR TITLE
Auto Cast timestamp[s] to [ns] for parquet output

### DIFF
--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -31,7 +31,8 @@ pub struct Config {
     pub worker_threads: usize,
     #[envconfig(from = "BEACON_ENABLE_SYS_INFO", default = "false")]
     pub enable_sys_info: bool,
-
+    #[envconfig(from = "BEACON_AUTO_CAST_PARQUET", default = "false")]
+    pub auto_cast_parquet: bool,
     /// CORS CONFIG
     #[envconfig(
         from = "BEACON_CORS_ALLOWED_METHODS",


### PR DESCRIPTION
This pull request introduces a new feature to enable automatic casting of Parquet output fields and updates the configuration and parsing logic to support it. The changes include adding a new configuration option, enhancing the parser to perform conditional casting, and updating dependencies to facilitate the implementation.

### Configuration Updates:
* Added a new configuration option `auto_cast_parquet` to the `Config` struct in `beacon-config/src/lib.rs`. This option is set via the `BEACON_AUTO_CAST_PARQUET` environment variable and defaults to `false`.

### Parser Enhancements:
* Updated the `Parser` implementation in `beacon-query/src/parser.rs` to conditionally cast Parquet output fields to nanoseconds when the `auto_cast_parquet` configuration is enabled. This involves:
  - Adding logic to inspect the schema of the logical plan and apply casting to `Timestamp(Second, tz)` fields.
  - Modifying the `copy_to` method to use the potentially modified logical plan.