### PR TITLE
Update CSVFileFormat with settings (delimiter)

### DIFF
--- a/beacon-data-lake/src/table/table_formats.rs
+++ b/beacon-data-lake/src/table/table_formats.rs
@@ -50,13 +50,21 @@ impl TableFileFormat for ParquetFileFormat {
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct CSVFileFormat {
-    pub delimiter: u8,
+    pub delimiter: char,
     pub infer_records: usize,
 }
 #[typetag::serde(name = "csv")]
 impl TableFileFormat for CSVFileFormat {
     fn file_ext(&self) -> String {
         "csv".to_string()
+    }
+
+    fn file_format(&self) -> Option<Arc<dyn FileFormat>> {
+        Some(Arc::new(
+            datafusion::datasource::file_format::csv::CsvFormat::default()
+                .with_delimiter(self.delimiter as u8)
+                .with_schema_infer_max_rec(self.infer_records),
+        ))
     }
 }
 


### PR DESCRIPTION
Fixes #175 

This pull request updates the `CSVFileFormat` struct and its implementation in `table_formats.rs` to improve how CSV file formats are handled, particularly regarding the delimiter type and integration with DataFusion's CSV format.

**CSV file format improvements:**

* Changed the `delimiter` field in the `CSVFileFormat` struct from `u8` to `char` to make delimiter specification more intuitive and type-safe.
* Added a new `file_format` method to the `TableFileFormat` implementation for `CSVFileFormat`, which returns a configured `CsvFormat` from DataFusion, using the struct's delimiter and record inference settings.