### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,11 @@ COPY beacon-arrow-odv/ /beacon-arrow-odv/
 COPY beacon-common/ /beacon-common/
 COPY beacon-config/ /beacon-config/
 COPY beacon-core/ /beacon-core/
+COPY beacon-data-lake/ /beacon-data-lake/
+COPY beacon-formats/ /beacon-formats/
 COPY beacon-functions/ /beacon-functions/
-COPY beacon-output/ /beacon-output/
 COPY beacon-planner/ /beacon-planner/
 COPY beacon-query/ /beacon-query/
-COPY beacon-sources/ /beacon-sources/
-COPY beacon-tables/ /beacon-tables/
 COPY Cargo.toml /
 COPY Cargo.lock /
 
@@ -47,7 +46,9 @@ COPY --from=builder /target/release/beacon-api /beacon/
 
 #Install Dependencies
 RUN apt-get update
+RUN apt-get install -y curl
 RUN apt-get install -y netcdf-bin
+RUN apt-get install -y libnetcdf-dev
 
 EXPOSE 5001
 

--- a/beacon-data-lake/src/lib.rs
+++ b/beacon-data-lake/src/lib.rs
@@ -131,11 +131,14 @@ impl DataLake {
             Arc::new(NetCDFObjectResolver::new(endpoint, Some(bucket), None))
         } else {
             let base_path = PathBuf::from("./data");
+
+            std::fs::create_dir_all(&base_path).expect("Failed to create datasets directory");
+
             let absolute_path = base_path.canonicalize().unwrap();
 
             // Create directories if they do not exist
             std::fs::create_dir_all(&absolute_path).expect("Failed to create datasets directory");
-            println!(
+            tracing::debug!(
                 "Using local NetCDF datasets path: {}",
                 absolute_path.display()
             );
@@ -149,10 +152,12 @@ impl DataLake {
 
     pub fn netcdf_sink_resolver() -> Arc<NetCDFSinkResolver> {
         let base_path = PathBuf::from("./data");
+        std::fs::create_dir_all(&base_path).expect("Failed to create datasets directory");
         let absolute_path = base_path.canonicalize().unwrap();
 
+        tracing::debug!("Using local NetCDF sink path: {}", absolute_path.display());
+
         // Create directories if they do not exist
-        std::fs::create_dir_all(&absolute_path).expect("Failed to create datasets directory");
         Arc::new(NetCDFSinkResolver::new(absolute_path))
     }
 


### PR DESCRIPTION
**Dockerfile updates:**

* Added `beacon-data-lake` and `beacon-formats` modules to the build context, while removing `beacon-output`, `beacon-sources`, and `beacon-tables` to streamline the build.
* Installed `curl` and `libnetcdf-dev` in addition to `netcdf-bin` to ensure all required dependencies for NetCDF operations are present.

**Data lake reliability and logging improvements:**

* Ensured the `./data` directory is created before resolving NetCDF objects or sinks, preventing runtime errors if the directory is missing. 
* Updated debug logging to use `tracing::debug!` instead of `println!` for more consistent and configurable logging output. 