### PR TITLE
Add beacon_version UDF to retrieve package version

### DIFF
--- a/beacon-functions/src/util/beacon_version.rs
+++ b/beacon-functions/src/util/beacon_version.rs
@@ -1,0 +1,21 @@
+use std::sync::Arc;
+
+use datafusion::{logical_expr::ScalarUDF, prelude::create_udf, scalar::ScalarValue};
+
+pub fn beacon_version() -> ScalarUDF {
+    create_udf(
+        "beacon_version",
+        vec![],
+        datafusion::arrow::datatypes::DataType::Utf8,
+        datafusion::logical_expr::Volatility::Immutable,
+        Arc::new(beacon_version_impl),
+    )
+}
+
+fn beacon_version_impl(
+    _parameters: &[datafusion::logical_expr::ColumnarValue],
+) -> datafusion::error::Result<datafusion::logical_expr::ColumnarValue> {
+    Ok(datafusion::logical_expr::ColumnarValue::Scalar(
+        ScalarValue::Utf8(Some(env!("CARGO_PKG_VERSION").to_string())),
+    ))
+}

--- a/beacon-functions/src/util/mod.rs
+++ b/beacon-functions/src/util/mod.rs
@@ -1,5 +1,6 @@
 use datafusion::logical_expr::ScalarUDF;
 
+pub mod beacon_version;
 pub mod cast_int8_as_char;
 pub mod coalesce_label;
 pub mod try_arrow_cast;
@@ -9,5 +10,6 @@ pub fn util_udfs() -> Vec<ScalarUDF> {
         cast_int8_as_char::cast_int8_as_char(),
         try_arrow_cast::try_arrow_cast(),
         coalesce_label::coalesce_label(),
+        beacon_version::beacon_version(),
     ]
 }


### PR DESCRIPTION
This pull request adds a new utility function to expose the current package version as a scalar user-defined function (UDF) in DataFusion. The most important changes are grouped below:

**New UDF Implementation:**

* Added a new module `beacon_version` with a `beacon_version` scalar UDF that returns the current package version using the `CARGO_PKG_VERSION` environment variable.

**Module and Registration Updates:**

* Registered the new `beacon_version` UDF in the `util_udfs` function so it's available for use.
* Added the `beacon_version` module to the `util` module's public exports.