### PR TITLE
Maximize file parallelism schema inference ulimit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,6 +990,7 @@ dependencies = [
  "ordered-float 5.1.0",
  "parking_lot",
  "parquet 56.2.0",
+ "rlimit",
  "serde",
  "serde_json",
  "tempfile",
@@ -5332,6 +5333,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/beacon-formats/Cargo.toml
+++ b/beacon-formats/Cargo.toml
@@ -41,6 +41,7 @@ which = "8.0.0"
 num-traits = "0.2.19"
 ndarray = { version = "0.17.1" }
 once_cell = "1.21.3"
+rlimit = "0.11.0"
 chrono = { workspace = true }
 
 beacon-common = { path = "../beacon-common" }

--- a/beacon-formats/src/arrow.rs
+++ b/beacon-formats/src/arrow.rs
@@ -16,7 +16,7 @@ use object_store::{ObjectMeta, ObjectStore};
 use beacon_common::super_typing::super_type_schema;
 use futures::{StreamExt, TryStreamExt, stream};
 
-use crate::{Dataset, DatasetFormat, FileFormatFactoryExt, max_open_fd};
+use crate::{Dataset, DatasetFormat, FileFormatFactoryExt, file_open_parallelism};
 
 #[derive(Debug)]
 pub struct ArrowFormatFactory;
@@ -124,7 +124,7 @@ impl FileFormat for ArrowFormat {
                         .await
                 }
             })
-            .buffer_unordered(max_open_fd() as usize) // tune this
+            .buffer_unordered(file_open_parallelism()) // tune this
             .try_collect::<Vec<_>>()
             .await?;
 

--- a/beacon-formats/src/arrow.rs
+++ b/beacon-formats/src/arrow.rs
@@ -14,9 +14,9 @@ use datafusion::{
 use object_store::{ObjectMeta, ObjectStore};
 
 use beacon_common::super_typing::super_type_schema;
-use futures::future::try_join_all;
+use futures::{StreamExt, TryStreamExt, stream};
 
-use crate::{Dataset, DatasetFormat, FileFormatFactoryExt};
+use crate::{Dataset, DatasetFormat, FileFormatFactoryExt, max_open_fd};
 
 #[derive(Debug)]
 pub struct ArrowFormatFactory;
@@ -115,16 +115,18 @@ impl FileFormat for ArrowFormat {
         objects: &[ObjectMeta],
     ) -> datafusion::error::Result<SchemaRef> {
         //Retrieve the schema for each object
-        let schemas = try_join_all(objects.iter().map(|object| {
-            let store = Arc::clone(store);
-            let object = object.clone();
-            async move {
-                self.inner_format
-                    .infer_schema(state, &store, &[object])
-                    .await
-            }
-        }))
-        .await?;
+        let schemas = stream::iter(objects.iter().cloned())
+            .map(|object| {
+                let store = Arc::clone(store);
+                async move {
+                    self.inner_format
+                        .infer_schema(state, &store, &[object])
+                        .await
+                }
+            })
+            .buffer_unordered(max_open_fd() as usize) // tune this
+            .try_collect::<Vec<_>>()
+            .await?;
 
         let super_schema = super_type_schema(&schemas).map_err(|e| {
             datafusion::error::DataFusionError::Execution(format!("Failed to infer schema: {}", e))

--- a/beacon-formats/src/bbf/mod.rs
+++ b/beacon-formats/src/bbf/mod.rs
@@ -1,6 +1,8 @@
 use std::{any::Any, collections::HashMap, sync::Arc};
 
-use crate::{Dataset, DatasetFormat, FileFormatFactoryExt, bbf::source::BBFSource, max_open_fd};
+use crate::{
+    Dataset, DatasetFormat, FileFormatFactoryExt, bbf::source::BBFSource, file_open_parallelism,
+};
 use arrow::datatypes::SchemaRef;
 use beacon_binary_format::{
     object_store::ArrowBBFObjectReader, reader::async_reader::AsyncBBFReader,
@@ -120,7 +122,7 @@ impl FileFormat for BBFFormat {
                     Ok::<_, datafusion::error::DataFusionError>(Arc::new(reader.arrow_schema()))
                 }
             })
-            .buffer_unordered(max_open_fd() as usize) // 🔑 limit open readers
+            .buffer_unordered(file_open_parallelism())
             .try_collect::<Vec<_>>()
             .await?;
 

--- a/beacon-formats/src/csv.rs
+++ b/beacon-formats/src/csv.rs
@@ -16,7 +16,7 @@ use object_store::{ObjectMeta, ObjectStore};
 use beacon_common::super_typing::super_type_schema;
 use futures::{StreamExt, TryStreamExt, stream};
 
-use crate::{Dataset, DatasetFormat, FileFormatFactoryExt, max_open_fd};
+use crate::{Dataset, DatasetFormat, FileFormatFactoryExt, file_open_parallelism};
 
 #[derive(Debug, Default)]
 pub struct CsvFormatFactory;
@@ -119,7 +119,7 @@ impl FileFormat for CsvFormat {
                         .await
                 }
             })
-            .buffer_unordered(max_open_fd() as usize) // tune this
+            .buffer_unordered(file_open_parallelism()) // tune this
             .try_collect::<Vec<_>>()
             .await?;
 

--- a/beacon-formats/src/netcdf/source/mod.rs
+++ b/beacon-formats/src/netcdf/source/mod.rs
@@ -188,6 +188,19 @@ lazy_static::lazy_static!(
     static ref READER_CACHE: parking_lot::Mutex<lru::LruCache<ReaderCacheKey, Arc<NetCDFArrowReader>>> = {
         let capacity = NonZeroUsize::new(beacon_config::CONFIG.netcdf_reader_cache_size)
             .unwrap_or_else(|| NonZeroUsize::new(1).expect("non-zero"));
+
+        // If platform unix. then get the rlimit to check the capacity is at best rlimit/2 to avoid hitting the open file limit. This is a soft limit and can be increased by the user, but we want to avoid hitting it by default.
+        #[cfg(unix)]
+        {
+            use rlimit::{getrlimit, Resource};
+            if let Ok((soft_limit, _)) = getrlimit(Resource::NOFILE) {
+                let max_capacity = (soft_limit / 2) as usize;
+                if capacity.get() > max_capacity {
+                    capacity = NonZeroUsize::new(max_capacity).expect("non-zero");
+                }
+            }
+        }
+
         parking_lot::Mutex::new(lru::LruCache::new(capacity))
     };
 );

--- a/beacon-formats/src/parquet.rs
+++ b/beacon-formats/src/parquet.rs
@@ -17,7 +17,7 @@ use object_store::{ObjectMeta, ObjectStore};
 use beacon_common::super_typing::super_type_schema;
 use futures::{StreamExt, TryStreamExt, stream};
 
-use crate::{Dataset, DatasetFormat, FileFormatFactoryExt, max_open_fd};
+use crate::{Dataset, DatasetFormat, FileFormatFactoryExt, file_open_parallelism};
 
 #[derive(Debug)]
 pub struct ParquetFormatFactory;
@@ -123,7 +123,7 @@ impl FileFormat for ParquetFormat {
                 let store = Arc::clone(store);
                 async move { self.inner.infer_schema(state, &store, &[object]).await }
             })
