### PR TITLE
Add streaming arrow output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-streams"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de41ac9161c75912e405c28b1b60f3309081f72ef1fa04b5ccec6f1d3fa715b"
+dependencies = [
+ "arrow",
+ "axum",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "mime",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +569,7 @@ dependencies = [
  "arrow",
  "arrow-schema",
  "axum",
+ "axum-streams",
  "base64",
  "beacon-config",
  "beacon-core",
@@ -5199,6 +5218,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/beacon-api/Cargo.toml
+++ b/beacon-api/Cargo.toml
@@ -9,6 +9,7 @@ pprof = { version = "0.15", features = ["flamegraph"] }
 
 [dependencies]
 axum = { version = "0.8.1", features = ["tracing", "multipart"] }
+axum-streams = { version = "0.21.0", features = ["arrow"]}
 tower-http = { version = "0.6.1", features = ["trace", "cors"] }
 base64 = "0.22.1"
 

--- a/beacon-core/src/query_result.rs
+++ b/beacon-core/src/query_result.rs
@@ -1,6 +1,63 @@
+use std::{collections::HashMap, sync::Arc};
+
+use arrow::datatypes::SchemaRef;
+use beacon_planner::{metrics::ConsolidatedMetrics, prelude::MetricsTracker};
 use beacon_query::output::QueryOutputFile;
+use datafusion::execution::SendableRecordBatchStream;
+use futures::Stream;
+use parking_lot::Mutex;
 
 pub struct QueryResult {
-    pub output_buffer: QueryOutputFile,
+    pub query_output: QueryOutput,
     pub query_id: uuid::Uuid,
+}
+
+pub enum QueryOutput {
+    File(QueryOutputFile),
+    Stream(ArrowOutputStream),
+}
+
+pub struct ArrowOutputStream {
+    pub stream: SendableRecordBatchStream,
+    pub metrics: Arc<MetricsTracker>,
+    pub all_consolidated_metrics: Arc<Mutex<HashMap<uuid::Uuid, ConsolidatedMetrics>>>,
+}
+
+impl ArrowOutputStream {
+    pub fn schema(&self) -> SchemaRef {
+        self.stream.schema()
+    }
+}
+
+impl Stream for ArrowOutputStream {
+    type Item = datafusion::error::Result<arrow::record_batch::RecordBatch>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let poll = std::pin::Pin::new(&mut self.stream).poll_next(cx);
+        match &poll {
+            // On receiving a batch, update the output metrics.
+            std::task::Poll::Ready(Some(Ok(batch))) => {
+                self.metrics.add_output_rows(batch.num_rows() as u64);
+                self.metrics
+                    .add_output_bytes(batch.get_array_memory_size() as u64);
+            }
+            // When the stream is finished, store the consolidated metrics.
+            std::task::Poll::Ready(None) => {
+                let consolidated = self.metrics.get_consolidated_metrics();
+                tracing::info!(
+                    "Stream output size in bytes: {}",
+                    consolidated.result_size_in_bytes
+                );
+                tracing::info!("Stream output rows: {}", consolidated.result_num_rows);
+                self.all_consolidated_metrics
+                    .lock()
+                    .insert(self.metrics.query_id, consolidated);
+            }
+            _ => {}
+        }
+        poll
+    }
 }

--- a/beacon-planner/src/plan.rs
+++ b/beacon-planner/src/plan.rs
@@ -16,8 +16,8 @@ pub struct BeaconQueryPlan {
     pub metrics_tracker: Arc<MetricsTracker>,
     /// The physical execution plan for the query.
     pub physical_plan: Arc<dyn datafusion::physical_plan::ExecutionPlan>,
-    /// Output buffer for the query results.
-    pub output_buffer: QueryOutputFile,
+    /// Optional output file for the query results. Otherwise, results are streamed back directly to the user.
+    pub output_file: Option<QueryOutputFile>,
 }
 
 /// Plans a query by parsing, optimizing, and generating a physical plan.
@@ -65,7 +65,7 @@ pub async fn plan_query(
         query_id,
         metrics_tracker,
         physical_plan: tracked_physical_plan,
-        output_buffer: parsed_plan.output,
+        output_file: parsed_plan.output_file,
     })
 }
 

--- a/beacon-query/src/lib.rs
+++ b/beacon-query/src/lib.rs
@@ -26,7 +26,7 @@ pub struct Query {
     #[serde(flatten)]
     pub inner: InnerQuery,
     #[schema(value_type = Object)]
-    pub output: Output,
+    pub output: Option<Output>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, ToSchema)]

