### PR TITLE
Improving api datasets output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,7 @@ dependencies = [
  "beacon-config",
  "beacon-core",
  "beacon-data-lake",
+ "beacon-formats",
  "beacon-functions",
  "beacon-planner",
  "beacon-query",

--- a/beacon-api/Cargo.toml
+++ b/beacon-api/Cargo.toml
@@ -35,4 +35,5 @@ beacon-core = { path = "../beacon-core" }
 beacon-query = { path = "../beacon-query" }
 beacon-planner = { path = "../beacon-planner" }
 beacon-functions = { path = "../beacon-functions" }
+beacon-formats = { path = "../beacon-formats" }
 beacon-data-lake = { path = "../beacon-data-lake" }

--- a/beacon-api/src/client/datasets.rs
+++ b/beacon-api/src/client/datasets.rs
@@ -7,6 +7,7 @@ use axum::{
     Json,
 };
 use beacon_core::runtime::Runtime;
+use beacon_formats::Dataset;
 use utoipa::{IntoParams, ToSchema};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, IntoParams)]
@@ -32,7 +33,7 @@ pub struct ListDatasetsQuery {
 pub(crate) async fn list_datasets(
     State(state): State<Arc<Runtime>>,
     Query(query): Query<ListDatasetsQuery>,
-) -> Result<Json<Vec<String>>, (StatusCode, String)> {
+) -> Result<Json<Vec<Dataset>>, (StatusCode, String)> {
     let result = state
         .list_datasets(query.pattern, query.offset, query.limit)
         .await;

--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use arrow::datatypes::SchemaRef;
 use beacon_data_lake::table::Table;
+use beacon_formats::Dataset;
 use beacon_functions::function_doc::FunctionDoc;
 use beacon_planner::metrics::ConsolidatedMetrics;
 use beacon_query::{parser::Parser, Query};
@@ -108,7 +109,7 @@ impl Runtime {
         pattern: Option<String>,
         offset: Option<usize>,
         limit: Option<usize>,
-    ) -> anyhow::Result<Vec<String>> {
+    ) -> anyhow::Result<Vec<Dataset>> {
         self.virtual_machine
             .list_datasets(pattern, offset, limit)
             .await

--- a/beacon-core/src/virtual_machine.rs
+++ b/beacon-core/src/virtual_machine.rs
@@ -5,10 +5,12 @@ use arrow::{
     datatypes::{SchemaRef, UInt64Type},
 };
 use beacon_data_lake::{table::Table, DataLake};
+use beacon_formats::{Dataset, FileFormatFactoryExt};
 use beacon_functions::{file_formats::BeaconTableFunctionImpl, function_doc::FunctionDoc};
 use beacon_planner::plan::BeaconQueryPlan;
 use datafusion::{
     catalog::{SchemaProvider, TableFunctionImpl},
+    datasource::listing::ListingTableUrl,
     execution::{
         disk_manager::DiskManagerConfig, memory_pool::FairSpillPool,
         runtime_env::RuntimeEnvBuilder, SessionStateBuilder,
@@ -96,17 +98,11 @@ impl VirtualMachine {
             .with_memory_pool(mem_pool)
             .build_arc()?;
 
-        let mut session_state = SessionStateBuilder::new()
+        let session_state = SessionStateBuilder::new()
             .with_config(config)
             .with_runtime_env(runtime_env)
             .with_default_features()
             .build();
-
-        beacon_formats::register_file_formats(
-            &mut session_state,
-            DataLake::netcdf_object_resolver(),
-            DataLake::netcdf_sink_resolver(),
-        )?;
 
         let session_context = Arc::new(SessionContext::new_with_state(session_state));
 
@@ -230,7 +226,7 @@ impl VirtualMachine {
         pattern: Option<String>,
         offset: Option<usize>,
         limit: Option<usize>,
-    ) -> anyhow::Result<Vec<String>> {
+    ) -> anyhow::Result<Vec<Dataset>> {
         Ok(self.data_lake.list_datasets(offset, limit, pattern).await?)
     }
 

--- a/beacon-formats/src/lib.rs
+++ b/beacon-formats/src/lib.rs
@@ -1,16 +1,11 @@
 use std::sync::Arc;
 
-use ::arrow::datatypes::{DataType, Field};
-use datafusion::{
-    execution::SessionState,
-    functions::core::arrow_cast::ArrowCastFunc,
-    logical_expr::{Documentation, Signature},
-};
+use datafusion::prelude::SessionContext;
+use object_store::ObjectMeta;
 
 use crate::{
     arrow::ArrowFormatFactory,
     csv::CsvFormatFactory,
-    geo_parquet::GeoParquetFormatFactory,
     netcdf::{
         NetCDFFormatFactory, NetcdfOptions,
         object_resolver::{NetCDFObjectResolver, NetCDFSinkResolver},
@@ -27,24 +22,62 @@ pub mod odv_ascii;
 pub mod parquet;
 pub mod zarr;
 
+pub trait FileFormatFactoryExt:
+    datafusion::datasource::file_format::FileFormatFactory + Send + Sync
+{
+    fn discover_datasets(&self, objects: &[ObjectMeta]) -> datafusion::error::Result<Vec<Dataset>>;
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Dataset {
+    pub file_path: String,
+    pub format: DatasetFormat,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DatasetFormat {
+    Parquet,
+    Csv,
+    Arrow,
+    NetCDF,
+    Zarr,
+}
+
+impl Dataset {
+    pub fn update_file_path(&mut self, new_path: String) {
+        self.file_path = new_path;
+    }
+
+    pub fn file_path(&self) -> &str {
+        &self.file_path
+    }
+}
+
 /// Register file formats with the session state that can be used for reading
-pub fn register_file_formats(
-    session_state: &mut SessionState,
+pub fn file_formats(
+    session_context: Arc<SessionContext>,
     netcdf_object_resolver: Arc<NetCDFObjectResolver>,
     netcdf_sink_resolver: Arc<NetCDFSinkResolver>,
-) -> datafusion::error::Result<()> {
-    session_state.register_file_format(Arc::new(ParquetFormatFactory), true)?;
-    session_state.register_file_format(Arc::new(CsvFormatFactory), true)?;
-    session_state.register_file_format(Arc::new(ArrowFormatFactory), true)?;
-    session_state.register_file_format(Arc::new(GeoParquetFormatFactory::default()), true)?;
-    session_state.register_file_format(
+) -> datafusion::error::Result<Vec<Arc<dyn FileFormatFactoryExt>>> {
+    let state_ref = session_context.state_ref();
+    let mut state = state_ref.write();
+
+    let formats: Vec<Arc<dyn FileFormatFactoryExt>> = vec![
+        Arc::new(ParquetFormatFactory),
+        Arc::new(CsvFormatFactory),
+        Arc::new(ArrowFormatFactory),
         Arc::new(NetCDFFormatFactory::new(
             NetcdfOptions::default(),
             netcdf_object_resolver,
             netcdf_sink_resolver,
         )),
-        true,
-    )?;
-    session_state.register_file_format(Arc::new(ZarrFormatFactory), true)?;
-    Ok(())
+        Arc::new(ZarrFormatFactory),
+    ];
+
+    for format in formats.iter() {
+        state.register_file_format(format.clone(), true)?;
+    }
+
+    Ok(formats)
 }

--- a/beacon-formats/src/parquet.rs
+++ b/beacon-formats/src/parquet.rs
@@ -18,6 +18,8 @@ use object_store::{ObjectMeta, ObjectStore};
 use beacon_common::super_typing::super_type_schema;
 use futures::future::try_join_all;
 
+use crate::{Dataset, DatasetFormat, FileFormatFactoryExt};
+
 #[derive(Debug)]
 pub struct ParquetFormatFactory;
 
@@ -42,6 +44,28 @@ impl FileFormatFactory for ParquetFormatFactory {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+impl FileFormatFactoryExt for ParquetFormatFactory {
+    fn discover_datasets(
+        &self,
+        objects: &[ObjectMeta],
+    ) -> datafusion::error::Result<Vec<crate::Dataset>> {
+        let datasets = objects
+            .iter()
+            .filter(|obj| {
+                obj.location
+                    .extension()
+                    .map(|ext| ext == "parquet")
+                    .unwrap_or(false)
+            })
+            .map(|obj| Dataset {
+                file_path: obj.location.to_string(),
+                format: DatasetFormat::Parquet,
+            })
+            .collect();
+        Ok(datasets)
     }
 }
 


### PR DESCRIPTION
This pull request introduces a new structured way to discover and return datasets, enhancing the dataset listing functionality across the beacon project. Instead of returning plain file path strings, the API now returns rich `Dataset` objects that include both the file path and the file format. This change is supported by a new extensible trait, `FileFormatFactoryExt`, which allows each file format to define its own logic for discovering datasets. The update is reflected in the API, core runtime, data lake, and all supported file formats.

### Dataset Discovery and API Improvements

* The dataset listing API endpoint now returns a list of `Dataset` objects (with file path and format) instead of plain strings, improving the ability to distinguish and filter datasets by format. (`beacon-api/src/client/datasets.rs`, `beacon-core/src/runtime.rs`, `beacon-core/src/virtual_machine.rs`, `beacon-data-lake/src/lib.rs`) [[1]](diffhunk://#diff-a6e611b20bc2fe0fd0e54326a453f04a1f584bcc763ae0e8b6cb6f35b39c66e5L35-R36) [[2]](diffhunk://#diff-69cadc4c0e11d4adf2181c4aa421522d21ad882b85cc5d80c4de20e62de276e4L111-R112) [[3]](diffhunk://#diff-0a265f5d75707425f77911260d7a603777b03b159d34eabd71cfa356b16ddadbL233-R229) [[4]](diffhunk://#diff-4e9c327c76a22001c83c7515657ea64743198b5b5b854e183de354c680c638eaL374-R388)

* The `Dataset` struct and `DatasetFormat` enum are introduced in `beacon-formats`, providing a standardized representation for datasets and their formats. (`beacon-formats/src/lib.rs`)

### Extensible File Format Support

* A new trait, `FileFormatFactoryExt`, is added to allow each file format to implement custom logic for discovering datasets from object metadata. All major file formats (Parquet, CSV, Arrow, NetCDF, Zarr) now implement this trait. (`beacon-formats/src/lib.rs`, `beacon-formats/src/parquet.rs`, `beacon-formats/src/csv.rs`, `beacon-formats/src/arrow.rs`, `beacon-formats/src/netcdf/mod.rs`, `beacon-formats/src/zarr/mod.rs`) [[1]](diffhunk://#diff-4150b54236782f0a5ef17087ff292ecfd9607279136a252be505f55874194f3eR25-R82) [[2]](diffhunk://#diff-09a860878a3c52ff403d9acfff05085b9f24740b167c3121546168966c63712fR50-R71) [[3]](diffhunk://#diff-94701fe124d41322ec029a03d70668760b6779a240a2f272959c8296e50a9f85R50-R71) [[4]](diffhunk://#diff-a6a4ad93e25fb70e2cde4f80825de20b52b8bac05428f2c4966e5618f05cbed6R48-R69) [[5]](diffhunk://#diff-86d09822c90a2fcaeec6aa73f404681c8cb75490743d881f8b806301748e3672R92-R113) [[6]](diffhunk://#diff-65a0cdbcba071a242c79ecd1c265123288027e82a8887f633794f818f453b63eR90-R124)

* The file format registration logic is refactored: instead of just registering formats, the system now also collects format factories for dataset discovery. (`beacon-formats/src/lib.rs`, `beacon-data-lake/src/lib.rs`, `beacon-core/src/virtual_machine.rs`) [[1]](diffhunk://#diff-4150b54236782f0a5ef17087ff292ecfd9607279136a252be505f55874194f3eR25-R82) [[2]](diffhunk://#diff-4e9c327c76a22001c83c7515657ea64743198b5b5b854e183de354c680c638eaR160-R166) [[3]](diffhunk://#diff-0a265f5d75707425f77911260d7a603777b03b159d34eabd71cfa356b16ddadbL99-L110)

### Data Lake Refactoring

* The `DataLake` struct now stores a list of file format factories and uses them to discover datasets, applying offset and limit after filtering and normalization. (`beacon-data-lake/src/lib.rs`) [[1]](diffhunk://#diff-4e9c327c76a22001c83c7515657ea64743198b5b5b854e183de354c680c638eaR61-R63) [[2]](diffhunk://#diff-4e9c327c76a22001c83c7515657ea64743198b5b5b854e183de354c680c638eaR160-R166) [[3]](diffhunk://#diff-4e9c327c76a22001c83c7515657ea64743198b5b5b854e183de354c680c638eaL374-R388) [[4]](diffhunk://#diff-4e9c327c76a22001c83c7515657ea64743198b5b5b854e183de354c680c638eaL384-R436)

### Dependency Updates

* The `beacon-formats` crate is added as a dependency in `beacon-api` and imported where needed. (`beacon-api/Cargo.toml`, `beacon-api/src/client/datasets.rs`, `beacon-core/src/runtime.rs`, `beacon-core/src/virtual_machine.rs`, `beacon-data-lake/src/lib.rs`) [[1]](diffhunk://#diff-71c91dc46585f7858ffc2fc92479bd98cac3cf7422e034b32a9d248471389b95R38) [[2]](diffhunk://#diff-a6e611b20bc2fe0fd0e54326a453f04a1f584bcc763ae0e8b6cb6f35b39c66e5R10) [[3]](diffhunk://#diff-69cadc4c0e11d4adf2181c4aa421522d21ad882b85cc5d80c4de20e62de276e4R8) [[4]](diffhunk://#diff-0a265f5d75707425f77911260d7a603777b03b159d34eabd71cfa356b16ddadbR8-R13) [[5]](diffhunk://#diff-4e9c327c76a22001c83c7515657ea64743198b5b5b854e183de354c680c638eaL11-R14)

These changes make dataset discovery more robust, extensible, and informative for API consumers and internal logic.