### PR TITLE
Fast pushdown projection

### DIFF
--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -66,6 +66,8 @@ pub struct Config {
     pub allowed_credentials: bool,
     #[envconfig(from = "BEACON_CORS_MAX_AGE", default = "3600")]
     pub max_age: u64,
+    #[envconfig(from = "BEACON_ENABLE_PUSHDOWN_PROJECTION", default = "false")]
+    pub enable_pushdown_projection: bool,
 }
 
 impl Config {

--- a/beacon-query/src/lib.rs
+++ b/beacon-query/src/lib.rs
@@ -94,6 +94,23 @@ impl Literal {
 }
 
 impl Select {
+    pub fn collect_columns(&self, columns: &mut Vec<String>) {
+        match self {
+            Select::ColumnName(name) => {
+                columns.push(name.clone());
+            }
+            Select::Column { column, .. } => {
+                columns.push(column.clone());
+            }
+            Select::Literal { .. } => {}
+            Select::Function { args, .. } => {
+                for arg in args {
+                    arg.collect_columns(columns);
+                }
+            }
+        }
+    }
+
     pub fn to_expr(&self, session_state: &SessionState) -> anyhow::Result<Expr> {
         match self {
             Select::ColumnName(name) => Ok(column_name(name)),


### PR DESCRIPTION
Enable the fast pushdown of selected columns when using the JSON API. This can provide big performance improvements. Its is feature blocked by the flag `BEACON_ENABLE_PUSHDOWN_PROJECTION`