--- a/beacon-query/src/parser.rs
+++ b/beacon-query/src/parser.rs
@@ -19,12 +19,15 @@ impl Parser {
         let datafusion_logical_plan =
             Self::parse_to_logical_plan(session, data_lake, query.inner).await?;
 
-        let (plan, output_file) = query
-            .output
-            .parse(session, data_lake, datafusion_logical_plan)
-            .await?;
+        if let Some(output) = &query.output {
+            let (plan, output_file) = output
+                .parse(session, data_lake, datafusion_logical_plan)
+                .await?;
 
-        Ok(ParsedPlan::new(plan, output_file))
+            Ok(ParsedPlan::new(plan, Some(output_file)))
+        } else {
+            Ok(ParsedPlan::new(datafusion_logical_plan, None))
+        }
     }
 
     pub async fn parse_to_logical_plan(

--- a/beacon-query/src/plan.rs
+++ b/beacon-query/src/plan.rs
@@ -4,14 +4,14 @@ use crate::output::QueryOutputFile;
 
 pub struct ParsedPlan {
     pub datafusion_plan: LogicalPlan,
-    pub output: QueryOutputFile,
+    pub output_file: Option<QueryOutputFile>,
 }
 
 impl ParsedPlan {
-    pub fn new(datafusion_plan: LogicalPlan, output: QueryOutputFile) -> Self {
+    pub fn new(datafusion_plan: LogicalPlan, output_file: Option<QueryOutputFile>) -> Self {
         Self {
             datafusion_plan,
-            output,
+            output_file,
         }
     }
 }


### PR DESCRIPTION
Fixes #119 
Fixes #120 as using GeoArrow Native

This pull request introduces significant improvements to the query execution and response streaming logic in the beacon API, enabling direct streaming of Arrow IPC results and refactoring the handling of query outputs. The changes enhance flexibility by supporting both file-based and stream-based query outputs, improve metrics tracking for streamed results, and clean up the codebase for better maintainability.

**Query Output Refactoring and Streaming Support**

* Introduced a new `QueryOutput` enum and `ArrowOutputStream` struct in `beacon-core/src/query_result.rs` to represent either file-based or stream-based query results, allowing direct streaming of Arrow IPC data with metrics tracking.
* Refactored the query execution flow in `beacon-core/src/virtual_machine.rs` and `beacon-core/src/runtime.rs` to support both output file and streaming results, updating the API to return a `QueryResult` with the appropriate output type. [[1]](diffhunk://#diff-0a265f5d75707425f77911260d7a603777b03b159d34eabd71cfa356b16ddadbL185-R245) [[2]](diffhunk://#diff-69cadc4c0e11d4adf2181c4aa421522d21ad882b85cc5d80c4de20e62de276e4L40-R41)
* Updated the API handler in `beacon-api/src/client/query.rs` to handle both file-based and Arrow IPC stream responses, including new logic for setting headers and streaming data using `axum-streams`.

**API and Planning Changes**

* Modified the query planning logic in `beacon-planner/src/plan.rs` and `beacon-query/src/parser.rs` to make the output file optional, enabling queries to return streamed results when no output file is specified. [[1]](diffhunk://#diff-8d4f7c71a68a2305ba2b72bf3b553d2975bdb75a92b979f957f4fb8be4521d67L19-R20) [[2]](diffhunk://#diff-8d8cc83f173d98c47977ca53c3df9b2e82da32bd1f110a7de68d68b7912b5e1fL22-R30) [[3]](diffhunk://#diff-c08cdd7471f381bc6781750b8be48b9de1026f99250c7fd5df295a57dae3a602L7-R14)
* Changed the query struct in `beacon-query/src/lib.rs` to make the output field optional, supporting queries without explicit output file requests.

**Dependency and Codebase Updates**

* Added the `axum-streams` dependency with Arrow support in `beacon-api/Cargo.toml` to enable efficient Arrow IPC streaming in the API.
* Updated imports and types throughout the codebase to use the new output and metrics structures, improving code clarity and maintainability. [[1]](diffhunk://#diff-69cadc4c0e11d4adf2181c4aa421522d21ad882b85cc5d80c4de20e62de276e4L14-R26) [[2]](diffhunk://#diff-0a265f5d75707425f77911260d7a603777b03b159d34eabd71cfa356b16ddadbL1-R1) [[3]](diffhunk://#diff-0a265f5d75707425f77911260d7a603777b03b159d34eabd71cfa356b16ddadbL10-R10) [[4]](diffhunk://#diff-0a265f5d75707425f77911260d7a603777b03b159d34eabd71cfa356b16ddadbR20-R23)

These changes collectively modernize the API's query response handling, making it more flexible and performant for large data results and future streaming use cases.