### PR TITLE
improve performance netcdf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
  "tokio-util",
  "tower-http",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "utoipa",
  "utoipa-axum",
@@ -990,6 +991,7 @@ dependencies = [
  "tracing",
  "typetag",
  "url",
+ "which",
  "zarrs",
  "zarrs_object_store",
  "zarrs_storage",
@@ -2435,6 +2437,12 @@ name = "endian-type"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "envconfig"
@@ -6175,6 +6183,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.17",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6579,6 +6599,17 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix",
+ "winsafe",
 ]
 
 [[package]]
@@ -7010,6 +7041,12 @@ dependencies = [
  "serde",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "2.0.12"
 
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-appender = "0.2.4"
 tracing-test = "0.2.5"
 glob = "0.3.2"
 tempfile = "3.15.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY beacon-core/ /beacon-core/
 COPY beacon-data-lake/ /beacon-data-lake/
 COPY beacon-formats/ /beacon-formats/
 COPY beacon-functions/ /beacon-functions/
+COPY beacon-object-storage/ /beacon-object-storage/
 COPY beacon-planner/ /beacon-planner/
 COPY beacon-query/ /beacon-query/
 COPY Cargo.toml /

--- a/beacon-api/Cargo.toml
+++ b/beacon-api/Cargo.toml
@@ -31,6 +31,7 @@ arrow-schema = { workspace = true}
 uuid = { version = "1.16.0" }
 tracing = { workspace = true}
 tracing-subscriber = { workspace = true}
+tracing-appender = { workspace = true}
 
 # Local dependencies
 beacon-config = { path = "../beacon-config" }

--- a/beacon-arrow-netcdf-mpio/src/main.rs
+++ b/beacon-arrow-netcdf-mpio/src/main.rs
@@ -40,6 +40,7 @@ fn main() -> io::Result<()> {
     let mut stdin = BufReader::new(io::stdin());
     let mut stdout = BufWriter::with_capacity(4 * 1024 * 1024, io::stdout());
     let mut reader_cache: HashMap<String, NetCDFArrowReader> = std::collections::HashMap::new();
+    let mut log_file = std::fs::File::create("mpio.log")?;
 
     loop {
         let Some(json_buf) = read_framed_json(&mut stdin)? else {
@@ -56,6 +57,11 @@ fn main() -> io::Result<()> {
 
         match &cmd {
             ReadCommand::ReadArrowSchema { request_id, path } => {
+                writeln!(
+                    log_file,
+                    "mpio worker: received ReadArrowSchema request {} for path {}",
+                    request_id, path
+                )?;
                 let schema = if let Some(reader) = reader_cache.get(path) {
                     // already cached
                     reader.schema().clone()
@@ -92,6 +98,11 @@ fn main() -> io::Result<()> {
                 stdout.write_all(&response_len)?;
                 stdout.write_all(&response_json)?;
                 stdout.flush()?;
+                writeln!(
+                    log_file,
+                    "mpio worker: sent schema response for request {}",
+                    request_id
+                )?;
             }
             ReadCommand::ReadFile {
                 request_id,
@@ -100,6 +111,11 @@ fn main() -> io::Result<()> {
                 chunk_size: _chunk_size,
                 stream_size: _stream_size,
             } => {
+                write!(
+                    log_file,
+                    "mpio worker: received ReadFile request {} for path {}",
+                    request_id, path
+                )?;
                 let reader = if let Some(reader) = reader_cache.get_mut(path) {
                     // already cached
                     reader
@@ -184,12 +200,20 @@ fn main() -> io::Result<()> {
                 stdout.write_all(&response_json)?;
                 stdout.write_all(&buffer)?;
                 stdout.flush()?;
+                writeln!(
+                    log_file,
+                    "mpio worker: sent {} bytes for request {}",
+                    buffer.len(),
+                    request_id
+                )?;
             }
             ReadCommand::Exit => {
+                writeln!(log_file, "mpio worker: exiting as requested")?;
                 break;
             }
         }
     }
+    writeln!(log_file, "mpio worker: shutting down")?;
     Ok(())
 }
 

--- a/beacon-arrow-netcdf-mpio/src/main.rs
+++ b/beacon-arrow-netcdf-mpio/src/main.rs
@@ -111,7 +111,7 @@ fn main() -> io::Result<()> {
                 chunk_size: _chunk_size,
                 stream_size: _stream_size,
             } => {
-                write!(
+                writeln!(
                     log_file,
                     "mpio worker: received ReadFile request {} for path {}",
                     request_id, path

--- a/beacon-formats/Cargo.toml
+++ b/beacon-formats/Cargo.toml
@@ -37,6 +37,7 @@ zarrs = {"version" = "0.22.2", features = ["async"]}
 
 url = "2.5.4"
 glob = "0.3.3"
+which = "8.0.0"
 num-traits = "0.2.19"
 ndarray = { version = ">=0.15,<=0.16" }
 once_cell = "1.21.3"

--- a/beacon-formats/src/netcdf/source/mpio.rs
+++ b/beacon-formats/src/netcdf/source/mpio.rs
@@ -239,10 +239,33 @@ fn worker_executable_path() -> PathBuf {
     }
 
     if let Some(path) = CONFIG.netcdf_mpio_worker.clone() {
+        tracing::debug!(path = ?path, "using beacon-arrow-netcdf-mpio from config");
         return path;
     }
 
+    // Check for `beacon-arrow-netcdf-mpio` in PATH.
+    if let Ok(path) = which::which("beacon-arrow-netcdf-mpio") {
+        tracing::debug!(path = ?path, "using beacon-arrow-netcdf-mpio from PATH");
+        return path;
+    }
+
+    // As a last resort, check if it nexts to the current executable (ourselves).
+    if let Ok(current_exe) = std::env::current_exe() {
+        let candidate = current_exe
+            .parent()
+            .unwrap()
+            .join("beacon-arrow-netcdf-mpio");
+        if candidate.exists() {
+            tracing::debug!(
+                path = ?candidate,
+                "using beacon-arrow-netcdf-mpio next to current executable"
+            );
+            return candidate;
+        }
+    }
+
     // Default to resolving from PATH.
+    tracing::debug!("using beacon-arrow-netcdf-mpio from default PATH resolution");
     PathBuf::from("beacon-arrow-netcdf-mpio")
 }
 


### PR DESCRIPTION
Fixes #147

This pull request adds detailed logging to the `beacon-arrow-netcdf-mpio` worker process and increases the trace-level logging in the `beacon-formats` MPIO dispatcher and worker code. These changes are intended to make it easier to debug and monitor the behavior of MPIO requests and worker activity.

**Logging improvements in worker process (`beacon-arrow-netcdf-mpio/src/main.rs`):**
- Added a log file (`mpio.log`) to record key events in the worker lifecycle, including when requests are received, responses are sent, and when the worker exits or shuts down. [[1]](diffhunk://#diff-b016e1326eeeef661f8048821dc5920a7150f13a18cc690737923725a116d5bdR43) [[2]](diffhunk://#diff-b016e1326eeeef661f8048821dc5920a7150f13a18cc690737923725a116d5bdR60-R64) [[3]](diffhunk://#diff-b016e1326eeeef661f8048821dc5920a7150f13a18cc690737923725a116d5bdR101-R105) [[4]](diffhunk://#diff-b016e1326eeeef661f8048821dc5920a7150f13a18cc690737923725a116d5bdR114-R118) [[5]](diffhunk://#diff-b016e1326eeeef661f8048821dc5920a7150f13a18cc690737923725a116d5bdR203-R216)

**Enhanced trace-level logging in dispatcher and worker (`beacon-formats/src/netcdf/source/mpio.rs`):**
- Increased trace-level logging throughout the dispatcher loop to track queue lengths, idle worker counts, and request dispatching, making the system's internal state more observable. [[1]](diffhunk://#diff-19843dfc2e4fbdeaf24ed08b22d58fa411aeb414d721536b378ea1f54d319cf1R274-L298) [[2]](diffhunk://#diff-19843dfc2e4fbdeaf24ed08b22d58fa411aeb414d721536b378ea1f54d319cf1R343)
- Changed worker-side logging from debug to trace level for request handling and completion, reducing log noise at higher log levels while retaining detailed information for troubleshooting. [[1]](diffhunk://#diff-19843dfc2e4fbdeaf24ed08b22d58fa411aeb414d721536b378ea1f54d319cf1L360-R376) [[2]](diffhunk://#diff-19843dfc2e4fbdeaf24ed08b22d58fa411aeb414d721536b378ea1f54d319cf1L386-R402)