### PR TITLE
Refactor table deletion methods to be asynchronous and improve error …

### DIFF
--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -84,7 +84,7 @@ impl Runtime {
     }
 
     pub async fn delete_table(&self, table_name: &str) -> anyhow::Result<()> {
-        self.virtual_machine.delete_table(table_name)
+        self.virtual_machine.delete_table(table_name).await
     }
 
     pub fn list_tables(&self) -> Vec<String> {

--- a/beacon-core/src/virtual_machine.rs
+++ b/beacon-core/src/virtual_machine.rs
@@ -181,11 +181,8 @@ impl VirtualMachine {
         Ok(self.data_lake.create_table(table).await?)
     }
 
-    pub fn delete_table(&self, table_name: &str) -> anyhow::Result<()> {
-        self.data_lake
-            .deregister_table(table_name)?
-            .ok_or(anyhow::anyhow!("Table not found"))?;
-        Ok(())
+    pub async fn delete_table(&self, table_name: &str) -> anyhow::Result<()> {
+        Ok(self.data_lake.remove_table(table_name).await?)
     }
 
     #[tracing::instrument(skip(self, beacon_plan))]


### PR DESCRIPTION
This pull request refactors the table deletion logic in the data lake and runtime layers to be asynchronous, ensures proper cleanup of table files in object storage, and improves error handling for table deletion operations. The changes enhance reliability and consistency when deleting tables.

**Table Deletion Refactoring and Improvements**

* The `delete_table` method in `Runtime` and `VirtualMachine` is now asynchronous, allowing for proper propagation of async deletion logic through the stack. [[1]](diffhunk://#diff-69cadc4c0e11d4adf2181c4aa421522d21ad882b85cc5d80c4de20e62de276e4L87-R87) [[2]](diffhunk://#diff-0a265f5d75707425f77911260d7a603777b03b159d34eabd71cfa356b16ddadbL184-R185)
* The `remove_table` method in `DataLake` is refactored to be async, now returning a `Result` with a specific error if the table is not found, and performing file cleanup in object storage.
* A new async `delete_table` method is added to the `Table` struct, which iterates and deletes all files in the table's object store directory, logging errors and actions for observability.

**Dependency and Import Updates**

* Added import of `futures::StreamExt` in `beacon-data-lake/src/table/mod.rs` to support asynchronous stream iteration for file deletion.