### PR TITLE
gracefully handle unsupported child arrays

### DIFF
--- a/beacon-arrow-zarr/src/reader.rs
+++ b/beacon-arrow-zarr/src/reader.rs
@@ -49,7 +49,12 @@ impl AsyncArrowZarrGroupReader {
 
         let group_path = group.path();
 
-        for array in group.async_child_arrays().await.unwrap() {
+        let child_arrays = group
+            .async_child_arrays()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        for array in child_arrays {
             let array_json_attributes = array.attributes();
             let array_node_path = array.path().clone();
             let array_name = array_node_path


### PR DESCRIPTION
Fixes #149 

This pull request improves error handling in the `AsyncArrowZarrGroupReader` by converting errors from the `async_child_arrays` call into string errors, rather than unwrapping and panicking. This change makes the code more robust and user-friendly by providing clearer error messages.

Error handling improvements:

* Updated the call to `group.async_child_arrays()` to map errors into string messages using `.map_err(|e| e.to_string())?`, replacing the previous use of `.unwrap()`. This prevents panics and allows errors to be handled gracefully.