### PR TITLE
Implement merged table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,7 @@ dependencies = [
 name = "beacon-data-lake"
 version = "1.5.4"
 dependencies = [
+ "anyhow",
  "arrow",
  "async-trait",
  "beacon-arrow-zarr",

--- a/beacon-core/src/virtual_machine.rs
+++ b/beacon-core/src/virtual_machine.rs
@@ -42,6 +42,8 @@ impl VirtualMachine {
             .unwrap()
             .register_schema("public", data_lake.clone())?;
 
+        data_lake.init_tables(session_ctx.clone()).await?;
+
         // INIT Functions from geodatafusion
         geodatafusion::register(&session_ctx);
 
@@ -89,6 +91,7 @@ impl VirtualMachine {
 
     fn init_ctx(mem_pool: Arc<FairSpillPool>) -> anyhow::Result<Arc<SessionContext>> {
         let mut config = SessionConfig::new()
+            .with_batch_size(beacon_config::CONFIG.beacon_batch_size)
             .with_coalesce_batches(true)
             .with_information_schema(true)
             .with_collect_statistics(true);
@@ -98,6 +101,11 @@ impl VirtualMachine {
             .options_mut()
             .execution
             .listing_table_ignore_subdirectory = false;
+        config
+            .options_mut()
+            .execution
+            .parquet
+            .allow_single_file_parallelism = true;
 
         let disk_manager_conf = DiskManagerConfig::NewOs;
 

--- a/beacon-data-lake/Cargo.toml
+++ b/beacon-data-lake/Cargo.toml
@@ -9,6 +9,7 @@ datafusion = { workspace = true }
 geoarrow = { workspace = true }
 geoarrow-array = { workspace = true }
 geoparquet = { workspace = true }
+anyhow = { workspace = true }
 parquet = { version = "^55"}
 
 object_store = { version = "0.12.3", features = ["aws"] }

--- a/beacon-data-lake/src/lib.rs
+++ b/beacon-data-lake/src/lib.rs
@@ -26,7 +26,7 @@ use url::Url;
 
 use crate::{
     files::{collection::FileCollection, temp_output_file::TempOutputFile},
-    table::{Table, empty::EmptyTable, error::TableError},
+    table::{_type::TableType, Table, empty::EmptyTable, error::TableError},
 };
 
 pub mod files;
@@ -81,6 +81,28 @@ pub static INDEX_OBJECT_STORE_URL: LazyLock<ObjectStoreUrl> =
     LazyLock::new(|| ObjectStoreUrl::parse("index://").expect("Failed to parse index URL")); // ToDo: implement indexing on top of existing files utilizing the notified storage events.
 
 impl DataLake {
+    fn merged_table_references(
+        tables: &HashMap<String, Table>,
+        table_name: &str,
+    ) -> Option<String> {
+        for (candidate_name, candidate) in tables {
+            if candidate_name == table_name {
+                continue;
+            }
+
+            if let TableType::Merged(merged_table) = &candidate.table_type
+                && merged_table
+                    .table_names
+                    .iter()
+                    .any(|name| name == table_name)
+            {
+                return Some(candidate_name.clone());
+            }
+        }
+
+        None
+    }
+
     #[inline(always)]
     pub fn try_create_listing_url(
         &self,
@@ -193,6 +215,7 @@ impl DataLake {
             .object_store(&tables_object_store_url)
             .unwrap();
 
+        let mut merged_tables = Vec::new();
         let mut entry_stream = tables_object_store.list(None);
         while let Some(entry) = entry_stream.next().await {
             tracing::info!("Found table entry: {:?}", entry);
@@ -211,29 +234,55 @@ impl DataLake {
                 // Open the table
                 match Table::open(tables_object_store.clone(), table_directory).await {
                     Ok(table) => {
-                        let provider = table
-                            .table_provider(
-                                session_context.clone(),
-                                data_directory_store_url.clone(),
-                                tables_object_store_url.clone(),
-                            )
-                            .await;
-
-                        if let Ok(provider) = provider {
-                            table_providers.insert(table.table_name.clone(), provider);
-                            tables.insert(table.table_name.clone(), table);
+                        if matches!(table.table_type, table::_type::TableType::Merged(_)) {
+                            merged_tables.push(table);
                         } else {
-                            tracing::error!(
-                                "Failed to create table provider for {}: {}",
-                                table.table_name,
-                                provider.unwrap_err()
-                            );
+                            let provider = table
+                                .table_provider(
+                                    session_context.clone(),
+                                    data_directory_store_url.clone(),
+                                    tables_object_store_url.clone(),
+                                )
+                                .await;
+
+                            if let Ok(provider) = provider {
+                                table_providers.insert(table.table_name.clone(), provider);
+                                tables.insert(table.table_name.clone(), table);
+                            } else {
+                                tracing::error!(
+                                    "Failed to create table provider for {}: {}",
+                                    table.table_name,
+                                    provider.unwrap_err()
+                                );
+                            }
                         }
                     }
                     Err(e) => {
                         eprintln!("Failed to open table: {}", e);
                     }
                 }
+            }
+        }
+
+        // Resolve merged tables after all other tables so named dependencies already exist.
+        for table in merged_tables {
+            let provider = table
+                .table_provider(
+                    session_context.clone(),
+                    data_directory_store_url.clone(),
+                    tables_object_store_url.clone(),
+                )
+                .await;
+
+            if let Ok(provider) = provider {
+                table_providers.insert(table.table_name.clone(), provider);
+                tables.insert(table.table_name.clone(), table);
+            } else {
+                tracing::error!(
+                    "Failed to create merged table provider for {}: {}",
+                    table.table_name,
+                    provider.unwrap_err()
+                );
             }
         }
     }
@@ -534,12 +583,24 @@ impl DataLake {
     }
 
     pub async fn remove_table(&self, table_name: &str) -> Result<(), TableError> {
+        let mut tables = self.tables.lock();
+        if !tables.contains_key(table_name) {
+            return Err(TableError::TableNotFound(table_name.to_string()));
+        }
+
+        if let Some(merged_table) = Self::merged_table_references(&tables, table_name) {
+            return Err(TableError::TableReferencedByMerged {
+                table_name: table_name.to_string(),
+                merged_table,
+            });
+        }
+
+        let table = tables.remove(table_name);
+        drop(tables); // Release the lock before async call
+
         let mut table_providers = self.table_providers.lock();
         table_providers.remove(table_name);
         drop(table_providers); // Release the lock before deleting the table
-        let mut tables = self.tables.lock();
-        let table = tables.remove(table_name);
-        drop(tables); // Release the lock before async call
 
         if let Some(table) = table {
             let table_object_store_url = self.table_directory_store_url.clone();
@@ -551,6 +612,42 @@ impl DataLake {
         } else {
             Err(TableError::TableNotFound(table_name.to_string()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::table::{_type::TableType, merged::MergedTable};
+
+    #[test]
+    fn merged_table_references_detects_dependency() {
+        let mut tables = HashMap::new();
+
+        tables.insert(
+            "base_table".to_string(),
+            Table {
+                table_directory: vec![],
+                table_name: "base_table".to_string(),
+                table_type: TableType::Empty(EmptyTable::new()),
+                description: None,
+            },
+        );
+
+        tables.insert(
+            "merged_table".to_string(),
+            Table {
+                table_directory: vec![],
+                table_name: "merged_table".to_string(),
+                table_type: TableType::Merged(MergedTable {
+                    table_names: vec!["base_table".to_string()],
+                }),
+                description: None,
+            },
+        );
+
+        let dependent = DataLake::merged_table_references(&tables, "base_table");
+        assert_eq!(dependent, Some("merged_table".to_string()));
     }
 }
 

--- a/beacon-data-lake/src/lib.rs
+++ b/beacon-data-lake/src/lib.rs
@@ -2,7 +2,7 @@ use std::{
     any::Any,
     collections::HashMap,
     fmt::Debug,
-    path::{Path, PathBuf},
+    path::Path,
     sync::{Arc, LazyLock},
 };
 
@@ -46,7 +46,6 @@ pub struct Config {
 pub struct DataLake {
     data_directory_store_url: ObjectStoreUrl,
     table_directory_store_url: ObjectStoreUrl,
-    tmp_directory_store_url: ObjectStoreUrl,
 
     /// The session context used for executing queries and managing the session state.
     session_context: Arc<SessionContext>,
@@ -81,6 +80,37 @@ pub static INDEX_OBJECT_STORE_URL: LazyLock<ObjectStoreUrl> =
     LazyLock::new(|| ObjectStoreUrl::parse("index://").expect("Failed to parse index URL")); // ToDo: implement indexing on top of existing files utilizing the notified storage events.
 
 impl DataLake {
+    fn table_directory_from_location(
+        location: &object_store::path::Path,
+    ) -> Option<Vec<PathPart<'static>>> {
+        if location.filename() != Some("table.json") {
+            return None;
+        }
+
+        let mut table_directory = location
+            .parts()
+            .map(|part| part.as_ref().to_string().into())
+            .collect::<Vec<_>>();
+        table_directory.pop();
+
+        Some(table_directory)
+    }
+
+    fn partition_tables_for_initialization(tables: Vec<Table>) -> (Vec<Table>, Vec<Table>) {
+        let mut regular_tables = Vec::new();
+        let mut merged_tables = Vec::new();
+
+        for table in tables {
+            if matches!(table.table_type, TableType::Merged(_)) {
+                merged_tables.push(table);
+            } else {
+                regular_tables.push(table);
+            }
+        }
+
+        (regular_tables, merged_tables)
+    }
+
     fn merged_table_references(
         tables: &HashMap<String, Table>,
         table_name: &str,
@@ -168,47 +198,21 @@ impl DataLake {
 
         let config = Self::read_config();
 
-        let mut table_providers = HashMap::new();
-        let mut tables = HashMap::new();
+        let table_providers = HashMap::new();
+        let tables = HashMap::new();
 
         let file_formats =
             file_formats(session_context.clone(), get_datasets_object_store().await).unwrap();
 
-        Self::init_tables(
-            tables_object_store_url.clone(),
-            datasets_object_store_url.clone(),
-            session_context.clone(),
-            &mut table_providers,
-            &mut tables,
-        )
-        .await;
-
-        let data_lake = Self {
+        Self {
             data_directory_store_url: datasets_object_store_url,
             table_directory_store_url: tables_object_store_url,
-            tmp_directory_store_url: tmp_object_store_url,
             session_context,
             config,
             file_formats,
             table_providers: parking_lot::Mutex::new(table_providers),
             tables: parking_lot::Mutex::new(tables),
-        };
-
-        if !data_lake.table_exist("default") {
-            let default_table_type = EmptyTable::new();
-            let table = Table {
-                table_directory: vec![],
-                table_name: "default".to_string(),
-                table_type: table::_type::TableType::Empty(default_table_type),
-                description: Some("Default Table.".to_string()),
-            };
-            data_lake
-                .create_table(table)
-                .await
-                .expect("Failed to create default table.");
         }
-
-        data_lake
     }
 
     fn read_config() -> Config {
@@ -218,70 +222,61 @@ impl DataLake {
         }
     }
 
-    async fn init_tables(
-        tables_object_store_url: ObjectStoreUrl,
-        data_directory_store_url: ObjectStoreUrl,
-        session_context: Arc<SessionContext>,
-        table_providers: &mut HashMap<String, Arc<dyn TableProvider>>,
-        tables: &mut HashMap<String, Table>,
-    ) {
-        tracing::info!("Initializing tables from object store");
-        let tables_object_store = session_context
-            .runtime_env()
-            .object_store(&tables_object_store_url)
-            .unwrap();
+    async fn ensure_default_table(&self) -> anyhow::Result<()> {
+        if self.table_exist("default") {
+            return Ok(());
+        }
 
-        let mut merged_tables = Vec::new();
+        let table = Table {
+            table_directory: vec![],
+            table_name: "default".to_string(),
+            table_type: table::_type::TableType::Empty(EmptyTable::new()),
+            description: Some("Default Table.".to_string()),
+        };
+
+        self.create_table(table)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to create default table: {}", e))
+    }
+
+    async fn load_tables_from_object_store(
+        tables_object_store: Arc<dyn ObjectStore>,
+    ) -> Vec<Table> {
+        let mut discovered_tables = Vec::new();
         let mut entry_stream = tables_object_store.list(None);
+
         while let Some(entry) = entry_stream.next().await {
             tracing::info!("Found table entry: {:?}", entry);
-            if let Ok(entry) = entry
-                && entry.location.to_string().ends_with("table.json")
-            {
-                // Extract the table name from the path
-                let mut table_directory: Vec<PathPart<'static>> = entry
-                    .location
-                    .parts()
-                    .map(|part| part.as_ref().to_string().into())
-                    .collect();
-                // Pop the last part which is "table.json"
-                table_directory.pop();
 
-                // Open the table
-                match Table::open(tables_object_store.clone(), table_directory).await {
-                    Ok(table) => {
-                        if matches!(table.table_type, table::_type::TableType::Merged(_)) {
-                            merged_tables.push(table);
-                        } else {
-                            let provider = table
-                                .table_provider(
-                                    session_context.clone(),
-                                    data_directory_store_url.clone(),
-                                    tables_object_store_url.clone(),
-                                )
-                                .await;
+            let Ok(entry) = entry else {
+                continue;
+            };
 
-                            if let Ok(provider) = provider {
-                                table_providers.insert(table.table_name.clone(), provider);
-                                tables.insert(table.table_name.clone(), table);
-                            } else {
-                                tracing::error!(
-                                    "Failed to create table provider for {}: {}",
-                                    table.table_name,
-                                    provider.unwrap_err()
-                                );
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!("Failed to open table: {}", e);
-                    }
+            let Some(table_directory) = Self::table_directory_from_location(&entry.location) else {
+                continue;
+            };
+
+            match Table::open(tables_object_store.clone(), table_directory).await {
+                Ok(table) => discovered_tables.push(table),
+                Err(e) => {
+                    tracing::error!("Failed to open table at {:?}: {}", entry.location, e);
                 }
             }
         }
 
-        // Resolve merged tables after all other tables so named dependencies already exist.
-        for table in merged_tables {
+        discovered_tables
+    }
+
+    async fn register_tables(
+        tables_to_register: Vec<Table>,
+        tables_object_store_url: &ObjectStoreUrl,
+        data_directory_store_url: &ObjectStoreUrl,
+        session_context: &Arc<SessionContext>,
+        table_providers: &mut HashMap<String, Arc<dyn TableProvider>>,
+        tables: &mut HashMap<String, Table>,
+        table_kind: &str,
+    ) {
+        for table in tables_to_register {
             let provider = table
                 .table_provider(
                     session_context.clone(),
@@ -295,12 +290,77 @@ impl DataLake {
                 tables.insert(table.table_name.clone(), table);
             } else {
                 tracing::error!(
-                    "Failed to create merged table provider for {}: {}",
+                    "Failed to create {} provider for {}: {}",
+                    table_kind,
                     table.table_name,
                     provider.unwrap_err()
                 );
             }
         }
+    }
+
+    fn replace_registered_tables(
+        &self,
+        table_providers: HashMap<String, Arc<dyn TableProvider>>,
+        tables: HashMap<String, Table>,
+    ) {
+        *self.table_providers.lock() = table_providers;
+        *self.tables.lock() = tables;
+    }
+
+    pub async fn init_tables(&self, session_context: Arc<SessionContext>) -> anyhow::Result<()> {
+        let (regular_tables, merged_tables) = Self::init_tables_impl(
+            self.table_directory_store_url.clone(),
+            self.data_directory_store_url.clone(),
+            session_context,
+        )
+        .await?;
+
+        let mut table_providers = HashMap::new();
+        let mut tables = HashMap::new();
+
+        Self::register_tables(
+            regular_tables,
+            &self.table_directory_store_url,
+            &self.data_directory_store_url,
+            &self.session_context,
+            &mut table_providers,
+            &mut tables,
+            "table",
+        )
+        .await;
+
+        self.replace_registered_tables(table_providers.clone(), tables.clone());
+
+        Self::register_tables(
+            merged_tables,
+            &self.table_directory_store_url,
+            &self.data_directory_store_url,
+            &self.session_context,
+            &mut table_providers,
+            &mut tables,
+            "merged table",
+        )
+        .await;
+
+        self.replace_registered_tables(table_providers, tables);
+
+        self.ensure_default_table().await
+    }
+
+    async fn init_tables_impl(
+        tables_object_store_url: ObjectStoreUrl,
+        _data_directory_store_url: ObjectStoreUrl,
+        session_context: Arc<SessionContext>,
+    ) -> anyhow::Result<(Vec<Table>, Vec<Table>)> {
+        tracing::info!("Initializing tables from object store");
+        let tables_object_store = session_context
+            .runtime_env()
+            .object_store(&tables_object_store_url)
+            .map_err(|e| anyhow::anyhow!("Failed to get tables object store: {}", e))?;
+
+        let discovered_tables = Self::load_tables_from_object_store(tables_object_store).await;
+        Ok(Self::partition_tables_for_initialization(discovered_tables))
     }
 
     pub fn spawn_sync_table_refresh(self: &Arc<Self>, interval_secs: u64) {
@@ -434,8 +494,8 @@ impl DataLake {
         tables.get(table_name).cloned()
     }
 
-    pub async fn update_table(&self, mut table: Table) -> Result<(), TableError> {
-        self.remove_table(&table.table_name);
+    pub async fn update_table(&self, table: Table) -> Result<(), TableError> {
+        self.remove_table(&table.table_name).await?;
         self.create_table(table).await
     }
 
@@ -451,8 +511,8 @@ impl DataLake {
             .object_store(&self.table_directory_store_url)
             .unwrap();
 
-        let mut table_directory: Vec<PathPart<'static>> = vec![];
-        table_directory.push(PathPart::from(table.table_name.clone()));
+        let table_directory: Vec<PathPart<'static>> =
+            vec![PathPart::from(table.table_name.clone())];
         drop(tables); // Release the lock before saving the table as to not deadlock across the async call
         table.save(table_object_store, table_directory).await;
         let table_provider = table
@@ -665,6 +725,74 @@ impl SchemaProvider for DataLake {
 mod tests {
     use super::*;
     use crate::table::{_type::TableType, merged::MergedTable};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_table(name: &str, table_type: TableType) -> Table {
+        Table {
+            table_directory: vec![],
+            table_name: name.to_string(),
+            table_type,
+            description: None,
+        }
+    }
+
+    #[test]
+    fn table_directory_from_location_extracts_parent_directory() {
+        let location = object_store::path::Path::from("folder/example/table.json");
+
+        let table_directory = DataLake::table_directory_from_location(&location)
+            .expect("table.json path should produce a directory");
+        let parts = table_directory
+            .iter()
+            .map(|part| part.as_ref())
+            .collect::<Vec<_>>();
+
+        assert_eq!(parts, vec!["folder", "example"]);
+    }
+
+    #[test]
+    fn table_directory_from_location_ignores_non_table_config_files() {
+        let location = object_store::path::Path::from("folder/example/not-a-table.json");
+
+        assert!(DataLake::table_directory_from_location(&location).is_none());
+    }
+
+    #[test]
+    fn partition_tables_for_initialization_keeps_merged_tables_separate() {
+        let tables = vec![
+            test_table("base_a", TableType::Empty(EmptyTable::new())),
+            test_table(
+                "merged_x",
+                TableType::Merged(MergedTable {
+                    table_names: vec!["base_a".to_string()],
+                }),
+            ),
+            test_table("base_b", TableType::Empty(EmptyTable::new())),
+            test_table(
+                "merged_y",
+                TableType::Merged(MergedTable {
+                    table_names: vec!["base_b".to_string()],
+                }),
+            ),
+        ];
+
+        let (regular_tables, merged_tables) = DataLake::partition_tables_for_initialization(tables);
+
+        assert_eq!(
+            regular_tables
+                .into_iter()
+                .map(|table| table.table_name)
+                .collect::<Vec<_>>(),
+            vec!["base_a", "base_b"]
+        );
+        assert_eq!(
+            merged_tables
+                .into_iter()
+                .map(|table| table.table_name)
+                .collect::<Vec<_>>(),
+            vec!["merged_x", "merged_y"]
+        );
+    }
 
     #[test]
     fn merged_table_references_detects_dependency() {
@@ -672,24 +800,17 @@ mod tests {
 
         tables.insert(
             "base_table".to_string(),
-            Table {
-                table_directory: vec![],
-                table_name: "base_table".to_string(),
-                table_type: TableType::Empty(EmptyTable::new()),
-                description: None,
-            },
+            test_table("base_table", TableType::Empty(EmptyTable::new())),
         );
 
         tables.insert(
             "merged_table".to_string(),
-            Table {
-                table_directory: vec![],
-                table_name: "merged_table".to_string(),
-                table_type: TableType::Merged(MergedTable {
+            test_table(
+                "merged_table",
+                TableType::Merged(MergedTable {
                     table_names: vec!["base_table".to_string()],
                 }),
-                description: None,
-            },
+            ),
         );
 
         let dependent = DataLake::merged_table_references(&tables, "base_table");
@@ -702,34 +823,22 @@ mod tests {
 
         tables.insert(
             "base_a".to_string(),
-            Table {
-                table_directory: vec![],
-                table_name: "base_a".to_string(),
-                table_type: TableType::Empty(EmptyTable::new()),
-                description: None,
-            },
+            test_table("base_a", TableType::Empty(EmptyTable::new())),
         );
 
         tables.insert(
             "base_b".to_string(),
-            Table {
-                table_directory: vec![],
-                table_name: "base_b".to_string(),
-                table_type: TableType::Empty(EmptyTable::new()),
-                description: None,
-            },
+            test_table("base_b", TableType::Empty(EmptyTable::new())),
         );
 
         tables.insert(
             "merged_x".to_string(),
-            Table {
-                table_directory: vec![],
-                table_name: "merged_x".to_string(),
-                table_type: TableType::Merged(MergedTable {
+            test_table(
+                "merged_x",
+                TableType::Merged(MergedTable {
                     table_names: vec!["base_a".to_string(), "base_b".to_string()],
                 }),
-                description: None,
-            },
+            ),
         );
 
         let order = DataLake::ordered_table_names_for_refresh(&tables);
@@ -752,5 +861,101 @@ mod tests {
                 .into_iter()
                 .all(|idx| idx < merged_positions[0])
         );
+    }
+
+    #[tokio::test]
+    async fn init_tables_registers_base_tables_before_merged_tables() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+
+        let base_a_name = format!("init-order-base-a-{suffix}");
+        let base_b_name = format!("init-order-base-b-{suffix}");
+        let merged_name = format!("init-order-merged-{suffix}");
+
+        let creator_ctx = Arc::new(SessionContext::new());
+        let creator = Arc::new(DataLake::new(creator_ctx.clone()).await);
+        creator_ctx
+            .catalog("datafusion")
+            .expect("default catalog should exist")
+            .register_schema("public", creator.clone())
+            .expect("schema registration should succeed");
+
+        creator
+            .create_table(test_table(
+                &base_a_name,
+                TableType::Empty(EmptyTable::new()),
+            ))
+            .await
+            .expect("base table A should be created");
+        creator
+            .create_table(test_table(
+                &base_b_name,
+                TableType::Empty(EmptyTable::new()),
+            ))
+            .await
+            .expect("base table B should be created");
+        creator
+            .create_table(test_table(
+                &merged_name,
+                TableType::Merged(MergedTable {
+                    table_names: vec![base_a_name.clone(), base_b_name.clone()],
+                }),
+            ))
+            .await
+            .expect("merged table should be created");
+
+        let reload_ctx = Arc::new(SessionContext::new());
+        let reloaded = Arc::new(DataLake::new(reload_ctx.clone()).await);
+        reload_ctx
+            .catalog("datafusion")
+            .expect("default catalog should exist")
+            .register_schema("public", reloaded.clone())
+            .expect("schema registration should succeed");
+
+        reloaded
+            .init_tables(reload_ctx.clone())
+            .await
+            .expect("table initialization should succeed");
+
+        assert!(reloaded.table_exist(&base_a_name));
+        assert!(reloaded.table_exist(&base_b_name));
+        assert!(reloaded.table_exist(&merged_name));
+
+        let merged_table = reloaded
+            .list_table(&merged_name)
+            .expect("merged table metadata should be present");
+        match merged_table.table_type {
+            TableType::Merged(merged) => {
+                assert_eq!(
+                    merged.table_names,
+                    vec![base_a_name.clone(), base_b_name.clone()]
+                );
+            }
+            other => panic!("expected merged table, got {other:?}"),
+        }
+
+        let merged_provider = reload_ctx
+            .table_provider(&merged_name)
+            .await
+            .expect("merged provider lookup should succeed");
+        assert_eq!(
+            merged_provider.table_type(),
+            datafusion::datasource::TableType::Base
+        );
+
+        reloaded
+            .remove_table(&merged_name)
+            .await
+            .expect("merged table cleanup should succeed");
+        reloaded
+            .remove_table(&base_a_name)
+            .await
+            .expect("base table A cleanup should succeed");
+        reloaded
+            .remove_table(&base_b_name)
+            .await
+            .expect("base table B cleanup should succeed");
     }
 }

--- a/beacon-data-lake/src/lib.rs
+++ b/beacon-data-lake/src/lib.rs
@@ -103,6 +103,22 @@ impl DataLake {
         None
     }
 
+    fn ordered_table_names_for_refresh(tables: &HashMap<String, Table>) -> Vec<String> {
+        let mut non_merged = Vec::new();
+        let mut merged = Vec::new();
+
+        for (name, table) in tables {
+            if matches!(table.table_type, TableType::Merged(_)) {
+                merged.push(name.clone());
+            } else {
+                non_merged.push(name.clone());
+            }
+        }
+
+        non_merged.extend(merged);
+        non_merged
+    }
+
     #[inline(always)]
     pub fn try_create_listing_url(
         &self,
@@ -302,7 +318,7 @@ impl DataLake {
                 tracing::info!("Refreshing tables...");
                 let table_names: Vec<String> = {
                     let tables = data_lake.tables.lock();
-                    tables.keys().cloned().collect()
+                    Self::ordered_table_names_for_refresh(&tables)
                 };
                 for table_name in table_names {
                     if let Err(e) = data_lake.refresh_table(&table_name).await {
@@ -455,9 +471,11 @@ impl DataLake {
     }
 
     pub async fn refresh_table(&self, table_name: &str) -> Result<(), TableError> {
-        let tables = self.tables.lock();
-        let table = tables
+        let table = self
+            .tables
+            .lock()
             .get(table_name)
+            .cloned()
             .ok_or(TableError::TableNotFound(table_name.to_string()))?;
 
         let refreshed_table_provider = table
@@ -615,6 +633,34 @@ impl DataLake {
     }
 }
 
+#[async_trait::async_trait]
+impl SchemaProvider for DataLake {
+    /// Returns true if table exist in the schema provider, false otherwise.
+    fn table_exist(&self, name: &str) -> bool {
+        let tables = self.tables.lock();
+        tables.contains_key(name)
+    }
+
+    /// Returns this `SchemaProvider` as [`Any`] so that it can be downcast to a
+    /// specific implementation.
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Retrieves the list of available table names in this schema.
+    fn table_names(&self) -> Vec<String> {
+        let tables = self.tables.lock();
+        tables.keys().cloned().collect()
+    }
+
+    /// Retrieves a specific table from the schema by name, if it exists,
+    /// otherwise returns `None`.
+    async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
+        let table_providers = self.table_providers.lock();
+        Ok(table_providers.get(name).cloned())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -649,32 +695,62 @@ mod tests {
         let dependent = DataLake::merged_table_references(&tables, "base_table");
         assert_eq!(dependent, Some("merged_table".to_string()));
     }
-}
 
-#[async_trait::async_trait]
-impl SchemaProvider for DataLake {
-    /// Returns true if table exist in the schema provider, false otherwise.
-    fn table_exist(&self, name: &str) -> bool {
-        let tables = self.tables.lock();
-        tables.contains_key(name)
-    }
+    #[test]
+    fn ordered_table_names_for_refresh_puts_merged_last() {
+        let mut tables = HashMap::new();
 
-    /// Returns this `SchemaProvider` as [`Any`] so that it can be downcast to a
-    /// specific implementation.
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
+        tables.insert(
+            "base_a".to_string(),
+            Table {
+                table_directory: vec![],
+                table_name: "base_a".to_string(),
+                table_type: TableType::Empty(EmptyTable::new()),
+                description: None,
+            },
+        );
 
-    /// Retrieves the list of available table names in this schema.
-    fn table_names(&self) -> Vec<String> {
-        let tables = self.tables.lock();
-        tables.keys().cloned().collect()
-    }
+        tables.insert(
+            "base_b".to_string(),
+            Table {
+                table_directory: vec![],
+                table_name: "base_b".to_string(),
+                table_type: TableType::Empty(EmptyTable::new()),
+                description: None,
+            },
+        );
 
-    /// Retrieves a specific table from the schema by name, if it exists,
-    /// otherwise returns `None`.
-    async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
-        let table_providers = self.table_providers.lock();
-        Ok(table_providers.get(name).cloned())
+        tables.insert(
+            "merged_x".to_string(),
+            Table {
+                table_directory: vec![],
+                table_name: "merged_x".to_string(),
+                table_type: TableType::Merged(MergedTable {
+                    table_names: vec!["base_a".to_string(), "base_b".to_string()],
+                }),
+                description: None,
+            },
+        );
+
+        let order = DataLake::ordered_table_names_for_refresh(&tables);
+
+        let merged_positions = order
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, name)| (name == "merged_x").then_some(idx))
+            .collect::<Vec<_>>();
+        let base_positions = order
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, name)| ((name == "base_a") || (name == "base_b")).then_some(idx))
+            .collect::<Vec<_>>();
+
+        assert_eq!(merged_positions.len(), 1);
+        assert_eq!(base_positions.len(), 2);
+        assert!(
+            base_positions
+                .into_iter()
+                .all(|idx| idx < merged_positions[0])
+        );
     }
 }

--- a/beacon-data-lake/src/table/_type.rs
+++ b/beacon-data-lake/src/table/_type.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::table::{
     empty::EmptyTable, error::TableError, geospatial::GeoSpatialTable, logical::LogicalTable,
-    preset::PresetTable,
+    merged::MergedTable, preset::PresetTable,
 };
 use beacon_common::listing_url::parse_listing_table_url;
 use datafusion::{
@@ -16,6 +16,7 @@ pub enum TableType {
     Logical(LogicalTable),
     Preset(PresetTable),
     GeoSpatial(GeoSpatialTable),
+    Merged(MergedTable),
     Empty(EmptyTable),
 }
 
@@ -40,6 +41,14 @@ impl TableType {
             }
             TableType::GeoSpatial(geo_spatial_table) => {
                 Box::pin(geo_spatial_table.table_provider(
+                    table_directory_store_url,
+                    data_directory_store_url,
+                    session_ctx,
+                ))
+                .await
+            }
+            TableType::Merged(merged_table) => {
+                Box::pin(merged_table.table_provider(
                     table_directory_store_url,
                     data_directory_store_url,
                     session_ctx,

--- a/beacon-data-lake/src/table/error.rs
+++ b/beacon-data-lake/src/table/error.rs
@@ -10,6 +10,13 @@ pub enum TableError {
     TableAlreadyExists(String),
     #[error("Table not found: {0}")]
     TableNotFound(String),
+    #[error(
+        "Cannot delete table '{table_name}' because it is referenced by merged table '{merged_table}'"
+    )]
+    TableReferencedByMerged {
+        table_name: String,
+        merged_table: String,
+    },
     #[error("Datafusion Error: {0}")]
     DatafusionError(#[from] datafusion::error::DataFusionError),
 }

--- a/beacon-data-lake/src/table/geospatial/mod.rs
+++ b/beacon-data-lake/src/table/geospatial/mod.rs
@@ -36,6 +36,9 @@ impl GeoSpatialTable {
             TableType::GeoSpatial(geo_spatial_table) => {
                 Box::pin(geo_spatial_table.create(table_directory, session_ctx)).await?
             }
+            TableType::Merged(merged_table) => {
+                Box::pin(merged_table.create(table_directory, session_ctx)).await?
+            }
             TableType::Empty(default_table) => {
                 Box::pin(default_table.create(table_directory, session_ctx)).await?
             }

--- a/beacon-data-lake/src/table/merged/mod.rs
+++ b/beacon-data-lake/src/table/merged/mod.rs
@@ -10,8 +10,7 @@ use datafusion::{
     logical_expr::{Expr, ExprSchemable, TableProviderFilterPushDown},
     physical_expr::create_physical_expr,
     physical_plan::{
-        ExecutionPlan, empty::EmptyExec, filter::FilterExec, projection::ProjectionExec,
-        union::UnionExec,
+        ExecutionPlan, empty::EmptyExec, projection::ProjectionExec, union::UnionExec,
     },
     prelude::{SessionContext, lit},
     scalar::ScalarValue,
@@ -160,23 +159,37 @@ impl TableProvider for MergedTableProvider {
                 .cloned()
                 .collect::<Vec<_>>();
 
-            let scan = provider.scan(state, None, &child_filters, None).await?;
+            let child_projection = projection.map(|projection_indices| {
+                let mut required_columns = std::collections::BTreeSet::new();
+
+                for index in projection_indices {
+                    required_columns.insert(self.merged_schema.field(*index).name().clone());
+                }
+
+                for filter in &child_filters {
+                    for column in filter.column_refs() {
+                        required_columns.insert(column.name().to_string());
+                    }
+                }
+
+                child_schema
+                    .fields()
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, field)| {
+                        required_columns.contains(field.name()).then_some(index)
+                    })
+                    .collect::<Vec<_>>()
+            });
+
+            let scan = provider
+                .scan(state, child_projection.as_ref(), &child_filters, _limit)
+                .await?;
             let aligned = self.aligned_projection_exec(state, scan)?;
             plans.push(aligned);
         }
 
         let mut merged_plan: Arc<dyn ExecutionPlan> = Arc::new(UnionExec::new(plans));
-
-        if !filters.is_empty() {
-            let merged_df_schema = DFSchema::try_from(merged_plan.schema())?;
-            let execution_props = state.execution_props();
-
-            for filter in filters {
-                let physical_filter =
-                    create_physical_expr(filter, &merged_df_schema, execution_props)?;
-                merged_plan = Arc::new(FilterExec::try_new(physical_filter, merged_plan)?);
-            }
-        }
 
         if let Some(projection_indices) = projection {
             let merged_df_schema = DFSchema::try_from(merged_plan.schema())?;

--- a/beacon-data-lake/src/table/merged/mod.rs
+++ b/beacon-data-lake/src/table/merged/mod.rs
@@ -1,0 +1,489 @@
+use std::{any::Any, sync::Arc};
+
+use arrow::datatypes::SchemaRef;
+use datafusion::{
+    catalog::{Session, TableProvider},
+    common::{Column, DFSchema},
+    datasource::TableType as DataFusionTableType,
+    error::DataFusionError,
+    execution::object_store::ObjectStoreUrl,
+    logical_expr::{Expr, ExprSchemable, TableProviderFilterPushDown},
+    physical_expr::create_physical_expr,
+    physical_plan::{
+        ExecutionPlan, empty::EmptyExec, filter::FilterExec, projection::ProjectionExec,
+        union::UnionExec,
+    },
+    prelude::{SessionContext, lit},
+    scalar::ScalarValue,
+};
+
+use crate::{table::error::TableError, util::super_type_schema};
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct MergedTable {
+    #[serde(alias = "tables")]
+    pub table_names: Vec<String>,
+}
+
+impl MergedTable {
+    pub async fn create(
+        &self,
+        _table_directory: object_store::path::Path,
+        _session_ctx: Arc<SessionContext>,
+    ) -> Result<(), TableError> {
+        Ok(())
+    }
+
+    pub async fn table_provider(
+        &self,
+        _table_directory_store_url: ObjectStoreUrl,
+        _data_directory_store_url: ObjectStoreUrl,
+        session_ctx: Arc<SessionContext>,
+    ) -> Result<Arc<dyn TableProvider>, TableError> {
+        let mut providers = Vec::with_capacity(self.table_names.len());
+        for table_name in &self.table_names {
+            let provider = session_ctx
+                .table_provider(table_name)
+                .await
+                .map_err(|_| TableError::TableNotFound(table_name.clone()))?;
+            providers.push(provider);
+        }
+
+        let merged = MergedTableProvider::try_new(providers)
+            .map_err(|e| TableError::GenericTableError(e.to_string()))?;
+
+        Ok(Arc::new(merged))
+    }
+}
+
+#[derive(Debug)]
+struct MergedTableProvider {
+    providers: Vec<Arc<dyn TableProvider>>,
+    merged_schema: SchemaRef,
+}
+
+impl MergedTableProvider {
+    fn try_new(providers: Vec<Arc<dyn TableProvider>>) -> Result<Self, DataFusionError> {
+        if providers.is_empty() {
+            return Ok(Self {
+                providers,
+                merged_schema: Arc::new(arrow::datatypes::Schema::empty()),
+            });
+        }
+
+        let schemas: Vec<_> = providers.iter().map(|provider| provider.schema()).collect();
+        let merged_schema =
+            Arc::new(super_type_schema(&schemas).map_err(|e| {
+                DataFusionError::Execution(format!("Failed to merge schemas: {e}"))
+            })?);
+
+        Ok(Self {
+            providers,
+            merged_schema,
+        })
+    }
+
+    fn aligned_projection_exec(
+        &self,
+        state: &dyn Session,
+        plan: Arc<dyn ExecutionPlan>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        let input_schema = plan.schema();
+        let input_df_schema = DFSchema::try_from(input_schema.clone())?;
+        let execution_props = state.execution_props();
+
+        let mut projection_exprs = Vec::with_capacity(self.merged_schema.fields().len());
+        for field in self.merged_schema.fields() {
+            let field_name = field.name();
+            let target_type = field.data_type().clone();
+
+            let logical_expr = match input_schema.field_with_name(field_name) {
+                Ok(input_field) => {
+                    if input_field.data_type() == &target_type {
+                        Expr::Column(Column::new_unqualified(field_name.clone()))
+                    } else {
+                        Expr::Column(Column::new_unqualified(field_name.clone()))
+                            .cast_to(&target_type, &input_df_schema)?
+                    }
+                }
+                Err(_) => lit(ScalarValue::Null).cast_to(&target_type, &input_df_schema)?,
+            };
+
+            let physical_expr =
+                create_physical_expr(&logical_expr, &input_df_schema, execution_props)?;
+
+            projection_exprs.push((physical_expr, field_name.clone()));
+        }
+
+        Ok(Arc::new(ProjectionExec::try_new(projection_exprs, plan)?))
+    }
+
+    fn filter_applicable_to_schema(filter: &Expr, schema: &SchemaRef) -> bool {
+        let referenced_columns = filter.column_refs();
+        referenced_columns
+            .iter()
+            .all(|column| schema.field_with_name(column.name()).is_ok())
+    }
+}
+
+#[async_trait::async_trait]
+impl TableProvider for MergedTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.merged_schema.clone()
+    }
+
+    fn table_type(&self) -> DataFusionTableType {
+        DataFusionTableType::Base
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        if self.providers.is_empty() {
+            return Ok(Arc::new(EmptyExec::new(self.merged_schema.clone())));
+        }
+
+        let mut plans = Vec::with_capacity(self.providers.len());
+        for provider in &self.providers {
+            let child_schema = provider.schema();
+            let child_filters = filters
+                .iter()
+                .filter(|filter| Self::filter_applicable_to_schema(filter, &child_schema))
+                .cloned()
+                .collect::<Vec<_>>();
+
+            let scan = provider.scan(state, None, &child_filters, None).await?;
+            let aligned = self.aligned_projection_exec(state, scan)?;
+            plans.push(aligned);
+        }
+
+        let mut merged_plan: Arc<dyn ExecutionPlan> = Arc::new(UnionExec::new(plans));
+
+        if !filters.is_empty() {
+            let merged_df_schema = DFSchema::try_from(merged_plan.schema())?;
+            let execution_props = state.execution_props();
+
+            for filter in filters {
+                let physical_filter =
+                    create_physical_expr(filter, &merged_df_schema, execution_props)?;
+                merged_plan = Arc::new(FilterExec::try_new(physical_filter, merged_plan)?);
+            }
+        }
+
+        if let Some(projection_indices) = projection {
+            let merged_df_schema = DFSchema::try_from(merged_plan.schema())?;
+            let execution_props = state.execution_props();
+            let projection_exprs = projection_indices
+                .iter()
+                .map(|index| {
+                    let field = self.merged_schema.field(*index);
+                    let expr = Expr::Column(Column::new_unqualified(field.name().clone()));
+                    let physical_expr =
+                        create_physical_expr(&expr, &merged_df_schema, execution_props)?;
+                    Ok((physical_expr, field.name().clone()))
+                })
+                .collect::<Result<Vec<_>, DataFusionError>>()?;
+
+            merged_plan = Arc::new(ProjectionExec::try_new(projection_exprs, merged_plan)?);
+        }
+
+        Ok(merged_plan)
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> datafusion::error::Result<Vec<TableProviderFilterPushDown>> {
+        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+    use arrow::{
+        array::{Array, ArrayRef, Float64Array, Int32Array},
+        datatypes::{DataType, Field, Schema},
+        record_batch::RecordBatch,
+    };
+    use datafusion::catalog::MemTable;
+    use datafusion::catalog::Session;
+    use datafusion::execution::object_store::ObjectStoreUrl;
+    use datafusion::physical_plan::collect;
+    use datafusion::prelude::col;
+
+    fn f64_values(column: &ArrayRef) -> Vec<Option<f64>> {
+        let col = column
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("expected Float64Array");
+        (0..col.len())
+            .map(|idx| {
+                if col.is_null(idx) {
+                    None
+                } else {
+                    Some(col.value(idx))
+                }
+            })
+            .collect()
+    }
+
+    fn i32_values(column: &ArrayRef) -> Vec<Option<i32>> {
+        let col = column
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("expected Int32Array");
+        (0..col.len())
+            .map(|idx| {
+                if col.is_null(idx) {
+                    None
+                } else {
+                    Some(col.value(idx))
+                }
+            })
+            .collect()
+    }
+
+    #[derive(Debug)]
+    struct RecordingProvider {
+        schema: SchemaRef,
+        scan_calls: Arc<AtomicUsize>,
+        pushed_filters: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl TableProvider for RecordingProvider {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn schema(&self) -> SchemaRef {
+            self.schema.clone()
+        }
+
+        fn table_type(&self) -> DataFusionTableType {
+            DataFusionTableType::Base
+        }
+
+        async fn scan(
+            &self,
+            _state: &dyn Session,
+            _projection: Option<&Vec<usize>>,
+            filters: &[Expr],
+            _limit: Option<usize>,
+        ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+            self.scan_calls.fetch_add(1, Ordering::SeqCst);
+            self.pushed_filters
+                .fetch_add(filters.len(), Ordering::SeqCst);
+            Ok(Arc::new(EmptyExec::new(self.schema.clone())))
+        }
+
+        fn supports_filters_pushdown(
+            &self,
+            filters: &[&Expr],
+        ) -> datafusion::error::Result<Vec<TableProviderFilterPushDown>> {
+            Ok(vec![TableProviderFilterPushDown::Exact; filters.len()])
+        }
+    }
+
+    #[tokio::test]
+    async fn merged_table_provider_merges_schema_using_super_type() {
+        let schema_a = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, true)]));
+        let schema_b = Arc::new(Schema::new(vec![Field::new("v", DataType::Float64, true)]));
+
+        let batch_a = RecordBatch::try_new(
+            schema_a.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef],
+        )
+        .unwrap();
+        let batch_b = RecordBatch::try_new(
+            schema_b.clone(),
+            vec![Arc::new(Float64Array::from(vec![3.5])) as ArrayRef],
+        )
+        .unwrap();
+
+        let table_a = Arc::new(MemTable::try_new(schema_a, vec![vec![batch_a]]).unwrap())
+            as Arc<dyn TableProvider>;
+        let table_b = Arc::new(MemTable::try_new(schema_b, vec![vec![batch_b]]).unwrap())
+            as Arc<dyn TableProvider>;
+
+        let provider = MergedTableProvider::try_new(vec![table_a, table_b]).unwrap();
+        assert_eq!(provider.schema().field(0).data_type(), &DataType::Float64);
+    }
+
+    #[tokio::test]
+    async fn merged_table_provider_scans_with_aligned_schema() {
+        let schema_a = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("shared", DataType::Int32, true),
+        ]));
+        let schema_b = Arc::new(Schema::new(vec![
+            Field::new("b", DataType::Int32, true),
+            Field::new("shared", DataType::Float64, true),
+        ]));
+
+        let batch_a = RecordBatch::try_new(
+            schema_a.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
+                Arc::new(Int32Array::from(vec![10, 20])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        let batch_b = RecordBatch::try_new(
+            schema_b.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![7])) as ArrayRef,
+                Arc::new(Float64Array::from(vec![3.5])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        let table_a = Arc::new(MemTable::try_new(schema_a, vec![vec![batch_a]]).unwrap())
+            as Arc<dyn TableProvider>;
+        let table_b = Arc::new(MemTable::try_new(schema_b, vec![vec![batch_b]]).unwrap())
+            as Arc<dyn TableProvider>;
+
+        let provider = Arc::new(MergedTableProvider::try_new(vec![table_a, table_b]).unwrap());
+
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        let plan = provider.scan(&state, None, &[], None).await.unwrap();
+        let task_ctx = ctx.task_ctx();
+        let batches = collect(plan, task_ctx).await.unwrap();
+
+        let mut total_rows = 0usize;
+        let schema = provider.schema();
+
+        let a_idx = schema.index_of("a").unwrap();
+        let b_idx = schema.index_of("b").unwrap();
+        let shared_idx = schema.index_of("shared").unwrap();
+
+        let mut a_values = Vec::new();
+        let mut b_values = Vec::new();
+        let mut shared_values = Vec::new();
+
+        for batch in &batches {
+            total_rows += batch.num_rows();
+            a_values.extend(i32_values(batch.column(a_idx)));
+            b_values.extend(i32_values(batch.column(b_idx)));
+            shared_values.extend(f64_values(batch.column(shared_idx)));
+        }
+
+        assert_eq!(total_rows, 3);
+        assert_eq!(a_values, vec![Some(1), Some(2), None]);
+        assert_eq!(b_values, vec![None, None, Some(7)]);
+        assert_eq!(shared_values, vec![Some(10.0), Some(20.0), Some(3.5)]);
+    }
+
+    #[tokio::test]
+    async fn merged_table_provider_pushes_filters_to_matching_children() {
+        let schema_a = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
+        let schema_b = Arc::new(Schema::new(vec![Field::new("b", DataType::Int32, true)]));
+
+        let a_scan_calls = Arc::new(AtomicUsize::new(0));
+        let b_scan_calls = Arc::new(AtomicUsize::new(0));
+        let a_pushed_filters = Arc::new(AtomicUsize::new(0));
+        let b_pushed_filters = Arc::new(AtomicUsize::new(0));
+
+        let table_a = Arc::new(RecordingProvider {
+            schema: schema_a,
+            scan_calls: a_scan_calls.clone(),
+            pushed_filters: a_pushed_filters.clone(),
+        }) as Arc<dyn TableProvider>;
+
+        let table_b = Arc::new(RecordingProvider {
+            schema: schema_b,
+            scan_calls: b_scan_calls.clone(),
+            pushed_filters: b_pushed_filters.clone(),
+        }) as Arc<dyn TableProvider>;
+
+        let provider = MergedTableProvider::try_new(vec![table_a, table_b]).unwrap();
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+
+        let filter_a = col("a").gt(lit(10));
+        let _plan = provider
+            .scan(&state, None, &[filter_a], None)
+            .await
+            .expect("scan should succeed");
+
+        assert_eq!(a_scan_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(b_scan_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(a_pushed_filters.load(Ordering::SeqCst), 1);
+        assert_eq!(b_pushed_filters.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn merged_table_resolves_providers_by_table_name() {
+        let ctx = Arc::new(SessionContext::new());
+
+        let schema_a = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
+        let schema_b = Arc::new(Schema::new(vec![Field::new("b", DataType::Int32, true)]));
+
+        let batch_a = RecordBatch::try_new(
+            schema_a.clone(),
+            vec![Arc::new(Int32Array::from(vec![1])) as ArrayRef],
+        )
+        .unwrap();
+        let batch_b = RecordBatch::try_new(
+            schema_b.clone(),
+            vec![Arc::new(Int32Array::from(vec![2])) as ArrayRef],
+        )
+        .unwrap();
+
+        let table_a = Arc::new(MemTable::try_new(schema_a, vec![vec![batch_a]]).unwrap());
+        let table_b = Arc::new(MemTable::try_new(schema_b, vec![vec![batch_b]]).unwrap());
+
+        ctx.register_table("t_a", table_a).unwrap();
+        ctx.register_table("t_b", table_b).unwrap();
+
+        let merged = MergedTable {
+            table_names: vec!["t_a".to_string(), "t_b".to_string()],
+        };
+
+        let provider = merged
+            .table_provider(
+                ObjectStoreUrl::parse("file://").unwrap(),
+                ObjectStoreUrl::parse("file://").unwrap(),
+                ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(provider.schema().field_with_name("a").is_ok());
+        assert!(provider.schema().field_with_name("b").is_ok());
+    }
+
+    #[tokio::test]
+    async fn merged_table_returns_not_found_for_missing_table_name() {
+        let ctx = Arc::new(SessionContext::new());
+        let merged = MergedTable {
+            table_names: vec!["missing_table".to_string()],
+        };
+
+        let result = merged
+            .table_provider(
+                ObjectStoreUrl::parse("file://").unwrap(),
+                ObjectStoreUrl::parse("file://").unwrap(),
+                ctx,
+            )
+            .await;
+
+        match result {
+            Err(TableError::TableNotFound(name)) => assert_eq!(name, "missing_table"),
+            _ => panic!("Expected TableError::TableNotFound"),
+        }
+    }
+}

--- a/beacon-data-lake/src/table/mod.rs
+++ b/beacon-data-lake/src/table/mod.rs
@@ -16,6 +16,7 @@ pub mod empty;
 pub mod error;
 pub mod geospatial;
 pub mod logical;
+pub mod merged;
 pub mod preset;
 pub mod table_formats;
 

--- a/beacon-data-lake/src/table/preset/mod.rs
+++ b/beacon-data-lake/src/table/preset/mod.rs
@@ -91,6 +91,9 @@ impl PresetTable {
             TableType::GeoSpatial(geo_spatial_table) => {
                 Box::pin(geo_spatial_table.create(table_directory, session_ctx)).await?
             }
+            TableType::Merged(merged_table) => {
+                Box::pin(merged_table.create(table_directory, session_ctx)).await?
+            }
             TableType::Empty(default_table) => {
                 Box::pin(default_table.create(table_directory, session_ctx)).await?
             }


### PR DESCRIPTION
This pull request introduces support for "merged" tables in the data lake, enabling tables to reference and combine data from other tables. The changes ensure that merged tables are created and resolved correctly, and add safeguards to prevent deletion of tables that are dependencies of merged tables. Tests are included to verify the new dependency logic.

**Merged Table Support and Dependency Management:**

* Added a new `Merged` variant to the `TableType` enum, along with its implementation and integration throughout the codebase, allowing tables to be defined as merged from other tables. [[1]](diffhunk://#diff-52d02a0b8913094a96306b8179c2aef48c91fbb4ee384ec96d0f481a84c53eb7R19) [[2]](diffhunk://#diff-52d02a0b8913094a96306b8179c2aef48c91fbb4ee384ec96d0f481a84c53eb7L5-R5) [[3]](diffhunk://#diff-08bcaa53f02fb708399c8d05575fd6adc6bbf99615db5e9c9b063de24b87f11eR19)
* Updated the table creation and provider logic to handle merged tables, ensuring they are resolved after their dependencies and properly registered. [[1]](diffhunk://#diff-4e9c327c76a22001c83c7515657ea64743198b5b5b854e183de354c680c638eaR237-R239) [[2]](diffhunk://#diff-4e9c327c76a22001c83c7515657ea64743198b5b5b854e183de354c680c638eaR259-R287) [[3]](diffhunk://#diff-4e9c327c76a22001c83c7515657ea64743198b5b5b854e183de354c680c638eaR84-R105)
* Implemented checks in the `remove_table` method to prevent deletion of tables that are referenced by merged tables, returning a specific error if such a dependency exists. [[1]](diffhunk://#diff-4e9c327c76a22001c83c7515657ea64743198b5b5b854e183de354c680c638eaL537-R604) [[2]](diffhunk://#diff-c7067cfafffa8e815ba7109bd4be7518fa8a2b7798f141d1bb9e364cc4e241e6R13-R19)

**Testing and Error Handling:**

* Added a test to verify that the dependency detection logic for merged tables works as expected.
* Enhanced the `TableError` enum to include a new error variant for attempts to delete tables that are dependencies of merged tables.

**Integration with Table Types:**

* Updated the logic in geospatial and preset table modules to support creation of merged tables, ensuring consistent behavior across different table types. [[1]](diffhunk://#diff-3520f9402d865030eeb7c72e2f9f8a96b8f7c9829747791a3a757c41b495e714R39-R41) [[2]](diffhunk://#diff-c760254bcae1edd2cb8910970b64856d95b365a1b247dbb3ffa014707b00656eR94-R96)