### PR TITLE
Fix bbf query metrics publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,6 +1060,7 @@ dependencies = [
  "anyhow",
  "beacon-config",
  "beacon-data-lake",
+ "beacon-formats",
  "beacon-functions",
  "beacon-query",
  "chrono",

--- a/beacon-binary-format-toolbox/Cargo.lock
+++ b/beacon-binary-format-toolbox/Cargo.lock
@@ -410,7 +410,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beacon-arrow-netcdf"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "arrow",

--- a/beacon-core/src/virtual_machine.rs
+++ b/beacon-core/src/virtual_machine.rs
@@ -217,6 +217,11 @@ impl VirtualMachine {
                     .metrics_tracker
                     .add_output_bytes(output_file.size()?);
 
+                let consolidated_metrics = beacon_plan.metrics_tracker.get_consolidated_metrics();
+                query_metrics
+                    .lock()
+                    .insert(beacon_plan.query_id, consolidated_metrics);
+
                 Ok(QueryResult {
                     query_output: QueryOutput::File(output_file),
                     query_id: beacon_plan.query_id,

--- a/beacon-planner/Cargo.toml
+++ b/beacon-planner/Cargo.toml
@@ -20,3 +20,4 @@ beacon-config = { path = "../beacon-config" }
 beacon-functions = { path = "../beacon-functions" }
 beacon-query = { path = "../beacon-query" }
 beacon-data-lake = { path = "../beacon-data-lake" }
+beacon-formats = { path = "../beacon-formats" }

--- a/beacon-planner/src/metrics.rs
+++ b/beacon-planner/src/metrics.rs
@@ -196,3 +196,12 @@ fn collect_metrics_json(plan: &dyn ExecutionPlan) -> NodeMetrics {
         children,
     }
 }
+
+/// Extended:
+/// Extend the metrics tracker to expose the files as a tracer we can use for BBF
+impl MetricsTracker {
+    /// Get a tracer that can be passed to BBFSource to track files read
+    pub fn get_as_file_tracer(&self) -> Arc<Mutex<Vec<String>>> {
+        self.file_paths.clone()
+    }
+}


### PR DESCRIPTION
This pull request fixes how file access and metrics are tracked and reported within the query execution pipeline, with a particular focus on supporting BBF (Beacon Binary Format) sources. The changes enhance the metrics collection infrastructure by allowing the system to trace files accessed by BBF sources and consolidate metrics for reporting.

**Metrics and File Tracing Enhancements:**

- Added a method `get_as_file_tracer` to `MetricsTracker` to expose file paths as a tracer, enabling BBF sources to track files read during query execution.
- In the query planning logic, updated the handling of file scans to recognize `BBFSource` and set its file tracer using the new method from `MetricsTracker`. This ensures BBF sources can report all files accessed. [[1]](diffhunk://#diff-8d4f7c71a68a2305ba2b72bf3b553d2975bdb75a92b979f957f4fb8be4521d67R93-R101) [[2]](diffhunk://#diff-8d4f7c71a68a2305ba2b72bf3b553d2975bdb75a92b979f957f4fb8be4521d67R110)
- Included the new `beacon-formats` dependency in `beacon-planner/Cargo.toml` to support BBF source integration.

**Metrics Reporting Improvements:**

- After query execution, consolidated metrics from the `metrics_tracker` are now stored in `query_metrics` keyed by the query ID, improving metrics visibility and reporting.

**Codebase Integration:**

- Imported `BBFSource` from the new `beacon-formats` crate to enable the above functionality.