-            .buffer_unordered(max_open_fd() as usize) // tune this
+            .buffer_unordered(file_open_parallelism()) // tune this
             .try_collect::<Vec<_>>()
             .await?;
 

--- a/beacon-formats/src/zarr/mod.rs
+++ b/beacon-formats/src/zarr/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use std::{fmt::Debug, sync::Arc};
 
 use arrow::datatypes::SchemaRef;
 use datafusion::{


### PR DESCRIPTION
This pull request introduces a parallel file opening mechanism across all file format readers (Arrow, Parquet, CSV, BBF) in the `beacon-formats` crate, leveraging the system's open file descriptor limits to optimize performance and prevent resource exhaustion. It also cleans up some imports and ensures that file descriptor usage is managed safely, especially on Unix systems.

Key changes include:

**Parallel file opening and resource management:**

* Introduced a new utility function, `file_open_parallelism`, which determines the parallelism for file opening based on half of the system's maximum allowed open file descriptors (`NOFILE` rlimit on Unix), with a fallback for non-Unix systems. (`beacon-formats/src/lib.rs`)
* Updated all file format readers (Arrow, Parquet, CSV, BBF) to use `stream::iter(...).buffer_unordered(file_open_parallelism())` for parallel schema inference, replacing the previous `try_join_all` approach. This change improves efficiency and reduces the risk of hitting open file limits. (`beacon-formats/src/arrow.rs`, `beacon-formats/src/parquet.rs`, `beacon-formats/src/csv.rs`, `beacon-formats/src/bbf/mod.rs`) [[1]](diffhunk://#diff-a6a4ad93e25fb70e2cde4f80825de20b52b8bac05428f2c4966e5618f05cbed6L118-R128) [[2]](diffhunk://#diff-09a860878a3c52ff403d9acfff05085b9f24740b167c3121546168966c63712fL122-R128) [[3]](diffhunk://#diff-94701fe124d41322ec029a03d70668760b6779a240a2f272959c8296e50a9f85L115-R123) [[4]](diffhunk://#diff-fd13a90871188796ed7999d8a41e1ff0b7b708f9ef0e1739b6f6f1a8ebb8dc5cL111-R127)
* The NetCDF reader cache now also respects the system's open file descriptor limits by capping its size at half the `NOFILE` rlimit, further preventing resource exhaustion. (`beacon-formats/src/netcdf/source/mod.rs`)

**Dependency and import updates:**

* Added the `rlimit` crate as a dependency to access system resource limits. (`beacon-formats/Cargo.toml`)
* Cleaned up and reorganized imports in several modules for clarity and to remove unused dependencies. (`beacon-formats/src/parquet.rs`, `beacon-formats/src/csv.rs`, `beacon-formats/src/bbf/mod.rs`, `beacon-formats/src/lib.rs`, `beacon-formats/src/zarr/mod.rs`) [[1]](diffhunk://#diff-fd13a90871188796ed7999d8a41e1ff0b7b708f9ef0e1739b6f6f1a8ebb8dc5cR3-R5) [[2]](diffhunk://#diff-fd13a90871188796ed7999d8a41e1ff0b7b708f9ef0e1739b6f6f1a8ebb8dc5cL17-L21) [[3]](diffhunk://#diff-94701fe124d41322ec029a03d70668760b6779a240a2f272959c8296e50a9f85L3-R19) [[4]](diffhunk://#diff-4150b54236782f0a5ef17087ff292ecfd9607279136a252be505f55874194f3eL10-R10) [[5]](diffhunk://#diff-65a0cdbcba071a242c79ecd1c265123288027e82a8887f633794f818f453b63eL1-R1)

**API and code simplification:**

* Minor adjustments to function signatures (e.g., unused parameters in `CsvFormatFactory::create` are now prefixed with underscores). (`beacon-formats/src/csv.rs`)