### PR TITLE
Add admin health check endpoint

### DIFF
--- a/beacon-api/src/admin/check.rs
+++ b/beacon-api/src/admin/check.rs
@@ -1,0 +1,22 @@
+use axum::Json;
+
+#[tracing::instrument(level = "info")]
+#[utoipa::path(
+    tag = "admin",
+    get,
+    path = "/api/admin/check", 
+    responses((status = 200, description = "Admin API is reachable")),
+    security(
+        ("basic-auth" = []),
+        ("bearer" = [])
+    ))
+]
+pub async fn check() -> Json<CheckReponse> {
+    let check = CheckReponse { is_admin: true };
+    Json(check)
+}
+
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+pub struct CheckReponse {
+    is_admin: bool,
+}

--- a/beacon-api/src/admin/mod.rs
+++ b/beacon-api/src/admin/mod.rs
@@ -14,6 +14,7 @@ use utoipa::{
 };
 use utoipa_axum::{router::OpenApiRouter, routes};
 
+mod check;
 mod file;
 mod tables;
 
@@ -64,6 +65,7 @@ pub(crate) fn setup_admin_router() -> (Router<Arc<Runtime>>, utoipa::openapi::Op
         .routes(routes!(file::upload_file))
         .routes(routes!(file::download_handler))
         .routes(routes!(file::delete_file))
+        .routes(routes!(check::check))
         .layer(axum::middleware::from_fn(basic_auth))
         .layer(DefaultBodyLimit::disable())
         .split_for_parts();


### PR DESCRIPTION
This pull request adds a new admin health check endpoint to the API, allowing clients to verify that the admin API is reachable and that authentication is working. The endpoint is documented for OpenAPI and supports both basic and bearer authentication. The following are the most important changes:

**New Admin Health Check Endpoint:**

* Added a new `check` handler in `beacon-api/src/admin/check.rs` that responds to `GET /api/admin/check` with a JSON object indicating admin status.
* Introduced the `CheckReponse` struct for the response payload, with serialization, deserialization, and OpenAPI schema derivations.