### PR TITLE
Table Data Lake Synchronization

### DIFF
--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -22,10 +22,12 @@ pub struct Config {
     pub vm_memory_size: usize,
     #[envconfig(from = "BEACON_DEFAULT_TABLE", default = "default")]
     pub default_table: String,
-    #[envconfig(from = "BEACON_ENABLE_SQL", default = "false")]
-    pub enable_sql: bool,
+    #[envconfig(from = "BEACON_TABLE_SYNC_INTERVAL_SECS", default = "300")] // 5 minutes
+    pub table_sync_interval_secs: u64,
     #[envconfig(from = "BEACON_SANITIZE_SCHEMA", default = "false")]
     pub sanitize_schema: bool,
+    #[envconfig(from = "BEACON_ENABLE_SQL", default = "false")]
+    pub enable_sql: bool,
     #[envconfig(from = "BEACON_ST_WITHIN_POINT_CACHE_SIZE", default = "10000")]
     pub st_within_point_cache_size: usize,
     #[envconfig(from = "BEACON_WORKER_THREADS", default = "8")]

--- a/beacon-core/src/virtual_machine.rs
+++ b/beacon-core/src/virtual_machine.rs
@@ -76,6 +76,9 @@ impl VirtualMachine {
             );
         }
 
+        // Spawn the background task to sync tables from the data lake at regular intervals
+        data_lake.spawn_sync_table_refresh(beacon_config::CONFIG.table_sync_interval_secs);
+
         //FINISH INIT FUNCTIONS FROM beacon-functions module
         Ok(Self {
             table_functions,

--- a/beacon-data-lake/src/lib.rs
+++ b/beacon-data-lake/src/lib.rs
@@ -239,6 +239,10 @@ impl DataLake {
     }
 
     pub fn spawn_sync_table_refresh(self: &Arc<Self>, interval_secs: u64) {
+        if interval_secs == 0 {
+            tracing::info!("Table sync interval is set to 0, skipping table refresh task.");
+            return;
+        }
         let data_lake = Arc::clone(self);
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));

--- a/docs/docs/1.5.2/data-lake/configuration.md
+++ b/docs/docs/1.5.2/data-lake/configuration.md
@@ -21,6 +21,7 @@ Some of the configuration options can be set using environment variables. The fo
 - `BEACON_VM_MEMORY_SIZE` - The amount of memory to allocate to the Beacon Virtual Machine in MB (default is 4096MB). More is better for performance, especially when working with larger datasets and performing actions such as spatial joins and group by.
 - `BEACON_ENABLE_SQL` - Whether to enable the SQL query engine. Set to `true` to enable. Default is `false`.
 - `BEACON_WORKER_THREADS` - Number of worker threads to use (default is 8).
+- `BEACON_TABLE_SYNC_INTERVAL_SECS` - Interval in seconds for syncing tables from the data lake (default is 300 seconds, i.e., 5 minutes). This controls how often Beacon will check for updates in the underlying data lake and refresh its table metadata accordingly.
 - `BEACON_ST_WITHIN_POINT_CACHE_SIZE` - Size of the cache for ST_WithinPoint queries (default is 10000).
 - `BEACON_DEFAULT_TABLE` - The default table to use when no table is specified in the `from` clause of a query.
 - `BEACON_LOG_LEVEL` - Log level [`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`]. Default is `INFO`.


### PR DESCRIPTION
This pull request introduces a new background mechanism for periodically refreshing table metadata from the data lake, along with an associated configuration option. The changes ensure that table information remains up-to-date without manual intervention and provide users with control over the refresh interval.

**Background table sync mechanism:**

* Added a new `table_sync_interval_secs` configuration option to `Config`, allowing users to set the interval (in seconds) for background table refreshes. The default is 300 seconds (5 minutes). (`beacon-config/src/lib.rs`, `docs/docs/1.5.2/data-lake/configuration.md`) [[1]](diffhunk://#diff-80981d833c81ce35e79147856f8db40c791c91e29679379269e76e81f0740e71L25-R30) [[2]](diffhunk://#diff-4271aa8f1db63ed08d857f47311654bc1186f9ce075eaaf7c383740853e439b5R24)
* Implemented a `spawn_sync_table_refresh` method in `DataLake` that launches a background task to periodically refresh all registered tables, removing any that fail to refresh. (`beacon-data-lake/src/lib.rs`)
* Added a `refresh_table` async method to `DataLake` to handle refreshing individual tables' metadata and updating their providers. (`beacon-data-lake/src/lib.rs`)
* Updated `VirtualMachine` initialization to start the background table sync task using the configured interval. (`beacon-core/src/virtual_machine.rs`)