### PR TITLE
Allow generic table operations specific to file formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,7 @@ dependencies = [
  "futures-util",
  "pprof",
  "serde",
+ "serde_json",
  "tikv-jemallocator",
  "tokio",
  "tokio-util",

--- a/beacon-api/Cargo.toml
+++ b/beacon-api/Cargo.toml
@@ -22,6 +22,7 @@ utoipa-swagger-ui = { workspace = true }
 tokio = { workspace = true}
 tokio-util = { workspace = true}
 serde = { workspace = true}
+serde_json = { workspace = true}
 anyhow = { workspace = true}
 arrow = { workspace = true}
 arrow-schema = { workspace = true}

--- a/beacon-api/src/admin/mod.rs
+++ b/beacon-api/src/admin/mod.rs
@@ -58,6 +58,7 @@ async fn basic_auth(
 pub(crate) fn setup_admin_router() -> (Router<Arc<Runtime>>, utoipa::openapi::OpenApi) {
     let (admin_router, admin_api) = OpenApiRouter::with_openapi(AdminApiDoc::openapi())
         .routes(routes!(tables::create_table))
+        .routes(routes!(tables::apply_table_operation))
         .routes(routes!(tables::delete_table))
         .layer(axum::middleware::from_fn(basic_auth))
         .split_for_parts();

--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -80,6 +80,16 @@ impl Runtime {
         self.virtual_machine.add_table(table).await
     }
 
+    pub async fn apply_table_operation(
+        &self,
+        table_name: &str,
+        op: serde_json::Value,
+    ) -> anyhow::Result<()> {
+        self.virtual_machine
+            .apply_table_operation(table_name, op)
+            .await
+    }
+
     pub async fn delete_table(&self, table_name: &str) -> anyhow::Result<()> {
         self.virtual_machine.delete_table(table_name)
     }

--- a/beacon-core/src/virtual_machine.rs
+++ b/beacon-core/src/virtual_machine.rs
@@ -237,4 +237,12 @@ impl VirtualMachine {
     pub(crate) async fn list_table_config(&self, table_name: String) -> Option<Table> {
         self.data_lake.list_table(&table_name)
     }
+
+    pub(crate) async fn apply_table_operation(
+        &self,
+        table_name: &str,
+        op: serde_json::Value,
+    ) -> Result<(), anyhow::Error> {
+        Ok(self.data_lake.apply_operation(table_name, op).await?)
+    }
 }

--- a/beacon-data-lake/src/table/logical/mod.rs
+++ b/beacon-data-lake/src/table/logical/mod.rs
@@ -17,10 +17,10 @@ use crate::{
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct LogicalTable {
     #[serde(alias = "paths")]
-    glob_paths: Vec<String>,
+    pub glob_paths: Vec<String>,
     /// The file format for this logical table.
     #[serde(flatten)]
-    file_format: Arc<dyn TableFileFormat>,
+    pub file_format: Arc<dyn TableFileFormat>,
 }
 
 impl LogicalTable {

--- a/beacon-data-lake/src/table/table_formats.rs
+++ b/beacon-data-lake/src/table/table_formats.rs
@@ -1,10 +1,25 @@
 use std::{collections::HashMap, sync::Arc};
 
 use beacon_formats::zarr::{ZarrFormat, statistics::ZarrStatisticsSelection};
-use datafusion::datasource::file_format::FileFormat;
+use datafusion::{
+    datasource::{
+        file_format::FileFormat,
+        listing::{ListingTable, ListingTableUrl},
+    },
+    prelude::SessionContext,
+};
 
 #[typetag::serde(tag = "file_format")]
+#[async_trait::async_trait]
 pub trait TableFileFormat: std::fmt::Debug + Send + Sync {
+    async fn apply_operation(
+        &self,
+        _op: serde_json::Value,
+        _urls: Vec<ListingTableUrl>,
+        _session_ctx: Arc<SessionContext>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Err("No operations supported for this file format".into())
+    }
     fn file_ext(&self) -> String;
     fn file_format(&self) -> Option<Arc<dyn FileFormat>> {
         None


### PR DESCRIPTION
This pull request introduces a new API endpoint for applying operations to tables in the admin router, along with the necessary backend support for handling such operations. The changes enable clients to send arbitrary operations (as JSON) to be performed on a table, with initial support focused on logical tables and extensibility for future table types.

**API and Routing Enhancements:**

* Added a new `POST /api/admin/apply-table-operation` endpoint to the admin router, allowing operations to be applied to tables via the `apply_table_operation` handler. [[1]](diffhunk://#diff-a2bbf8a173401af3b6c9248e5e09ce293d64a0cd1eaff5f3d86637073894fa70R61) [[2]](diffhunk://#diff-36496755a0542985708745a336a7e8c10f4124a65d86c5925fc433e1a88b9764R78-R110)

**Backend and Data Model Support:**

* Implemented the `TableOperation` struct for deserializing incoming operation requests and added backend methods (`apply_table_operation`) in `Runtime`, `VirtualMachine`, and `DataLake` to process these operations. [[1]](diffhunk://#diff-36496755a0542985708745a336a7e8c10f4124a65d86c5925fc433e1a88b9764R78-R110) [[2]](diffhunk://#diff-69cadc4c0e11d4adf2181c4aa421522d21ad882b85cc5d80c4de20e62de276e4R83-R92) [[3]](diffhunk://#diff-0a265f5d75707425f77911260d7a603777b03b159d34eabd71cfa356b16ddadbR240-R247) [[4]](diffhunk://#diff-4e9c327c76a22001c83c7515657ea64743198b5b5b854e183de354c680c638eaR533-R554)
* Extended the `TableType` enum and `TableFileFormat` trait to support an async `apply_operation` method, currently implemented for logical tables and designed for future extensibility. [[1]](diffhunk://#diff-52d02a0b8913094a96306b8179c2aef48c91fbb4ee384ec96d0f481a84c53eb7R72-R103) [[2]](diffhunk://#diff-40c9c532325fa940a1f111e84a903d69b3ae61132c5297bad943f678d86dfe39L4-R22)

**Logical Table Extensibility:**

* Made `glob_paths` and `file_format` fields of `LogicalTable` public to allow operation application logic to access necessary table metadata.

**Dependency Updates:**

* Added `serde_json` to the workspace dependencies to support JSON-based table operations.