### PR TITLE
Update separator l05 multi mapping

### DIFF
--- a/beacon-functions/src/blue_cloud/emodnet_chemistry/map_instrument_l05_multi.rs
+++ b/beacon-functions/src/blue_cloud/emodnet_chemistry/map_instrument_l05_multi.rs
@@ -41,6 +41,8 @@ pub fn map_emodnet_chemistry_instrument_l05_multi() -> ScalarUDF {
     )
 }
 
+const SEPARATOR: &str = " | ";
+
 fn map_emodnet_chemistry_instrument_l05_multi_impl(
     parameters: &[ColumnarValue],
 ) -> datafusion::error::Result<ColumnarValue> {
@@ -54,7 +56,7 @@ fn map_emodnet_chemistry_instrument_l05_multi_impl(
             let array = flag_array.iter().map(|flag| {
                 flag.map(|value| {
                     extract_parenthesized_values_ref(value)
-                        .join("|")
+                        .join(SEPARATOR)
                         .to_string()
                 })
             });
@@ -66,7 +68,7 @@ fn map_emodnet_chemistry_instrument_l05_multi_impl(
         ColumnarValue::Scalar(ScalarValue::Utf8(value)) => {
             let sdn_flag = value.as_ref().map(|value| {
                 extract_parenthesized_values_ref(value)
-                    .join("|")
+                    .join(SEPARATOR)
                     .to_string()
             });
 


### PR DESCRIPTION
Fixes #176 

This pull request introduces a small but important change to the way joined strings are formatted in the EMODnet chemistry instrument mapping function. The separator used when joining extracted values has been updated for improved clarity and consistency.

String formatting update:

* Introduced a `SEPARATOR` constant set to `" | "` and replaced the previous `"|"` separator with this constant in all relevant join operations within the `map_emodnet_chemistry_instrument_l05_multi_impl` function. [[1]](diffhunk://#diff-6dfb54f69ae2d4c339230f12c6e447077261db21b2315aa15379b6ec6fce5032R44-R45) [[2]](diffhunk://#diff-6dfb54f69ae2d4c339230f12c6e447077261db21b2315aa15379b6ec6fce5032L57-R59) [[3]](diffhunk://#diff-6dfb54f69ae2d4c339230f12c6e447077261db21b2315aa15379b6ec6fce5032L69-R71)