### PR TITLE
Integrate beacon-binary-format to the main repo

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]

--- a/.github/workflows/release-bbf-python.yml
+++ b/.github/workflows/release-bbf-python.yml
@@ -1,4 +1,4 @@
-name: Publish beacon_bbf
+name: Publish beacon-binary-format
 
 on:
   release:

--- a/.github/workflows/release-bbf-python.yml
+++ b/.github/workflows/release-bbf-python.yml
@@ -1,0 +1,44 @@
+name: Publish beacon_bbf
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    name: Build & Publish Wheels
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: beacon-binary-format-py
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install maturin pytest
+
+      - name: Build extension
+        run: maturin develop --release
+
+      - name: Run tests
+        run: python -m pytest
+
+      - name: Publish to PyPI
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: maturin publish --release --skip-existing

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ node_modules/
 test-datasets/GL_TS_MO_ooi-gs-gs01sumo_1.nc
 benchmarks/
 test.ipynb
+.pytest_cache/
+__pycache__/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,7 @@ name = "beacon-binary-format"
 version = "1.5.0"
 dependencies = [
  "arrow",
+ "arrow-ipc 56.2.0",
  "arrow-schema 56.2.0",
  "hmac-sha256",
  "indexmap 2.12.1",
@@ -795,6 +796,7 @@ dependencies = [
  "object_store 0.12.4",
  "parquet 56.2.0",
  "serde",
+ "serde_json",
  "sha256",
  "tempfile",
  "thiserror 2.0.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
  "arrow",
  "arrow-ipc 56.2.0",
  "arrow-schema 56.2.0",
+ "bytes",
  "flume",
  "futures",
  "hmac-sha256",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "beacon-binary-format-py"
+version = "0.1.0"
+dependencies = [
+ "arrow",
+ "arrow-schema 56.2.0",
+ "beacon-binary-format",
+ "futures",
+ "nd-arrow-array",
+ "numpy",
+ "object_store 0.12.4",
+ "pyo3",
+ "tokio",
+]
+
+[[package]]
 name = "beacon-common"
 version = "1.4.1"
 dependencies = [
@@ -3425,6 +3440,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inferno"
 version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3821,6 +3845,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4113,6 +4146,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "numpy"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb929bc0da91a4d85ed6c0a84deaa53d411abfb387fc271124f91bf6b89f14e"
+dependencies = [
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -4574,6 +4622,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4624,7 +4735,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror 2.0.17",
@@ -4644,7 +4755,7 @@ dependencies = [
  "lru-slab",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4976,6 +5087,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -5561,6 +5678,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6007,6 +6130,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe_cell_slice"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
  "arrow",
  "arrow-ipc 56.2.0",
  "arrow-schema 56.2.0",
+ "flume",
  "futures",
  "hmac-sha256",
  "indexmap 2.12.1",
@@ -2410,6 +2411,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3789,6 +3802,15 @@ dependencies = [
  "mime",
  "spin 0.9.8",
  "version_check",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
  "arrow",
  "arrow-ipc 56.2.0",
  "arrow-schema 56.2.0",
+ "futures",
  "hmac-sha256",
  "indexmap 2.12.1",
  "moka",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "beacon-binary-format"
+version = "1.5.0"
+dependencies = [
+ "arrow",
+ "arrow-schema 56.2.0",
+ "hmac-sha256",
+ "indexmap 2.12.1",
+ "moka",
+ "nd-arrow-array",
+ "object_store 0.12.4",
+ "parquet 56.2.0",
+ "serde",
+ "sha256",
+ "tempfile",
+ "thiserror 2.0.17",
+ "tokio",
+]
+
+[[package]]
 name = "beacon-common"
 version = "1.4.1"
 dependencies = [
@@ -2967,6 +2986,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac-sha256"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6880c8d4a9ebf39c6e8b77007ce223f646a4d21ce29d99f70cb16420545425"
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5052,6 +5077,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha256"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f880fc8562bdeb709793f00eb42a2ad0e672c4f883bbe59122b926eca935c8f6"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "hex",
+ "sha2",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "beacon-binary-format"
-version = "1.5.0"
+version = "3.0.0"
 dependencies = [
  "arrow",
  "arrow-ipc 56.2.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +802,7 @@ dependencies = [
  "arrow-ipc 56.2.0",
  "arrow-schema 56.2.0",
  "bytes",
+ "criterion",
  "flume",
  "futures",
  "hmac-sha256",
@@ -1226,6 +1239,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1274,31 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "comfy-table"
@@ -1355,6 +1420,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -3392,6 +3495,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
@@ -4104,6 +4216,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4337,6 +4455,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -5555,6 +5701,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["beacon-api", "beacon-arrow-netcdf", "beacon-arrow-odv", "beacon-common", "beacon-config", "beacon-core", "beacon-functions", "beacon-query", "beacon-planner", "beacon-data-lake", "beacon-formats", "beacon-arrow-zarr"]
+members = ["beacon-api", "beacon-arrow-netcdf", "beacon-arrow-odv", "beacon-common", "beacon-config", "beacon-core", "beacon-functions", "beacon-query", "beacon-planner", "beacon-data-lake", "beacon-formats", "beacon-arrow-zarr", "beacon-binary-format"]
 
 [workspace.dependencies]
 tokio = { version = "1.47.1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ bytes = "1.9.0"
 parking_lot = { version = "0.12.3", features = ["send_guard", "serde"] }
 ordered-float = "5.1.0"
 
-
 utoipa = { version= "=5.3.1", features = ["chrono","preserve_order", "preserve_path_order","rc_schema", "axum_extras"] }
 utoipa-axum = "0.2.0"
 utoipa-scalar = { version = "0.3.0", features = ["axum"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["beacon-api", "beacon-arrow-netcdf", "beacon-arrow-odv", "beacon-common", "beacon-config", "beacon-core", "beacon-functions", "beacon-query", "beacon-planner", "beacon-data-lake", "beacon-formats", "beacon-arrow-zarr", "beacon-binary-format"]
+members = ["beacon-api", "beacon-arrow-netcdf", "beacon-arrow-odv", "beacon-common", "beacon-config", "beacon-core", "beacon-functions", "beacon-query", "beacon-planner", "beacon-data-lake", "beacon-formats", "beacon-arrow-zarr", "beacon-binary-format", "beacon-binary-format-py"]
 
 [workspace.dependencies]
 tokio = { version = "1.47.1", features = ["full"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY beacon-api/ /beacon-api/
 COPY beacon-arrow-netcdf/ /beacon-arrow-netcdf/
 COPY beacon-arrow-zarr/ /beacon-arrow-zarr/
 COPY beacon-arrow-odv/ /beacon-arrow-odv/
+COPY beacon-binary-format/ /beacon-binary-format/
 COPY beacon-common/ /beacon-common/
 COPY beacon-config/ /beacon-config/
 COPY beacon-core/ /beacon-core/

--- a/beacon-api/src/admin/file.rs
+++ b/beacon-api/src/admin/file.rs
@@ -1,9 +1,12 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::{Multipart, Query, State}, http::StatusCode, response::IntoResponse, Json
+    extract::{Multipart, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
 };
-use beacon_core::{runtime::Runtime};
+use beacon_core::runtime::Runtime;
 use futures::StreamExt;
 use serde::Deserialize;
 use utoipa::{IntoParams, ToSchema};
@@ -138,7 +141,10 @@ pub async fn download_handler(
                 StatusCode::OK,
                 [
                     ("Content-Type", "application/octet-stream"),
-                    ("Content-Disposition", &format!("attachment; filename=\"{filename}\"")),
+                    (
+                        "Content-Disposition",
+                        &format!("attachment; filename=\"{filename}\""),
+                    ),
                 ],
                 body,
             )
@@ -146,11 +152,14 @@ pub async fn download_handler(
         }
         Err(e) => {
             tracing::error!("❌ Download error: {e}");
-            (StatusCode::NOT_FOUND, format!("File not found: {file_path}")).into_response()
+            (
+                StatusCode::NOT_FOUND,
+                format!("File not found: {file_path}"),
+            )
+                .into_response()
         }
     }
 }
-
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, IntoParams)]
 pub struct DeleteQuery {
@@ -170,9 +179,9 @@ pub struct DeleteQuery {
     ))
 ]
 pub async fn delete_file(
-        State(state): State<Arc<Runtime>>,
-        Query(query): Query<DeleteQuery>,
-) -> impl IntoResponse{
+    State(state): State<Arc<Runtime>>,
+    Query(query): Query<DeleteQuery>,
+) -> impl IntoResponse {
     tracing::info!("📤 Delete request for `{}`", query.file_path);
     let file_path = query.file_path.clone();
 
@@ -180,13 +189,14 @@ pub async fn delete_file(
         Ok(_) => {
             tracing::info!("✅ Deleted `{}`", file_path);
             (StatusCode::OK, format!("File deleted: {file_path}")).into_response()
-        },
+        }
         Err(e) => {
             tracing::error!("❌ Delete error: {e}");
-            (StatusCode::NOT_FOUND, format!("File not found: {file_path}")).into_response()
-        },
+            (
+                StatusCode::NOT_FOUND,
+                format!("File not found: {file_path}"),
+            )
+                .into_response()
+        }
     }
-
 }
-
-

--- a/beacon-api/src/admin/tables.rs
+++ b/beacon-api/src/admin/tables.rs
@@ -6,7 +6,7 @@ use axum::{
     http::StatusCode,
     Json,
 };
-use beacon_core::{runtime::Runtime};
+use beacon_core::runtime::Runtime;
 use beacon_data_lake::table::Table;
 use utoipa::{IntoParams, ToSchema};
 
@@ -31,7 +31,7 @@ pub struct CreateTable {
 pub(crate) async fn create_table(
     State(state): State<Arc<Runtime>>,
     Json(create_table): Json<CreateTable>,
-) -> Result<(StatusCode,String), Json<String>> {
+) -> Result<(StatusCode, String), Json<String>> {
     let table_name = create_table.inner.table_name().to_string();
     let result = state.add_table(create_table.inner).await;
     match result {
@@ -42,7 +42,6 @@ pub(crate) async fn create_table(
         }
     }
 }
-
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, IntoParams)]
 pub struct DeleteTable {
@@ -68,10 +67,16 @@ pub(crate) async fn delete_table(
     let result = state.delete_table(&delete_table.table_name).await;
 
     match result {
-        Ok(_) => (StatusCode::OK, format!("Table: {} was deleted", delete_table.table_name)),
+        Ok(_) => (
+            StatusCode::OK,
+            format!("Table: {} was deleted", delete_table.table_name),
+        ),
         Err(err) => {
             tracing::error!("Error deleting table: {:?}", err);
-            (StatusCode::INTERNAL_SERVER_ERROR, format!("Error deleting table: {:?}", err))
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Error deleting table: {:?}", err),
+            )
         }
     }
 }
@@ -101,10 +106,16 @@ pub(crate) async fn apply_table_operation(
         .apply_table_operation(&table_operation.table_name, table_operation.operation)
         .await;
     match result {
-        Ok(_) => (StatusCode::OK, format!("Operation applied to table: {}", table_operation.table_name)),
+        Ok(_) => (
+            StatusCode::OK,
+            format!("Operation applied to table: {}", table_operation.table_name),
+        ),
         Err(err) => {
             tracing::error!("Error applying operation to table: {:?}", err);
-            (StatusCode::BAD_REQUEST, format!("Error applying operation to table: {:?}", err))
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Error applying operation to table: {:?}", err),
+            )
         }
     }
 }

--- a/beacon-api/src/client/functions.rs
+++ b/beacon-api/src/client/functions.rs
@@ -16,9 +16,7 @@ use beacon_functions::function_doc::FunctionDoc;
         ("bearer" = [])
     )
 )]
-pub(crate) async fn list_functions(
-    State(state): State<Arc<Runtime>>,
-) -> Json<Vec<FunctionDoc>> {
+pub(crate) async fn list_functions(State(state): State<Arc<Runtime>>) -> Json<Vec<FunctionDoc>> {
     let functions = state.list_functions();
     Json(functions)
 }

--- a/beacon-api/src/client/info.rs
+++ b/beacon-api/src/client/info.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use axum::{extract::State, Json};
 use beacon_core::{runtime::Runtime, sys::SystemInfo};
 
-
 #[tracing::instrument(level = "info", skip(state))]
 #[utoipa::path(
     tag = "system",

--- a/beacon-api/src/client/tables.rs
+++ b/beacon-api/src/client/tables.rs
@@ -53,7 +53,10 @@ pub(crate) async fn list_tables_with_schema(
     let mut result = Vec::new();
     for table_name in table_names {
         if let Some(schema) = state.list_table_schema(table_name.clone()).await {
-            result.push(TableWithSchema { table_name, columns: schema.fields().iter().map(|f| f.as_ref().clone()).collect() });
+            result.push(TableWithSchema {
+                table_name,
+                columns: schema.fields().iter().map(|f| f.as_ref().clone()).collect(),
+            });
         }
     }
 

--- a/beacon-binary-format-py/Cargo.toml
+++ b/beacon-binary-format-py/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [lib]
-name = "beacon_bbf"
+name = "beacon_binary_format"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]

--- a/beacon-binary-format-py/Cargo.toml
+++ b/beacon-binary-format-py/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "beacon-binary-format-py"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+name = "beacon_bbf"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+pyo3 = { version = "0.22.6", features = ["extension-module"] }
+beacon-binary-format = { path = "../beacon-binary-format" }
+arrow = { workspace = true }
+arrow-schema = { workspace = true }
+nd-arrow-array = { git = "https://github.com/maris-development/nd-arrow-array.git", branch = "main", version = "1.3.0" }
+object_store = { workspace = true }
+tokio = { workspace = true }
+futures = { workspace = true }
+numpy = { version = "0.22.0" }

--- a/beacon-binary-format-py/README.md
+++ b/beacon-binary-format-py/README.md
@@ -22,7 +22,7 @@ Run the following inside `beacon-binary-format-py/`:
 maturin develop --release
 ```
 
-This builds the Rust crate in release mode and installs the resulting Python module (`beacon_bbf`) into your active virtual environment. Re-run the command whenever you change the Rust sources.
+This builds the Rust crate in release mode and installs the resulting Python module (`beacon_binary_format`) into your active virtual environment. Re-run the command whenever you change the Rust sources.
 
 ## Usage
 
@@ -31,7 +31,7 @@ The module now exposes a `Collection` object that can host any number of partiti
 ```python
 from pathlib import Path
 import numpy as np
-from beacon_bbf import Collection
+from beacon_binary_format import Collection
 
 tmp_dir = Path("/tmp/beacon")
 collection = Collection(str(tmp_dir), "example")
@@ -92,7 +92,7 @@ Any position masked in NumPy is written as a null value in the corresponding Arr
 A matching `CollectionReader` can reconstruct logical entries as dictionaries of NumPy payloads. Every field is returned as `{"data": <ndarray|masked array>, "dims": [...], "shape": [...]}` so dimension metadata survives round-trips.
 
 ```python
-from beacon_bbf import CollectionReader
+from beacon_binary_format import CollectionReader
 
 reader = CollectionReader(str(tmp_dir), "example")
 partition = reader.open_partition("partition-0")
@@ -111,7 +111,7 @@ Optional `projection=["temperature", "salinity"]` narrows the arrays fetched fro
 `storage_options` mirrors the values you would normally pass to [`fsspec`](https://filesystem-spec.readthedocs.io/), which means existing credential dictionaries can be reused verbatim:
 
 ```python
-from beacon_bbf import Collection
+from beacon_binary_format import Collection
 
 collection = Collection(
     base_dir="s3://beacon-dev/datasets",
@@ -135,7 +135,7 @@ Prefer to pass the filesystem object itself? Provide it via the `filesystem` key
 ```python
 import numpy as np
 import fsspec
-from beacon_bbf import Collection, CollectionReader
+from beacon_binary_format import Collection, CollectionReader
 
 fs = fsspec.filesystem(
 	"s3",

--- a/beacon-binary-format-py/README.md
+++ b/beacon-binary-format-py/README.md
@@ -1,0 +1,111 @@
+# Beacon Binary Format Python Bindings
+
+This crate exposes the Beacon Binary Format collection writer to Python via [PyO3](https://pyo3.rs/) and ships as a native extension built with [maturin](https://www.maturin.rs/).
+
+## Prerequisites
+
+- Rust toolchain that matches the workspace (`rustup` suggested)
+- Python 3.9+ with development headers available
+- `pip install maturin`
+
+If your default `python3` differs from the interpreter you want to target, set `PYO3_PYTHON` to its absolute path before building:
+
+```shell
+export PYO3_PYTHON=$(which python3.11)
+```
+
+## Local install
+
+Run the following inside `beacon-binary-format-py/`:
+
+```shell
+maturin develop --release
+```
+
+This builds the Rust crate in release mode and installs the resulting Python module (`beacon_bbf`) into your active virtual environment. Re-run the command whenever you change the Rust sources.
+
+## Usage
+
+The module now exposes a `Collection` object that can host any number of partitions. Each partition is managed by a `PartitionBuilder` which mirrors the original single-partition workflow:
+
+```python
+from pathlib import Path
+import numpy as np
+from beacon_bbf import Collection
+
+tmp_dir = Path("/tmp/beacon")
+collection = Collection(str(tmp_dir), "example")
+
+partition = collection.create_partition("partition-0")
+partition.write_entry(
+	"row-0",
+	{
+		"salinity": np.array([34.5, 34.6], dtype=np.float32),
+		"temperature": np.array([9.2, 9.0], dtype=np.float32),
+	},
+)
+partition.finish()
+
+# Materialize a second partition later on the same collection
+second = collection.create_partition()
+second.write_entry("row-1", {"flags": np.array([True, False])})
+second.finish()
+
+print(collection.library_version())
+
+### Named dimensions
+
+NumPy arrays default to synthetic dimension names (`dim0`, `dim1`, ...). You can override them per array by wrapping the data in either a tuple or a tiny mapping when calling `write_entry`:
+
+```python
+partition.write_entry(
+	"row-2",
+	{
+		# tuple form -> (<array-like>, <sequence-of-dimension-names>)
+		"salinity_grid": (np.ones((2, 3), dtype=np.float32), ["depth", "lat", "lon"]),
+		# mapping form -> keys `data` + `dims`
+		"temperature_grid": {
+			"data": np.ones((2, 3), dtype=np.float32),
+			"dims": ["depth", "lat", "lon"],
+		},
+	},
+)
+```
+
+The number of names must match the rank of the array (or be exactly one for scalars). Any mismatch raises a `ValueError`, which keeps the partition builder in a valid state for additional writes.
+
+### NumPy masked arrays
+
+Masked arrays created via `numpy.ma.array` automatically translate their mask into the Arrow validity bitmap used by Beacon. You only need to pass the masked array instance; there is no additional API surface:
+
+```python
+masked = np.ma.array(
+	[1.0, 2.0, 3.0, 4.0],
+	mask=[False, True, False, True],
+)
+partition.write_entry("row-0", {"masked": masked})
+```
+
+Any position masked in NumPy is written as a null value in the corresponding Arrow array.
+
+### Reading collections back into NumPy
+
+A matching `CollectionReader` can reconstruct logical entries as dictionaries of NumPy payloads. Every field is returned as `{"data": <ndarray|masked array>, "dims": [...], "shape": [...]}` so dimension metadata survives round-trips.
+
+```python
+from beacon_bbf import CollectionReader
+
+reader = CollectionReader(str(tmp_dir), "example")
+partition = reader.open_partition("partition-0")
+entries = partition.read_entries()
+
+for entry in entries:
+    print(entry["__entry_key"]["data"], entry["temperature"]["dims"])
+```
+
+Optional `projection=["temperature", "salinity"]` narrows the arrays fetched from disk, and `max_concurrent_reads` lets you tune object-store fanout.
+
+The legacy `CollectionBuilder` class remains available for scripts that only ever deal with a single partition, but the `Collection`/`PartitionBuilder` pair is the recommended interface moving forward. Shipping `.pyi` stubs and `py.typed` ensures editors and static type checkers understand the API surface.
+```
+
+The legacy `CollectionBuilder` class remains available for scripts that only ever deal with a single partition, but the `Collection`/`PartitionBuilder` pair is the recommended interface moving forward. Shipping `.pyi` stubs and `py.typed` ensures editors and static type checkers understand the API surface.

--- a/beacon-binary-format-py/beacon_bbf.pyi
+++ b/beacon-binary-format-py/beacon_bbf.pyi
@@ -24,7 +24,13 @@ EntryPayload = Mapping[str, ArrayPayload]
 
 class Collection:
     """Logical Beacon collection that can host multiple partitions."""
-    def __init__(self, base_dir: str, collection_path: str) -> None: ...
+    def __init__(
+        self,
+        base_dir: str,
+        collection_path: str,
+        storage_options: Optional[Mapping[str, Any]] = ...,
+        filesystem: Optional[Any] = ...,
+    ) -> None: ...
     def create_partition(
         self,
         partition_name: Optional[str] = ..., 
@@ -49,6 +55,8 @@ class CollectionBuilder:
         collection_path: str,
         partition_name: Optional[str] = ..., 
         max_group_size: Optional[int] = ...,
+        storage_options: Optional[Mapping[str, Any]] = ...,
+        filesystem: Optional[Any] = ...,
     ) -> None: ...
     def write_entry(self, entry_key: str, arrays: ArrayMap) -> None:
         """Shortcut to the single-partition workflow retained for legacy scripts."""
@@ -65,6 +73,8 @@ class CollectionReader:
         base_dir: str,
         collection_path: str,
         cache_bytes: Optional[int] = ...,
+        storage_options: Optional[Mapping[str, Any]] = ...,
+        filesystem: Optional[Any] = ...,
     ) -> None: ...
 
     def metadata(self) -> CollectionMetadata: ...

--- a/beacon-binary-format-py/beacon_bbf.pyi
+++ b/beacon-binary-format-py/beacon_bbf.pyi
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Mapping, Any, Optional, Sequence, Union, TypedDict, Iterable, List
+
+ArrayLike = Any
+DimensionNames = Sequence[str]
+ArrayWithDimensions = Mapping[str, Any]
+ArrayValue = Union[ArrayLike, tuple[ArrayLike, DimensionNames], ArrayWithDimensions]
+ArrayMap = Mapping[str, ArrayValue]
+
+class ArrayPayload(TypedDict, total=False):
+    data: ArrayLike
+    dims: Sequence[str]
+    shape: Sequence[int]
+    mask: ArrayLike
+
+class CollectionMetadata(TypedDict):
+    collection_byte_size: int
+    collection_num_elements: int
+    partition_count: int
+    library_version: str
+
+EntryPayload = Mapping[str, ArrayPayload]
+
+class Collection:
+    """Logical Beacon collection that can host multiple partitions."""
+    def __init__(self, base_dir: str, collection_path: str) -> None: ...
+    def create_partition(
+        self,
+        partition_name: Optional[str] = ..., 
+        max_group_size: Optional[int] = ...,
+    ) -> PartitionBuilder:
+        """Create a new partition; names default to `partition-{n}` when omitted."""
+    def library_version(self) -> str:
+        """Return the Beacon Binary Format library version baked into the writer."""
+
+class PartitionBuilder:
+    """Builder that gathers per-entry Arrow arrays before flushing to disk."""
+    def write_entry(self, entry_key: str, arrays: ArrayMap) -> None:
+        """Write a logical row using bare NumPy arrays, named-dimension tuples, or masked arrays."""
+    def finish(self) -> None:
+        """Flush buffered data and attach the partition to its parent collection."""
+
+class CollectionBuilder:
+    """Backwards-compatible façade that opens one partition immediately."""
+    def __init__(
+        self,
+        base_dir: str,
+        collection_path: str,
+        partition_name: Optional[str] = ..., 
+        max_group_size: Optional[int] = ...,
+    ) -> None: ...
+    def write_entry(self, entry_key: str, arrays: ArrayMap) -> None:
+        """Shortcut to the single-partition workflow retained for legacy scripts."""
+    def finish(self) -> None:
+        """Finalize the eagerly-created partition and release internal resources."""
+    def library_version(self) -> str:
+        """Mirror of :meth:`Collection.library_version`."""
+
+class CollectionReader:
+    """Read Beacon Binary Format collections back into NumPy payloads."""
+
+    def __init__(
+        self,
+        base_dir: str,
+        collection_path: str,
+        cache_bytes: Optional[int] = ...,
+    ) -> None: ...
+
+    def metadata(self) -> CollectionMetadata: ...
+    def partition_names(self) -> List[str]: ...
+    def open_partition(self, partition_name: str) -> PartitionReader: ...
+
+class PartitionReader:
+    """Read logical entries inside a specific collection partition."""
+
+    def name(self) -> str: ...
+    def num_entries(self) -> int: ...
+    def read_entries(
+        self,
+        projection: Optional[Iterable[str]] = ...,
+        max_concurrent_reads: Optional[int] = ...,
+    ) -> List[EntryPayload]: ...
+
+def crate_version() -> str:
+    """Return the underlying Rust crate version bundled with beacon_bbf."""

--- a/beacon-binary-format-py/beacon_binary_format.pyi
+++ b/beacon-binary-format-py/beacon_binary_format.pyi
@@ -92,5 +92,6 @@ class PartitionReader:
         max_concurrent_reads: Optional[int] = ...,
     ) -> List[EntryPayload]: ...
 
+
 def crate_version() -> str:
-    """Return the underlying Rust crate version bundled with beacon_bbf."""
+    """Return the underlying Rust crate version bundled with beacon_binary_format."""

--- a/beacon-binary-format-py/pyproject.toml
+++ b/beacon-binary-format-py/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.24",
+    "fsspec>=2023.1.0",
 ]
 
 [tool.maturin]

--- a/beacon-binary-format-py/pyproject.toml
+++ b/beacon-binary-format-py/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.7,<2"]
 build-backend = "maturin"
 
 [project]
-name = "beacon-bbf"
+name = "beacon-binary-format"
 version = "3.0.0a0"
 description = "Python bindings for the Beacon Binary Format collection writer."
 readme = "README.md"
@@ -23,9 +23,9 @@ dependencies = [
 
 [tool.maturin]
 bindings = "pyo3"
-module-name = "beacon_bbf"
+module-name = "beacon_binary_format"
 features = []
-include = ["beacon_bbf.pyi", "py.typed"]
+include = ["beacon_binary_format.pyi", "py.typed"]
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/beacon-binary-format-py/pyproject.toml
+++ b/beacon-binary-format-py/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["maturin>=1.7,<2"]
+build-backend = "maturin"
+
+[project]
+name = "beacon-bbf"
+version = "3.0.0a0"
+description = "Python bindings for the Beacon Binary Format collection writer."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { file = "../LICENSE" }
+keywords = ["ocean", "arrow", "beacon", "bbf"]
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "numpy>=1.24",
+]
+
+[tool.maturin]
+bindings = "pyo3"
+module-name = "beacon_bbf"
+features = []
+include = ["beacon_bbf.pyi", "py.typed"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra"
+testpaths = ["tests"]

--- a/beacon-binary-format-py/src/collection_builder.rs
+++ b/beacon-binary-format-py/src/collection_builder.rs
@@ -1,0 +1,255 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use beacon_binary_format::collection::CollectionWriter;
+use beacon_binary_format::collection_partition::{CollectionPartitionWriter, WriterOptions};
+use futures::stream;
+use object_store::ObjectStore;
+use object_store::path::Path;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use crate::numpy_arrays::build_nd_array;
+use crate::utils::{init_store, to_py_err};
+
+struct CollectionInner {
+    runtime: Arc<tokio::runtime::Runtime>,
+    store: Arc<dyn ObjectStore>,
+    collection_path: Path,
+    writer: Arc<Mutex<CollectionWriter>>,
+    partition_counter: AtomicUsize,
+}
+
+impl CollectionInner {
+    fn new(base_dir: String, collection_path: String) -> PyResult<Self> {
+        let runtime =
+            Arc::new(tokio::runtime::Runtime::new().map_err(|err| {
+                PyRuntimeError::new_err(format!("failed to start runtime: {err}"))
+            })?);
+        let store = init_store(base_dir)?;
+        let path = Path::from(collection_path.as_str());
+        let writer = runtime
+            .block_on(CollectionWriter::new(store.clone(), path.clone()))
+            .map_err(to_py_err)?;
+        Ok(Self {
+            runtime,
+            store,
+            collection_path: path,
+            writer: Arc::new(Mutex::new(writer)),
+            partition_counter: AtomicUsize::new(0),
+        })
+    }
+
+    fn next_partition_name(&self, provided: Option<String>) -> String {
+        match provided {
+            Some(name) => {
+                self.partition_counter.fetch_add(1, Ordering::SeqCst);
+                name
+            }
+            None => {
+                let id = self.partition_counter.fetch_add(1, Ordering::SeqCst);
+                format!("partition-{id}")
+            }
+        }
+    }
+}
+
+/// Python-facing façade for the Beacon Binary Format collection writer.
+///
+/// A [`Collection`] can host any number of logical partitions that are flushed
+/// individually, which mirrors the ergonomics of the Python bindings. Each
+/// partition exposes the same `write_entry` interface, while the collection
+/// ensures metadata is persisted exactly once per partition.
+#[pyclass]
+#[derive(Clone)]
+pub struct Collection {
+    inner: Arc<CollectionInner>,
+}
+
+#[pymethods]
+impl Collection {
+    #[new]
+    pub fn new(base_dir: String, collection_path: String) -> PyResult<Self> {
+        Ok(Self {
+            inner: Arc::new(CollectionInner::new(base_dir, collection_path)?),
+        })
+    }
+
+    /// Create a new logical partition writer.
+    ///
+    /// `partition_name` defaults to `partition-{n}` if omitted, while
+    /// `max_group_size` controls the Arrow IPC chunking threshold inside the
+    /// partition.
+    #[pyo3(signature = (partition_name=None, max_group_size=None))]
+    pub fn create_partition(
+        &self,
+        partition_name: Option<String>,
+        max_group_size: Option<usize>,
+    ) -> PyResult<PartitionBuilder> {
+        let name = self.inner.next_partition_name(partition_name);
+        let writer_options = WriterOptions {
+            max_group_size: max_group_size.unwrap_or(8 * 1024 * 1024),
+        };
+        let partition_writer = CollectionPartitionWriter::new(
+            self.inner.collection_path.clone(),
+            self.inner.store.clone(),
+            name,
+            writer_options,
+        );
+        Ok(PartitionBuilder {
+            collection: self.clone(),
+            partition_writer: Some(partition_writer),
+        })
+    }
+
+    /// Return the Beacon Binary Format crate version embedded in the writer metadata.
+    pub fn library_version(&self) -> PyResult<String> {
+        let writer = lock_writer(&self.inner.writer)?;
+        Ok(writer.metadata().library_version.clone())
+    }
+}
+
+impl Collection {
+    fn runtime(&self) -> &Arc<tokio::runtime::Runtime> {
+        &self.inner.runtime
+    }
+
+    fn append_partition(
+        &self,
+        metadata: beacon_binary_format::collection_partition::CollectionPartitionMetadata,
+    ) -> PyResult<()> {
+        let mut writer = lock_writer(&self.inner.writer)?;
+        writer.append_partition(metadata).map_err(to_py_err)?;
+        self.runtime().block_on(writer.persist()).map_err(to_py_err)
+    }
+}
+
+/// Builder for a single logical partition belonging to a [`Collection`].
+#[pyclass]
+pub struct PartitionBuilder {
+    collection: Collection,
+    partition_writer: Option<CollectionPartitionWriter>,
+}
+
+#[pymethods]
+impl PartitionBuilder {
+    /// Append a logical entry to the current partition.
+    ///
+    /// `arrays` accepts the dict described in the Python README/stubs. Each
+    /// value can be a bare NumPy array, a `(array, [dim, ...])` tuple, or a
+    /// `{"data": array, "dims": [...]}` mapping. Named dimensions and
+    /// NumPy masked arrays are both honored before the Arrow payload is
+    /// materialized.
+    /// Mirror of [`PartitionBuilder::write_entry`] for scripts that rely on the
+    /// legacy single-partition builder.
+    pub fn write_entry(
+        &mut self,
+        py: Python<'_>,
+        entry_key: &str,
+        arrays: Bound<'_, PyDict>,
+    ) -> PyResult<()> {
+        let writer = self
+            .partition_writer
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("partition already finalized"))?;
+
+        let mut entries = Vec::with_capacity(arrays.len());
+        for (key, value) in arrays.iter() {
+            let name: String = key.extract()?;
+            let (field, nd_array) = build_nd_array(py, &name, value.to_object(py))?;
+            entries.push((field, nd_array));
+        }
+
+        let stream = stream::iter(entries);
+        self.collection
+            .runtime()
+            .block_on(writer.write_entry(entry_key, stream))
+            .map_err(to_py_err)
+    }
+
+    /// Finish the partition, append it to the collection, and persist metadata.
+    ///
+    /// Once a partition is finished the same builder cannot be reused, which
+    /// mirrors the behavior of the lower-level `CollectionPartitionWriter`.
+    pub fn finish(&mut self) -> PyResult<()> {
+        let writer = self
+            .partition_writer
+            .take()
+            .ok_or_else(|| PyRuntimeError::new_err("partition already finalized"))?;
+        let metadata = self
+            .collection
+            .runtime()
+            .block_on(writer.finish())
+            .map_err(to_py_err)?;
+        self.collection.append_partition(metadata)
+    }
+}
+
+/// Backwards-compatible façade that creates a single partition on initialization.
+///
+/// `CollectionBuilder` still exists so that legacy scripts which only ever
+/// target a single partition do not need to be rewritten immediately. All new
+/// code should favor [`Collection`] + [`PartitionBuilder`].
+#[pyclass]
+pub struct CollectionBuilder {
+    collection: Collection,
+    partition: Option<PartitionBuilder>,
+}
+
+#[pymethods]
+impl CollectionBuilder {
+    #[new]
+    #[pyo3(signature = (base_dir, collection_path, partition_name=None, max_group_size=None))]
+    pub fn new(
+        base_dir: String,
+        collection_path: String,
+        partition_name: Option<String>,
+        max_group_size: Option<usize>,
+    ) -> PyResult<Self> {
+        let collection = Collection::new(base_dir, collection_path)?;
+        let partition = collection.create_partition(partition_name, max_group_size)?;
+        Ok(Self {
+            collection,
+            partition: Some(partition),
+        })
+    }
+
+    pub fn write_entry(
+        &mut self,
+        py: Python<'_>,
+        entry_key: &str,
+        arrays: Bound<'_, PyDict>,
+    ) -> PyResult<()> {
+        self.partition
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("builder already finalized"))?
+            .write_entry(py, entry_key, arrays)
+    }
+
+    /// Finalize the underlying partition and release the builder handle.
+    pub fn finish(&mut self) -> PyResult<()> {
+        let result = self
+            .partition
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("builder already finalized"))?
+            .finish();
+        self.partition = None;
+        result
+    }
+
+    /// Convenience proxy for [`Collection::library_version`].
+    pub fn library_version(&self) -> PyResult<String> {
+        self.collection.library_version()
+    }
+}
+
+fn lock_writer<'a>(
+    writer: &'a Arc<Mutex<CollectionWriter>>,
+) -> PyResult<MutexGuard<'a, CollectionWriter>> {
+    writer
+        .lock()
+        .map_err(|_| PyRuntimeError::new_err("collection writer poisoned"))
+}

--- a/beacon-binary-format-py/src/collection_reader.rs
+++ b/beacon-binary-format-py/src/collection_reader.rs
@@ -1,0 +1,518 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, BinaryArray, BooleanArray, PrimitiveArray, StringArray};
+use arrow::datatypes::{
+    ArrowPrimitiveType, DataType, Float32Type, Float64Type, Int8Type, Int16Type, Int32Type,
+    Int64Type, TimeUnit, TimestampNanosecondType, UInt8Type, UInt16Type, UInt32Type, UInt64Type,
+};
+use beacon_binary_format::collection::CollectionReader;
+use beacon_binary_format::collection_partition::{
+    CollectionPartitionReadOptions, CollectionPartitionReader,
+};
+use beacon_binary_format::error::BBFError;
+use beacon_binary_format::io_cache::ArrayIoCache;
+use futures::StreamExt;
+use nd_arrow_array::{NdArrowArray, batch::NdRecordBatch, dimensions::Dimensions};
+use numpy::PyArray1;
+use object_store::path::Path;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyDict, PyList, PyString, PyTuple};
+
+use crate::utils::{init_store, to_py_err};
+
+const DEFAULT_CACHE_SIZE_BYTES: usize = 128 * 1024 * 1024;
+const DEFAULT_MAX_CONCURRENCY: usize = 32;
+const ENTRY_KEY_FIELD: &str = "__entry_key";
+
+struct ReaderInner {
+    runtime: Arc<tokio::runtime::Runtime>,
+    reader: CollectionReader,
+}
+
+impl ReaderInner {
+    fn new(
+        base_dir: String,
+        collection_path: String,
+        cache_bytes: Option<usize>,
+    ) -> PyResult<Self> {
+        let runtime =
+            Arc::new(tokio::runtime::Runtime::new().map_err(|err| {
+                PyRuntimeError::new_err(format!("failed to start runtime: {err}"))
+            })?);
+        let store = init_store(base_dir)?;
+        let path = Path::from(collection_path.as_str());
+        let cache = ArrayIoCache::new(cache_bytes.unwrap_or(DEFAULT_CACHE_SIZE_BYTES));
+        let reader = runtime
+            .block_on(CollectionReader::new(store, path, cache))
+            .map_err(to_py_err)?;
+        Ok(Self { runtime, reader })
+    }
+}
+
+impl ReaderInner {
+    fn metadata(&self) -> &beacon_binary_format::collection::CollectionMetadata {
+        self.reader.metadata()
+    }
+}
+
+#[pyclass(name = "CollectionReader")]
+#[derive(Clone)]
+pub struct CollectionReaderHandle {
+    inner: Arc<ReaderInner>,
+}
+
+#[pymethods]
+impl CollectionReaderHandle {
+    #[new]
+    #[pyo3(signature = (base_dir, collection_path, cache_bytes=None))]
+    pub fn new(
+        base_dir: String,
+        collection_path: String,
+        cache_bytes: Option<usize>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            inner: Arc::new(ReaderInner::new(base_dir, collection_path, cache_bytes)?),
+        })
+    }
+
+    pub fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let meta = self.inner.metadata();
+        let dict = PyDict::new_bound(py);
+        dict.set_item("collection_byte_size", meta.collection_byte_size)?;
+        dict.set_item("collection_num_elements", meta.collection_num_elements)?;
+        dict.set_item("partition_count", meta.partitions.len())?;
+        dict.set_item("library_version", meta.library_version.clone())?;
+        Ok(dict.into())
+    }
+
+    pub fn partition_names(&self) -> Vec<String> {
+        self.inner.metadata().partitions.keys().cloned().collect()
+    }
+
+    pub fn open_partition(&self, partition_name: &str) -> PyResult<PartitionReaderHandle> {
+        let partition_reader = self
+            .inner
+            .reader
+            .partition_reader(partition_name)
+            .ok_or_else(|| {
+                PyValueError::new_err(format!("unknown partition '{partition_name}'"))
+            })?;
+        Ok(PartitionReaderHandle {
+            collection: self.clone(),
+            reader: partition_reader,
+            partition_name: partition_name.to_string(),
+        })
+    }
+}
+
+#[pyclass(name = "PartitionReader")]
+pub struct PartitionReaderHandle {
+    collection: CollectionReaderHandle,
+    reader: CollectionPartitionReader,
+    partition_name: String,
+}
+
+#[pymethods]
+impl PartitionReaderHandle {
+    pub fn name(&self) -> &str {
+        &self.partition_name
+    }
+
+    pub fn num_entries(&self) -> usize {
+        self.reader.metadata.num_entries
+    }
+
+    #[pyo3(signature = (projection=None, max_concurrent_reads=None))]
+    pub fn read_entries(
+        &self,
+        py: Python<'_>,
+        projection: Option<Vec<String>>,
+        max_concurrent_reads: Option<usize>,
+    ) -> PyResult<Vec<PyObject>> {
+        let projection = self.normalize_projection(projection);
+        let options = CollectionPartitionReadOptions {
+            max_concurrent_reads: max_concurrent_reads.unwrap_or(DEFAULT_MAX_CONCURRENCY),
+        };
+        let scheduler = self
+            .collection
+            .inner
+            .runtime
+            .block_on(self.reader.read_indexed(projection, options))
+            .map_err(to_py_err)?;
+
+        let total_entries = self.reader.metadata.num_entries;
+        let batches = self
+            .collection
+            .inner
+            .runtime
+            .block_on(async {
+                let mut stream = scheduler.shared_pollable_stream_ref().await;
+                let mut ordered = vec![None; total_entries];
+                while let Some(batch_result) = stream.next().await {
+                    match batch_result {
+                        Ok((index, batch)) => ordered[index] = Some(batch),
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok::<_, BBFError>(ordered)
+            })
+            .map_err(to_py_err)?;
+
+        let mut entries = Vec::with_capacity(total_entries);
+        for maybe_batch in batches {
+            let batch = maybe_batch.ok_or_else(|| {
+                PyRuntimeError::new_err("partition reader returned incomplete results")
+            })?;
+            entries.push(batch_to_python(py, &batch)?);
+        }
+        Ok(entries)
+    }
+}
+
+impl PartitionReaderHandle {
+    fn normalize_projection(&self, projection: Option<Vec<String>>) -> Option<Arc<[String]>> {
+        projection.map(|mut names| {
+            if !names.iter().any(|name| name == ENTRY_KEY_FIELD) {
+                names.push(ENTRY_KEY_FIELD.to_string());
+            }
+            Arc::<[String]>::from(names.into_boxed_slice())
+        })
+    }
+}
+
+fn batch_to_python(py: Python<'_>, batch: &NdRecordBatch) -> PyResult<PyObject> {
+    let dict = PyDict::new_bound(py);
+    for (field, array) in batch.schema().fields().iter().zip(batch.arrays().iter()) {
+        let payload = array_to_python(py, array)?;
+        dict.set_item(field.name(), payload)?;
+    }
+    Ok(dict.into())
+}
+
+fn array_to_python(py: Python<'_>, array: &NdArrowArray) -> PyResult<PyObject> {
+    let dims = DimensionMetadata::from_nd(array);
+    let arrow_array = array.as_arrow_array();
+    match arrow_array.data_type() {
+        DataType::Null => build_null_payload(py, &dims),
+        DataType::Boolean => {
+            let bool_array = arrow_array
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .expect("BooleanArray");
+            let conversion = boolean_array_to_numpy(py, bool_array)?;
+            finalize_array(py, conversion, &dims, None)
+        }
+        DataType::Int8 => primitive_payload::<Int8Type>(py, arrow_array, &dims, None),
+        DataType::Int16 => primitive_payload::<Int16Type>(py, arrow_array, &dims, None),
+        DataType::Int32 => primitive_payload::<Int32Type>(py, arrow_array, &dims, None),
+        DataType::Int64 => primitive_payload::<Int64Type>(py, arrow_array, &dims, None),
+        DataType::UInt8 => primitive_payload::<UInt8Type>(py, arrow_array, &dims, None),
+        DataType::UInt16 => primitive_payload::<UInt16Type>(py, arrow_array, &dims, None),
+        DataType::UInt32 => primitive_payload::<UInt32Type>(py, arrow_array, &dims, None),
+        DataType::UInt64 => primitive_payload::<UInt64Type>(py, arrow_array, &dims, None),
+        DataType::Float32 => primitive_payload::<Float32Type>(py, arrow_array, &dims, None),
+        DataType::Float64 => primitive_payload::<Float64Type>(py, arrow_array, &dims, None),
+        DataType::Timestamp(TimeUnit::Nanosecond, _) => {
+            primitive_payload::<TimestampNanosecondType>(
+                py,
+                arrow_array,
+                &dims,
+                Some(ValueTransform::DatetimeNs),
+            )
+        }
+        DataType::Timestamp(unit, _) => Err(PyValueError::new_err(format!(
+            "unsupported timestamp unit: {unit:?}"
+        ))),
+        DataType::Utf8 => {
+            let string_array = arrow_array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("StringArray");
+            let conversion = string_array_to_numpy(py, string_array)?;
+            finalize_array(py, conversion, &dims, None)
+        }
+        DataType::Binary => {
+            let binary_array = arrow_array
+                .as_any()
+                .downcast_ref::<BinaryArray>()
+                .expect("BinaryArray");
+            let conversion = binary_array_to_numpy(py, binary_array)?;
+            finalize_array(py, conversion, &dims, None)
+        }
+        other => Err(PyValueError::new_err(format!(
+            "unsupported Arrow data type: {other:?}"
+        ))),
+    }
+}
+
+enum ValueTransform {
+    DatetimeNs,
+}
+
+fn primitive_payload<T>(
+    py: Python<'_>,
+    array_ref: &ArrayRef,
+    dims: &DimensionMetadata,
+    transform: Option<ValueTransform>,
+) -> PyResult<PyObject>
+where
+    T: ArrowPrimitiveType,
+    T::Native: numpy::Element + Default + Copy,
+{
+    let primitive_array = array_ref
+        .as_any()
+        .downcast_ref::<PrimitiveArray<T>>()
+        .expect("primitive array");
+    let conversion = primitive_array_to_numpy(py, primitive_array)?;
+    finalize_array(py, conversion, dims, transform)
+}
+
+fn finalize_array(
+    py: Python<'_>,
+    conversion: NumpyConversion,
+    dims: &DimensionMetadata,
+    transform: Option<ValueTransform>,
+) -> PyResult<PyObject> {
+    let reshaped_data = reshape_array_object(py, conversion.data, dims)?;
+    let reshaped_mask = match conversion.mask {
+        Some(mask) => Some(reshape_array_object(py, mask, dims)?),
+        None => None,
+    };
+
+    let transformed = match transform {
+        Some(ValueTransform::DatetimeNs) => {
+            let view = reshaped_data
+                .bind(py)
+                .call_method1("view", ("datetime64[ns]",))?;
+            view.into()
+        }
+        None => reshaped_data,
+    };
+
+    let masked = apply_mask(py, transformed, reshaped_mask)?;
+    build_array_payload(py, dims, masked)
+}
+
+fn build_null_payload(py: Python<'_>, dims: &DimensionMetadata) -> PyResult<PyObject> {
+    let total = dims.element_count();
+    let zeros = vec![0f64; total];
+    let mask = vec![true; total];
+    let data = PyArray1::from_vec_bound(py, zeros).into_any().unbind();
+    let mask_obj = PyArray1::from_vec_bound(py, mask).into_any().unbind();
+    let reshaped_data = reshape_array_object(py, data, dims)?;
+    let reshaped_mask = reshape_array_object(py, mask_obj, dims)?;
+    let masked = apply_mask(py, reshaped_data, Some(reshaped_mask))?;
+    build_array_payload(py, dims, masked)
+}
+
+struct NumpyConversion {
+    data: PyObject,
+    mask: Option<PyObject>,
+}
+
+fn primitive_array_to_numpy<T>(
+    py: Python<'_>,
+    array: &PrimitiveArray<T>,
+) -> PyResult<NumpyConversion>
+where
+    T: ArrowPrimitiveType,
+    T::Native: numpy::Element + Default + Copy,
+{
+    let len = array.len();
+    let mut values = Vec::with_capacity(len);
+    let mut mask = if array.null_count() > 0 {
+        Some(vec![false; len])
+    } else {
+        None
+    };
+    for (idx, value) in array.iter().enumerate() {
+        match value {
+            Some(v) => values.push(v),
+            None => {
+                values.push(T::Native::default());
+                if let Some(bits) = mask.as_mut() {
+                    bits[idx] = true;
+                }
+            }
+        }
+    }
+    let data = PyArray1::from_vec_bound(py, values).into_any().unbind();
+    let mask_obj = mask.map(|bits| PyArray1::from_vec_bound(py, bits).into_any().unbind());
+    Ok(NumpyConversion {
+        data,
+        mask: mask_obj,
+    })
+}
+
+fn boolean_array_to_numpy(py: Python<'_>, array: &BooleanArray) -> PyResult<NumpyConversion> {
+    let len = array.len();
+    let mut values = Vec::with_capacity(len);
+    let mut mask = if array.null_count() > 0 {
+        Some(vec![false; len])
+    } else {
+        None
+    };
+    for idx in 0..len {
+        if array.is_null(idx) {
+            values.push(false);
+            if let Some(bits) = mask.as_mut() {
+                bits[idx] = true;
+            }
+        } else {
+            values.push(array.value(idx));
+        }
+    }
+    let data = PyArray1::from_vec_bound(py, values).into_any().unbind();
+    let mask_obj = mask.map(|bits| PyArray1::from_vec_bound(py, bits).into_any().unbind());
+    Ok(NumpyConversion {
+        data,
+        mask: mask_obj,
+    })
+}
+
+fn string_array_to_numpy(py: Python<'_>, array: &StringArray) -> PyResult<NumpyConversion> {
+    let len = array.len();
+    let mut values = Vec::with_capacity(len);
+    let mut mask = if array.null_count() > 0 {
+        Some(vec![false; len])
+    } else {
+        None
+    };
+    for idx in 0..len {
+        if array.is_null(idx) {
+            values.push(String::new());
+            if let Some(bits) = mask.as_mut() {
+                bits[idx] = true;
+            }
+        } else {
+            values.push(array.value(idx).to_string());
+        }
+    }
+    let py_values: Vec<PyObject> = values
+        .iter()
+        .map(|value| PyString::new_bound(py, value).into())
+        .collect();
+    let list = PyList::new_bound(py, py_values);
+    let numpy = py.import_bound("numpy")?;
+    let data = numpy.getattr("array")?.call1((list,))?;
+    let mask_obj = mask.map(|bits| PyArray1::from_vec_bound(py, bits).into_any().unbind());
+    Ok(NumpyConversion {
+        data: data.into(),
+        mask: mask_obj,
+    })
+}
+
+fn binary_array_to_numpy(py: Python<'_>, array: &BinaryArray) -> PyResult<NumpyConversion> {
+    let len = array.len();
+    let mut values = Vec::with_capacity(len);
+    let mut mask = if array.null_count() > 0 {
+        Some(vec![false; len])
+    } else {
+        None
+    };
+    for idx in 0..len {
+        if array.is_null(idx) {
+            values.push(Vec::new());
+            if let Some(bits) = mask.as_mut() {
+                bits[idx] = true;
+            }
+        } else {
+            values.push(array.value(idx).to_vec());
+        }
+    }
+    let py_values: Vec<PyObject> = values
+        .iter()
+        .map(|value| PyBytes::new_bound(py, value).into())
+        .collect();
+    let list = PyList::new_bound(py, py_values);
+    let numpy = py.import_bound("numpy")?;
+    let data = numpy.getattr("array")?.call1((list,))?;
+    let mask_obj = mask.map(|bits| PyArray1::from_vec_bound(py, bits).into_any().unbind());
+    Ok(NumpyConversion {
+        data: data.into(),
+        mask: mask_obj,
+    })
+}
+
+fn reshape_array_object(
+    py: Python<'_>,
+    array: PyObject,
+    dims: &DimensionMetadata,
+) -> PyResult<PyObject> {
+    let shape = shape_tuple(py, &dims.shape)?;
+    let reshaped = array.bind(py).call_method1("reshape", (shape,))?;
+    Ok(reshaped.into())
+}
+
+fn shape_tuple<'py>(py: Python<'py>, dims: &[usize]) -> PyResult<Bound<'py, PyTuple>> {
+    if dims.is_empty() {
+        Ok(PyTuple::empty_bound(py))
+    } else {
+        let converted = dims
+            .iter()
+            .map(|size| {
+                isize::try_from(*size)
+                    .map_err(|_| PyValueError::new_err("dimension size exceeds platform limits"))
+            })
+            .collect::<PyResult<Vec<isize>>>()?;
+        Ok(PyTuple::new_bound(py, converted))
+    }
+}
+
+fn apply_mask(py: Python<'_>, data: PyObject, mask: Option<PyObject>) -> PyResult<PyObject> {
+    if let Some(mask_obj) = mask {
+        let numpy = py.import_bound("numpy")?;
+        let ma = numpy.getattr("ma")?;
+        let kwargs = PyDict::new_bound(py);
+        kwargs.set_item("mask", mask_obj)?;
+        let masked = ma.call_method("array", (data,), Some(&kwargs))?;
+        Ok(masked.into())
+    } else {
+        Ok(data)
+    }
+}
+
+fn build_array_payload(
+    py: Python<'_>,
+    dims: &DimensionMetadata,
+    data: PyObject,
+) -> PyResult<PyObject> {
+    let payload = PyDict::new_bound(py);
+    payload.set_item("data", data)?;
+    let dims_list = PyList::new_bound(py, dims.names.iter().map(|name| name.as_str()));
+    payload.set_item("dims", dims_list)?;
+    let shape_tuple = PyTuple::new_bound(py, dims.shape.iter().cloned());
+    payload.set_item("shape", shape_tuple)?;
+    Ok(payload.into())
+}
+
+struct DimensionMetadata {
+    names: Vec<String>,
+    shape: Vec<usize>,
+}
+
+impl DimensionMetadata {
+    fn from_nd(array: &NdArrowArray) -> Self {
+        match array.dimensions() {
+            Dimensions::Scalar => Self {
+                names: Vec::new(),
+                shape: Vec::new(),
+            },
+            Dimensions::MultiDimensional(dims) => Self {
+                names: dims.iter().map(|d| d.name.clone()).collect(),
+                shape: dims.iter().map(|d| d.size).collect(),
+            },
+        }
+    }
+
+    fn element_count(&self) -> usize {
+        if self.shape.is_empty() {
+            1
+        } else {
+            self.shape.iter().product()
+        }
+    }
+}

--- a/beacon-binary-format-py/src/lib.rs
+++ b/beacon-binary-format-py/src/lib.rs
@@ -16,7 +16,7 @@ fn crate_version() -> &'static str {
 }
 
 #[pymodule]
-fn beacon_bbf(_py: Python<'_>, m: Bound<'_, PyModule>) -> PyResult<()> {
+fn beacon_binary_format(_py: Python<'_>, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Collection>()?;
     m.add_class::<PartitionBuilder>()?;
     m.add_class::<CollectionBuilder>()?;

--- a/beacon-binary-format-py/src/lib.rs
+++ b/beacon-binary-format-py/src/lib.rs
@@ -1,0 +1,27 @@
+//! Python bindings for the Beacon Binary Format writer APIs.
+
+mod collection_builder;
+mod collection_reader;
+mod numpy_arrays;
+mod utils;
+
+use collection_builder::{Collection, CollectionBuilder, PartitionBuilder};
+use collection_reader::{CollectionReaderHandle, PartitionReaderHandle};
+use pyo3::prelude::*;
+use pyo3::types::PyModule;
+
+#[pyfunction]
+fn crate_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+#[pymodule]
+fn beacon_bbf(_py: Python<'_>, m: Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<Collection>()?;
+    m.add_class::<PartitionBuilder>()?;
+    m.add_class::<CollectionBuilder>()?;
+    m.add_class::<CollectionReaderHandle>()?;
+    m.add_class::<PartitionReaderHandle>()?;
+    m.add_function(wrap_pyfunction!(crate_version, &m)?)?;
+    Ok(())
+}

--- a/beacon-binary-format-py/src/numpy_arrays.rs
+++ b/beacon-binary-format-py/src/numpy_arrays.rs
@@ -1,0 +1,814 @@
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, BinaryBuilder, BooleanBuilder, Float32Builder, Float64Builder, Int8Builder,
+    Int16Builder, Int32Builder, Int64Builder, StringBuilder, TimestampNanosecondBuilder,
+    UInt8Builder, UInt16Builder, UInt32Builder, UInt64Builder,
+};
+use arrow_schema::{DataType, Field, FieldRef, TimeUnit};
+use nd_arrow_array::NdArrowArray;
+use nd_arrow_array::dimensions::{Dimension, Dimensions};
+use numpy::{PyArrayDyn, PyArrayMethods, PyReadonlyArrayDyn};
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::PySequenceMethods;
+use pyo3::types::{PyAny, PyBytes, PyDict, PyList, PySequence, PyTuple, PyUnicode};
+
+macro_rules! try_numpy_array {
+    ($value:expr, $ty:ty, $builder:ident, $field_name:expr, $dims:expr, $mask:expr) => {
+        if let Ok(array) = $value.downcast::<PyArrayDyn<$ty>>() {
+            return $builder($field_name, array.readonly(), $dims, $mask);
+        }
+    };
+}
+
+macro_rules! define_numeric_builder {
+    ($fn_name:ident, $ty:ty, $builder:ty, $data_type:expr) => {
+        fn $fn_name(
+            field_name: &str,
+            array: PyReadonlyArrayDyn<'_, $ty>,
+            dimension_names: Option<&[String]>,
+            mask: Option<&MaskValues>,
+        ) -> PyResult<(FieldRef, NdArrowArray)> {
+            let view = array.as_array();
+            let mut builder = <$builder>::with_capacity(view.len());
+            if let Some(mask_values) = mask {
+                mask_values.ensure_len(view.len())?;
+            }
+            for (idx, value) in view.iter().enumerate() {
+                if mask.map_or(false, |m| m.is_masked(idx)) {
+                    builder.append_null();
+                } else {
+                    builder.append_value(*value);
+                }
+            }
+            let dimensions = dimensions_from_shape(view.shape(), dimension_names)?;
+            make_nd_array(
+                field_name,
+                $data_type,
+                Arc::new(builder.finish()),
+                dimensions,
+            )
+        }
+    };
+}
+
+/// Flattened mask extracted from a `numpy.ma.MaskedArray`.
+struct MaskValues {
+    flags: Vec<bool>,
+}
+
+impl MaskValues {
+    fn from_flags(flags: Vec<bool>) -> Option<Self> {
+        if flags.iter().any(|flag| *flag) {
+            Some(Self { flags })
+        } else {
+            None
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.flags.len()
+    }
+
+    fn ensure_len(&self, expected: usize) -> PyResult<()> {
+        if self.len() != expected {
+            Err(PyValueError::new_err(format!(
+                "masked array length mismatch (expected {expected}, found {})",
+                self.len()
+            )))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn is_masked(&self, index: usize) -> bool {
+        self.flags[index]
+    }
+}
+
+/// Convert a Python/Numpy value plus optional metadata into an [`NdArrowArray`].
+///
+/// `build_nd_array` is the single place where dtype inspection, dimension name
+/// validation, and mask propagation occur before Arrow builders run.
+pub(crate) fn build_nd_array(
+    py: Python<'_>,
+    field_name: &str,
+    value: PyObject,
+) -> PyResult<(FieldRef, NdArrowArray)> {
+    let (array_object, dimension_metadata) = extract_array_payload(py, value)?;
+    let (array_object, mask_state) = separate_masked_array(py, array_object)?;
+    let dimension_names = dimension_metadata.as_ref().map(|names| names.as_slice());
+    let mask = mask_state.as_ref();
+    let bound_value = array_object.bind(py);
+    if let Some(dtype) = numpy_dtype(&bound_value)? {
+        if let Some(kind) = numpy_kind(&dtype)? {
+            match kind {
+                'U' => {
+                    return build_numpy_unicode_array(
+                        py,
+                        field_name,
+                        &bound_value,
+                        dimension_names,
+                        mask,
+                    );
+                }
+                'S' | 'a' => {
+                    return build_numpy_binary_array(
+                        py,
+                        field_name,
+                        &bound_value,
+                        dimension_names,
+                        mask,
+                    );
+                }
+                'M' => {
+                    return build_numpy_datetime64(
+                        py,
+                        field_name,
+                        &bound_value,
+                        &dtype,
+                        dimension_names,
+                        mask,
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
+    try_numpy_array!(
+        &bound_value,
+        bool,
+        build_bool_numpy,
+        field_name,
+        dimension_names,
+        mask
+    );
+    try_numpy_array!(
+        &bound_value,
+        i8,
+        build_int8_numpy,
+        field_name,
+        dimension_names,
+        mask
+    );
+    try_numpy_array!(
+        &bound_value,
+        i16,
+        build_int16_numpy,
+        field_name,
+        dimension_names,
+        mask
+    );
+    try_numpy_array!(
+        &bound_value,
+        i32,
+        build_int32_numpy,
+        field_name,
+        dimension_names,
+        mask
+    );
+    try_numpy_array!(
+        &bound_value,
+        i64,
+        build_int64_numpy,
+        field_name,
+        dimension_names,
+        mask
+    );
+    try_numpy_array!(
+        &bound_value,
+        u8,
+        build_uint8_numpy,
+        field_name,
+        dimension_names,
+        mask
+    );
+    try_numpy_array!(
+        &bound_value,
+        u16,
+        build_uint16_numpy,
+        field_name,
+        dimension_names,
+        mask
+    );
+    try_numpy_array!(
+        &bound_value,
+        u32,
+        build_uint32_numpy,
+        field_name,
+        dimension_names,
+        mask
+    );
+    try_numpy_array!(
+        &bound_value,
+        u64,
+        build_uint64_numpy,
+        field_name,
+        dimension_names,
+        mask
+    );
+    try_numpy_array!(
+        &bound_value,
+        f32,
+        build_float32_numpy,
+        field_name,
+        dimension_names,
+        mask
+    );
+    try_numpy_array!(
+        &bound_value,
+        f64,
+        build_float64_numpy,
+        field_name,
+        dimension_names,
+        mask
+    );
+
+    build_from_sequence(py, field_name, &bound_value, dimension_names)
+}
+
+fn build_from_sequence(
+    py: Python<'_>,
+    field_name: &str,
+    value: &Bound<'_, PyAny>,
+    dimension_names: Option<&[String]>,
+) -> PyResult<(FieldRef, NdArrowArray)> {
+    let sequence = value.downcast::<PySequence>()?;
+    let len = sequence.len()? as usize;
+    let mut items = Vec::with_capacity(len);
+    for item in sequence.iter()? {
+        items.push(item?.to_object(py));
+    }
+
+    let kind = infer_kind(py, &items)?;
+    let (data_type, array): (DataType, ArrayRef) = match kind {
+        ValueKind::Bool => build_bool_array(py, &items)?,
+        ValueKind::Int => build_int_array(py, &items)?,
+        ValueKind::Float => build_float_array(py, &items)?,
+        ValueKind::Utf8 => build_string_array(py, &items, None)?,
+        ValueKind::Binary => build_binary_array(py, &items, None)?,
+    };
+
+    let len = array.len();
+    let shape = [len];
+    let dimensions = dimensions_from_shape(&shape, dimension_names)?;
+    make_nd_array(field_name, data_type, array, dimensions)
+}
+
+fn build_bool_numpy(
+    field_name: &str,
+    array: PyReadonlyArrayDyn<'_, bool>,
+    dimension_names: Option<&[String]>,
+    mask: Option<&MaskValues>,
+) -> PyResult<(FieldRef, NdArrowArray)> {
+    let view = array.as_array();
+    let mut builder = BooleanBuilder::with_capacity(view.len());
+    if let Some(mask_values) = mask {
+        mask_values.ensure_len(view.len())?;
+    }
+    for (idx, value) in view.iter().enumerate() {
+        if mask.map_or(false, |m| m.is_masked(idx)) {
+            builder.append_null();
+        } else {
+            builder.append_value(*value);
+        }
+    }
+    let dimensions = dimensions_from_shape(view.shape(), dimension_names)?;
+    make_nd_array(
+        field_name,
+        DataType::Boolean,
+        Arc::new(builder.finish()),
+        dimensions,
+    )
+}
+
+define_numeric_builder!(build_int8_numpy, i8, Int8Builder, DataType::Int8);
+define_numeric_builder!(build_int16_numpy, i16, Int16Builder, DataType::Int16);
+define_numeric_builder!(build_int32_numpy, i32, Int32Builder, DataType::Int32);
+define_numeric_builder!(build_int64_numpy, i64, Int64Builder, DataType::Int64);
+define_numeric_builder!(build_uint8_numpy, u8, UInt8Builder, DataType::UInt8);
+define_numeric_builder!(build_uint16_numpy, u16, UInt16Builder, DataType::UInt16);
+define_numeric_builder!(build_uint32_numpy, u32, UInt32Builder, DataType::UInt32);
+define_numeric_builder!(build_uint64_numpy, u64, UInt64Builder, DataType::UInt64);
+define_numeric_builder!(build_float32_numpy, f32, Float32Builder, DataType::Float32);
+define_numeric_builder!(build_float64_numpy, f64, Float64Builder, DataType::Float64);
+
+fn build_numpy_datetime64(
+    py: Python<'_>,
+    field_name: &str,
+    array: &Bound<'_, PyAny>,
+    dtype: &Bound<'_, PyAny>,
+    dimension_names: Option<&[String]>,
+    mask: Option<&MaskValues>,
+) -> PyResult<(FieldRef, NdArrowArray)> {
+    let numpy = py.import_bound("numpy")?;
+    let int64_type = numpy.getattr("int64")?;
+    let viewed = array.call_method1("view", (int64_type,))?;
+    let int_array = viewed.downcast::<PyArrayDyn<i64>>()?;
+    build_datetime_numpy(
+        field_name,
+        int_array.readonly(),
+        dtype,
+        dimension_names,
+        mask,
+    )
+}
+
+fn build_datetime_numpy(
+    field_name: &str,
+    array: PyReadonlyArrayDyn<'_, i64>,
+    dtype: &Bound<'_, PyAny>,
+    dimension_names: Option<&[String]>,
+    mask: Option<&MaskValues>,
+) -> PyResult<(FieldRef, NdArrowArray)> {
+    let multiplier = datetime_unit_multiplier(dtype)?;
+    let view = array.as_array();
+    let mut builder = TimestampNanosecondBuilder::with_capacity(view.len());
+    if let Some(mask_values) = mask {
+        mask_values.ensure_len(view.len())?;
+    }
+    for (idx, value) in view.iter().enumerate() {
+        if mask.map_or(false, |m| m.is_masked(idx)) {
+            builder.append_null();
+        } else {
+            builder.append_value(convert_datetime_value(*value, multiplier)?);
+        }
+    }
+    let dimensions = dimensions_from_shape(view.shape(), dimension_names)?;
+    make_nd_array(
+        field_name,
+        DataType::Timestamp(TimeUnit::Nanosecond, None),
+        Arc::new(builder.finish()),
+        dimensions,
+    )
+}
+
+fn build_numpy_unicode_array(
+    py: Python<'_>,
+    field_name: &str,
+    array: &Bound<'_, PyAny>,
+    dimension_names: Option<&[String]>,
+    mask: Option<&MaskValues>,
+) -> PyResult<(FieldRef, NdArrowArray)> {
+    let shape = numpy_shape(array)?;
+    let items = flatten_numpy_items(py, array)?;
+    if let Some(mask_values) = mask {
+        mask_values.ensure_len(items.len())?;
+    }
+    let (data_type, array_ref) = build_string_array(py, &items, mask)?;
+    let dimensions = dimensions_from_shape(&shape, dimension_names)?;
+    make_nd_array(field_name, data_type, array_ref, dimensions)
+}
+
+fn build_numpy_binary_array(
+    py: Python<'_>,
+    field_name: &str,
+    array: &Bound<'_, PyAny>,
+    dimension_names: Option<&[String]>,
+    mask: Option<&MaskValues>,
+) -> PyResult<(FieldRef, NdArrowArray)> {
+    let shape = numpy_shape(array)?;
+    let items = flatten_numpy_items(py, array)?;
+    if let Some(mask_values) = mask {
+        mask_values.ensure_len(items.len())?;
+    }
+    let (data_type, array_ref) = build_binary_array(py, &items, mask)?;
+    let dimensions = dimensions_from_shape(&shape, dimension_names)?;
+    make_nd_array(field_name, data_type, array_ref, dimensions)
+}
+
+fn flatten_numpy_items(py: Python<'_>, array: &Bound<'_, PyAny>) -> PyResult<Vec<PyObject>> {
+    let flat = array.call_method0("ravel")?;
+    let list = flat.call_method0("tolist")?;
+    let sequence = list.downcast::<PySequence>()?;
+    let len = sequence.len()? as usize;
+    let mut items = Vec::with_capacity(len);
+    for item in sequence.iter()? {
+        items.push(item?.to_object(py));
+    }
+    Ok(items)
+}
+
+fn numpy_shape(array: &Bound<'_, PyAny>) -> PyResult<Vec<usize>> {
+    let shape_obj = array.getattr("shape")?;
+    let dims = shape_obj.downcast::<PySequence>()?;
+    let ndim = dims.len()? as usize;
+    if ndim == 0 {
+        return Ok(vec![1]);
+    }
+    let mut shape = Vec::with_capacity(ndim);
+    for dim in dims.iter()? {
+        shape.push(dim?.extract::<usize>()?);
+    }
+    Ok(shape)
+}
+
+fn numpy_dtype<'py>(value: &Bound<'py, PyAny>) -> PyResult<Option<Bound<'py, PyAny>>> {
+    if value.hasattr("dtype")? {
+        Ok(Some(value.getattr("dtype")?))
+    } else {
+        Ok(None)
+    }
+}
+
+fn numpy_kind(dtype: &Bound<'_, PyAny>) -> PyResult<Option<char>> {
+    let kind_obj = dtype.getattr("kind")?;
+    let kind: String = kind_obj.extract()?;
+    Ok(kind.chars().next())
+}
+
+fn datetime_unit_multiplier(dtype: &Bound<'_, PyAny>) -> PyResult<i64> {
+    let name_obj = dtype.getattr("name")?;
+    let descriptor: String = name_obj.extract()?;
+    datetime_unit_multiplier_from_descriptor(&descriptor)
+}
+
+fn datetime_unit_multiplier_from_descriptor(descriptor: &str) -> PyResult<i64> {
+    let unit = descriptor
+        .split_once('[')
+        .and_then(|(_, rest)| rest.strip_suffix(']'))
+        .unwrap_or("ns");
+    match unit {
+        "s" => Ok(1_000_000_000i64),
+        "ms" => Ok(1_000_000i64),
+        "us" => Ok(1_000i64),
+        "ns" => Ok(1i64),
+        "m" => Ok(60i64 * 1_000_000_000i64),
+        "h" => Ok(3_600i64 * 1_000_000_000i64),
+        "D" => Ok(86_400i64 * 1_000_000_000i64),
+        other => Err(PyValueError::new_err(format!(
+            "unsupported numpy datetime64 unit: {other}"
+        ))),
+    }
+}
+
+fn convert_datetime_value(value: i64, multiplier: i64) -> PyResult<i64> {
+    if multiplier == 1 {
+        return Ok(value);
+    }
+    let scaled = (value as i128)
+        .checked_mul(multiplier as i128)
+        .ok_or_else(|| {
+            PyValueError::new_err("datetime64 value overflow when converting to nanoseconds")
+        })?;
+    Ok(scaled as i64)
+}
+
+fn extract_array_payload(
+    py: Python<'_>,
+    value: PyObject,
+) -> PyResult<(PyObject, Option<Vec<String>>)> {
+    let bound_value = value.bind(py);
+    if let Some(result) = try_extract_from_named_sequence(py, &bound_value)? {
+        return Ok(result);
+    }
+    if let Some(result) = try_extract_from_mapping(py, &bound_value)? {
+        return Ok(result);
+    }
+    Ok((value, None))
+}
+
+/// If `value` is a `numpy.ma.MaskedArray`, peel off the mask and return the
+/// raw data object plus pre-flattened mask bits.
+fn separate_masked_array(
+    py: Python<'_>,
+    value: PyObject,
+) -> PyResult<(PyObject, Option<MaskValues>)> {
+    let numpy = py.import_bound("numpy")?;
+    let ma = numpy.getattr("ma")?;
+    let bound_value = value.bind(py);
+    let is_masked: bool = ma
+        .call_method1("isMaskedArray", (bound_value.clone(),))?
+        .extract()?;
+    if !is_masked {
+        return Ok((value, None));
+    }
+    let mask_array_obj = ma.call_method1("getmaskarray", (bound_value.clone(),))?;
+    let mask_array = mask_array_obj.downcast::<PyArrayDyn<bool>>()?;
+    let mask_view = mask_array.readonly();
+    let flags: Vec<bool> = mask_view.as_array().iter().copied().collect();
+    let mask_values = MaskValues::from_flags(flags);
+    let data_obj = bound_value.getattr("data")?;
+    Ok((data_obj.to_object(py), mask_values))
+}
+
+fn try_extract_from_named_sequence(
+    py: Python<'_>,
+    value: &Bound<'_, PyAny>,
+) -> PyResult<Option<(PyObject, Option<Vec<String>>)>> {
+    if let Ok(tuple) = value.downcast::<PyTuple>() {
+        if tuple.len() != 2 {
+            return Ok(None);
+        }
+        let dims_obj = tuple.get_item(1)?;
+        return match parse_dimension_names(&dims_obj)? {
+            DimensionNameParse::Names(names) => {
+                let data_obj = tuple.get_item(0)?;
+                Ok(Some((data_obj.to_object(py), Some(names))))
+            }
+            DimensionNameParse::NotDimensions => Ok(None),
+        };
+    }
+
+    if let Ok(list) = value.downcast::<PyList>() {
+        if list.len() != 2 {
+            return Ok(None);
+        }
+        let dims_obj = list.get_item(1)?;
+        return match parse_dimension_names(&dims_obj)? {
+            DimensionNameParse::Names(names) => {
+                let data_obj = list.get_item(0)?;
+                Ok(Some((data_obj.to_object(py), Some(names))))
+            }
+            DimensionNameParse::NotDimensions => Ok(None),
+        };
+    }
+
+    Ok(None)
+}
+
+fn try_extract_from_mapping(
+    py: Python<'_>,
+    value: &Bound<'_, PyAny>,
+) -> PyResult<Option<(PyObject, Option<Vec<String>>)>> {
+    let Ok(mapping) = value.downcast::<PyDict>() else {
+        return Ok(None);
+    };
+    let Some(array_obj) = find_mapping_value(mapping, &["data", "array", "values"]) else {
+        return Ok(None);
+    };
+    let dims = if let Some(dims_obj) = find_mapping_value(mapping, &["dims", "dimensions"]) {
+        match parse_dimension_names(&dims_obj)? {
+            DimensionNameParse::Names(names) => Some(names),
+            DimensionNameParse::NotDimensions => {
+                return Err(PyValueError::new_err(
+                    "dimension names must be sequences of strings when using 'dims' or 'dimensions'",
+                ));
+            }
+        }
+    } else {
+        None
+    };
+    Ok(Some((array_obj.to_object(py), dims)))
+}
+
+fn find_mapping_value<'py>(
+    mapping: &Bound<'py, PyDict>,
+    keys: &[&str],
+) -> Option<Bound<'py, PyAny>> {
+    for key in keys {
+        if let Ok(Some(value)) = mapping.get_item(*key) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+enum DimensionNameParse {
+    Names(Vec<String>),
+    NotDimensions,
+}
+
+fn parse_dimension_names(value: &Bound<'_, PyAny>) -> PyResult<DimensionNameParse> {
+    if value.is_none() {
+        return Ok(DimensionNameParse::NotDimensions);
+    }
+
+    if value.is_instance_of::<PyUnicode>() {
+        let name: String = value.extract()?;
+        validate_dimension_name(&name)?;
+        return Ok(DimensionNameParse::Names(vec![name]));
+    }
+
+    if let Ok(sequence) = value.downcast::<PySequence>() {
+        let len = sequence.len()? as usize;
+        if len == 0 {
+            return Err(PyValueError::new_err(
+                "dimension name sequences cannot be empty",
+            ));
+        }
+        let mut names = Vec::with_capacity(len);
+        for item in sequence.iter()? {
+            let item = item?;
+            if !item.is_instance_of::<PyUnicode>() {
+                return Ok(DimensionNameParse::NotDimensions);
+            }
+            let name: String = item.extract()?;
+            validate_dimension_name(&name)?;
+            names.push(name);
+        }
+        return Ok(DimensionNameParse::Names(names));
+    }
+
+    Ok(DimensionNameParse::NotDimensions)
+}
+
+fn validate_dimension_name(name: &str) -> PyResult<()> {
+    if name.trim().is_empty() {
+        Err(PyValueError::new_err(
+            "dimension names must contain at least one non-whitespace character",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn build_bool_array(py: Python<'_>, items: &[PyObject]) -> PyResult<(DataType, ArrayRef)> {
+    let mut builder = BooleanBuilder::with_capacity(items.len());
+    for obj in items {
+        let any = obj.bind(py);
+        if any.is_none() {
+            builder.append_null();
+        } else {
+            let value: bool = any.extract()?;
+            builder.append_value(value);
+        }
+    }
+    Ok((DataType::Boolean, Arc::new(builder.finish())))
+}
+
+fn build_int_array(py: Python<'_>, items: &[PyObject]) -> PyResult<(DataType, ArrayRef)> {
+    let mut builder = Int64Builder::with_capacity(items.len());
+    for obj in items {
+        let any = obj.bind(py);
+        if any.is_none() {
+            builder.append_null();
+        } else {
+            let value: i64 = any.extract()?;
+            builder.append_value(value);
+        }
+    }
+    Ok((DataType::Int64, Arc::new(builder.finish())))
+}
+
+fn build_float_array(py: Python<'_>, items: &[PyObject]) -> PyResult<(DataType, ArrayRef)> {
+    let mut builder = Float64Builder::with_capacity(items.len());
+    for obj in items {
+        let any = obj.bind(py);
+        if any.is_none() {
+            builder.append_null();
+        } else {
+            let value: f64 = any.extract()?;
+            builder.append_value(value);
+        }
+    }
+    Ok((DataType::Float64, Arc::new(builder.finish())))
+}
+
+fn build_string_array(
+    py: Python<'_>,
+    items: &[PyObject],
+    mask: Option<&MaskValues>,
+) -> PyResult<(DataType, ArrayRef)> {
+    let mut builder = StringBuilder::with_capacity(items.len(), items.len() * 4);
+    for (idx, obj) in items.iter().enumerate() {
+        if mask.map_or(false, |m| m.is_masked(idx)) {
+            builder.append_null();
+            continue;
+        }
+        let any = obj.bind(py);
+        if any.is_none() {
+            builder.append_null();
+        } else {
+            let value: String = any.extract()?;
+            builder.append_value(value);
+        }
+    }
+    Ok((DataType::Utf8, Arc::new(builder.finish())))
+}
+
+fn build_binary_array(
+    py: Python<'_>,
+    items: &[PyObject],
+    mask: Option<&MaskValues>,
+) -> PyResult<(DataType, ArrayRef)> {
+    let mut builder = BinaryBuilder::with_capacity(items.len(), items.len() * 4);
+    for (idx, obj) in items.iter().enumerate() {
+        if mask.map_or(false, |m| m.is_masked(idx)) {
+            builder.append_null();
+            continue;
+        }
+        let any = obj.bind(py);
+        if any.is_none() {
+            builder.append_null();
+        } else {
+            let value = any.downcast::<PyBytes>()?;
+            builder.append_value(value.as_bytes());
+        }
+    }
+    Ok((DataType::Binary, Arc::new(builder.finish())))
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ValueKind {
+    Bool,
+    Int,
+    Float,
+    Utf8,
+    Binary,
+}
+
+fn infer_kind(py: Python<'_>, items: &[PyObject]) -> PyResult<ValueKind> {
+    if has_type(py, items, |any| {
+        Ok(any.is_instance_of::<pyo3::types::PyUnicode>())
+    })? {
+        return Ok(ValueKind::Utf8);
+    }
+    if has_type(py, items, |any| Ok(any.is_instance_of::<PyBytes>()))? {
+        return Ok(ValueKind::Binary);
+    }
+    if has_type(py, items, |any| {
+        Ok(any.is_instance_of::<pyo3::types::PyFloat>())
+    })? {
+        return Ok(ValueKind::Float);
+    }
+    if has_type(py, items, |any| {
+        Ok(any.is_instance_of::<pyo3::types::PyBool>())
+    })? {
+        return Ok(ValueKind::Bool);
+    }
+    if has_type(py, items, |any| {
+        Ok(any.is_instance_of::<pyo3::types::PyLong>())
+    })? {
+        return Ok(ValueKind::Int);
+    }
+    Err(PyValueError::new_err(
+        "unable to determine array type from empty or null-only sequence",
+    ))
+}
+
+fn has_type<F>(py: Python<'_>, items: &[PyObject], mut predicate: F) -> PyResult<bool>
+where
+    F: FnMut(&Bound<'_, PyAny>) -> PyResult<bool>,
+{
+    for obj in items {
+        let any = obj.bind(py);
+        if any.is_none() {
+            continue;
+        }
+        if predicate(&any)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn make_nd_array(
+    field_name: &str,
+    data_type: DataType,
+    array: ArrayRef,
+    dimensions: Vec<Dimension>,
+) -> PyResult<(FieldRef, NdArrowArray)> {
+    let field: FieldRef = Arc::new(Field::new(field_name.to_string(), data_type.clone(), true));
+    let nd_array = NdArrowArray::new(array, Dimensions::MultiDimensional(dimensions))
+        .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
+    Ok((field, nd_array))
+}
+
+/// Build Nd-array dimension metadata, validating optional user supplied names.
+fn dimensions_from_shape(shape: &[usize], names: Option<&[String]>) -> PyResult<Vec<Dimension>> {
+    if shape.is_empty() {
+        let name = match names {
+            Some(provided) => {
+                if provided.len() != 1 {
+                    return Err(PyValueError::new_err(format!(
+                        "dimension name count ({}) must be 1 for scalar arrays",
+                        provided.len()
+                    )));
+                }
+                provided[0].clone()
+            }
+            None => "dim0".to_string(),
+        };
+        return Ok(vec![Dimension { name, size: 1 }]);
+    }
+
+    if let Some(provided) = names {
+        if provided.len() != shape.len() {
+            return Err(PyValueError::new_err(format!(
+                "dimension name count ({}) does not match array rank ({})",
+                provided.len(),
+                shape.len()
+            )));
+        }
+        return Ok(shape
+            .iter()
+            .enumerate()
+            .map(|(idx, size)| Dimension {
+                name: provided[idx].clone(),
+                size: *size,
+            })
+            .collect());
+    }
+
+    Ok(shape
+        .iter()
+        .enumerate()
+        .map(|(idx, size)| Dimension {
+            name: format!("dim{idx}"),
+            size: *size,
+        })
+        .collect())
+}

--- a/beacon-binary-format-py/src/utils.rs
+++ b/beacon-binary-format-py/src/utils.rs
@@ -2,11 +2,211 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use object_store::ObjectStore;
+use object_store::aws::AmazonS3Builder;
 use object_store::local::LocalFileSystem;
-use pyo3::exceptions::PyRuntimeError;
+use object_store::path::Path;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyDict};
 
-pub(crate) fn init_store(base_dir: String) -> PyResult<Arc<dyn ObjectStore>> {
+#[derive(Clone, Debug, Default)]
+pub(crate) struct StorageOptions {
+    pub s3: Option<S3Config>,
+}
+
+impl StorageOptions {
+    pub fn merge(mut self, overrides: StorageOptions) -> StorageOptions {
+        if let Some(override_cfg) = overrides.s3 {
+            self.s3 = Some(match self.s3 {
+                Some(existing) => existing.merge(override_cfg),
+                None => override_cfg,
+            });
+        }
+        self
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct S3Config {
+    pub region: Option<String>,
+    pub endpoint_url: Option<String>,
+    pub access_key_id: Option<String>,
+    pub secret_access_key: Option<String>,
+    pub session_token: Option<String>,
+    pub allow_http: Option<bool>,
+}
+
+impl S3Config {
+    fn merge(mut self, overrides: S3Config) -> S3Config {
+        if overrides.region.is_some() {
+            self.region = overrides.region;
+        }
+        if overrides.endpoint_url.is_some() {
+            self.endpoint_url = overrides.endpoint_url;
+        }
+        if overrides.access_key_id.is_some() {
+            self.access_key_id = overrides.access_key_id;
+        }
+        if overrides.secret_access_key.is_some() {
+            self.secret_access_key = overrides.secret_access_key;
+        }
+        if overrides.session_token.is_some() {
+            self.session_token = overrides.session_token;
+        }
+        if overrides.allow_http.is_some() {
+            self.allow_http = overrides.allow_http;
+        }
+        self
+    }
+}
+
+pub(crate) fn storage_options_from_py(
+    options: Option<Bound<'_, PyDict>>,
+) -> PyResult<StorageOptions> {
+    let mut overrides = S3Config::default();
+    let mut saw_s3_key = false;
+
+    if let Some(mapping) = options {
+        for (raw_key, value) in mapping.iter() {
+            let key: String = raw_key.extract()?;
+            match key.as_str() {
+                "key" => {
+                    if !value.is_none() {
+                        overrides.access_key_id = Some(value.extract()?);
+                        saw_s3_key = true;
+                    }
+                }
+                "secret" => {
+                    if !value.is_none() {
+                        overrides.secret_access_key = Some(value.extract()?);
+                        saw_s3_key = true;
+                    }
+                }
+                "token" => {
+                    if !value.is_none() {
+                        overrides.session_token = Some(value.extract()?);
+                        saw_s3_key = true;
+                    }
+                }
+                "region" | "region_name" => {
+                    if !value.is_none() {
+                        overrides.region = Some(value.extract()?);
+                        saw_s3_key = true;
+                    }
+                }
+                "endpoint_url" => {
+                    if !value.is_none() {
+                        overrides.endpoint_url = Some(value.extract()?);
+                        saw_s3_key = true;
+                    }
+                }
+                "use_ssl" => {
+                    let use_ssl: bool = value.extract()?;
+                    overrides.allow_http = Some(!use_ssl);
+                    saw_s3_key = true;
+                }
+                "client_kwargs" => {
+                    if !value.is_none() {
+                        let Ok(kwargs) = value.downcast::<PyDict>() else {
+                            continue;
+                        };
+                        if let Some(endpoint) = kwargs.get_item("endpoint_url")? {
+                            overrides.endpoint_url = Some(endpoint.extract()?);
+                            saw_s3_key = true;
+                        }
+                        if let Some(allow_http) = kwargs.get_item("allow_http")? {
+                            overrides.allow_http = Some(allow_http.extract()?);
+                            saw_s3_key = true;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(StorageOptions {
+        s3: if saw_s3_key { Some(overrides) } else { None },
+    })
+}
+
+pub(crate) fn prepare_store_inputs(
+    base_dir: String,
+    storage_options: Option<Bound<'_, PyDict>>,
+    filesystem: Option<Bound<'_, PyAny>>,
+) -> PyResult<(String, StorageOptions)> {
+    let mut combined = StorageOptions::default();
+
+    if let Some(fs) = filesystem.as_ref() {
+        if let Some(fs_options) = storage_options_from_filesystem(fs)? {
+            combined = combined.merge(fs_options);
+        }
+    }
+
+    let explicit = storage_options_from_py(storage_options)?;
+    combined = combined.merge(explicit);
+
+    let mut normalized = base_dir.trim().to_string();
+    if normalized.contains("://") {
+        return Ok((normalized, combined));
+    }
+
+    if let Some(fs) = filesystem.as_ref() {
+        if let Some(protocol) = protocol_from_filesystem(fs)? {
+            if protocol != "file" && protocol != "local" {
+                let trimmed = normalized.trim_matches('/');
+                if trimmed.is_empty() {
+                    return Err(PyValueError::new_err(
+                        "base_dir cannot be empty when inferring protocol from filesystem",
+                    ));
+                }
+                normalized = format!("{protocol}://{trimmed}");
+            }
+        }
+    }
+
+    Ok((normalized, combined))
+}
+
+pub(crate) struct StoreHandle {
+    pub store: Arc<dyn ObjectStore>,
+    prefix: Option<String>,
+}
+
+impl StoreHandle {
+    fn new(store: Arc<dyn ObjectStore>, prefix: Option<String>) -> Self {
+        Self { store, prefix }
+    }
+
+    pub fn resolve_collection_path(&self, collection_path: &str) -> PyResult<Path> {
+        let suffix = collection_path.trim_matches('/');
+        let joined = match (&self.prefix, suffix.is_empty()) {
+            (Some(prefix), false) => format!("{prefix}/{suffix}"),
+            (Some(prefix), true) => prefix.clone(),
+            (None, false) => suffix.to_string(),
+            (None, true) => {
+                return Err(PyValueError::new_err(
+                    "collection_path cannot be empty when base_dir has no embedded path",
+                ));
+            }
+        };
+
+        Ok(Path::from(joined.as_str()))
+    }
+}
+
+pub(crate) fn init_store(base_dir: String, storage: StorageOptions) -> PyResult<StoreHandle> {
+    let trimmed = base_dir.trim();
+    if trimmed.starts_with("s3://") {
+        init_s3_store(trimmed, storage)
+    } else if let Some(path) = trimmed.strip_prefix("file://") {
+        init_local_store(path.to_string())
+    } else {
+        init_local_store(trimmed.to_string())
+    }
+}
+
+fn init_local_store(base_dir: String) -> PyResult<StoreHandle> {
     let mut base = PathBuf::from(base_dir);
     if base.to_string_lossy().is_empty() {
         base = std::env::temp_dir();
@@ -15,9 +215,143 @@ pub(crate) fn init_store(base_dir: String) -> PyResult<Arc<dyn ObjectStore>> {
         .map_err(|err| PyRuntimeError::new_err(format!("failed to create base dir: {err}")))?;
     let fs = LocalFileSystem::new_with_prefix(base)
         .map_err(|err| PyRuntimeError::new_err(format!("failed to create store: {err}")))?;
-    Ok(Arc::new(fs))
+    Ok(StoreHandle::new(Arc::new(fs), None))
+}
+
+fn init_s3_store(base_uri: &str, storage: StorageOptions) -> PyResult<StoreHandle> {
+    let parsed = parse_s3_location(base_uri)?;
+    let mut builder = AmazonS3Builder::new().with_bucket_name(&parsed.bucket);
+
+    if let Some(overrides) = storage.s3 {
+        if let Some(region) = overrides.region {
+            builder = builder.with_region(region);
+        }
+        if let Some(endpoint) = overrides.endpoint_url.clone() {
+            builder = builder.with_endpoint(&endpoint);
+            if overrides
+                .allow_http
+                .unwrap_or_else(|| endpoint.starts_with("http://"))
+            {
+                builder = builder.with_allow_http(true);
+            }
+        } else if let Some(allow_http) = overrides.allow_http {
+            if allow_http {
+                builder = builder.with_allow_http(true);
+            }
+        }
+        if let Some(access_key) = overrides.access_key_id {
+            builder = builder.with_access_key_id(access_key);
+        }
+        if let Some(secret) = overrides.secret_access_key {
+            builder = builder.with_secret_access_key(secret);
+        }
+        if let Some(token) = overrides.session_token {
+            builder = builder.with_token(token);
+        }
+    }
+
+    let store = builder
+        .build()
+        .map_err(|err| PyRuntimeError::new_err(format!("failed to create S3 store: {err}")))?;
+
+    Ok(StoreHandle::new(
+        Arc::new(store),
+        parsed
+            .prefix
+            .map(|prefix| prefix.trim_matches('/').to_string()),
+    ))
+}
+
+fn storage_options_from_filesystem(
+    filesystem: &Bound<'_, PyAny>,
+) -> PyResult<Option<StorageOptions>> {
+    let storage_attr = match filesystem.getattr("storage_options") {
+        Ok(attr) => attr,
+        Err(_) => return Ok(None),
+    };
+    if storage_attr.is_none() {
+        return Ok(None);
+    }
+    let mapping = storage_attr
+        .downcast::<PyDict>()
+        .map_err(|_| PyValueError::new_err("filesystem.storage_options must be a mapping"))?;
+    storage_options_from_py(Some(mapping.clone())).map(Some)
+}
+
+fn protocol_from_filesystem(filesystem: &Bound<'_, PyAny>) -> PyResult<Option<String>> {
+    let obj = match filesystem.getattr("protocol") {
+        Ok(value) => value,
+        Err(_) => return Ok(None),
+    };
+    if obj.is_none() {
+        return Ok(None);
+    }
+    if let Ok(proto) = obj.extract::<String>() {
+        return Ok(Some(proto));
+    }
+    if let Ok(list) = obj.extract::<Vec<String>>() {
+        for entry in list {
+            if !entry.is_empty() {
+                return Ok(Some(entry));
+            }
+        }
+    }
+    Ok(None)
+}
+
+struct S3Location {
+    bucket: String,
+    prefix: Option<String>,
+}
+
+fn parse_s3_location(uri: &str) -> PyResult<S3Location> {
+    let trimmed = uri.trim_start_matches("s3://");
+    let (path_part, _) = trimmed.split_once('?').unwrap_or((trimmed, ""));
+    let mut segments = path_part.splitn(2, '/');
+    let bucket = segments
+        .next()
+        .filter(|segment| !segment.is_empty())
+        .ok_or_else(|| PyValueError::new_err("s3 URI must include a bucket name"))?;
+    let prefix = segments
+        .next()
+        .map(|segment| segment.trim_matches('/').to_string())
+        .filter(|segment| !segment.is_empty());
+    Ok(S3Location {
+        bucket: bucket.to_string(),
+        prefix,
+    })
 }
 
 pub(crate) fn to_py_err<E: std::fmt::Display>(err: E) -> PyErr {
     PyRuntimeError::new_err(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_store_handle(prefix: Option<&str>) -> StoreHandle {
+        let store = LocalFileSystem::new_with_prefix(std::env::temp_dir()).expect("local store");
+        StoreHandle::new(Arc::new(store), prefix.map(|p| p.to_string()))
+    }
+
+    #[test]
+    fn s3_location_parsing_handles_prefix() {
+        let location = parse_s3_location("s3://bucket/foo/bar").unwrap();
+        assert_eq!(location.bucket, "bucket");
+        assert_eq!(location.prefix.as_deref(), Some("foo/bar"));
+    }
+
+    #[test]
+    fn resolve_requires_collection_path_without_prefix() {
+        let handle = dummy_store_handle(None);
+        assert!(handle.resolve_collection_path("").is_err());
+    }
+
+    #[test]
+    fn resolve_combines_prefix_and_suffix() {
+        let handle = dummy_store_handle(Some("datasets/base"));
+        let path = handle.resolve_collection_path("collection").unwrap();
+        assert_eq!(path.to_string(), "datasets/base/collection");
+    }
 }

--- a/beacon-binary-format-py/src/utils.rs
+++ b/beacon-binary-format-py/src/utils.rs
@@ -1,0 +1,23 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use object_store::ObjectStore;
+use object_store::local::LocalFileSystem;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+
+pub(crate) fn init_store(base_dir: String) -> PyResult<Arc<dyn ObjectStore>> {
+    let mut base = PathBuf::from(base_dir);
+    if base.to_string_lossy().is_empty() {
+        base = std::env::temp_dir();
+    }
+    std::fs::create_dir_all(&base)
+        .map_err(|err| PyRuntimeError::new_err(format!("failed to create base dir: {err}")))?;
+    let fs = LocalFileSystem::new_with_prefix(base)
+        .map_err(|err| PyRuntimeError::new_err(format!("failed to create store: {err}")))?;
+    Ok(Arc::new(fs))
+}
+
+pub(crate) fn to_py_err<E: std::fmt::Display>(err: E) -> PyErr {
+    PyRuntimeError::new_err(err.to_string())
+}

--- a/beacon-binary-format-py/tests/test_mask_roundtrip.py
+++ b/beacon-binary-format-py/tests/test_mask_roundtrip.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from beacon_bbf import Collection, CollectionReader
+
+
+def test_masked_values_roundtrip(tmp_path):
+    collection = Collection(str(tmp_path), "masked")
+    partition = collection.create_partition("p0")
+    masked = np.ma.array([1.0, 2.0, 3.0], mask=[False, True, False])
+    partition.write_entry("entry-0", {"masked": masked})
+    partition.finish()
+
+    reader = CollectionReader(str(tmp_path), "masked")
+    partition_reader = reader.open_partition("p0")
+    entries = partition_reader.read_entries()
+    entry = entries[0]
+    masked_result = entry["masked"]["data"]
+    assert masked_result.mask.tolist() == [False, True, False]
+    np.testing.assert_allclose(masked_result.data, np.array([1.0, 0.0, 3.0]))

--- a/beacon-binary-format-py/tests/test_mask_roundtrip.py
+++ b/beacon-binary-format-py/tests/test_mask_roundtrip.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from beacon_bbf import Collection, CollectionReader
+from beacon_binary_format import Collection, CollectionReader
 
 
 def test_masked_values_roundtrip(tmp_path):

--- a/beacon-binary-format-py/tests/test_numpy_types.py
+++ b/beacon-binary-format-py/tests/test_numpy_types.py
@@ -1,11 +1,11 @@
 import numpy as np
 import pytest
 
-import beacon_bbf
+import beacon_binary_format as bbf
 
 
 def test_collection_supports_multiple_partitions(tmp_path):
-    collection = beacon_bbf.Collection(str(tmp_path), "collection")
+    collection = bbf.Collection(str(tmp_path), "collection")
     partition = collection.create_partition("partition-0")
 
     arrays = {
@@ -60,7 +60,7 @@ def test_collection_supports_multiple_partitions(tmp_path):
 
 
 def test_numpy_arrays_support_named_dimensions(tmp_path):
-    collection = beacon_bbf.Collection(str(tmp_path), "dims")
+    collection = bbf.Collection(str(tmp_path), "dims")
     partition = collection.create_partition("partition-dims")
 
     grid = np.ones((2, 3, 4), dtype=np.float32)
@@ -92,7 +92,7 @@ def test_numpy_arrays_support_named_dimensions(tmp_path):
 
 
 def test_numpy_masked_arrays_respect_nulls(tmp_path):
-    collection = beacon_bbf.Collection(str(tmp_path), "masked")
+    collection = bbf.Collection(str(tmp_path), "masked")
     partition = collection.create_partition("partition-masked")
 
     masked_floats = np.ma.array(

--- a/beacon-binary-format-py/tests/test_numpy_types.py
+++ b/beacon-binary-format-py/tests/test_numpy_types.py
@@ -1,0 +1,115 @@
+import numpy as np
+import pytest
+
+import beacon_bbf
+
+
+def test_collection_supports_multiple_partitions(tmp_path):
+    collection = beacon_bbf.Collection(str(tmp_path), "collection")
+    partition = collection.create_partition("partition-0")
+
+    arrays = {
+        "bools": np.array([True, False, True], dtype=np.bool_),
+        "int8s": np.array([-8, 9], dtype=np.int8),
+        "int16s": np.array([-1000, 1000], dtype=np.int16),
+        "int32s": np.array([-1, 2, 3], dtype=np.int32),
+        "int64s": np.array([1, 2, 3], dtype=np.int64),
+        "uint8s": np.array([1, 255], dtype=np.uint8),
+        "uint16s": np.array([1, 500], dtype=np.uint16),
+        "uint32s": np.array([1, 2, 3], dtype=np.uint32),
+        "uint64s": np.array([1, 2, 3], dtype=np.uint64),
+        "float32s": np.array([1.5, 2.5], dtype=np.float32),
+        "float64s": np.array([1.5, 2.5], dtype=np.float64),
+        "unicode_values": np.array(["alpha", "beta"], dtype="U10"),
+        "binary_values": np.array([b"alpha", b"beta"], dtype="S5"),
+        "datetimes": np.array([
+            "2020-01-01T00:00:00",
+            "2020-01-02T12:34:56",
+        ], dtype="datetime64[ms]"),
+    }
+
+    partition.write_entry("row-0", arrays)
+    partition.finish()
+
+    second = collection.create_partition()
+    second_arrays = {
+        "bools": np.array([False, True, False], dtype=np.bool_),
+        "int8s": np.array([1, 2], dtype=np.int8),
+        "int16s": np.array([500, -500], dtype=np.int16),
+        "int32s": np.array([4, 5, 6], dtype=np.int32),
+        "int64s": np.array([4, 5, 6], dtype=np.int64),
+        "uint8s": np.array([5, 6], dtype=np.uint8),
+        "uint16s": np.array([600, 700], dtype=np.uint16),
+        "uint32s": np.array([4, 5, 6], dtype=np.uint32),
+        "uint64s": np.array([4, 5, 6], dtype=np.uint64),
+        "float32s": np.array([3.5, 4.5], dtype=np.float32),
+        "float64s": np.array([3.5, 4.5], dtype=np.float64),
+        "unicode_values": np.array(["gamma", "delta"], dtype="U10"),
+        "binary_values": np.array([b"gamma", b"delta"], dtype="S5"),
+        "datetimes": np.array([
+            "2020-01-03T00:00:00",
+            "2020-01-04T12:34:56",
+        ], dtype="datetime64[ms]"),
+    }
+    second.write_entry("row-1", second_arrays)
+    second.finish()
+
+    version = collection.library_version()
+    assert isinstance(version, str)
+    assert version
+
+
+def test_numpy_arrays_support_named_dimensions(tmp_path):
+    collection = beacon_bbf.Collection(str(tmp_path), "dims")
+    partition = collection.create_partition("partition-dims")
+
+    grid = np.ones((2, 3, 4), dtype=np.float32)
+
+    partition.write_entry(
+        "row-0",
+        {
+            "grid": (grid, ["depth", "lat", "lon"]),
+        },
+    )
+
+    partition.write_entry(
+        "row-1",
+        {
+            "grid": {
+                "data": grid,
+                "dims": ["depth", "lat", "lon"],
+            }
+        },
+    )
+
+    with pytest.raises(ValueError):
+        partition.write_entry("row-2", {"grid": (grid, ["only_depth"])})
+
+    with pytest.raises(ValueError):
+        partition.write_entry("row-3", {"grid": {"data": grid, "dims": ["depth", 1]}})
+
+    partition.finish()
+
+
+def test_numpy_masked_arrays_respect_nulls(tmp_path):
+    collection = beacon_bbf.Collection(str(tmp_path), "masked")
+    partition = collection.create_partition("partition-masked")
+
+    masked_floats = np.ma.array(
+        np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32),
+        mask=[False, True, False, True],
+    )
+    masked_unicode = np.ma.array(
+        np.array(["alpha", "beta", "gamma"], dtype="U10"),
+        mask=[False, False, True],
+    )
+
+    partition.write_entry(
+        "row-0",
+        {
+            "masked_floats": masked_floats,
+            "masked_unicode": masked_unicode,
+        },
+    )
+
+    partition.finish()

--- a/beacon-binary-format-py/tests/test_reader_roundtrip.py
+++ b/beacon-binary-format-py/tests/test_reader_roundtrip.py
@@ -1,4 +1,5 @@
 import numpy as np
+import fsspec
 import pytest
 
 from beacon_bbf import Collection, CollectionReader
@@ -29,3 +30,38 @@ def test_roundtrip_readback(tmp_path):
         entry["b"]["data"],
         np.array([[1.0, 2.0]], dtype=np.float64),
     )
+
+
+def test_storage_options_file_scheme(tmp_path):
+    base_uri = f"file://{tmp_path}"
+    storage_options = {
+        "region_name": "us-east-1",
+        "client_kwargs": {
+            "endpoint_url": "http://localhost:9000",
+            "allow_http": True,
+        },
+    }
+    collection = Collection(base_uri, "with-storage", storage_options=storage_options)
+    partition = collection.create_partition("sp0")
+    partition.write_entry("entry-0", {"a": np.array([1], dtype=np.int32)})
+    partition.finish()
+
+    reader = CollectionReader(base_uri, "with-storage", storage_options=storage_options)
+    entries = reader.open_partition("sp0").read_entries()
+    assert entries[0]["__entry_key"]["data"] == "entry-0"
+    assert np.array_equal(entries[0]["a"]["data"], np.array([1], dtype=np.int32))
+
+
+def test_filesystem_instance_roundtrip(tmp_path):
+    fs = fsspec.filesystem("file")
+    base_path = str(tmp_path)
+
+    collection = Collection(base_path, "fs-example", filesystem=fs)
+    partition = collection.create_partition("p0")
+    partition.write_entry("entry-0", {"value": np.array([42], dtype=np.int64)})
+    partition.finish()
+
+    reader = CollectionReader(base_path, "fs-example", filesystem=fs)
+    entries = reader.open_partition("p0").read_entries()
+    assert entries[0]["__entry_key"]["data"] == "entry-0"
+    assert np.array_equal(entries[0]["value"]["data"], np.array([42], dtype=np.int64))

--- a/beacon-binary-format-py/tests/test_reader_roundtrip.py
+++ b/beacon-binary-format-py/tests/test_reader_roundtrip.py
@@ -2,7 +2,7 @@ import numpy as np
 import fsspec
 import pytest
 
-from beacon_bbf import Collection, CollectionReader
+from beacon_binary_format import Collection, CollectionReader
 
 
 def test_roundtrip_readback(tmp_path):

--- a/beacon-binary-format-py/tests/test_reader_roundtrip.py
+++ b/beacon-binary-format-py/tests/test_reader_roundtrip.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+
+from beacon_bbf import Collection, CollectionReader
+
+
+def test_roundtrip_readback(tmp_path):
+    collection = Collection(str(tmp_path), "example")
+    partition = collection.create_partition("p0")
+    partition.write_entry(
+        "entry-0",
+        {
+            "a": np.array([1, 2, 3], dtype=np.int32),
+            "b": (np.array([[1.0, 2.0]], dtype=np.float64), ["y", "x"]),
+        },
+    )
+    partition.finish()
+
+    reader = CollectionReader(str(tmp_path), "example")
+    partition_reader = reader.open_partition("p0")
+    entries = partition_reader.read_entries()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["__entry_key"]["data"] == "entry-0"
+    assert np.array_equal(entry["a"]["data"], np.array([1, 2, 3], dtype=np.int32))
+    assert entry["a"]["dims"] == ["dim0"]
+    assert entry["b"]["dims"] == ["y", "x"]
+    assert np.array_equal(
+        entry["b"]["data"],
+        np.array([[1.0, 2.0]], dtype=np.float64),
+    )

--- a/beacon-binary-format/Cargo.toml
+++ b/beacon-binary-format/Cargo.toml
@@ -9,6 +9,7 @@ arrow-schema = { workspace = true }
 parquet = { workspace = true }
 object_store = { workspace = true }
 tokio = { workspace = true }
+futures = { workspace = true }
 nd-arrow-array = { git = "https://github.com/maris-development/nd-arrow-array.git", branch = "main", version = "1.3.0"}
 
 serde = { workspace = true }

--- a/beacon-binary-format/Cargo.toml
+++ b/beacon-binary-format/Cargo.toml
@@ -13,6 +13,7 @@ futures = { workspace = true }
 nd-arrow-array = { git = "https://github.com/maris-development/nd-arrow-array.git", branch = "main", version = "1.3.0"}
 
 serde = { workspace = true }
+serde_json = { workspace = true }
 indexmap = { workspace = true }
 
 
@@ -22,6 +23,5 @@ tempfile = "3.19.1"
 hmac-sha256 = "1.1.12"
 sha256 = "1.6.0"
 moka = { version = "0.12.10", features = ["future"] }
+flume = { version = "0.11.1", "features" = ["async"] }
 
-[dev-dependencies]
-serde_json = { workspace = true }

--- a/beacon-binary-format/Cargo.toml
+++ b/beacon-binary-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon-binary-format"
-version = "1.5.0"
+version = "3.0.0"
 edition = "2024"
 
 [dependencies]

--- a/beacon-binary-format/Cargo.toml
+++ b/beacon-binary-format/Cargo.toml
@@ -15,8 +15,12 @@ serde = { workspace = true }
 indexmap = { workspace = true }
 
 
+arrow-ipc = { version = "^56.0.0", features = ["zstd"] }
 thiserror = "2.0.12"
 tempfile = "3.19.1"
 hmac-sha256 = "1.1.12"
 sha256 = "1.6.0"
 moka = { version = "0.12.10", features = ["future"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/beacon-binary-format/Cargo.toml
+++ b/beacon-binary-format/Cargo.toml
@@ -26,3 +26,14 @@ sha256 = "1.6.0"
 moka = { version = "0.12.10", features = ["future"] }
 flume = { version = "0.11.1", "features" = ["async"] }
 
+[dev-dependencies]
+criterion = { version = "0.5", features = ["async_tokio"] }
+
+[[bench]]
+name = "io_cache"
+harness = false
+
+[[bench]]
+name = "collection_partition"
+harness = false
+

--- a/beacon-binary-format/Cargo.toml
+++ b/beacon-binary-format/Cargo.toml
@@ -10,6 +10,7 @@ parquet = { workspace = true }
 object_store = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
+bytes ={ workspace = true }
 nd-arrow-array = { git = "https://github.com/maris-development/nd-arrow-array.git", branch = "main", version = "1.3.0"}
 
 serde = { workspace = true }

--- a/beacon-binary-format/Cargo.toml
+++ b/beacon-binary-format/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "beacon-binary-format"
+version = "1.5.0"
+edition = "2024"
+
+[dependencies]
+arrow = { workspace = true }
+arrow-schema = { workspace = true }
+parquet = { workspace = true }
+object_store = { workspace = true }
+tokio = { workspace = true }
+nd-arrow-array = { git = "https://github.com/maris-development/nd-arrow-array.git", branch = "main", version = "1.3.0"}
+
+serde = { workspace = true }
+indexmap = { workspace = true }
+
+
+thiserror = "2.0.12"
+tempfile = "3.19.1"
+hmac-sha256 = "1.1.12"
+sha256 = "1.6.0"
+moka = { version = "0.12.10", features = ["future"] }

--- a/beacon-binary-format/README.md
+++ b/beacon-binary-format/README.md
@@ -1,0 +1,128 @@
+# beacon-binary-format
+
+Rust primitives for writing and reading the Beacon binary format. The crate exposes
+modular building blocks—array partition writers/readers, collection metadata
+orchestration, IO caching, and async scheduling—that higher-level services can compose
+into ingestion or query pipelines.
+
+## Capabilities
+
+- **Array partitions** – Stream `NdArrowArray` batches into compressed Arrow IPC blobs
+  and lazily read them back with pruning index support (`array_partition`).
+- **Collection metadata** – Persist `bbf.json` files that track every collection
+  partition, enforce schema compatibility, and surface partition readers
+  (`collection`, `collection_partition`).
+- **Partition groups** – Aggregate multiple partitions belonging to the same logical
+  array while keeping cumulative statistics and type promotion logic
+  (`array_partition_group`).
+- **IO cache** – Deduplicate expensive Arrow IPC fetches via an async LRU cache
+  (`io_cache`).
+- **Async scheduling** – Bound concurrent entry reads using a cooperative scheduler
+  (`stream`).
+- **Utilities** – Common helpers for Arrow super-type resolution and metadata
+  serialization (`util`).
+
+## Getting Started
+
+Add the crate to your workspace (already part of the monorepo) and enable the
+workspace dependencies declared in `Cargo.toml`. All functionality is available on
+stable Rust.
+
+### Writing an array partition
+
+```rust
+use std::sync::Arc;
+use arrow_schema::{DataType, Field};
+use beacon_binary_format::array_partition::ArrayPartitionWriter;
+use nd_arrow_array::NdArrowArray;
+use object_store::{memory::InMemory, path::Path};
+
+# async fn demo() -> beacon_binary_format::error::BBFResult<()> {
+let store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+let array_path = Path::from("demo/temp");
+let mut writer = ArrayPartitionWriter::new(
+    store.clone(),
+    array_path,
+    "temp".to_string(),
+    8 * 1024 * 1024,
+    Some(DataType::Float64),
+    0,
+)
+.await?;
+
+let temp_field = Field::new("temp", DataType::Float64, true);
+let values = NdArrowArray::from_arrow_array(temp_field.data_type().clone(), vec![1.0, 2.0])?;
+writer.append_array(Some(values)).await?;
+let metadata = writer.finish().await?; // Uploads IPC file + pruning index
+# Ok(())
+# }
+```
+
+### Reading a collection partition
+
+```rust
+use beacon_binary_format::collection_partition::{
+    CollectionPartitionReader, CollectionPartitionReadOptions
+};
+use beacon_binary_format::io_cache::ArrayIoCache;
+use object_store::{memory::InMemory, path::Path};
+
+# async fn read_partition_example(meta: beacon_binary_format::collection_partition::CollectionPartitionMetadata) -> beacon_binary_format::error::BBFResult<()> {
+let store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+let partition_root = Path::from("collections/demo/partition-0");
+let reader = CollectionPartitionReader::new(
+    partition_root,
+    store,
+    meta,
+    ArrayIoCache::new(64 * 1024 * 1024),
+);
+
+let scheduler = reader
+    .read(None, CollectionPartitionReadOptions { max_concurrent_reads: 32 })
+    .await?;
+let mut stream = scheduler.shared_pollable_stream_ref().await;
+while let Some(batch) = stream.next().await {
+    let batch = batch?;
+    // process NdRecordBatch for each logical entry
+}
+# Ok(())
+# }
+```
+
+## Development
+
+- **Tests**: `cargo test -p beacon-binary-format`
+- **Benchmarks**: `cargo bench -p beacon-binary-format collection_partition`
+- **Linting**: The workspace relies on `cargo fmt` / `cargo clippy` run from the repo root.
+
+### Repository layout
+
+```
+beacon-binary-format/
+├── benches/
+│   ├── collection_partition.rs   # Criterion benchmarks for collection IO
+│   └── io_cache.rs               # Cache hit/miss microbenchmarks
+├── src/
+│   ├── array_group.rs            # NdArrowArray ↔ Arrow record batch glue
+│   ├── array_partition*.rs       # Array partition readers/writers/indexes
+│   ├── collection*.rs            # Collection + partition orchestration
+│   ├── io_cache.rs               # Async LRU cache wrapper
+│   ├── stream.rs                 # Async scheduler helper
+│   └── util.rs                   # Arrow utilities
+└── Cargo.toml
+```
+
+## Design Notes
+
+- The crate deliberately stays low-level: it only assumes access to an Arrow-compatible
+  object store and leaves higher-level orchestration (retry, logging, metrics) to
+  integrating services.
+- Metadata files (`bbf.json`, `apg.json`) are JSON for debuggability. Arrow IPC blobs
+  are compressed with ZSTD by default, but writers gracefully fall back to
+  uncompressed IPC when required by the environment.
+- `ArrayIoCache` uses `moka` under the hood; tune cache size and eviction policies at
+  construction time to match workload characteristics.
+
+## License
+
+This crate inherits the workspace license; see the top-level `LICENSE` file.

--- a/beacon-binary-format/benches/collection_partition.rs
+++ b/beacon-binary-format/benches/collection_partition.rs
@@ -1,0 +1,204 @@
+use std::sync::{Arc, OnceLock};
+
+use arrow::array::{ArrayRef, Float64Array, Int32Array};
+use arrow_schema::{DataType, Field, FieldRef};
+use beacon_binary_format::collection::{CollectionReader, CollectionWriter};
+use beacon_binary_format::collection_partition::{
+    CollectionPartitionReadOptions, CollectionPartitionWriter, WriterOptions,
+};
+use beacon_binary_format::io_cache::ArrayIoCache;
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use futures::{StreamExt, stream};
+use nd_arrow_array::NdArrowArray;
+use nd_arrow_array::dimensions::{Dimension, Dimensions};
+use object_store::ObjectStore;
+use object_store::local::LocalFileSystem;
+use object_store::path::Path;
+use tempfile::TempDir;
+use tokio::runtime::Runtime;
+
+const ENTRY_COUNT: usize = 20_000;
+const MAX_GROUP_SIZE: usize = 8 * 1024 * 1024;
+const ENTRY_VALUE_COUNT: usize = 10_000;
+const IO_CACHE_CAPACITY: usize = 32 * 1024 * 1024;
+const READ_CONCURRENCY: usize = 512;
+
+struct CollectionFixture {
+    store: Arc<dyn ObjectStore>,
+    root: Path,
+    temp_dir: TempDir,
+}
+
+fn local_object_store(tag: &str) -> (Arc<dyn ObjectStore>, TempDir) {
+    // mkdir
+    let temp_dir = tempfile::Builder::new()
+        .prefix(&format!("bbf-bench-collection-{tag}-"))
+        .tempdir()
+        .expect("create temp dir");
+    let fs = Arc::new(
+        LocalFileSystem::new_with_prefix(temp_dir.path()).expect("initialize local object store"),
+    );
+    (fs, temp_dir)
+}
+
+fn make_field(name: &str, data_type: DataType) -> FieldRef {
+    Arc::new(Field::new(name, data_type, true))
+}
+
+fn nd_from_array(array: ArrayRef) -> NdArrowArray {
+    let dimension = Dimension {
+        name: "dim0".to_string(),
+        size: array.len(),
+    };
+    NdArrowArray::new(array, Dimensions::MultiDimensional(vec![dimension]))
+        .expect("nd array creation")
+}
+
+fn nd_i32_payload(seed: usize) -> NdArrowArray {
+    let base = seed as i32;
+    let values = (0..ENTRY_VALUE_COUNT)
+        .map(|offset| base + offset as i32)
+        .collect::<Vec<_>>();
+    let array: ArrayRef = Arc::new(Int32Array::from(values));
+    nd_from_array(array)
+}
+
+fn nd_f64_payload(seed: usize) -> NdArrowArray {
+    let base = seed as f64;
+    let values = (0..ENTRY_VALUE_COUNT)
+        .map(|offset| base * 0.1 + offset as f64 * 0.01)
+        .collect::<Vec<_>>();
+    let array: ArrayRef = Arc::new(Float64Array::from(values));
+    nd_from_array(array)
+}
+
+async fn populate_collection(
+    store: Arc<dyn ObjectStore>,
+    collection_root: Path,
+    entry_count: usize,
+) {
+    let temp_field = make_field("temp", DataType::Int32);
+    let sal_field = make_field("salinity", DataType::Int32);
+    let depth_field = make_field("depth", DataType::Float64);
+
+    let mut partition_writer = CollectionPartitionWriter::new(
+        collection_root.clone(),
+        store.clone(),
+        "partition-0".to_string(),
+        WriterOptions {
+            max_group_size: MAX_GROUP_SIZE,
+        },
+    );
+
+    for idx in 0..entry_count {
+        let entry_key = format!("entry-{idx:06}");
+        let entry_stream = stream::iter(vec![
+            (temp_field.clone(), nd_i32_payload(idx)),
+            (sal_field.clone(), nd_i32_payload(idx + 1)),
+            (depth_field.clone(), nd_f64_payload(idx)),
+        ]);
+        partition_writer
+            .write_entry(&entry_key, entry_stream)
+            .await
+            .expect("write entry");
+    }
+
+    let partition_metadata = partition_writer.finish().await.expect("finish partition");
+
+    let mut collection_writer = CollectionWriter::new(store.clone(), collection_root.clone())
+        .await
+        .expect("collection writer init");
+
+    collection_writer
+        .append_partition(partition_metadata)
+        .expect("append partition");
+    collection_writer.persist().await.expect("persist metadata");
+
+    black_box(collection_writer.metadata().collection_num_elements);
+}
+
+async fn build_collection_fixture(entry_count: usize) -> CollectionFixture {
+    let (store, temp_dir) = local_object_store("collection");
+    let collection_root = Path::from("collection");
+    populate_collection(store.clone(), collection_root.clone(), entry_count).await;
+    CollectionFixture {
+        store,
+        root: collection_root,
+        temp_dir,
+    }
+}
+
+fn cached_collection_fixture(runtime: &Runtime, entry_count: usize) -> Arc<CollectionFixture> {
+    Arc::new(runtime.block_on(build_collection_fixture(entry_count)))
+}
+
+async fn read_partition(fixture: Arc<CollectionFixture>) {
+    let reader = CollectionReader::new(
+        fixture.store.clone(),
+        fixture.root.clone(),
+        ArrayIoCache::new(IO_CACHE_CAPACITY),
+    )
+    .await
+    .expect("collection reader init");
+
+    let partition_reader = reader
+        .partition_reader("partition-0")
+        .expect("partition metadata exists");
+
+    let scheduler = partition_reader
+        .read(
+            None,
+            CollectionPartitionReadOptions {
+                max_concurrent_reads: READ_CONCURRENCY,
+            },
+        )
+        .await
+        .expect("schedule partition read");
+
+    let mut stream = scheduler.shared_pollable_stream_ref().await;
+    while let Some(batch_result) = stream.next().await {
+        let batch = batch_result.expect("batch read");
+        black_box(batch);
+    }
+}
+
+fn bench_collection_partition_write(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("collection_partition_write");
+    group.sample_size(10);
+    group.bench_function("write_100k_entries", |b| {
+        b.to_async(&runtime).iter(|| async {
+            let _fixture = build_collection_fixture(ENTRY_COUNT).await;
+        });
+    });
+    group.finish();
+}
+
+fn bench_collection_partition_read(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("tokio runtime");
+    let fixture = cached_collection_fixture(&runtime, ENTRY_COUNT);
+
+    let mut group = c.benchmark_group("collection_partition_read");
+    group.sample_size(20);
+    group.bench_function("read_100k_entries", |b| {
+        let fixture = fixture.clone();
+        b.to_async(&runtime).iter(|| {
+            let fixture = fixture.clone();
+            async move {
+                read_partition(fixture).await;
+            }
+        });
+    });
+    println!(
+        "Finished reading benchmark with fixture at {:?}",
+        fixture.root
+    );
+    group.finish();
+}
+
+criterion_group!(
+    collection_partition_benches,
+    // bench_collection_partition_write,
+    bench_collection_partition_read
+);
+criterion_main!(collection_partition_benches);

--- a/beacon-binary-format/benches/io_cache.rs
+++ b/beacon-binary-format/benches/io_cache.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use arrow::array::Int32Array;
+use arrow::record_batch::RecordBatch;
+use arrow_schema::{DataType, Field, Schema};
+use beacon_binary_format::io_cache::{ArrayIoCache, CacheKey};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use object_store::path::Path;
+
+fn build_batch() -> RecordBatch {
+    let field = Field::new("values", DataType::Int32, false);
+    let schema = Arc::new(Schema::new(vec![field]));
+    let values = Arc::new(Int32Array::from_iter(0..1024));
+    RecordBatch::try_new(schema, vec![values]).expect("record batch creation")
+}
+
+fn bench_cache_hits(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("runtime");
+    let cache = Arc::new(ArrayIoCache::new(10 * 1024 * 1024));
+    let key = CacheKey {
+        array_partition_path: Path::from("bench/partition.arrow"),
+        group_index: 0,
+    };
+    let batch = Arc::new(build_batch());
+    let warm_batch = batch.clone();
+
+    // Warm the cache so subsequent iterations hit the stored batch.
+    runtime
+        .block_on(cache.try_get_or_insert_with(key.clone(), move |_key| {
+            let batch = warm_batch.clone();
+            async move { Ok(Some(batch.as_ref().clone())) }
+        }))
+        .expect("warm cache");
+
+    c.bench_function("io_cache_hit", |b| {
+        let cache = cache.clone();
+        let key = key.clone();
+        b.to_async(&runtime).iter(move || {
+            let cache = cache.clone();
+            let key = key.clone();
+            async move {
+                let result = cache
+                    .try_get_or_insert_with(key.clone(), |_key| async move {
+                        unreachable!("loader should not run on hits")
+                    })
+                    .await
+                    .expect("cache lookup");
+                black_box(result);
+            }
+        });
+    });
+}
+
+fn bench_cache_misses(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("runtime");
+    let cache = Arc::new(ArrayIoCache::new(10 * 1024 * 1024));
+    let counter = Arc::new(AtomicUsize::new(0));
+    let batch = Arc::new(build_batch());
+
+    c.bench_function("io_cache_miss", |b| {
+        let batch = batch.clone();
+        let cache = cache.clone();
+        let counter = counter.clone();
+        b.to_async(&runtime).iter(move || {
+            let batch = batch.clone();
+            let cache = cache.clone();
+            let counter = counter.clone();
+            let idx = counter.fetch_add(1, Ordering::Relaxed);
+            let key = CacheKey {
+                array_partition_path: Path::from(format!("bench/partition_{idx}.arrow")),
+                group_index: 0,
+            };
+            async move {
+                let loader_batch = batch.clone();
+                let result = cache
+                    .try_get_or_insert_with(key, move |_key| {
+                        let batch = loader_batch.clone();
+                        async move { Ok(Some(batch.as_ref().clone())) }
+                    })
+                    .await
+                    .expect("cache insert");
+                black_box(result);
+            }
+        });
+    });
+}
+
+criterion_group!(io_cache_benches, bench_cache_hits, bench_cache_misses);
+criterion_main!(io_cache_benches);

--- a/beacon-binary-format/src/array_group.rs
+++ b/beacon-binary-format/src/array_group.rs
@@ -1,0 +1,327 @@
+use std::sync::Arc;
+
+use arrow::{
+    array::{
+        Array, ArrayRef, AsArray, ListArray, ListBuilder, NullBufferBuilder, RecordBatch,
+        StringBuilder, UInt32Builder,
+    },
+    buffer::OffsetBuffer,
+    datatypes::UInt32Type,
+};
+use arrow_schema::DataType;
+use nd_arrow_array::{NdArrowArray, dimensions::Dimensions};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::{BBFReadingError, BBFResult, BBFWritingError},
+    util::super_type_arrow,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArrayGroupMetadata {
+    pub uncompressed_array_byte_size: usize,
+    pub num_chunks: usize,
+    pub num_elements: usize,
+}
+
+#[derive(Debug)]
+/// A built array group containing a `RecordBatch` and computed metadata.
+///
+/// The `RecordBatch` contains three columns: `values` (a list array of
+/// concatenated element arrays), `dimension_names` and `dimension_sizes`.
+pub struct ArrayGroup {
+    /// Summary metadata about the group (sizes, number of chunks, elements).
+    pub metadata: ArrayGroupMetadata,
+    /// The Arrow `RecordBatch` representing the group contents.
+    pub batch: RecordBatch,
+}
+
+/// Builder for creating an `ArrayGroup`.
+///
+/// The builder accepts `NdArrowArray` values and null entries. It will
+/// maintain a `data_type` that represents the common super-type of all
+/// appended arrays and will cast existing arrays when a new, larger
+/// super-type is required.
+pub struct ArrayGroupBuilder {
+    array_name: String,
+    data_type: DataType,
+    arrays: Vec<Option<NdArrowArray>>,
+}
+
+impl ArrayGroupBuilder {
+    pub fn new(array_name: String, data_type: Option<DataType>) -> Self {
+        let data_type = data_type.unwrap_or(DataType::Null);
+        Self {
+            array_name,
+            data_type,
+            arrays: Vec::new(),
+        }
+    }
+
+    pub fn array_data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    /// Return the total buffer memory size (in bytes) of arrays in the
+    /// current group (ignores null entries).
+    pub fn group_size(&self) -> usize {
+        self.arrays
+            .iter()
+            .filter_map(|arr| {
+                arr.as_ref()
+                    .map(|a| a.as_arrow_array().get_buffer_memory_size())
+            })
+            .sum()
+    }
+
+    pub fn build(self) -> BBFResult<ArrayGroup> {
+        let values_array = self.build_values_array();
+        let dimension_names_array = self.build_dimension_names_array();
+        let dimension_sizes_array = self.build_dimension_sizes_array();
+
+        // Build RecordBatch
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("values", values_array.data_type().clone(), true),
+            arrow::datatypes::Field::new(
+                "dimension_names",
+                dimension_names_array.data_type().clone(),
+                true,
+            ),
+            arrow::datatypes::Field::new(
+                "dimension_sizes",
+                dimension_sizes_array.data_type().clone(),
+                true,
+            ),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![values_array, dimension_names_array, dimension_sizes_array],
+        )
+        .map_err(|e| BBFWritingError::ArrayGroupBuildFailure(Box::new(e)))?;
+
+        let uncompressed_array_byte_size = batch
+            .columns()
+            .iter()
+            .map(|col| col.get_buffer_memory_size())
+            .sum();
+        let num_chunks = self.arrays.len();
+        let num_elements = self
+            .arrays
+            .iter()
+            .filter_map(|arr| arr.as_ref().map(|a| a.as_arrow_array().len()))
+            .sum();
+
+        Ok(ArrayGroup {
+            metadata: ArrayGroupMetadata {
+                uncompressed_array_byte_size,
+                num_chunks,
+                num_elements,
+            },
+            batch,
+        })
+    }
+
+    /// Build the flattened `ListArray` of values for this group.
+    ///
+    /// This concatenates all non-null underlying arrays into a single
+    /// values array and creates a list offsets buffer describing where each
+    /// entry starts and ends. Null entries are represented with a null
+    /// bitmap.
+    fn build_values_array(&self) -> ArrayRef {
+        let all_arrays = self
+            .arrays
+            .iter()
+            .filter_map(|a| a.as_ref().map(|a| a.as_arrow_array().as_ref()))
+            .collect::<Vec<_>>();
+
+        let arrow_array_flat = arrow::compute::concat(all_arrays.as_slice()).unwrap();
+        // Build a vector of lengths (one length per entry). `from_lengths` expects
+        // per-list lengths (not cumulative offsets), and produces an offsets buffer.
+        let mut lengths = vec![];
+        let mut nulls_builder = NullBufferBuilder::new(self.arrays.len());
+        for arr in self.arrays.iter() {
+            if let Some(a) = arr {
+                lengths.push(a.as_arrow_array().len());
+                nulls_builder.append_non_null();
+            } else {
+                lengths.push(0usize);
+                nulls_builder.append_null();
+            }
+        }
+
+        let offsets = OffsetBuffer::from_lengths(lengths);
+
+        let list_field = Arc::new(arrow::datatypes::Field::new(
+            "array",
+            self.data_type.clone(),
+            true,
+        ));
+
+        Arc::new(ListArray::new(
+            list_field,
+            offsets,
+            arrow_array_flat,
+            nulls_builder.finish(),
+        ))
+    }
+
+    /// Build a list-of-string array with dimension names for each entry.
+    fn build_dimension_names_array(&self) -> ArrayRef {
+        let mut builder = ListBuilder::new(StringBuilder::new());
+        for arr in self.arrays.iter() {
+            if let Some(a) = arr {
+                match a.dimensions() {
+                    Dimensions::MultiDimensional(dims) => {
+                        for dim in dims.iter() {
+                            builder.values().append_value(&dim.name);
+                        }
+                    }
+                    Dimensions::Scalar => {}
+                }
+                builder.append(true);
+            } else {
+                builder.append(false);
+            }
+        }
+        Arc::new(builder.finish())
+    }
+
+    /// Build a list-of-uint32 array with dimension sizes for each entry.
+    fn build_dimension_sizes_array(&self) -> ArrayRef {
+        let mut builder = ListBuilder::new(UInt32Builder::new());
+        for arr in self.arrays.iter() {
+            if let Some(a) = arr {
+                match a.dimensions() {
+                    Dimensions::MultiDimensional(dims) => {
+                        for dim in dims.iter() {
+                            builder.values().append_value(dim.size as u32);
+                        }
+                    }
+                    Dimensions::Scalar => {}
+                }
+                builder.append(true);
+            } else {
+                builder.append(false);
+            }
+        }
+        Arc::new(builder.finish())
+    }
+
+    /// Append an explicit null entry to the group.
+    pub fn append_null_array(&mut self) {
+        self.arrays.push(None);
+    }
+
+    pub fn append_array(&mut self, mut array: NdArrowArray) -> BBFResult<()> {
+        let array_data_type = array.as_arrow_array().data_type();
+        if self.data_type != *array_data_type {
+            // Super cast to the super type of both
+            let super_type = super_type_arrow(&self.data_type, array_data_type).ok_or(
+                BBFWritingError::SuperTypeNotFound(
+                    crate::util::SuperTypeError::NoCommonSuperType {
+                        left: self.data_type.clone(),
+                        right: array_data_type.clone(),
+                        column_name: self.array_name.clone(),
+                    },
+                ),
+            )?;
+
+            // Cast existing arrays
+            if self.data_type != super_type {
+                for arr in self.arrays.iter_mut().flatten() {
+                    *arr = Self::cast_nd_array(arr, &super_type)?;
+                }
+            }
+
+            self.data_type = super_type.clone();
+
+            // Cast new array
+            if *array_data_type != super_type {
+                array = Self::cast_nd_array(&array, &super_type)?;
+            }
+        }
+
+        self.arrays.push(Some(array));
+
+        Ok(())
+    }
+
+    fn cast_nd_array(array: &NdArrowArray, data_type: &DataType) -> BBFResult<NdArrowArray> {
+        let arrow_array = array.as_arrow_array();
+        let casted_array = arrow::compute::cast(&arrow_array, data_type).map_err(|e| {
+            BBFWritingError::ArrowCastFailure(arrow_array.data_type().clone(), data_type.clone(), e)
+        })?;
+        Ok(
+            NdArrowArray::new(casted_array, array.dimensions().clone()).map_err(|e| {
+                BBFWritingError::NdArrowArrayCreationFailure(
+                    e,
+                    format!("Failed to create NdArrowArray after casting to {data_type}"),
+                )
+            })?,
+        )
+    }
+}
+
+pub struct ArrayGroupReader {
+    array_name: String,
+    batch: RecordBatch,
+}
+
+impl ArrayGroupReader {
+    pub fn new(array_name: String, batch: RecordBatch) -> Self {
+        Self { array_name, batch }
+    }
+
+    pub fn try_get_array(&self, array_index: usize) -> BBFResult<Option<NdArrowArray>> {
+        let batch_values_array = self.batch.column(0).as_list::<i32>();
+
+        if batch_values_array.is_null(array_index) {
+            return Ok(None);
+        }
+
+        let inner_values_array = batch_values_array.value(array_index);
+        let dimension_names = self.batch.column(1).as_list::<i32>().value(array_index);
+        let dimension_length = self.batch.column(2).as_list::<i32>().value(array_index);
+
+        if dimension_names.len() != dimension_length.len() {
+            return Err(BBFReadingError::ArrayGroupReadFailure(
+                self.array_name.clone(),
+                format!(
+                    "Mismatched dimension names and sizes lengths for array at index {array_index}"
+                )
+                .into(),
+            )
+            .into());
+        }
+
+        let dimensions = if dimension_names.is_empty() {
+            Dimensions::MultiDimensional(
+                dimension_names
+                    .as_string::<i32>()
+                    .iter()
+                    .zip(dimension_length.as_primitive::<UInt32Type>().iter())
+                    .filter_map(|(name, length)| match (name, length) {
+                        (Some(n), Some(l)) => Some(nd_arrow_array::dimensions::Dimension {
+                            name: n.to_string(),
+                            size: l as usize,
+                        }),
+                        _ => None,
+                    })
+                    .collect(),
+            )
+        } else {
+            Dimensions::Scalar
+        };
+
+        let nd_array = NdArrowArray::new(inner_values_array.clone(), dimensions).map_err(|e| {
+            BBFReadingError::ArrayGroupReadFailure(
+                self.array_name.clone(),
+                format!("Failed to create NdArrowArray for array at index {array_index}: {e}")
+                    .into(),
+            )
+        })?;
+
+        Ok(Some(nd_array))
+    }
+}

--- a/beacon-binary-format/src/array_group.rs
+++ b/beacon-binary-format/src/array_group.rs
@@ -296,6 +296,8 @@ impl ArrayGroupReader {
         }
 
         let dimensions = if dimension_names.is_empty() {
+            Dimensions::Scalar
+        } else {
             Dimensions::MultiDimensional(
                 dimension_names
                     .as_string::<i32>()
@@ -310,8 +312,6 @@ impl ArrayGroupReader {
                     })
                     .collect(),
             )
-        } else {
-            Dimensions::Scalar
         };
 
         let nd_array = NdArrowArray::new(inner_values_array.clone(), dimensions).map_err(|e| {

--- a/beacon-binary-format/src/array_group.rs
+++ b/beacon-binary-format/src/array_group.rs
@@ -1,3 +1,10 @@
+//! Arrow record batch builders for grouped Nd arrays.
+//!
+//! An `ArrayGroup` represents a bundle of logically-related `NdArrowArray`
+//! entries.  Writers rely on this module to flatten multidimensional tensors
+//! into Arrow-friendly batches while preserving dimension metadata.  The
+//! accompanying `ArrayGroupReader` reverses the process.
+
 use std::sync::Arc;
 
 use arrow::{

--- a/beacon-binary-format/src/array_partition.rs
+++ b/beacon-binary-format/src/array_partition.rs
@@ -288,7 +288,8 @@ impl ArrayPartitionWriter {
                     self.hasher.update(&buffer[..bytes_read]);
                 }
                 let hash_result = self.hasher.finalize();
-                let hash_string = String::from_utf8_lossy(&hash_result).to_string();
+                let hash_string: String =
+                    hash_result.iter().map(|b| format!("{:02x}", b)).collect();
                 // Set the hash of the partition in the metadata
                 self.partition_metadata.hash = hash_string.clone();
                 self.partition_metadata.data_type = self.partition_data_type.clone();

--- a/beacon-binary-format/src/array_partition.rs
+++ b/beacon-binary-format/src/array_partition.rs
@@ -1,0 +1,367 @@
+use std::{fs::File, sync::Arc};
+
+use arrow::{
+    array::RecordBatch,
+    ipc::{
+        Block, CompressionType,
+        reader::FileDecoder,
+        writer::{FileWriter, IpcWriteOptions},
+    },
+};
+use arrow_schema::DataType;
+use hmac_sha256::Hash;
+use indexmap::IndexMap;
+use nd_arrow_array::NdArrowArray;
+use object_store::ObjectStore;
+use serde::{Deserialize, Serialize};
+use tempfile::tempfile;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+
+use crate::{
+    array_group::{ArrayGroup, ArrayGroupBuilder, ArrayGroupMetadata},
+    error::{BBFError, BBFResult, BBFWritingError},
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArrayPartitionMetadata {
+    pub num_elements: usize,
+    pub hash: String,
+    pub data_type: arrow::datatypes::DataType,
+    #[serde(with = "range_index_map")]
+    pub groups: IndexMap<std::ops::Range<usize>, ArrayGroupMetadata>,
+}
+
+/// Writer that groups arrays into Arrow IPC batches and uploads them to an
+/// object store.
+///
+/// `ArrayPartitionWriter` maintains a temporary IPC file; groups appended
+/// arrays into `ArrayGroup`s and writes them as record batches. On `finish()`
+/// the temporary file is hashed and uploaded to the configured `ObjectStore`.
+pub struct ArrayPartitionWriter {
+    /// Hasher used to compute the hash of the final IPC file.
+    pub hasher: Hash,
+    /// Optional temp file writer used while building the IPC file.
+    pub temp_file: Option<arrow::ipc::writer::FileWriter<std::fs::File>>,
+    /// The object store to which the completed partition will be uploaded.
+    /// Object store used to upload finalized partition files.
+    pub store: Arc<dyn ObjectStore>,
+    /// Directory path in the object store where files are written.
+    pub dir: object_store::path::Path,
+    /// Name of the array being written.
+    pub array_name: String,
+    /// Maximum byte size for a group before it is flushed.
+    pub max_group_size: usize,
+    /// Partition-wide super type for arrays (if known).
+    pub partition_data_type: arrow::datatypes::DataType,
+    /// Offset of the first chunk in this partition.
+    pub array_chunk_offset: usize,
+    /// Total number of chunks written to the partition.
+    pub total_chunks: usize,
+    /// Currently accumulating group builder (flushed when large enough).
+    pub current_group_writer: ArrayGroupBuilder,
+    /// Metadata collected for the partition as arrays/groups are flushed.
+    pub partition_metadata: ArrayPartitionMetadata,
+}
+
+impl ArrayPartitionWriter {
+    /// Return IPC writer options used when creating temporary Arrow writers.
+    ///
+    /// Currently uses Arrow's default IPC options (no compression requested)
+    /// to remain compatible with environments where optional compression
+    /// features may not be available.
+    pub fn ipc_opts() -> IpcWriteOptions {
+        IpcWriteOptions::default()
+            .try_with_compression(Some(CompressionType::ZSTD))
+            .unwrap_or_default()
+    }
+
+    /// Create a new `ArrayPartitionWriter`.
+    ///
+    /// `store` is the object store to which finalized partition files will be
+    /// uploaded. `array_blob_dir` is the destination path inside the store.
+    pub async fn new(
+        store: Arc<dyn ObjectStore>,
+        array_blob_dir: object_store::path::Path,
+        array_name: String,
+        max_group_size: usize,
+        partition_data_type: Option<DataType>,
+        array_chunk_offset: usize,
+    ) -> BBFResult<Self> {
+        let partition_data_type = partition_data_type.unwrap_or(DataType::Null);
+        Ok(Self {
+            hasher: Hash::new(),
+            temp_file: None,
+            store,
+            dir: array_blob_dir,
+            max_group_size,
+            partition_metadata: ArrayPartitionMetadata {
+                num_elements: 0,
+                hash: String::new(),
+                data_type: partition_data_type.clone(),
+                groups: IndexMap::new(),
+            },
+            array_name: array_name.clone(),
+            partition_data_type: partition_data_type.clone(),
+            current_group_writer: ArrayGroupBuilder::new(
+                array_name.clone(),
+                Some(partition_data_type.clone()),
+            ),
+            array_chunk_offset,
+            total_chunks: 0,
+        })
+    }
+
+    /// Append an `Option<NdArrowArray>` to the current partition.
+    ///
+    /// Arrays are accumulated in an internal `ArrayGroupBuilder`. When the
+    /// current group's byte size exceeds `max_group_size` the group is
+    /// flushed and written to the temporary IPC file.
+    pub async fn append_array(&mut self, array: Option<NdArrowArray>) -> BBFResult<()> {
+        match array {
+            Some(arr) => self.current_group_writer.append_array(arr)?,
+            None => self.current_group_writer.append_null_array(),
+        };
+
+        if self.current_group_writer.group_size() >= self.max_group_size {
+            // Flush the current group
+            self.flush_current_group()?;
+        }
+
+        Ok(())
+    }
+
+    /// Flush the current group builder (if any), write its IPC batch and
+    /// update partition metadata.
+    fn flush_current_group(&mut self) -> BBFResult<()> {
+        // Set the partition data type based on the current group writer
+        self.partition_data_type = self.current_group_writer.array_data_type().clone();
+
+        let new_group_writer = ArrayGroupBuilder::new(
+            self.array_name.clone(),
+            self.partition_data_type.clone().into(),
+        );
+
+        // Swap out the current group writer to take ownership.
+        let old_group_writer = std::mem::replace(&mut self.current_group_writer, new_group_writer);
+
+        // Flush the old group writer
+        let group = old_group_writer.build()?;
+
+        // Flush the group to the temp file
+        Self::write_array_group(&mut self.temp_file, &self.array_name, &group)?;
+
+        let group_metadata = group.metadata;
+        self.partition_metadata.num_elements += group_metadata.num_elements;
+        let chunk_range = self.total_chunks..self.total_chunks + group_metadata.num_chunks;
+        self.total_chunks += group_metadata.num_chunks;
+        self.partition_metadata
+            .groups
+            .insert(chunk_range, group_metadata);
+
+        Ok(())
+    }
+
+    /// Write a single `ArrayGroup` as a record batch into the provided
+    /// temporary `FileWriter`. Initializes the writer if it doesn't exist
+    /// yet.
+    fn write_array_group(
+        current_temp_file: &mut Option<FileWriter<File>>,
+        array_name: &str,
+        array_group: &ArrayGroup,
+    ) -> BBFResult<()> {
+        // Check if temp_file is initialized
+        let file_writer = match current_temp_file.as_mut() {
+            Some(fw) => fw,
+            None => {
+                let temp_file = tempfile().map_err(|e| {
+                    BBFWritingError::TempFileCreationFailure(e, array_name.to_string())
+                })?;
+                let schema = array_group.batch.schema();
+                let file_writer = arrow::ipc::writer::FileWriter::try_new_with_options(
+                    temp_file,
+                    &schema,
+                    Self::ipc_opts(),
+                )
+                .map_err(BBFWritingError::ArrayGroupWriteFailure)?;
+                *current_temp_file = Some(file_writer);
+                current_temp_file.as_mut().unwrap()
+            }
+        };
+
+        // Compare schema's. If different, then map the type for the values list array column to the current array group as that always contains the super type of the two.
+        if *file_writer.schema() != array_group.batch.schema() {
+            // Iterate through the batches and update the values list array column to the partition type.
+            file_writer.finish().unwrap();
+            let new_temp_file = tempfile()
+                .map_err(|e| BBFWritingError::TempFileCreationFailure(e, array_name.to_string()))?;
+            let new_writer = arrow::ipc::writer::FileWriter::try_new_with_options(
+                new_temp_file,
+                &array_group.batch.schema(),
+                Self::ipc_opts(),
+            )
+            .map_err(BBFWritingError::ArrayGroupWriteFailure)?;
+            let input_file = std::mem::replace(file_writer, new_writer)
+                .into_inner()
+                .map_err(BBFWritingError::ArrayGroupWriteFailure)?;
+
+            let reader = arrow::ipc::reader::FileReader::try_new(input_file, None).unwrap();
+
+            for maybe_batch in reader {
+                let batch = maybe_batch.map_err(BBFWritingError::ArrayGroupWriteFailure)?;
+                let updated_batch = batch
+                    .columns()
+                    .iter()
+                    .zip(array_group.batch.columns().iter())
+                    .map(|(old_col, new_col)| {
+                        if old_col.data_type() != new_col.data_type() {
+                            // Cast old_col to new_col's data type
+
+                            arrow::compute::cast(old_col, new_col.data_type()).unwrap()
+                        } else {
+                            old_col.clone()
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                let updated_record_batch =
+                    RecordBatch::try_new(array_group.batch.schema(), updated_batch)
+                        .map_err(BBFWritingError::ArrayGroupWriteFailure)?;
+
+                file_writer
+                    .write(&updated_record_batch)
+                    .map_err(BBFWritingError::ArrayGroupWriteFailure)?;
+            }
+        }
+
+        // Write the new batch
+        file_writer
+            .write(&array_group.batch)
+            .map_err(BBFWritingError::ArrayGroupWriteFailure)?;
+
+        Ok(())
+    }
+
+    /// Finalize the partition: flush remaining groups, finish the temp
+    /// IPC file, compute its hash and upload it to the object store. Returns
+    /// the finalized `ArrayPartitionMetadata`.
+    pub async fn finish(mut self) -> Result<ArrayPartitionMetadata, BBFError> {
+        self.flush_current_group()?;
+        // Finalize the temp file (if any)
+        match self.temp_file {
+            Some(mut fw) => {
+                fw.finish().unwrap();
+                let file = fw.into_inner().unwrap();
+                let tokio_f = tokio::fs::File::from_std(file);
+
+                // Create a hash of the temp file, read the file in chunks of 1MB
+                let chunk_size = 1024 * 1024;
+                let mut reader = tokio::io::BufReader::with_capacity(1024 * 1024, tokio_f);
+                let mut buffer = vec![0; chunk_size];
+                loop {
+                    let bytes_read = reader.read(&mut buffer).await.unwrap();
+                    if bytes_read == 0 {
+                        break;
+                    }
+                    self.hasher.update(&buffer[..bytes_read]);
+                }
+                let hash_result = self.hasher.finalize();
+                let hash_string = String::from_utf8_lossy(&hash_result).to_string();
+                // Set the hash of the partition in the metadata
+                self.partition_metadata.hash = hash_string.clone();
+
+                // Upload the temp file to object store
+                let object_path = self.dir.child(format!("{}.arrow", hash_string));
+
+                // Rewind the reader
+                reader
+                    .rewind()
+                    .await
+                    .map_err(|e| BBFWritingError::ArrayPartitionFinalizeFailure(Box::new(e)))?;
+
+                // Create put upload stream
+                let mut obj_writer =
+                    object_store::buffered::BufWriter::new(self.store, object_path);
+
+                tokio::io::copy_buf(&mut reader, &mut obj_writer)
+                    .await
+                    .map_err(|e| BBFWritingError::ArrayPartitionFinalizeFailure(Box::new(e)))?;
+
+                obj_writer
+                    .flush()
+                    .await
+                    .map_err(|e| BBFWritingError::ArrayPartitionFinalizeFailure(Box::new(e)))?;
+
+                Ok(self.partition_metadata)
+            }
+            None => {
+                // No data was written
+                Err(BBFError::Writing(
+                    BBFWritingError::ArrayPartitionFinalizeFailure(Box::new(
+                        std::io::Error::other("No data written to partition"),
+                    )),
+                ))
+            }
+        }
+    }
+}
+
+mod range_index_map {
+    use super::*;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Serialize, Deserialize)]
+    struct RangeSerde {
+        start: usize,
+        end: usize,
+    }
+
+    impl From<&std::ops::Range<usize>> for RangeSerde {
+        fn from(range: &std::ops::Range<usize>) -> Self {
+            Self {
+                start: range.start,
+                end: range.end,
+            }
+        }
+    }
+
+    impl From<RangeSerde> for std::ops::Range<usize> {
+        fn from(range: RangeSerde) -> Self {
+            range.start..range.end
+        }
+    }
+
+    pub fn serialize<S, V>(
+        map: &IndexMap<std::ops::Range<usize>, V>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        V: Serialize,
+    {
+        let items: Vec<(RangeSerde, &V)> = map
+            .iter()
+            .map(|(range, value)| (RangeSerde::from(range), value))
+            .collect();
+        items.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D, V>(
+        deserializer: D,
+    ) -> Result<IndexMap<std::ops::Range<usize>, V>, D::Error>
+    where
+        D: Deserializer<'de>,
+        V: Deserialize<'de>,
+    {
+        let items: Vec<(RangeSerde, V)> = Vec::deserialize(deserializer)?;
+        let mut map = IndexMap::with_capacity(items.len());
+        for (range, value) in items {
+            map.insert(range.into(), value);
+        }
+        Ok(map)
+    }
+}
+
+struct IPCDecoder {
+    file_decoder: FileDecoder,
+    blocks: Vec<Block>,
+}

--- a/beacon-binary-format/src/array_partition.rs
+++ b/beacon-binary-format/src/array_partition.rs
@@ -1,3 +1,9 @@
+//! Array partition readers and writers built on Arrow IPC.
+//!
+//! This module defines the primitives responsible for flushing streamed
+//! `NdArrowArray`s into compressed Arrow IPC files as well as the matching
+//! readers that recover `RecordBatch` data out of object storage.
+
 use std::{convert::TryFrom, fs::File, io::Cursor, sync::Arc};
 
 use arrow::{
@@ -30,6 +36,7 @@ use crate::{
     io_cache::{ArrayIoCache, CacheKey},
 };
 
+/// Summary describing one Arrow IPC partition stored in object storage.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArrayPartitionMetadata {
     pub num_elements: usize,
@@ -400,6 +407,7 @@ struct IPCDecoder {
     blocks: Vec<Block>,
 }
 
+/// Lazily reads batches out of an Arrow IPC partition.
 pub struct ArrayPartitionReader {
     store: Arc<dyn ObjectStore>,
     decoder: Arc<IPCDecoder>,
@@ -945,7 +953,7 @@ mod tests {
     async fn fetch_partition_group_errors_when_index_is_out_of_bounds() {
         let store: StdArc<dyn ObjectStore> = StdArc::new(InMemory::new());
         let dir = Path::from("tests/fetch_oob");
-        let (metadata, partition_path, decoder) =
+        let (_metadata, partition_path, decoder) =
             build_partition_for_reader(store.clone(), dir).await;
         let missing_index = decoder.blocks.len();
 

--- a/beacon-binary-format/src/array_partition_group.rs
+++ b/beacon-binary-format/src/array_partition_group.rs
@@ -1,3 +1,10 @@
+//! Metadata helpers for collections of array partitions.
+//!
+//! Array partition groups track every Arrow partition produced for a single
+//! logical array.  The reader and writer surfaces defined here own the JSON
+//! descriptor, enforce schema compatibility, and expose ergonomic helpers for
+//! fetching concrete `ArrayPartitionReader`s.
+
 use std::sync::Arc;
 
 use arrow_schema::DataType;
@@ -38,6 +45,7 @@ impl ArrayPartitionGroup {
     }
 }
 
+/// Provides lazy access to individual partitions referenced by a group.
 pub struct ArrayPartitionGroupReader {
     metadata: ArrayPartitionGroupMetadata,
     object_store: Arc<dyn ObjectStore>,

--- a/beacon-binary-format/src/array_partition_group.rs
+++ b/beacon-binary-format/src/array_partition_group.rs
@@ -1,0 +1,169 @@
+use std::sync::Arc;
+
+use arrow_schema::DataType;
+use indexmap::IndexMap;
+use object_store::ObjectStore;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    array_partition::{ArrayPartitionMetadata, ArrayPartitionReader},
+    error::{BBFReadingError, BBFResult},
+    io_cache::ArrayIoCache,
+    util::super_type_arrow,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArrayPartitionGroupMetadata {
+    pub array_name: String,
+    pub total_bytes_size: usize,
+    pub combined_num_elements: usize,
+    pub data_type: arrow::datatypes::DataType,
+    pub partitions: IndexMap<usize, ArrayPartitionMetadata>,
+}
+
+pub struct ArrayPartitionGroup {
+    metadata: ArrayPartitionGroupMetadata,
+}
+
+impl ArrayPartitionGroup {
+    const META_PATH: &str = "apg.json";
+
+    pub fn metadata(&self) -> &ArrayPartitionGroupMetadata {
+        &self.metadata
+    }
+}
+
+pub struct ArrayPartitionGroupReader {
+    metadata: ArrayPartitionGroupMetadata,
+    object_store: Arc<dyn ObjectStore>,
+    path: object_store::path::Path,
+    io_cache: ArrayIoCache,
+}
+
+impl ArrayPartitionGroupReader {
+    pub async fn new(
+        object_store: Arc<dyn ObjectStore>,
+        path: object_store::path::Path,
+        array_io_cache: ArrayIoCache,
+    ) -> BBFResult<Self> {
+        // Read metadata
+        let meta_path = path.child(ArrayPartitionGroup::META_PATH);
+        let meta_display = meta_path.to_string();
+        let metadata_bytes = object_store
+            .get(&meta_path)
+            .await
+            .map_err(|source| BBFReadingError::PartitionGroupMetadataFetch {
+                meta_path: meta_display.clone(),
+                source,
+            })?
+            .bytes()
+            .await
+            .map_err(|source| BBFReadingError::PartitionGroupMetadataFetch {
+                meta_path: meta_display.clone(),
+                source,
+            })?;
+        let metadata: ArrayPartitionGroupMetadata = serde_json::from_slice(&metadata_bytes)
+            .map_err(|err| BBFReadingError::PartitionGroupMetadataDecode {
+                meta_path: meta_display,
+                reason: err.to_string(),
+            })?;
+
+        Ok(Self {
+            metadata,
+            object_store,
+            path,
+            io_cache: array_io_cache,
+        })
+    }
+
+    pub fn metadata(&self) -> &ArrayPartitionGroupMetadata {
+        &self.metadata
+    }
+
+    pub async fn get_partition_reader(
+        &self,
+        partition: usize,
+    ) -> BBFResult<Option<ArrayPartitionReader>> {
+        if let Some(partition_metadata) = self.metadata.partitions.get(&partition) {
+            let partition_path = self.path.child(partition_metadata.hash.clone());
+            let partition_reader = ArrayPartitionReader::new(
+                self.object_store.clone(),
+                self.metadata.array_name.clone(),
+                partition_path,
+                partition_metadata.clone(),
+                self.io_cache.clone(),
+            )
+            .await?;
+            Ok(Some(partition_reader))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+pub struct ArrayPartitionGroupWriter {
+    metadata: ArrayPartitionGroupMetadata,
+}
+
+impl ArrayPartitionGroupWriter {
+    pub async fn new(
+        array_blob_dir: object_store::path::Path,
+        object_store: Arc<dyn ObjectStore>,
+    ) -> BBFResult<Self> {
+        // Read existing metadata if exists
+        let meta_path = array_blob_dir.child(ArrayPartitionGroup::META_PATH);
+        let metadata = if let Ok(metadata_bytes) = object_store.get(&meta_path).await {
+            let bytes = metadata_bytes.bytes().await.map_err(|source| {
+                BBFReadingError::PartitionGroupMetadataFetch {
+                    meta_path: meta_path.to_string(),
+                    source,
+                }
+            })?;
+            serde_json::from_slice(&bytes).map_err(|err| {
+                BBFReadingError::PartitionGroupMetadataDecode {
+                    meta_path: meta_path.to_string(),
+                    reason: err.to_string(),
+                }
+            })?
+        } else {
+            ArrayPartitionGroupMetadata {
+                array_name: String::new(),
+                total_bytes_size: 0,
+                combined_num_elements: 0,
+                data_type: DataType::Null,
+                partitions: IndexMap::new(),
+            }
+        };
+
+        Ok(Self { metadata })
+    }
+
+    pub fn append_partition(
+        &mut self,
+        partition_index: usize,
+        partition_metadata: ArrayPartitionMetadata,
+    ) -> BBFResult<()> {
+        // Compare data types
+        if self.metadata.data_type != partition_metadata.data_type {
+            // Find super type
+            let super_type =
+                super_type_arrow(&self.metadata.data_type, &partition_metadata.data_type)
+                    .ok_or_else(|| BBFReadingError::PartitionGroupMetadataDecode {
+                        meta_path: "N/A".to_string(),
+                        reason: format!(
+                            "Unable to find super type for data types: {:?} and {:?}",
+                            self.metadata.data_type, partition_metadata.data_type
+                        ),
+                    })?;
+            self.metadata.data_type = super_type;
+        }
+
+        self.metadata.total_bytes_size += partition_metadata.partition_byte_size;
+        self.metadata.combined_num_elements += partition_metadata.num_elements;
+        self.metadata
+            .partitions
+            .insert(partition_index, partition_metadata);
+
+        Ok(())
+    }
+}

--- a/beacon-binary-format/src/array_partition_group.rs
+++ b/beacon-binary-format/src/array_partition_group.rs
@@ -12,6 +12,8 @@ use crate::{
     util::super_type_arrow,
 };
 
+/// Metadata persisted for a set of array partitions sharing the same logical
+/// array.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArrayPartitionGroupMetadata {
     pub array_name: String,
@@ -21,6 +23,8 @@ pub struct ArrayPartitionGroupMetadata {
     pub partitions: IndexMap<usize, ArrayPartitionMetadata>,
 }
 
+/// Wrapper around group metadata to allow future helpers on the reader/writer
+/// side.
 pub struct ArrayPartitionGroup {
     metadata: ArrayPartitionGroupMetadata,
 }
@@ -28,6 +32,7 @@ pub struct ArrayPartitionGroup {
 impl ArrayPartitionGroup {
     const META_PATH: &str = "apg.json";
 
+    /// Returns the metadata envelope describing this partition group.
     pub fn metadata(&self) -> &ArrayPartitionGroupMetadata {
         &self.metadata
     }
@@ -41,6 +46,8 @@ pub struct ArrayPartitionGroupReader {
 }
 
 impl ArrayPartitionGroupReader {
+    /// Construct a reader by downloading the group metadata json and preparing
+    /// to lazily open individual partitions when requested.
     pub async fn new(
         object_store: Arc<dyn ObjectStore>,
         path: object_store::path::Path,
@@ -76,10 +83,13 @@ impl ArrayPartitionGroupReader {
         })
     }
 
+    /// Expose the group metadata to callers without re-fetching the json blob.
     pub fn metadata(&self) -> &ArrayPartitionGroupMetadata {
         &self.metadata
     }
 
+    /// Returns an [`ArrayPartitionReader`] for the provided partition index if it
+    /// exists, cloning the cached metadata and reusing the IO cache.
     pub async fn get_partition_reader(
         &self,
         partition: usize,
@@ -101,11 +111,14 @@ impl ArrayPartitionGroupReader {
     }
 }
 
+/// Accumulates partition metadata and handles super-type resolution while
+/// persisting the json descriptor back to object storage.
 pub struct ArrayPartitionGroupWriter {
     metadata: ArrayPartitionGroupMetadata,
 }
 
 impl ArrayPartitionGroupWriter {
+    /// Load existing metadata (when present) or initialize a blank descriptor.
     pub async fn new(
         array_blob_dir: object_store::path::Path,
         object_store: Arc<dyn ObjectStore>,
@@ -138,6 +151,8 @@ impl ArrayPartitionGroupWriter {
         Ok(Self { metadata })
     }
 
+    /// Records metadata for `partition_index`, updating totals and upcasting
+    /// the tracked Arrow data type if needed.
     pub fn append_partition(
         &mut self,
         partition_index: usize,
@@ -158,6 +173,8 @@ impl ArrayPartitionGroupWriter {
             self.metadata.data_type = super_type;
         }
 
+        // Accumulate overall byte/row counts so clients can quickly estimate the
+        // combined footprint without enumerating each partition.
         self.metadata.total_bytes_size += partition_metadata.partition_byte_size;
         self.metadata.combined_num_elements += partition_metadata.num_elements;
         self.metadata
@@ -165,5 +182,120 @@ impl ArrayPartitionGroupWriter {
             .insert(partition_index, partition_metadata);
 
         Ok(())
+    }
+
+    /// View the currently collected metadata prior to persisting it.
+    pub fn metadata(&self) -> &ArrayPartitionGroupMetadata {
+        &self.metadata
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::{PutPayload, memory::InMemory, path::Path};
+    use std::sync::Arc as StdArc;
+
+    /// Builds a lightweight `ArrayPartitionMetadata` pointing at a fake hash for
+    /// use inside unit tests.
+    fn sample_partition_metadata(
+        hash: &str,
+        data_type: DataType,
+        byte_size: usize,
+        elements: usize,
+    ) -> ArrayPartitionMetadata {
+        ArrayPartitionMetadata {
+            num_elements: elements,
+            partition_offset: 0,
+            partition_byte_size: byte_size,
+            hash: hash.to_string(),
+            data_type,
+            groups: IndexMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    /// Writer falls back to empty metadata when no apg.json exists yet.
+    async fn writer_initializes_default_metadata_when_missing_file() {
+        let store: StdArc<dyn ObjectStore> = StdArc::new(InMemory::new());
+        let dir = Path::from("tests/apg_defaults");
+
+        let writer = ArrayPartitionGroupWriter::new(dir, store)
+            .await
+            .expect("writer init");
+        let metadata = writer.metadata();
+
+        assert!(metadata.partitions.is_empty());
+        assert_eq!(metadata.total_bytes_size, 0);
+        assert_eq!(metadata.combined_num_elements, 0);
+        assert_eq!(metadata.data_type, DataType::Null);
+    }
+
+    #[tokio::test]
+    /// Existing apg.json files are parsed and returned untouched.
+    async fn writer_reads_existing_metadata_blob() {
+        let store: StdArc<dyn ObjectStore> = StdArc::new(InMemory::new());
+        let dir = Path::from("tests/apg_existing");
+        let meta_path = dir.child(ArrayPartitionGroup::META_PATH);
+        let mut metadata = ArrayPartitionGroupMetadata {
+            array_name: "temp".to_string(),
+            total_bytes_size: 10,
+            combined_num_elements: 2,
+            data_type: DataType::Int32,
+            partitions: IndexMap::new(),
+        };
+        metadata.partitions.insert(
+            0,
+            sample_partition_metadata("hash-0", DataType::Int32, 10, 2),
+        );
+        let payload = serde_json::to_vec(&metadata).expect("serialize");
+        store
+            .put(&meta_path, PutPayload::from_bytes(payload.into()))
+            .await
+            .expect("write metadata");
+
+        let writer = ArrayPartitionGroupWriter::new(dir, store)
+            .await
+            .expect("writer init");
+        let metadata_ref = writer.metadata();
+
+        assert_eq!(metadata_ref.array_name, "temp");
+        assert_eq!(metadata_ref.total_bytes_size, 10);
+        assert_eq!(metadata_ref.combined_num_elements, 2);
+        assert_eq!(metadata_ref.data_type, DataType::Int32);
+        assert!(metadata_ref.partitions.contains_key(&0));
+    }
+
+    #[tokio::test]
+    /// Appending partitions updates totals and promotes data types to their
+    /// appropriate super type.
+    async fn append_partition_updates_totals_and_supertypes() {
+        let store: StdArc<dyn ObjectStore> = StdArc::new(InMemory::new());
+        let dir = Path::from("tests/apg_append");
+        let mut writer = ArrayPartitionGroupWriter::new(dir, store)
+            .await
+            .expect("writer init");
+
+        let int32_partition = sample_partition_metadata("hash-int", DataType::Int32, 128, 10);
+        writer
+            .append_partition(0, int32_partition.clone())
+            .expect("append int32");
+        let metadata = writer.metadata();
+        assert_eq!(metadata.total_bytes_size, 128);
+        assert_eq!(metadata.combined_num_elements, 10);
+        assert_eq!(metadata.data_type, DataType::Int32);
+
+        let utf8_partition = sample_partition_metadata("hash-str", DataType::Utf8, 64, 5);
+        writer
+            .append_partition(1, utf8_partition.clone())
+            .expect("append utf8");
+
+        let metadata = writer.metadata();
+        assert_eq!(metadata.total_bytes_size, 192);
+        assert_eq!(metadata.combined_num_elements, 15);
+        assert_eq!(metadata.data_type, DataType::Utf8);
+        assert_eq!(metadata.partitions.len(), 2);
+        assert!(metadata.partitions.contains_key(&0));
+        assert!(metadata.partitions.contains_key(&1));
     }
 }

--- a/beacon-binary-format/src/array_partition_index.rs
+++ b/beacon-binary-format/src/array_partition_index.rs
@@ -1,0 +1,680 @@
+use std::{fs::File, sync::Arc};
+
+use arrow::array::{
+    Array, ArrayRef, AsArray, BinaryBuilder, BooleanBuilder, LargeBinaryBuilder,
+    LargeStringBuilder, ListArray, PrimitiveBuilder, RecordBatch, StringBuilder, UInt64Builder,
+};
+use arrow::datatypes::{
+    ArrowPrimitiveType, Float32Type, Float64Type, Int8Type, Int16Type, Int32Type, Int64Type,
+    TimestampMicrosecondType, TimestampMillisecondType, TimestampNanosecondType,
+    TimestampSecondType, UInt8Type, UInt16Type, UInt32Type, UInt64Type,
+};
+use arrow_ipc::reader::FileReader;
+use arrow_schema::DataType;
+
+use crate::error::{BBFResult, BBFWritingError};
+
+/// Returns a pruning schema containing min, max, null-count, and row-count fields
+/// derived from `data_type` for the provided `array_name`.
+///
+/// The schema matches the layout produced by [`build_pruning_index`] so that metadata
+/// batches can be concatenated cheaply across array partitions.
+fn schema_for_data_type(array_name: &str, data_type: &DataType) -> arrow::datatypes::Schema {
+    let min_field =
+        arrow::datatypes::Field::new(format!("{}:min", array_name), data_type.clone(), true);
+    let max_field =
+        arrow::datatypes::Field::new(format!("{}:max", array_name), data_type.clone(), true);
+    let null_count_field = arrow::datatypes::Field::new(
+        format!("{}:null_count", array_name),
+        DataType::UInt64,
+        false,
+    );
+    let row_count_field =
+        arrow::datatypes::Field::new(format!("{}:row_count", array_name), DataType::UInt64, false);
+
+    arrow::datatypes::Schema::new(vec![
+        min_field,
+        max_field,
+        null_count_field,
+        row_count_field,
+    ])
+}
+
+/// Builds a pruning index [`RecordBatch`] for `array_name` by scanning the IPC `file`
+/// and computing min/max metadata for each nested list according to `data_type`.
+///
+/// The IPC file is expected to contain a single column with list-arrays. Each nested
+/// list is summarized into four columns (min, max, null_count, row_count). The output
+/// is already aligned with the pruning schema which allows callers to persist the batch
+/// directly or concatenate it with previous index fragments.
+pub fn build_pruning_index(
+    array_name: &str,
+    file: &mut File,
+    data_type: DataType,
+) -> BBFResult<Option<RecordBatch>> {
+    let reader = FileReader::try_new(file, None)
+        .map_err(|e| BBFWritingError::ArrayPartitionFinalizeFailure(Box::new(e)))?;
+    let pruning_schema = schema_for_data_type(array_name, &data_type);
+    let mut pruning_batches = Vec::new();
+
+    // Iterate through all batches and build pruning index
+    for maybe_batch in reader {
+        let batch =
+            maybe_batch.map_err(|e| BBFWritingError::ArrayPartitionFinalizeFailure(Box::new(e)))?;
+        let values_column = batch.column(0).clone();
+        let values_list_column = values_column.as_list::<i32>();
+        if let Some(pruning_batch) = build_from_values(&pruning_schema, values_list_column)? {
+            pruning_batches.push(pruning_batch);
+        }
+    }
+
+    let result = match pruning_batches.len() {
+        0 => None,
+        1 => pruning_batches.pop(),
+        _ => {
+            let schema_ref = pruning_batches[0].schema();
+            let concatenated = arrow::compute::concat_batches(&schema_ref, &pruning_batches)
+                .map_err(|e| BBFWritingError::ArrayPartitionFinalizeFailure(Box::new(e)))?;
+            Some(concatenated)
+        }
+    };
+
+    Ok(result)
+}
+
+/// Derives a pruning [`RecordBatch`] from a [`ListArray`], returning `None` when there
+/// are no rows to index.
+///
+/// This function accepts the list column extracted from a [`RecordBatch`] and performs
+/// type-directed dispatch to the appropriate min/max implementation. Unsupported data
+/// types simply skip pruning generation to keep the caller fast-failing.
+fn build_from_values(
+    pruning_schema: &arrow::datatypes::Schema,
+    list_array: &ListArray,
+) -> BBFResult<Option<RecordBatch>> {
+    if list_array.len() == 0 {
+        return Ok(None);
+    }
+
+    let mut null_count_builder = UInt64Builder::with_capacity(list_array.len());
+    let mut row_count_builder = UInt64Builder::with_capacity(list_array.len());
+
+    let maybe_arrays = match list_array.value_type() {
+        DataType::Boolean => Some(build_boolean_min_max(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        DataType::Int8 => Some(build_primitive_min_max::<Int8Type>(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        DataType::Int16 => Some(build_primitive_min_max::<Int16Type>(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        DataType::Int32 => Some(build_primitive_min_max::<Int32Type>(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        DataType::Int64 => Some(build_primitive_min_max::<Int64Type>(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        DataType::UInt8 => Some(build_primitive_min_max::<UInt8Type>(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        DataType::UInt16 => Some(build_primitive_min_max::<UInt16Type>(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        DataType::UInt32 => Some(build_primitive_min_max::<UInt32Type>(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        DataType::UInt64 => Some(build_primitive_min_max::<UInt64Type>(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        DataType::Float32 => Some(build_primitive_min_max::<Float32Type>(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        DataType::Float64 => Some(build_primitive_min_max::<Float64Type>(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        DataType::Timestamp(time_unit, _) => match time_unit {
+            arrow_schema::TimeUnit::Second => Some(build_primitive_min_max::<TimestampSecondType>(
+                list_array,
+                &mut null_count_builder,
+                &mut row_count_builder,
+            )),
+            arrow_schema::TimeUnit::Millisecond => {
+                Some(build_primitive_min_max::<TimestampMillisecondType>(
+                    list_array,
+                    &mut null_count_builder,
+                    &mut row_count_builder,
+                ))
+            }
+            arrow_schema::TimeUnit::Microsecond => {
+                Some(build_primitive_min_max::<TimestampMicrosecondType>(
+                    list_array,
+                    &mut null_count_builder,
+                    &mut row_count_builder,
+                ))
+            }
+            arrow_schema::TimeUnit::Nanosecond => {
+                Some(build_primitive_min_max::<TimestampNanosecondType>(
+                    list_array,
+                    &mut null_count_builder,
+                    &mut row_count_builder,
+                ))
+            }
+        },
+        DataType::Binary => Some(build_binary_min_max(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        DataType::LargeBinary => Some(build_large_binary_min_max(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        DataType::Utf8 => Some(build_utf8_min_max(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        DataType::LargeUtf8 => Some(build_large_utf8_min_max(
+            list_array,
+            &mut null_count_builder,
+            &mut row_count_builder,
+        )),
+        _ => None,
+    };
+
+    let Some((min_array, max_array)) = maybe_arrays else {
+        return Ok(None);
+    };
+
+    let null_count_array: ArrayRef = Arc::new(null_count_builder.finish());
+    let row_count_array: ArrayRef = Arc::new(row_count_builder.finish());
+
+    let batch = RecordBatch::try_new(
+        Arc::new(pruning_schema.clone()),
+        vec![min_array, max_array, null_count_array, row_count_array],
+    )
+    .map_err(|e| BBFWritingError::ArrayPartitionFinalizeFailure(Box::new(e)))?;
+
+    Ok(Some(batch))
+}
+
+/// Computes min/max pairs for primitive list values while tracking row and null counts.
+///
+/// The helper leverages Arrow's `min`/`max` kernels which avoid materializing temporary
+/// vectors. Builders are appended in lockstep so every parent row contributes exactly one
+/// entry to the resulting metadata columns.
+fn build_primitive_min_max<T: ArrowPrimitiveType>(
+    list_array: &ListArray,
+    null_count_builder: &mut UInt64Builder,
+    row_count_builder: &mut UInt64Builder,
+) -> (ArrayRef, ArrayRef) {
+    let mut min_builder = PrimitiveBuilder::<T>::with_capacity(list_array.len());
+    let mut max_builder = PrimitiveBuilder::<T>::with_capacity(list_array.len());
+
+    // Iterate over each parent list row, emitting metadata no matter the child length.
+    for idx in 0..list_array.len() {
+        if list_array.is_null(idx) {
+            min_builder.append_null();
+            max_builder.append_null();
+            append_zero_counts(null_count_builder, row_count_builder);
+            continue;
+        }
+
+        let values = list_array.value(idx);
+        let typed_values = values.as_primitive::<T>();
+        append_counts(
+            null_count_builder,
+            row_count_builder,
+            typed_values.len(),
+            typed_values.null_count(),
+        );
+
+        match arrow::compute::min(typed_values) {
+            Some(value) => min_builder.append_value(value),
+            None => min_builder.append_null(),
+        }
+
+        match arrow::compute::max(typed_values) {
+            Some(value) => max_builder.append_value(value),
+            None => max_builder.append_null(),
+        }
+    }
+
+    (
+        Arc::new(min_builder.finish()) as ArrayRef,
+        Arc::new(max_builder.finish()) as ArrayRef,
+    )
+}
+
+/// Computes min/max values for boolean lists using Arrow's dedicated reducers.
+fn build_boolean_min_max(
+    list_array: &ListArray,
+    null_count_builder: &mut UInt64Builder,
+    row_count_builder: &mut UInt64Builder,
+) -> (ArrayRef, ArrayRef) {
+    let mut min_builder = BooleanBuilder::with_capacity(list_array.len());
+    let mut max_builder = BooleanBuilder::with_capacity(list_array.len());
+
+    // Boolean lists rely on their own min/max kernels for cheap aggregation.
+    for idx in 0..list_array.len() {
+        if list_array.is_null(idx) {
+            min_builder.append_null();
+            max_builder.append_null();
+            append_zero_counts(null_count_builder, row_count_builder);
+            continue;
+        }
+
+        let values = list_array.value(idx);
+        let boolean_values = values.as_boolean();
+        append_counts(
+            null_count_builder,
+            row_count_builder,
+            boolean_values.len(),
+            boolean_values.null_count(),
+        );
+
+        match arrow::compute::min_boolean(boolean_values) {
+            Some(value) => min_builder.append_value(value),
+            None => min_builder.append_null(),
+        }
+
+        match arrow::compute::max_boolean(boolean_values) {
+            Some(value) => max_builder.append_value(value),
+            None => max_builder.append_null(),
+        }
+    }
+
+    (
+        Arc::new(min_builder.finish()) as ArrayRef,
+        Arc::new(max_builder.finish()) as ArrayRef,
+    )
+}
+
+/// Computes lexical min/max for binary lists that use 32-bit offsets.
+fn build_binary_min_max(
+    list_array: &ListArray,
+    null_count_builder: &mut UInt64Builder,
+    row_count_builder: &mut UInt64Builder,
+) -> (ArrayRef, ArrayRef) {
+    let mut min_builder = BinaryBuilder::new();
+    let mut max_builder = BinaryBuilder::new();
+
+    // For lexical ordering the Arrow kernels operate on slices, no extra copies needed.
+    for idx in 0..list_array.len() {
+        if list_array.is_null(idx) {
+            min_builder.append_null();
+            max_builder.append_null();
+            append_zero_counts(null_count_builder, row_count_builder);
+            continue;
+        }
+
+        let values = list_array.value(idx);
+        let binary_values = values.as_binary::<i32>();
+        append_counts(
+            null_count_builder,
+            row_count_builder,
+            binary_values.len(),
+            binary_values.null_count(),
+        );
+
+        match arrow::compute::min_binary(binary_values) {
+            Some(bytes) => min_builder.append_value(bytes),
+            None => min_builder.append_null(),
+        }
+
+        match arrow::compute::max_binary(binary_values) {
+            Some(bytes) => max_builder.append_value(bytes),
+            None => max_builder.append_null(),
+        }
+    }
+
+    (
+        Arc::new(min_builder.finish()) as ArrayRef,
+        Arc::new(max_builder.finish()) as ArrayRef,
+    )
+}
+
+/// Computes lexical min/max for binary lists that use 64-bit offsets.
+fn build_large_binary_min_max(
+    list_array: &ListArray,
+    null_count_builder: &mut UInt64Builder,
+    row_count_builder: &mut UInt64Builder,
+) -> (ArrayRef, ArrayRef) {
+    let mut min_builder = LargeBinaryBuilder::new();
+    let mut max_builder = LargeBinaryBuilder::new();
+
+    for idx in 0..list_array.len() {
+        if list_array.is_null(idx) {
+            min_builder.append_null();
+            max_builder.append_null();
+            append_zero_counts(null_count_builder, row_count_builder);
+            continue;
+        }
+
+        let values = list_array.value(idx);
+        let binary_values = values.as_binary::<i64>();
+        append_counts(
+            null_count_builder,
+            row_count_builder,
+            binary_values.len(),
+            binary_values.null_count(),
+        );
+
+        match arrow::compute::min_binary(binary_values) {
+            Some(bytes) => min_builder.append_value(bytes),
+            None => min_builder.append_null(),
+        }
+
+        match arrow::compute::max_binary(binary_values) {
+            Some(bytes) => max_builder.append_value(bytes),
+            None => max_builder.append_null(),
+        }
+    }
+
+    (
+        Arc::new(min_builder.finish()) as ArrayRef,
+        Arc::new(max_builder.finish()) as ArrayRef,
+    )
+}
+
+/// Computes lexical min/max for UTF-8 string lists that use 32-bit offsets.
+fn build_utf8_min_max(
+    list_array: &ListArray,
+    null_count_builder: &mut UInt64Builder,
+    row_count_builder: &mut UInt64Builder,
+) -> (ArrayRef, ArrayRef) {
+    let mut min_builder = StringBuilder::new();
+    let mut max_builder = StringBuilder::new();
+
+    // UTF-8 min/max is performed lexically, matching the semantics of Arrow comparisons.
+    for idx in 0..list_array.len() {
+        if list_array.is_null(idx) {
+            min_builder.append_null();
+            max_builder.append_null();
+            append_zero_counts(null_count_builder, row_count_builder);
+            continue;
+        }
+
+        let values = list_array.value(idx);
+        let string_values = values.as_string::<i32>();
+        append_counts(
+            null_count_builder,
+            row_count_builder,
+            string_values.len(),
+            string_values.null_count(),
+        );
+
+        match arrow::compute::min_string(string_values) {
+            Some(value) => min_builder.append_value(value),
+            None => min_builder.append_null(),
+        }
+
+        match arrow::compute::max_string(string_values) {
+            Some(value) => max_builder.append_value(value),
+            None => max_builder.append_null(),
+        }
+    }
+
+    (
+        Arc::new(min_builder.finish()) as ArrayRef,
+        Arc::new(max_builder.finish()) as ArrayRef,
+    )
+}
+
+/// Computes lexical min/max for UTF-8 string lists that use 64-bit offsets.
+fn build_large_utf8_min_max(
+    list_array: &ListArray,
+    null_count_builder: &mut UInt64Builder,
+    row_count_builder: &mut UInt64Builder,
+) -> (ArrayRef, ArrayRef) {
+    let mut min_builder = LargeStringBuilder::new();
+    let mut max_builder = LargeStringBuilder::new();
+
+    for idx in 0..list_array.len() {
+        if list_array.is_null(idx) {
+            min_builder.append_null();
+            max_builder.append_null();
+            append_zero_counts(null_count_builder, row_count_builder);
+            continue;
+        }
+
+        let values = list_array.value(idx);
+        let string_values = values.as_string::<i64>();
+        append_counts(
+            null_count_builder,
+            row_count_builder,
+            string_values.len(),
+            string_values.null_count(),
+        );
+
+        match arrow::compute::min_string(string_values) {
+            Some(value) => min_builder.append_value(value),
+            None => min_builder.append_null(),
+        }
+
+        match arrow::compute::max_string(string_values) {
+            Some(value) => max_builder.append_value(value),
+            None => max_builder.append_null(),
+        }
+    }
+
+    (
+        Arc::new(min_builder.finish()) as ArrayRef,
+        Arc::new(max_builder.finish()) as ArrayRef,
+    )
+}
+
+/// Records zero row/null counts for parent entries that were null.
+fn append_zero_counts(
+    null_count_builder: &mut UInt64Builder,
+    row_count_builder: &mut UInt64Builder,
+) {
+    null_count_builder.append_value(0);
+    row_count_builder.append_value(0);
+}
+
+/// Records the total row count and null count for non-null parent entries.
+fn append_counts(
+    null_count_builder: &mut UInt64Builder,
+    row_count_builder: &mut UInt64Builder,
+    len: usize,
+    nulls: usize,
+) {
+    row_count_builder.append_value(len as u64);
+    null_count_builder.append_value(nulls as u64);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{BooleanBuilder, ListArray, ListBuilder, StringBuilder};
+    use arrow::datatypes::{DataType, Int32Type, UInt64Type};
+
+    fn build_boolean_list(rows: &[Option<Vec<Option<bool>>>]) -> ListArray {
+        let mut builder = ListBuilder::new(BooleanBuilder::new());
+        for row in rows {
+            match row {
+                Some(values) => {
+                    for value in values {
+                        match value {
+                            Some(bit) => {
+                                builder.values().append_value(*bit);
+                            }
+                            None => {
+                                builder.values().append_null();
+                            }
+                        }
+                    }
+                    builder.append(true);
+                }
+                None => {
+                    builder.append(false);
+                }
+            }
+        }
+
+        builder.finish()
+    }
+
+    fn build_utf8_list(rows: &[Option<Vec<Option<&str>>>]) -> ListArray {
+        let mut builder = ListBuilder::new(StringBuilder::new());
+        for row in rows {
+            match row {
+                Some(values) => {
+                    for value in values {
+                        match value {
+                            Some(text) => {
+                                builder.values().append_value(text);
+                            }
+                            None => {
+                                builder.values().append_null();
+                            }
+                        }
+                    }
+                    builder.append(true);
+                }
+                None => {
+                    builder.append(false);
+                }
+            }
+        }
+
+        builder.finish()
+    }
+
+    #[test]
+    fn primitive_lists_generate_expected_pruning_batch() {
+        let list_array = ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
+            Some(vec![Some(3), Some(1), None]),
+            Some(vec![Some(8), Some(4)]),
+            None,
+        ]);
+
+        let schema = schema_for_data_type("values", &DataType::Int32);
+        let batch = build_from_values(&schema, &list_array)
+            .expect("build succeeds")
+            .expect("batch generated");
+
+        let min_values = batch.column(0).as_primitive::<Int32Type>();
+        assert_eq!(min_values.len(), 3);
+        assert_eq!(min_values.value(0), 1);
+        assert_eq!(min_values.value(1), 4);
+        assert!(min_values.is_null(2));
+
+        let max_values = batch.column(1).as_primitive::<Int32Type>();
+        assert_eq!(max_values.value(0), 3);
+        assert_eq!(max_values.value(1), 8);
+        assert!(max_values.is_null(2));
+
+        let null_counts = batch.column(2).as_primitive::<UInt64Type>();
+        assert_eq!(null_counts.value(0), 1);
+        assert_eq!(null_counts.value(1), 0);
+        assert_eq!(null_counts.value(2), 0);
+
+        let row_counts = batch.column(3).as_primitive::<UInt64Type>();
+        assert_eq!(row_counts.value(0), 3);
+        assert_eq!(row_counts.value(1), 2);
+        assert_eq!(row_counts.value(2), 0);
+    }
+
+    #[test]
+    fn empty_list_array_produces_no_batch() {
+        let empty_lists: Vec<Option<Vec<Option<i32>>>> = Vec::new();
+        let list_array = ListArray::from_iter_primitive::<Int32Type, _, _>(empty_lists);
+        let schema = schema_for_data_type("values", &DataType::Int32);
+
+        let result = build_from_values(&schema, &list_array).expect("build succeeds");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn boolean_lists_report_expected_bounds() {
+        let list_array = build_boolean_list(&[
+            Some(vec![Some(true), Some(false), Some(true)]),
+            Some(vec![None, Some(true)]),
+            None,
+        ]);
+        let schema = schema_for_data_type("flags", &DataType::Boolean);
+        let batch = build_from_values(&schema, &list_array)
+            .expect("build succeeds")
+            .expect("batch generated");
+
+        let min_values = batch.column(0).as_boolean();
+        assert_eq!(min_values.len(), 3);
+        assert!(!min_values.value(0));
+        assert!(min_values.value(1));
+        assert!(min_values.is_null(2));
+
+        let max_values = batch.column(1).as_boolean();
+        assert!(max_values.value(0));
+        assert!(max_values.value(1));
+        assert!(max_values.is_null(2));
+
+        let null_counts = batch.column(2).as_primitive::<UInt64Type>();
+        assert_eq!(null_counts.value(0), 0);
+        assert_eq!(null_counts.value(1), 1);
+        assert_eq!(null_counts.value(2), 0);
+
+        let row_counts = batch.column(3).as_primitive::<UInt64Type>();
+        assert_eq!(row_counts.value(0), 3);
+        assert_eq!(row_counts.value(1), 2);
+        assert_eq!(row_counts.value(2), 0);
+    }
+
+    #[test]
+    fn utf8_lists_report_expected_bounds() {
+        let list_array = build_utf8_list(&[
+            Some(vec![Some("delta"), Some("alpha")]),
+            Some(vec![None, Some("zulu"), Some("beta")]),
+            None,
+        ]);
+        let schema = schema_for_data_type("labels", &DataType::Utf8);
+        let batch = build_from_values(&schema, &list_array)
+            .expect("build succeeds")
+            .expect("batch generated");
+
+        let min_values = batch.column(0).as_string::<i32>();
+        assert_eq!(min_values.value(0), "alpha");
+        assert_eq!(min_values.value(1), "beta");
+        assert!(min_values.is_null(2));
+
+        let max_values = batch.column(1).as_string::<i32>();
+        assert_eq!(max_values.value(0), "delta");
+        assert_eq!(max_values.value(1), "zulu");
+        assert!(max_values.is_null(2));
+
+        let null_counts = batch.column(2).as_primitive::<UInt64Type>();
+        assert_eq!(null_counts.value(0), 0);
+        assert_eq!(null_counts.value(1), 1);
+        assert_eq!(null_counts.value(2), 0);
+
+        let row_counts = batch.column(3).as_primitive::<UInt64Type>();
+        assert_eq!(row_counts.value(0), 2);
+        assert_eq!(row_counts.value(1), 3);
+        assert_eq!(row_counts.value(2), 0);
+    }
+}

--- a/beacon-binary-format/src/collection.rs
+++ b/beacon-binary-format/src/collection.rs
@@ -1,0 +1,14 @@
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+use crate::collection_partition::CollectionPartitionMetadata;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CollectionMetadata {
+    collection_byte_size: usize,
+    collection_num_elements: usize,
+    partitions: IndexMap<usize, CollectionPartitionMetadata>,
+    schema: Arc<arrow::datatypes::Schema>,
+}

--- a/beacon-binary-format/src/collection.rs
+++ b/beacon-binary-format/src/collection.rs
@@ -1,14 +1,264 @@
 use std::sync::Arc;
 
+use arrow::datatypes::Schema;
 use indexmap::IndexMap;
+use object_store::{Error as ObjectStoreError, ObjectStore, PutPayload, path::Path};
 use serde::{Deserialize, Serialize};
 
-use crate::collection_partition::CollectionPartitionMetadata;
+use crate::{
+    collection_partition::{CollectionPartitionMetadata, CollectionPartitionReader},
+    error::{BBFReadingError, BBFResult, BBFWritingError},
+    io_cache::ArrayIoCache,
+};
 
+pub const COLLECTION_META_FILE: &str = "bbf.json";
+
+/// Aggregate metadata for a collection spanning multiple collection partitions.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CollectionMetadata {
-    collection_byte_size: usize,
-    collection_num_elements: usize,
-    partitions: IndexMap<usize, CollectionPartitionMetadata>,
-    schema: Arc<arrow::datatypes::Schema>,
+    /// Sum of partition byte sizes.
+    pub collection_byte_size: usize,
+    /// Sum of partition element counts.
+    pub collection_num_elements: usize,
+    /// Map of partition index to its metadata descriptor.
+    pub partitions: IndexMap<usize, CollectionPartitionMetadata>,
+    /// Logical schema shared by every partition in the collection.
+    pub schema: Arc<Schema>,
+}
+
+impl CollectionMetadata {
+    fn empty() -> Self {
+        Self {
+            collection_byte_size: 0,
+            collection_num_elements: 0,
+            partitions: IndexMap::new(),
+            schema: Arc::new(Schema::empty()),
+        }
+    }
+}
+
+/// Reader that loads collection metadata and hands out collection partition readers.
+pub struct CollectionReader {
+    metadata: CollectionMetadata,
+    object_store: Arc<dyn ObjectStore>,
+    root_path: Path,
+    io_cache: ArrayIoCache,
+}
+
+impl CollectionReader {
+    /// Loads `collection.json` under `root_path` and prepares to serve partition readers.
+    pub async fn new(
+        object_store: Arc<dyn ObjectStore>,
+        root_path: Path,
+        io_cache: ArrayIoCache,
+    ) -> BBFResult<Self> {
+        let meta_path = root_path.child(COLLECTION_META_FILE);
+        let meta_display = meta_path.to_string();
+        let meta_object = object_store.get(&meta_path).await.map_err(|source| {
+            BBFReadingError::CollectionMetadataFetch {
+                meta_path: meta_display.clone(),
+                source,
+            }
+        })?;
+        let bytes = meta_object.bytes().await.map_err(|source| {
+            BBFReadingError::CollectionMetadataFetch {
+                meta_path: meta_display.clone(),
+                source,
+            }
+        })?;
+        let metadata = serde_json::from_slice(&bytes).map_err(|err| {
+            BBFReadingError::CollectionMetadataDecode {
+                meta_path: meta_display,
+                reason: err.to_string(),
+            }
+        })?;
+
+        Ok(Self {
+            metadata,
+            object_store,
+            root_path,
+            io_cache,
+        })
+    }
+
+    /// Returns the cached metadata snapshot.
+    pub fn metadata(&self) -> &CollectionMetadata {
+        &self.metadata
+    }
+
+    /// Builds a `CollectionPartitionReader` for `partition_index` when metadata is present.
+    pub fn partition_reader(&self, partition_index: usize) -> Option<CollectionPartitionReader> {
+        self.metadata
+            .partitions
+            .get(&partition_index)
+            .cloned()
+            .map(|partition_metadata| {
+                let partition_path = self.root_path.child(partition_index.to_string());
+                CollectionPartitionReader::new(
+                    partition_path,
+                    self.object_store.clone(),
+                    partition_metadata,
+                    self.io_cache.clone(),
+                )
+            })
+    }
+}
+
+/// Writer that manages collection metadata while new collection partitions are appended.
+pub struct CollectionWriter {
+    metadata: CollectionMetadata,
+    object_store: Arc<dyn ObjectStore>,
+    root_path: Path,
+}
+
+impl CollectionWriter {
+    /// Loads existing metadata if present, otherwise starts from an empty descriptor.
+    pub async fn new(object_store: Arc<dyn ObjectStore>, root_path: Path) -> BBFResult<Self> {
+        let meta_path = root_path.child(COLLECTION_META_FILE);
+        let meta_display = meta_path.to_string();
+        let metadata = match object_store.get(&meta_path).await {
+            Ok(existing) => {
+                let bytes = existing.bytes().await.map_err(|source| {
+                    BBFReadingError::CollectionMetadataFetch {
+                        meta_path: meta_display.clone(),
+                        source,
+                    }
+                })?;
+                serde_json::from_slice(&bytes).map_err(|err| {
+                    BBFReadingError::CollectionMetadataDecode {
+                        meta_path: meta_display.clone(),
+                        reason: err.to_string(),
+                    }
+                })?
+            }
+            Err(ObjectStoreError::NotFound { .. }) => CollectionMetadata::empty(),
+            Err(source) => {
+                return Err(BBFReadingError::CollectionMetadataFetch {
+                    meta_path: meta_display,
+                    source,
+                }
+                .into());
+            }
+        };
+
+        Ok(Self {
+            metadata,
+            object_store,
+            root_path,
+        })
+    }
+
+    /// Exposes the current metadata snapshot.
+    pub fn metadata(&self) -> &CollectionMetadata {
+        &self.metadata
+    }
+
+    /// Appends `partition_metadata` as the next partition, returning the assigned index.
+    pub fn append_partition(
+        &mut self,
+        partition_metadata: CollectionPartitionMetadata,
+    ) -> BBFResult<usize> {
+        if self.metadata.schema.fields().is_empty() {
+            self.metadata.schema = partition_metadata.partition_schema.clone();
+        } else if self.metadata.schema.as_ref() != partition_metadata.partition_schema.as_ref() {
+            return Err(BBFWritingError::CollectionSchemaMismatch {
+                expected: format!("{:?}", self.metadata.schema.as_ref()),
+                actual: format!("{:?}", partition_metadata.partition_schema.as_ref()),
+            }
+            .into());
+        }
+
+        let partition_index = self
+            .metadata
+            .partitions
+            .keys()
+            .max()
+            .map(|idx| idx + 1)
+            .unwrap_or(0);
+
+        self.metadata
+            .partitions
+            .insert(partition_index, partition_metadata.clone());
+
+        self.metadata.collection_byte_size += partition_metadata.byte_size;
+        self.metadata.collection_num_elements += partition_metadata.num_elements;
+
+        Ok(partition_index)
+    }
+
+    /// Persists the metadata to `collection.json`.
+    pub async fn persist(&self) -> BBFResult<()> {
+        let meta_path = self.root_path.child(COLLECTION_META_FILE);
+        let payload = serde_json::to_vec(&self.metadata)
+            .map_err(|err| BBFWritingError::CollectionMetadataWriteFailure(Box::new(err)))?;
+        self.object_store
+            .put(&meta_path, PutPayload::from_bytes(payload.into()))
+            .await
+            .map_err(|err| BBFWritingError::CollectionMetadataWriteFailure(Box::new(err)))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_schema::{DataType, Field};
+    use object_store::memory::InMemory;
+
+    fn sample_partition(byte_size: usize, num_elements: usize) -> CollectionPartitionMetadata {
+        let schema = Arc::new(Schema::new(vec![Field::new("temp", DataType::Int32, true)]));
+        CollectionPartitionMetadata {
+            byte_size,
+            num_elements,
+            num_entries: 1,
+            partition_schema: schema,
+            arrays: IndexMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn writer_appends_and_persists_metadata() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let root = Path::from("collections/demo");
+        let mut writer = CollectionWriter::new(store.clone(), root.clone())
+            .await
+            .expect("writer init");
+
+        let idx = writer
+            .append_partition(sample_partition(64, 10))
+            .expect("append partition");
+        assert_eq!(idx, 0);
+        writer.persist().await.expect("persist metadata");
+
+        let writer_again = CollectionWriter::new(store.clone(), root.clone())
+            .await
+            .expect("reload metadata");
+
+        assert_eq!(writer_again.metadata().collection_byte_size, 64);
+        assert_eq!(writer_again.metadata().collection_num_elements, 10);
+        assert!(writer_again.metadata().partitions.contains_key(&0));
+    }
+
+    #[tokio::test]
+    async fn reader_loads_metadata_and_returns_partition_reader() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let root = Path::from("collections/readers");
+        let mut writer = CollectionWriter::new(store.clone(), root.clone())
+            .await
+            .expect("writer init");
+        let idx = writer
+            .append_partition(sample_partition(32, 5))
+            .expect("append partition");
+        assert_eq!(idx, 0);
+        writer.persist().await.expect("persist metadata");
+
+        let reader = CollectionReader::new(store.clone(), root.clone(), ArrayIoCache::new(1024))
+            .await
+            .expect("reader init");
+        assert_eq!(reader.metadata().partitions.len(), 1);
+
+        let partition_reader = reader.partition_reader(idx).expect("reader exists");
+        assert_eq!(partition_reader.metadata.num_entries, 1);
+        assert_eq!(partition_reader.metadata.num_elements, 5);
+    }
 }

--- a/beacon-binary-format/src/collection_partition.rs
+++ b/beacon-binary-format/src/collection_partition.rs
@@ -1,0 +1,342 @@
+use std::pin;
+use std::sync::Arc;
+
+use arrow::array::StringArray;
+use arrow_schema::FieldRef;
+use futures::Stream;
+use futures::StreamExt;
+use indexmap::IndexMap;
+use nd_arrow_array::NdArrowArray;
+use nd_arrow_array::batch::NdRecordBatch;
+use object_store::ObjectStore;
+use serde::{Deserialize, Serialize};
+
+use crate::array_partition::ArrayPartitionReader;
+use crate::error::BBFError;
+use crate::error::BBFReadingError;
+use crate::io_cache;
+use crate::stream::AsyncStreamScheduler;
+use crate::{
+    array_partition::{ArrayPartitionMetadata, ArrayPartitionWriter},
+    error::BBFResult,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CollectionPartitionMetadata {
+    pub byte_size: usize,
+    pub num_elements: usize,
+    pub num_entries: usize,
+    pub partition_schema: Arc<arrow::datatypes::Schema>,
+    pub arrays: IndexMap<String, ArrayPartitionMetadata>,
+}
+
+pub struct CollectionPartitionReader {
+    pub metadata: CollectionPartitionMetadata,
+    pub path: object_store::path::Path,
+    pub object_store: Arc<dyn ObjectStore>,
+    pub io_cache: io_cache::ArrayIoCache,
+}
+
+pub struct CollectionPartitionReadOptions {
+    pub max_concurrent_reads: usize,
+}
+
+impl CollectionPartitionReader {
+    pub fn new(
+        path: object_store::path::Path,
+        object_store: Arc<dyn ObjectStore>,
+        metadata: CollectionPartitionMetadata,
+        io_cache: io_cache::ArrayIoCache,
+    ) -> Self {
+        Self {
+            metadata,
+            path,
+            object_store,
+            io_cache,
+        }
+    }
+
+    pub async fn read(
+        &self,
+        projection: Option<Arc<[String]>>,
+        options: CollectionPartitionReadOptions,
+    ) -> BBFResult<AsyncStreamScheduler<BBFResult<NdRecordBatch>>> {
+        let arrays_to_read = match projection {
+            Some(proj) => proj
+                .iter()
+                .filter_map(|name| {
+                    self.metadata
+                        .arrays
+                        .get(name)
+                        .map(|meta| (name.clone(), meta.clone()))
+                })
+                .collect::<IndexMap<String, ArrayPartitionMetadata>>(),
+            None => self.metadata.arrays.clone(),
+        };
+
+        let mut array_readers = IndexMap::new();
+        for (array_name, array_metadata) in &arrays_to_read {
+            let array_partition_reader = ArrayPartitionReader::new(
+                self.object_store.clone(),
+                array_name.clone(),
+                self.path.child(array_name.clone()),
+                array_metadata.clone(),
+                self.io_cache.clone(),
+            )
+            .await?;
+            array_readers.insert(array_name.clone(), array_partition_reader);
+        }
+        let shared_readers = Arc::new(array_readers);
+        let mut projected_fields = Vec::new();
+        for (array_name, array_metadata) in &arrays_to_read {
+            let field = self
+                .metadata
+                .partition_schema
+                .field_with_name(array_name)
+                .expect("field exists")
+                .clone();
+            projected_fields.push(field);
+        }
+        let projected_schema = Arc::new(arrow::datatypes::Schema::new(projected_fields.clone()));
+
+        let mut futures = Vec::new();
+        for index in 0..self.metadata.num_entries {
+            // For each entry, read arrays
+            let shared_readers = shared_readers.clone();
+            let projected_schema = projected_schema.clone();
+            let read_fut = async move {
+                let mut read_tasks = Vec::new();
+                for (_, array_reader) in shared_readers.as_ref() {
+                    let array_read_task = array_reader.read_array(index);
+                    read_tasks.push(array_read_task);
+                }
+
+                let array_results = futures::future::join_all(read_tasks).await;
+                let mut fields = Vec::new();
+                let mut arrays = Vec::new();
+
+                for (i, array_result) in array_results.into_iter().enumerate() {
+                    let field = projected_schema.field(i).clone();
+                    let array = array_result?.unwrap_or(NdArrowArray::new_null_scalar(Some(
+                        field.data_type().clone(),
+                    )));
+                    fields.push(field);
+                    arrays.push(array);
+                }
+
+                let nd_batch = NdRecordBatch::new(fields, arrays).map_err(|e| {
+                    BBFError::Reading(BBFReadingError::ArrayGroupReadFailure(
+                        format!("entry index {}", index),
+                        Box::new(e),
+                    ))
+                })?;
+                Ok::<_, BBFError>(nd_batch)
+            };
+            futures.push(read_fut);
+        }
+
+        let scheduler = AsyncStreamScheduler::new(futures, options.max_concurrent_reads);
+        Ok(scheduler)
+    }
+}
+
+pub struct CollectionPartitionWriter {
+    pub metadata: CollectionPartitionMetadata,
+    pub path: object_store::path::Path,
+    pub object_store: Arc<dyn ObjectStore>,
+    pub array_writers: IndexMap<String, ArrayPartitionWriter>,
+    pub write_options: WriterOptions,
+}
+
+pub struct WriterOptions {
+    pub max_group_size: usize,
+}
+
+impl CollectionPartitionWriter {
+    pub fn new(
+        path: object_store::path::Path,
+        object_store: Arc<dyn ObjectStore>,
+        options: WriterOptions,
+    ) -> Self {
+        let metadata = CollectionPartitionMetadata {
+            byte_size: 0,
+            num_elements: 0,
+            partition_schema: Arc::new(arrow::datatypes::Schema::empty()),
+            arrays: IndexMap::new(),
+            num_entries: 0,
+        };
+
+        Self {
+            metadata,
+            path,
+            object_store,
+            array_writers: IndexMap::new(),
+            write_options: options,
+        }
+    }
+
+    pub async fn write_entry(
+        &mut self,
+        entry_name: &str,
+        arrays: impl Stream<Item = (FieldRef, NdArrowArray)>,
+    ) -> BBFResult<()> {
+        let mut pinned = pin::pin!(arrays);
+        let mut skipped_arrays = (0..self.array_writers.len()).collect::<Vec<usize>>();
+
+        while let Some((field, array)) = pinned.next().await {
+            // Check if we have an array writer for this array
+            if !self.array_writers.contains_key(field.name()) {
+                // Create new array writer
+                let path = self.path.child(field.name().to_string());
+                let array_partition_writer = ArrayPartitionWriter::new(
+                    self.object_store.clone(),
+                    path,
+                    field.name().to_string(),
+                    self.write_options.max_group_size,
+                    Some(field.data_type().to_owned()),
+                    self.metadata.num_entries,
+                )
+                .await?;
+                self.array_writers
+                    .insert(field.name().to_string(), array_partition_writer);
+            }
+
+            // Write to array writer
+            let (idx, _, array_writer) = self.array_writers.get_full_mut(field.name()).unwrap();
+            array_writer.append_array(Some(array)).await?;
+            // Remove from skipped arrays
+            skipped_arrays.retain(|&i| i != idx);
+        }
+        // Write __entry_key array
+        if !self.array_writers.contains_key("__entry_key") {
+            let path = self.path.child("__entry_key".to_string());
+            let array_partition_writer = ArrayPartitionWriter::new(
+                self.object_store.clone(),
+                path,
+                "__entry_key".to_string(),
+                self.write_options.max_group_size,
+                Some(arrow::datatypes::DataType::Utf8),
+                self.metadata.num_entries,
+            )
+            .await?;
+            self.array_writers
+                .insert("__entry_key".to_string(), array_partition_writer);
+        }
+        let (idx, _, entry_key_writer) = self.array_writers.get_full_mut("__entry_key").unwrap();
+        let arrow_array = StringArray::from(vec![entry_name]);
+        let nd_arrow_array = NdArrowArray::new(
+            Arc::new(arrow_array),
+            nd_arrow_array::dimensions::Dimensions::Scalar,
+        )
+        .expect("create entry key array");
+        entry_key_writer.append_array(Some(nd_arrow_array)).await?;
+        // Remove from skipped arrays
+        skipped_arrays.retain(|&i| i != idx);
+
+        // For skipped arrays, write a null entry
+        for idx in skipped_arrays {
+            let (_, array_writer) = self
+                .array_writers
+                .get_index_mut(idx)
+                .expect("array writer exists");
+            array_writer.append_array(None).await?;
+        }
+
+        self.metadata.num_entries += 1;
+        Ok(())
+    }
+
+    pub async fn finish(mut self) -> BBFResult<CollectionPartitionMetadata> {
+        let mut total_byte_size = 0;
+        let mut total_num_elements = 0;
+        for (array_name, array_writer) in self.array_writers {
+            let array_metadata = array_writer.finish().await?;
+            total_byte_size += array_metadata.partition_byte_size;
+            total_num_elements += array_metadata.num_elements;
+            self.metadata.arrays.insert(array_name, array_metadata);
+        }
+
+        self.metadata.byte_size = total_byte_size;
+        self.metadata.num_elements = total_num_elements;
+
+        Ok(self.metadata)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{ArrayRef, Int32Array};
+    use arrow_schema::{DataType, Field};
+    use futures::stream;
+    use nd_arrow_array::dimensions::{Dimension, Dimensions};
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use std::sync::Arc as StdArc;
+
+    fn scalar_int32(values: &[i32]) -> NdArrowArray {
+        let array: ArrayRef = StdArc::new(Int32Array::from(values.to_vec()));
+        let dimension = Dimension {
+            name: "dim0".to_string(),
+            size: values.len(),
+        };
+        NdArrowArray::new(array, Dimensions::MultiDimensional(vec![dimension]))
+            .expect("nd array creation")
+    }
+
+    #[tokio::test]
+    async fn write_entry_records_arrays_and_entry_keys() {
+        let store: StdArc<dyn ObjectStore> = StdArc::new(InMemory::new());
+        let path = Path::from("collection/test");
+        let mut writer = CollectionPartitionWriter::new(
+            path,
+            store,
+            WriterOptions {
+                max_group_size: usize::MAX,
+            },
+        );
+
+        let temp_field: FieldRef = StdArc::new(Field::new("temp", DataType::Int32, true));
+        let sal_field: FieldRef = StdArc::new(Field::new("sal", DataType::Int32, true));
+
+        writer
+            .write_entry(
+                "entry-1",
+                stream::iter(vec![
+                    (temp_field.clone(), scalar_int32(&[1, 2])),
+                    (sal_field.clone(), scalar_int32(&[7])),
+                ]),
+            )
+            .await
+            .expect("write entry 1");
+
+        writer
+            .write_entry(
+                "entry-2",
+                stream::iter(vec![(temp_field.clone(), scalar_int32(&[3]))]),
+            )
+            .await
+            .expect("write entry 2");
+
+        let metadata = writer.finish().await.expect("finish success");
+
+        assert_eq!(metadata.num_entries, 2);
+        assert!(metadata.byte_size > 0);
+        assert_eq!(metadata.arrays.len(), 3);
+
+        let temp_meta = metadata.arrays.get("temp").expect("temp metadata");
+        assert_eq!(temp_meta.num_elements, 3);
+        assert_eq!(temp_meta.partition_offset, 0);
+
+        let sal_meta = metadata.arrays.get("sal").expect("sal metadata");
+        assert_eq!(sal_meta.num_elements, 1);
+        let sal_group = sal_meta.groups.values().next().expect("sal group metadata");
+        assert_eq!(sal_group.num_chunks, 2, "null entry was recorded");
+
+        let entry_key_meta = metadata
+            .arrays
+            .get("__entry_key")
+            .expect("entry key metadata");
+        assert_eq!(entry_key_meta.num_elements, 2);
+    }
+}

--- a/beacon-binary-format/src/error.rs
+++ b/beacon-binary-format/src/error.rs
@@ -34,6 +34,12 @@ pub enum BBFWritingError {
     ArrayGroupWriteFailure(ArrowError),
     #[error("Failed to finalize array partition: {0}")]
     ArrayPartitionFinalizeFailure(Box<dyn std::error::Error + Send + Sync>),
+    #[error("Failed to write pruning index for array partition: {0}")]
+    ArrayPartitionPruningIndexWriteFailure(Box<dyn std::error::Error + Send + Sync>),
+    #[error("Failed to write collection metadata: {0}")]
+    CollectionMetadataWriteFailure(Box<dyn std::error::Error + Send + Sync>),
+    #[error("Collection schema mismatch: expected {expected}, observed {actual}")]
+    CollectionSchemaMismatch { expected: String, actual: String },
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -48,6 +54,14 @@ pub enum BBFReadingError {
     },
     #[error("Failed to decode metadata for array partition group at {meta_path}: {reason}")]
     PartitionGroupMetadataDecode { meta_path: String, reason: String },
+    #[error("Failed to fetch metadata for collection at {meta_path}: {source}")]
+    CollectionMetadataFetch {
+        meta_path: String,
+        #[source]
+        source: ObjectStoreError,
+    },
+    #[error("Failed to decode metadata for collection at {meta_path}: {reason}")]
+    CollectionMetadataDecode { meta_path: String, reason: String },
     #[error("Failed to fetch bytes for partition {partition_path}: {source}")]
     PartitionBytesFetch {
         partition_path: String,
@@ -94,6 +108,11 @@ pub enum BBFReadingError {
     PartitionGroupDecode {
         partition_path: String,
         group_index: usize,
+        reason: String,
+    },
+    #[error("Failed to decode pruning index for partition {partition_path}: {reason}")]
+    PartitionPruningIndexDecode {
+        partition_path: String,
         reason: String,
     },
 }

--- a/beacon-binary-format/src/error.rs
+++ b/beacon-binary-format/src/error.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use arrow_schema::{ArrowError, DataType};
+use nd_arrow_array::error::NdArrayError;
+
+use crate::util::SuperTypeError;
+
+pub type BBFResult<T> = std::result::Result<T, BBFError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum BBFError {
+    #[error("BBF writing error: {0}")]
+    Writing(#[from] BBFWritingError),
+    #[error("BBF reading error: {0}")]
+    Reading(#[from] BBFReadingError),
+    #[error("Shared error: {0}")]
+    Shared(#[from] Arc<dyn std::error::Error + Send + Sync>),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BBFWritingError {
+    #[error("Failed to cast arrow array with data type {0} => {1} : {2}")]
+    ArrowCastFailure(DataType, DataType, ArrowError),
+    #[error("Failed to create NdArrowArray: {0}: {1}")]
+    NdArrowArrayCreationFailure(NdArrayError, String),
+    #[error("Unable to find super type for array group: {0}")]
+    SuperTypeNotFound(SuperTypeError),
+    #[error("Failed to build array group: {0}")]
+    ArrayGroupBuildFailure(Box<dyn std::error::Error + Send + Sync>),
+    #[error("Failed to create temporary file: {0} for array partition: {1}")]
+    TempFileCreationFailure(std::io::Error, String),
+    #[error("Failed to write array group to partition: {0}")]
+    ArrayGroupWriteFailure(ArrowError),
+    #[error("Failed to finalize array partition: {0}")]
+    ArrayPartitionFinalizeFailure(Box<dyn std::error::Error + Send + Sync>),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BBFReadingError {
+    #[error("Failed reading array from array group: {0} with error: {1}")]
+    ArrayGroupReadFailure(String, Box<dyn std::error::Error + Send + Sync>),
+}

--- a/beacon-binary-format/src/error.rs
+++ b/beacon-binary-format/src/error.rs
@@ -40,6 +40,14 @@ pub enum BBFWritingError {
 pub enum BBFReadingError {
     #[error("Failed reading array from array group: {0} with error: {1}")]
     ArrayGroupReadFailure(String, Box<dyn std::error::Error + Send + Sync>),
+    #[error("Failed to fetch metadata for array partition group at {meta_path}: {source}")]
+    PartitionGroupMetadataFetch {
+        meta_path: String,
+        #[source]
+        source: ObjectStoreError,
+    },
+    #[error("Failed to decode metadata for array partition group at {meta_path}: {reason}")]
+    PartitionGroupMetadataDecode { meta_path: String, reason: String },
     #[error("Failed to fetch bytes for partition {partition_path}: {source}")]
     PartitionBytesFetch {
         partition_path: String,

--- a/beacon-binary-format/src/io_cache.rs
+++ b/beacon-binary-format/src/io_cache.rs
@@ -1,15 +1,23 @@
+//! Async cache for deduplicating Arrow partition fetches.
+//!
+//! Many readers share object-store backed partitions.  `ArrayIoCache` stores
+//! previously materialized Arrow `RecordBatch`es keyed by partition path and
+//! logical group index to avoid redundant downloads.
+
 use std::{future::Future, sync::Arc};
 
 use arrow::array::RecordBatch;
 
 use crate::error::BBFError;
 
+/// Cache key that uniquely addresses a partition group inside object storage.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CacheKey {
     pub array_partition_path: object_store::path::Path,
     pub group_index: usize,
 }
 
+/// Thin wrapper around a moka cache that stores Arrow batches.
 #[derive(Debug, Clone)]
 pub struct ArrayIoCache<Key = CacheKey>
 where
@@ -22,6 +30,7 @@ impl<Key> ArrayIoCache<Key>
 where
     Key: std::hash::Hash + Eq + Clone + Send + Sync + 'static,
 {
+    /// Create a cache configured with an approximate max-size weigher.
     pub fn new(max_size_bytes: usize) -> Self {
         let cache = moka::future::Cache::builder()
             .max_capacity(max_size_bytes as u64)
@@ -36,6 +45,8 @@ where
         }
     }
 
+    /// Fetch the cached value for `key`, or compute and insert it using
+    /// `loader` when absent.
     pub async fn try_get_or_insert_with<F, Fut>(
         &self,
         key: Key,

--- a/beacon-binary-format/src/io_cache.rs
+++ b/beacon-binary-format/src/io_cache.rs
@@ -1,0 +1,58 @@
+use std::{future::Future, sync::Arc};
+
+use arrow::array::RecordBatch;
+
+use crate::error::BBFError;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CacheKey {
+    pub array_name: String,
+    pub partition_hash: String,
+    pub group_index: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct ArrayIoCache<Key = CacheKey>
+where
+    Key: std::hash::Hash + Eq + Clone + Send + Sync + 'static,
+{
+    inner: Arc<moka::future::Cache<Key, Option<arrow::array::RecordBatch>>>,
+}
+
+impl<Key> ArrayIoCache<Key>
+where
+    Key: std::hash::Hash + Eq + Clone + Send + Sync + 'static,
+{
+    pub fn new(max_size_bytes: usize) -> Self {
+        let cache = moka::future::Cache::builder()
+            .max_capacity(max_size_bytes as u64)
+            .weigher(|_key: &Key, value: &Option<arrow::array::RecordBatch>| {
+                value.as_ref().map_or(0, |rb| rb.get_array_memory_size()) as u32
+            })
+            .eviction_policy(moka::policy::EvictionPolicy::lru())
+            .time_to_idle(std::time::Duration::from_secs(60))
+            .build();
+        Self {
+            inner: Arc::new(cache),
+        }
+    }
+
+    pub async fn try_get_or_insert_with<F, Fut>(
+        &self,
+        key: Key,
+        loader: F,
+    ) -> Result<Option<RecordBatch>, BBFError>
+    where
+        F: FnOnce(&Key) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<Option<RecordBatch>, BBFError>> + Send + 'static,
+    {
+        // moka’s “load‐through” API
+        self.inner
+            .try_get_with(key.clone(), {
+                let key_clone = key.clone();
+                async move { loader(&key_clone).await }
+            })
+            .await
+            .map_err(|e| BBFError::Shared(Arc::new(e)))
+    }
+}

--- a/beacon-binary-format/src/io_cache.rs
+++ b/beacon-binary-format/src/io_cache.rs
@@ -6,8 +6,7 @@ use crate::error::BBFError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CacheKey {
-    pub array_name: String,
-    pub partition_hash: String,
+    pub array_partition_path: object_store::path::Path,
     pub group_index: usize,
 }
 

--- a/beacon-binary-format/src/lib.rs
+++ b/beacon-binary-format/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod array_group;
+pub mod array_partition;
+pub mod error;
+pub mod io_cache;
+pub mod util;

--- a/beacon-binary-format/src/lib.rs
+++ b/beacon-binary-format/src/lib.rs
@@ -1,5 +1,9 @@
 pub mod array_group;
 pub mod array_partition;
+pub mod array_partition_group;
+pub mod collection;
+pub mod collection_partition;
 pub mod error;
 pub mod io_cache;
+pub mod stream;
 pub mod util;

--- a/beacon-binary-format/src/lib.rs
+++ b/beacon-binary-format/src/lib.rs
@@ -1,3 +1,16 @@
+//! Building blocks for the Beacon binary format.
+//!
+//! This crate hosts the low-level readers, writers, caches, and helper
+//! utilities that manage Arrow-centric array partitions stored inside an
+//! object store.  Each module focuses on a single concern so applications can
+//! pick the components they need: from `array_partition` for authoring Arrow
+//! IPC blobs, to `collection` for orchestrating partition metadata, and
+//! `io_cache` for deduplicating expensive round-trips.
+//!
+//! The public API is intentionally granular; production services typically
+//! compose higher-level workflows by mixing the provided writers/readers with
+//! their own scheduling and persistence layers.
+
 pub mod array_group;
 pub mod array_partition;
 pub mod array_partition_group;

--- a/beacon-binary-format/src/lib.rs
+++ b/beacon-binary-format/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod array_group;
 pub mod array_partition;
 pub mod array_partition_group;
+pub mod array_partition_index;
 pub mod collection;
 pub mod collection_partition;
 pub mod error;

--- a/beacon-binary-format/src/stream.rs
+++ b/beacon-binary-format/src/stream.rs
@@ -1,0 +1,48 @@
+use std::{future::Future, sync::Arc};
+
+use futures::Stream;
+use tokio::sync::Semaphore;
+
+#[derive(Debug, Clone)]
+
+pub struct AsyncStreamScheduler<T: Send + 'static> {
+    receiver: flume::Receiver<T>,
+}
+
+impl<T: Send + 'static> AsyncStreamScheduler<T> {
+    pub fn new<Fut>(futures: Vec<Fut>, parallelism: usize) -> Self
+    where
+        Fut: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let (sender, receiver) = flume::bounded::<T>(parallelism);
+        let sem = Arc::new(Semaphore::new(parallelism));
+
+        tokio::spawn({
+            let sender = sender.clone();
+            async move {
+                let mut handles = Vec::with_capacity(futures.len());
+                for fut in futures {
+                    let permit = sem.clone().acquire_owned().await.unwrap();
+                    let sender = sender.clone();
+                    handles.push(tokio::spawn(async move {
+                        let _permit = permit; // lives until this task finishes
+                        let res = fut.await;
+                        let _ = sender.send_async(res).await;
+                    }));
+                }
+
+                for h in handles {
+                    let _ = h.await;
+                }
+                drop(sender);
+            }
+        });
+
+        Self { receiver }
+    }
+
+    pub async fn shared_pollable_stream_ref(&self) -> impl Stream<Item = T> + '_ {
+        self.receiver.clone().into_stream()
+    }
+}

--- a/beacon-binary-format/src/util.rs
+++ b/beacon-binary-format/src/util.rs
@@ -1,0 +1,256 @@
+use arrow::datatypes::{DataType, Fields, Schema, TimeUnit};
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum SuperTypeError {
+    #[error("Cannot find a common super type for {left} and {right} in column {column_name}")]
+    NoCommonSuperType {
+        left: DataType,
+        right: DataType,
+        column_name: String,
+    },
+    #[error("No schemas provided")]
+    NoSchemasProvided,
+}
+
+pub type Result<T> = std::result::Result<T, SuperTypeError>;
+
+pub fn super_type_schema(schemas: &[arrow::datatypes::SchemaRef]) -> Result<Schema> {
+    if schemas.is_empty() {
+        return Err(SuperTypeError::NoSchemasProvided);
+    }
+
+    let mut fields = indexmap::IndexMap::new();
+    for schema in schemas {
+        for field in schema.fields.iter() {
+            let name = field.name().to_string();
+            let dtype = field.data_type().clone();
+            match fields.get_mut(&name) {
+                Some(existing_dtype) => {
+                    if let Some(supert_type) = super_type_arrow(existing_dtype, &dtype) {
+                        *existing_dtype = supert_type;
+                    } else {
+                        return Err(SuperTypeError::NoCommonSuperType {
+                            left: existing_dtype.clone(),
+                            right: dtype,
+                            column_name: field.name().to_string(),
+                        });
+                    }
+                }
+                None => {
+                    fields.insert(name, dtype.into());
+                }
+            }
+        }
+    }
+
+    Ok(arrow::datatypes::Schema::new(Fields::from(
+        fields
+            .into_iter()
+            .map(|(name, dtype)| arrow::datatypes::Field::new(&name, dtype.into(), true))
+            .collect::<Vec<_>>(),
+    )))
+}
+
+pub fn super_type_arrow_schema(
+    schemas: &[arrow::datatypes::Schema],
+) -> Option<arrow::datatypes::Schema> {
+    let mut fields = indexmap::IndexMap::new();
+    for schema in schemas {
+        for field in schema.fields.iter() {
+            let name = field.name().to_string();
+            let dtype = field.data_type().clone();
+            match fields.get_mut(&name) {
+                Some(existing_dtype) => {
+                    if let Some(supert_type) = super_type_arrow(existing_dtype, &dtype) {
+                        *existing_dtype = supert_type;
+                    } else {
+                        return None;
+                    }
+                }
+                None => {
+                    fields.insert(name, dtype.into());
+                }
+            }
+        }
+    }
+
+    Some(arrow::datatypes::Schema::new(Fields::from(
+        fields
+            .into_iter()
+            .map(|(name, dtype)| arrow::datatypes::Field::new(&name, dtype.into(), false))
+            .collect::<Vec<_>>(),
+    )))
+}
+
+/// Determine the smallest common super type for two Arrow data types.
+///
+/// This function takes two data types (`left` and `right`) and returns an option
+/// containing the common super type if one exists.
+/// If both data types are equal, it returns a clone of that type.
+/// For certain type combinations, the super type is defined to follow conventions
+/// from libraries such as Polars and Numpy.
+///
+/// # Parameters
+///
+/// - `left`: A reference to the first Arrow data type.
+/// - `right`: A reference to the second Arrow data type.
+///
+/// # Returns
+///
+/// An `Option<DataType>` with the common super type if a valid one exists, otherwise `None`.
+pub fn super_type_arrow(left: &DataType, right: &DataType) -> Option<DataType> {
+    if left == right {
+        return Some(left.clone());
+    }
+
+    let super_type = match (left.clone(), right.clone()) {
+        (DataType::Null, _) => right.clone(),
+        (_, DataType::Null) => left.clone(),
+        (DataType::Int8, DataType::Boolean) => DataType::Int8,
+        (DataType::Int8, DataType::Int16) => DataType::Int16,
+        (DataType::Int8, DataType::Int32) => DataType::Int32,
+        (DataType::Int8, DataType::Int64) => DataType::Int64,
+        (DataType::Int8, DataType::UInt8) => DataType::Int16,
+        (DataType::Int8, DataType::UInt16) => DataType::Int32,
+        (DataType::Int8, DataType::UInt32) => DataType::Int64,
+        // Follow Polars + Numpy
+        (DataType::Int8, DataType::UInt64) => DataType::Float64,
+        (DataType::Int8, DataType::Float32) => DataType::Float32,
+        (DataType::Int8, DataType::Float64) => DataType::Float64,
+        (DataType::Int8, DataType::Utf8) => DataType::Utf8,
+        (DataType::Int8, DataType::Timestamp(_, _)) => DataType::Int64,
+
+        (DataType::Int16, DataType::Boolean) => DataType::Int16,
+        (DataType::Int16, DataType::Int8) => DataType::Int16,
+        (DataType::Int16, DataType::Int32) => DataType::Int32,
+        (DataType::Int16, DataType::Int64) => DataType::Int64,
+        (DataType::Int16, DataType::UInt8) => DataType::Int16,
+        (DataType::Int16, DataType::UInt16) => DataType::Int32,
+        (DataType::Int16, DataType::UInt32) => DataType::Int64,
+        // Follow Polars + Numpy
+        (DataType::Int16, DataType::UInt64) => DataType::Float64,
+        (DataType::Int16, DataType::Float32) => DataType::Float32,
+        (DataType::Int16, DataType::Float64) => DataType::Float64,
+        (DataType::Int16, DataType::Utf8) => DataType::Utf8,
+        (DataType::Int16, DataType::Timestamp(_, _)) => DataType::Int64,
+
+        (DataType::Int32, DataType::Boolean) => DataType::Int32,
+        (DataType::Int32, DataType::Int8) => DataType::Int32,
+        (DataType::Int32, DataType::Int16) => DataType::Int32,
+        (DataType::Int32, DataType::Int64) => DataType::Int64,
+        (DataType::Int32, DataType::UInt8) => DataType::Int32,
+        (DataType::Int32, DataType::UInt16) => DataType::Int32,
+        (DataType::Int32, DataType::UInt32) => DataType::Int64,
+        // Follow Polars + Numpy
+        (DataType::Int32, DataType::UInt64) => DataType::Float64,
+        (DataType::Int32, DataType::Float32) => DataType::Float32,
+        (DataType::Int32, DataType::Float64) => DataType::Float64,
+        (DataType::Int32, DataType::Utf8) => DataType::Utf8,
+        (DataType::Int32, DataType::Timestamp(_, _)) => DataType::Int64,
+
+        (DataType::Int64, DataType::Boolean) => DataType::Int64,
+        (DataType::Int64, DataType::Int8) => DataType::Int64,
+        (DataType::Int64, DataType::Int16) => DataType::Int64,
+        (DataType::Int64, DataType::Int32) => DataType::Int64,
+        (DataType::Int64, DataType::UInt8) => DataType::Int64,
+        (DataType::Int64, DataType::UInt16) => DataType::Int64,
+        (DataType::Int64, DataType::UInt32) => DataType::Int64,
+        // Follow Polars + Numpy
+        (DataType::Int64, DataType::UInt64) => DataType::Float64,
+        (DataType::Int64, DataType::Float32) => DataType::Float64,
+        (DataType::Int64, DataType::Float64) => DataType::Float64,
+        (DataType::Int64, DataType::Utf8) => DataType::Utf8,
+        (DataType::Int64, DataType::Timestamp(_, _)) => DataType::Int64,
+
+        (DataType::UInt8, DataType::Boolean) => DataType::UInt8,
+        (DataType::UInt8, DataType::Int8) => DataType::Int16,
+        (DataType::UInt8, DataType::Int16) => DataType::Int16,
+        (DataType::UInt8, DataType::Int32) => DataType::Int32,
+        (DataType::UInt8, DataType::Int64) => DataType::Int64,
+        (DataType::UInt8, DataType::UInt16) => DataType::UInt16,
+        (DataType::UInt8, DataType::UInt32) => DataType::UInt32,
+        (DataType::UInt8, DataType::UInt64) => DataType::UInt64,
+        (DataType::UInt8, DataType::Float32) => DataType::Float32,
+        (DataType::UInt8, DataType::Float64) => DataType::Float64,
+        (DataType::UInt8, DataType::Utf8) => DataType::Utf8,
+        (DataType::UInt8, DataType::Timestamp(_, _)) => DataType::Int64,
+
+        (DataType::UInt16, DataType::Boolean) => DataType::UInt16,
+        (DataType::UInt16, DataType::Int8) => DataType::Int32,
+        (DataType::UInt16, DataType::Int16) => DataType::Int32,
+        (DataType::UInt16, DataType::Int32) => DataType::Int32,
+        (DataType::UInt16, DataType::Int64) => DataType::Int64,
+        (DataType::UInt16, DataType::UInt8) => DataType::UInt16,
+        (DataType::UInt16, DataType::UInt32) => DataType::UInt32,
+        (DataType::UInt16, DataType::UInt64) => DataType::UInt64,
+        (DataType::UInt16, DataType::Float32) => DataType::Float32,
+        (DataType::UInt16, DataType::Float64) => DataType::Float64,
+        (DataType::UInt16, DataType::Utf8) => DataType::Utf8,
+        (DataType::UInt16, DataType::Timestamp(_, _)) => DataType::Int64,
+
+        (DataType::UInt32, DataType::Boolean) => DataType::UInt32,
+        (DataType::UInt32, DataType::Int8) => DataType::Int64,
+        (DataType::UInt32, DataType::Int16) => DataType::Int64,
+        (DataType::UInt32, DataType::Int32) => DataType::Int64,
+        (DataType::UInt32, DataType::Int64) => DataType::Int64,
+        (DataType::UInt32, DataType::UInt8) => DataType::UInt32,
+        (DataType::UInt32, DataType::UInt16) => DataType::UInt32,
+        (DataType::UInt32, DataType::UInt64) => DataType::UInt64,
+        (DataType::UInt32, DataType::Float32) => DataType::Float32,
+        (DataType::UInt32, DataType::Float64) => DataType::Float64,
+        (DataType::UInt32, DataType::Utf8) => DataType::Utf8,
+        (DataType::UInt32, DataType::Timestamp(_, _)) => DataType::Int64,
+
+        (DataType::UInt64, DataType::Boolean) => DataType::UInt64,
+        (DataType::UInt64, DataType::Int8) => DataType::Float64,
+        (DataType::UInt64, DataType::Int16) => DataType::Float64,
+        (DataType::UInt64, DataType::Int32) => DataType::Float64,
+        (DataType::UInt64, DataType::Int64) => DataType::Float64,
+        (DataType::UInt64, DataType::UInt8) => DataType::UInt64,
+        (DataType::UInt64, DataType::UInt16) => DataType::UInt64,
+        (DataType::UInt64, DataType::UInt32) => DataType::UInt64,
+        (DataType::UInt64, DataType::Float32) => DataType::Float64,
+        (DataType::UInt64, DataType::Float64) => DataType::Float64,
+        (DataType::UInt64, DataType::Utf8) => DataType::Utf8,
+        (DataType::UInt64, DataType::Timestamp(_, _)) => DataType::Float64,
+
+        (DataType::Float32, DataType::Boolean) => DataType::Float32,
+        (DataType::Float32, DataType::Int8) => DataType::Float32,
+        (DataType::Float32, DataType::Int16) => DataType::Float32,
+        (DataType::Float32, DataType::Int32) => DataType::Float64,
+        (DataType::Float32, DataType::Int64) => DataType::Float64,
+        (DataType::Float32, DataType::UInt8) => DataType::Float32,
+        (DataType::Float32, DataType::UInt16) => DataType::Float32,
+        (DataType::Float32, DataType::UInt32) => DataType::Float64,
+        (DataType::Float32, DataType::UInt64) => DataType::Float64,
+        (DataType::Float32, DataType::Float64) => DataType::Float64,
+        (DataType::Float32, DataType::Utf8) => DataType::Utf8,
+        (DataType::Float32, DataType::Timestamp(_, _)) => DataType::Float64,
+
+        (DataType::Float64, DataType::Utf8) => DataType::Utf8,
+        (DataType::Float64, _) => DataType::Float64,
+
+        (DataType::LargeUtf8, _) => DataType::LargeUtf8,
+        (_, DataType::LargeUtf8) => DataType::LargeUtf8,
+        (DataType::Utf8, _) => DataType::Utf8,
+
+        (DataType::Timestamp(_, _), DataType::Int8) => DataType::Int64,
+        (DataType::Timestamp(_, _), DataType::Int16) => DataType::Int64,
+        (DataType::Timestamp(_, _), DataType::Int32) => DataType::Int64,
+        (DataType::Timestamp(_, _), DataType::Int64) => DataType::Int64,
+        (DataType::Timestamp(_, _), DataType::UInt8) => DataType::Int64,
+        (DataType::Timestamp(_, _), DataType::UInt16) => DataType::Int64,
+        (DataType::Timestamp(_, _), DataType::UInt32) => DataType::Int64,
+        (DataType::Timestamp(_, _), DataType::UInt64) => DataType::Float64,
+        (DataType::Timestamp(_, _), DataType::Float32) => DataType::Float64,
+        (DataType::Timestamp(_, _), DataType::Float64) => DataType::Float64,
+        (DataType::Timestamp(_, _), DataType::Utf8) => DataType::Utf8,
+        (DataType::Timestamp(_, _), DataType::Timestamp(_, _)) => {
+            DataType::Timestamp(TimeUnit::Second, None)
+        }
+
+        _ => return None,
+    };
+
+    Some(super_type)
+}

--- a/beacon-binary-format/src/util.rs
+++ b/beacon-binary-format/src/util.rs
@@ -1,3 +1,8 @@
+//! Shared Arrow utility helpers.
+//!
+//! The functions in this module help reconcile Arrow schemas and serialize
+//! range-based metadata blobs shared across the crate.
+
 use arrow::datatypes::{DataType, Fields, Schema, TimeUnit};
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -256,7 +261,6 @@ pub fn super_type_arrow(left: &DataType, right: &DataType) -> Option<DataType> {
 }
 
 pub(crate) mod range_index_map {
-    use super::*;
     use indexmap::IndexMap;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 


### PR DESCRIPTION
This pull request introduces Python bindings for the Beacon Binary Format, enabling Python users to read and write Beacon collections using native NumPy arrays and supporting object store backends. It adds a new `beacon-binary-format-py` crate, a corresponding Python package, and a CI workflow for publishing Python wheels. Minor formatting and consistency improvements are also made to the Rust API codebase.

**Python bindings and packaging:**

* Added new `beacon-binary-format-py` crate and Python package, exposing the Beacon Binary Format collection writer and reader to Python via PyO3, with support for NumPy arrays, masked arrays, named dimensions, and object store backends. Includes comprehensive documentation and type stubs. [[1]](diffhunk://#diff-dde9dc8d02c749fbc350bd04aa5d4cf28ca2c79f2352f6715f63af9105b73b54R1-R19) [[2]](diffhunk://#diff-9338306da9d88bdc6b3f8918b08262014b181a0cf3fb4fa2caca5f5b230d760bR1-R169) [[3]](diffhunk://#diff-7d64dff1e515a6bdeafecf3957128a26a96400482bf4ead04958071ac7a92437R1-R97) [[4]](diffhunk://#diff-412b52544fcad5bddfe1351eb187597c9da5133a9c662c4ef4e639762e97e652R1-R33)
* Registered the new crates in the workspace by updating `Cargo.toml`.
* Added a GitHub Actions workflow to build, test, and publish the Python package to PyPI using `maturin`.

**Rust build and compatibility:**

* Updated `.cargo/config.toml` to set linker flags for macOS targets, improving compatibility for building Python extensions on both x86_64 and ARM Macs.

**Rust API formatting and consistency:**

* Improved formatting and consistency in API response construction and imports across several files, making the codebase cleaner and more maintainable. [[1]](diffhunk://#diff-b4f104c03fb4bbab56215688fe5006225afc2e696c860f03625ebe9fde5d87bdL4-R9) [[2]](diffhunk://#diff-b4f104c03fb4bbab56215688fe5006225afc2e696c860f03625ebe9fde5d87bdL141-L154) [[3]](diffhunk://#diff-b4f104c03fb4bbab56215688fe5006225afc2e696c860f03625ebe9fde5d87bdL183-L192) [[4]](diffhunk://#diff-36496755a0542985708745a336a7e8c10f4124a65d86c5925fc433e1a88b9764L9-R9) [[5]](diffhunk://#diff-36496755a0542985708745a336a7e8c10f4124a65d86c5925fc433e1a88b9764L46) [[6]](diffhunk://#diff-36496755a0542985708745a336a7e8c10f4124a65d86c5925fc433e1a88b9764L71-R79) [[7]](diffhunk://#diff-36496755a0542985708745a336a7e8c10f4124a65d86c5925fc433e1a88b9764L104-R118) [[8]](diffhunk://#diff-a7b308b23e3300a509a6f7d38b3ab6eecbc8166bf1fa0b3fa2abc4bf1a3632d5L19-R19) [[9]](diffhunk://#diff-2ad32fe83f7ee24347a7383f752917823bf282484e01783d63bcf2edf8aee3feL6) [[10]](diffhunk://#diff-2f5734f0815948cc6aee9e32b74ffeba173512ea4ba9ab4a49f2c1e0aef2cd83L56-R59) [[11]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L14)