### PR TITLE
BBF 16K sliced batches

### DIFF
--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -94,6 +94,10 @@ pub struct Config {
     /// Set to `0` to disable timeouts (default).
     #[envconfig(from = "BEACON_NETCDF_MPIO_REQUEST_TIMEOUT_MS", default = "0")]
     pub netcdf_mpio_request_timeout_ms: u64,
+
+    /// Whether to split streams into 16k row slices for better memory management and parallelism.
+    #[envconfig(from = "BEACON_ENABLE_BBF_SPLIT_STREAMS_SLICE", default = "false")]
+    pub bbf_split_streams_slice: bool,
 }
 
 impl Config {

--- a/docs/docs/1.5.3/data-lake/configuration.md
+++ b/docs/docs/1.5.3/data-lake/configuration.md
@@ -57,3 +57,7 @@ Some of the configuration options can be set using environment variables. The fo
 - `BEACON_NETCDF_MULTIPLEXER_PROCESSES` - Number of worker processes to spawn when NetCDF multiplexer is enabled (default is half of CPU cores).
 - `BEACON_NETCDF_MPIO_WORKER` - Optional path to the `beacon-arrow-netcdf-mpio` executable (used when NetCDF MPIO is enabled).
 - `BEACON_NETCDF_MPIO_REQUEST_TIMEOUT_MS` - Per-request timeout (in milliseconds) for NetCDF MPIO worker requests. Set to `0` to disable (default is `0`).
+
+### Beacon Binary Format
+
+- `BEACON_ENABLE_BBF_SPLIT_STREAMS_SLICE` - Whether to enable splitting large batches into smaller batches to better manage memory and parallelism for queries in the Beacon Binary Format (BBF). Set to `true` to enable. Default is `false`. When enabled, this allows for more efficient handling of large queries by splitting the data into multiple streams.


### PR DESCRIPTION
This pull request introduces an optional feature to improve memory management and parallelism when processing large BBF tables. By enabling a new configuration flag, the system will split incoming record batches into smaller 16,000-row slices, reducing the risk of out-of-memory (OOM) errors. The change is controlled by an environment variable and is disabled by default.

Configuration:

* Added a new `bbf_split_streams_slice` boolean field to the `Config` struct in `beacon-config`, controlled by the `BEACON_ENABLE_BBF_SPLIT_STREAMS_SLICE` environment variable.

BBF file processing:

* Updated the `BBFOpener` in `beacon-formats` to conditionally split large record batches into 16,000-row slices if the new config flag is enabled, improving memory usage and parallelism for wide tables.
* Implemented a helper function `split_record_batch` to handle the slicing of `RecordBatch` objects.