### PR TITLE
Preset Table Duplicate Columns

### DIFF
--- a/beacon-data-lake/src/lib.rs
+++ b/beacon-data-lake/src/lib.rs
@@ -500,10 +500,17 @@ impl DataLake {
     }
 
     pub async fn create_table(&self, mut table: Table) -> Result<(), TableError> {
-        let mut tables = self.tables.lock();
-        if tables.contains_key(&table.table_name) {
+        if self.tables.lock().contains_key(&table.table_name) {
             return Err(TableError::TableAlreadyExists(table.table_name));
         }
+
+        let table_provider = table
+            .table_provider(
+                self.session_context.clone(),
+                self.data_directory_store_url.clone(),
+                self.table_directory_store_url.clone(),
+            )
+            .await?;
 
         let table_object_store = self
             .session_context
@@ -513,17 +520,9 @@ impl DataLake {
 
         let table_directory: Vec<PathPart<'static>> =
             vec![PathPart::from(table.table_name.clone())];
-        drop(tables); // Release the lock before saving the table as to not deadlock across the async call
         table.save(table_object_store, table_directory).await;
-        let table_provider = table
-            .table_provider(
-                self.session_context.clone(),
-                self.data_directory_store_url.clone(),
-                self.table_directory_store_url.clone(),
-            )
-            .await?;
-        // Re-acquire the lock to insert the table
-        tables = self.tables.lock();
+
+        let mut tables = self.tables.lock();
         let mut table_providers = self.table_providers.lock();
         table_providers.insert(table.table_name.clone(), table_provider);
         tables.insert(table.table_name.clone(), table);

--- a/beacon-data-lake/src/table/preset/mod.rs
+++ b/beacon-data-lake/src/table/preset/mod.rs
@@ -85,7 +85,7 @@ impl PresetTable {
     fn insert_exposed_field(
         exposed_fields: &mut Vec<arrow::datatypes::Field>,
         exposed_names: &mut HashSet<String>,
-        renames: &mut IndexMap<String, String>,
+        source_columns: &mut HashMap<String, String>,
         field: &arrow::datatypes::Field,
         column_name: &str,
         alias: Option<&String>,
@@ -101,10 +101,11 @@ impl PresetTable {
 
         if let Some(alias) = alias {
             exposed_fields.push(field.clone().with_name(alias));
-            renames.insert(column_name.to_string(), alias.clone());
         } else {
             exposed_fields.push(field.clone());
         }
+
+        source_columns.insert(exposed_name, column_name.to_string());
 
         Ok(())
     }
@@ -151,14 +152,14 @@ impl PresetTable {
 
         let mut exposed_fields = Vec::new();
         let mut exposed_names = HashSet::new();
-        let mut renames = IndexMap::new();
+        let mut source_columns = HashMap::new();
 
         for column in self.data_columns.iter() {
             if let Ok(field) = current_schema.field_with_name(&column.column_name) {
                 Self::insert_exposed_field(
                     &mut exposed_fields,
                     &mut exposed_names,
-                    &mut renames,
+                    &mut source_columns,
                     field,
                     &column.column_name,
                     column.alias.as_ref(),
@@ -172,7 +173,7 @@ impl PresetTable {
                             Self::insert_exposed_field(
                                 &mut exposed_fields,
                                 &mut exposed_names,
-                                &mut renames,
+                                &mut source_columns,
                                 nested_field,
                                 &nested_column.column_name,
                                 nested_column.alias.as_ref(),
@@ -198,7 +199,7 @@ impl PresetTable {
                 Self::insert_exposed_field(
                     &mut exposed_fields,
                     &mut exposed_names,
-                    &mut renames,
+                    &mut source_columns,
                     field,
                     &column.column_name,
                     column.alias.as_ref(),
@@ -214,7 +215,7 @@ impl PresetTable {
         let schema = SchemaRef::new(arrow::datatypes::Schema::new(exposed_fields));
 
         let preset_table_provider =
-            PresetTableProvider::new(current_provider, schema.clone(), renames);
+            PresetTableProvider::new(current_provider, schema.clone(), source_columns);
 
         Ok(Arc::new(preset_table_provider))
     }
@@ -224,19 +225,19 @@ impl PresetTable {
 struct PresetTableProvider {
     inner: Arc<dyn TableProvider>,
     exposed_schema: SchemaRef,
-    renames: IndexMap<String, String>,
+    source_columns: HashMap<String, String>,
 }
 
 impl PresetTableProvider {
     pub fn new(
         inner: Arc<dyn TableProvider>,
         exposed_schema: SchemaRef,
-        renames: IndexMap<String, String>,
+        source_columns: HashMap<String, String>,
     ) -> Self {
         Self {
             inner,
             exposed_schema,
-            renames,
+            source_columns,
         }
     }
 }
@@ -263,39 +264,42 @@ impl TableProvider for PresetTableProvider {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        let inverted_renames: HashMap<_, _> = self
-            .renames
-            .iter()
-            .map(|(k, v)| (v.clone(), k.clone()))
-            .collect();
-
         let alias_exprs = filters
             .iter()
-            .map(|e| remap_filter(e.clone(), &inverted_renames))
+            .map(|e| remap_filter(e.clone(), &self.source_columns))
             .collect::<Result<Vec<_>, _>>()?;
 
         let projection = projection
             .cloned()
             .unwrap_or_else(|| (0..self.exposed_schema.fields().len()).collect::<Vec<_>>());
 
-        let mut source_projection = Vec::with_capacity(projection.len());
-
-        // Translate the projection indices to the actual column names
         let source_schema = self.inner.schema();
+        let mut source_projection = Vec::new();
+        let mut projected_columns = Vec::with_capacity(projection.len());
+        let mut projected_source_indices = IndexMap::new();
 
         for column_index in projection {
             let exposed_column_name = self.exposed_schema.field(column_index).name();
-            let source_name = inverted_renames
+            let source_name = self
+                .source_columns
                 .get(exposed_column_name)
                 .unwrap_or(exposed_column_name);
-            if let Ok(source_column_index) = source_schema.index_of(source_name) {
-                source_projection.push(source_column_index);
-            } else {
-                return Err(datafusion::error::DataFusionError::Configuration(format!(
+            let source_column_index = source_schema.index_of(source_name).map_err(|_| {
+                datafusion::error::DataFusionError::Configuration(format!(
                     "Column '{}' not found in the source schema",
-                    exposed_column_name
-                )));
-            }
+                    source_name
+                ))
+            })?;
+
+            let scan_column_index = *projected_source_indices
+                .entry(source_name.clone())
+                .or_insert_with(|| {
+                    let next_index = source_projection.len();
+                    source_projection.push(source_column_index);
+                    next_index
+                });
+
+            projected_columns.push((scan_column_index, exposed_column_name.clone()));
         }
 
         let scan = self
@@ -308,24 +312,19 @@ impl TableProvider for PresetTableProvider {
 
         let props = state.execution_props();
 
-        let mut proj_exprs = Vec::with_capacity(self.renames.len());
+        let mut proj_exprs = Vec::with_capacity(projected_columns.len());
 
-        for field in df_schema.fields() {
-            // Check if the field is in the renames map
-            if let Some(alias) = self.renames.get(field.name()) {
-                // Make a logical Expr::Column against the real name
-                let log_expr: Expr = Expr::Column(Column::new_unqualified(field.name().clone()));
-                // Plan it into a PhysicalExpr
-                let phys_expr = create_physical_expr(&log_expr, &df_schema, props).unwrap();
-                // Now alias it in the ProjectionExec
-                proj_exprs.push((phys_expr, alias.clone()));
+        for (scan_column_index, exposed_name) in projected_columns {
+            let scan_field = scan_schema.field(scan_column_index);
+            let log_expr: Expr = Expr::Column(Column::new_unqualified(scan_field.name().clone()));
+            let phys_expr = create_physical_expr(&log_expr, &df_schema, props).unwrap();
+            proj_exprs.push((phys_expr, exposed_name.clone()));
 
-                tracing::debug!(
-                    "Adding projection for column '{}' with alias '{}'",
-                    field.name(),
-                    alias
-                );
-            }
+            tracing::debug!(
+                "Adding projection for source column '{}' as '{}'",
+                scan_field.name(),
+                exposed_name
+            );
         }
 
         let phys_pushdown_filters = create_physical_exprs(alias_exprs.iter(), &df_schema, props);
@@ -386,7 +385,7 @@ mod tests {
         datatypes::{DataType, Field, Schema},
         record_batch::RecordBatch,
     };
-    use datafusion::{catalog::MemTable, prelude::SessionContext};
+    use datafusion::{catalog::MemTable, physical_plan::collect, prelude::SessionContext};
     use futures::StreamExt;
 
     use crate::{DataLake, TABLES_OBJECT_STORE_URL, table::Table};
@@ -529,5 +528,63 @@ mod tests {
             .unwrap();
         let mut entries = object_store.list(Some(&object_store::path::Path::from(table_name)));
         assert!(entries.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn preset_table_provider_supports_multiple_aliases_for_same_source_column() {
+        let provider = preset_provider_result(preset_table(
+            vec![
+                mapping("a", Some("a_first")),
+                mapping("a", Some("a_second")),
+                mapping("b", None),
+                mapping("a", None),
+            ],
+            vec![],
+        ))
+        .await
+        .expect("preset provider should be created");
+
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        let plan = provider
+            .scan(&state, None, &[], None)
+            .await
+            .expect("scan should succeed");
+        let batches = collect(plan, ctx.task_ctx())
+            .await
+            .expect("collect should succeed");
+
+        assert_eq!(batches.len(), 1);
+        let batch = &batches[0];
+        assert_eq!(batch.schema().field(0).name(), "a_first");
+        assert_eq!(batch.schema().field(1).name(), "a_second");
+        assert_eq!(batch.schema().field(2).name(), "b");
+        assert_eq!(batch.schema().field(3).name(), "a");
+
+        let a_first = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("first alias should be Int32Array");
+        let a_second = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("second alias should be Int32Array");
+        let b = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("unaliased column should be Int32Array");
+        let a_unaliased = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("unaliased column should be Int32Array");
+
+        assert_eq!(a_first.value(0), 1);
+        assert_eq!(a_second.value(0), 1);
+        assert_eq!(b.value(0), 2);
+        assert_eq!(a_unaliased.value(0), 1);
     }
 }

--- a/beacon-data-lake/src/table/preset/mod.rs
+++ b/beacon-data-lake/src/table/preset/mod.rs
@@ -1,4 +1,8 @@
-use std::{any::Any, collections::HashMap, sync::Arc};
+use std::{
+    any::Any,
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use arrow::datatypes::SchemaRef;
 use chrono::NaiveDateTime;
@@ -78,6 +82,33 @@ pub struct PresetTable {
 }
 
 impl PresetTable {
+    fn insert_exposed_field(
+        exposed_fields: &mut Vec<arrow::datatypes::Field>,
+        exposed_names: &mut HashSet<String>,
+        renames: &mut IndexMap<String, String>,
+        field: &arrow::datatypes::Field,
+        column_name: &str,
+        alias: Option<&String>,
+    ) -> Result<(), TableError> {
+        let exposed_name = alias.cloned().unwrap_or_else(|| field.name().clone());
+
+        if !exposed_names.insert(exposed_name.clone()) {
+            return Err(TableError::GenericTableError(format!(
+                "Preset table exposes duplicate column name '{}'",
+                exposed_name
+            )));
+        }
+
+        if let Some(alias) = alias {
+            exposed_fields.push(field.clone().with_name(alias));
+            renames.insert(column_name.to_string(), alias.clone());
+        } else {
+            exposed_fields.push(field.clone());
+        }
+
+        Ok(())
+    }
+
     pub async fn create(
         &self,
         table_directory: object_store::path::Path,
@@ -119,31 +150,33 @@ impl PresetTable {
         let current_schema = current_provider.schema();
 
         let mut exposed_fields = Vec::new();
+        let mut exposed_names = HashSet::new();
         let mut renames = IndexMap::new();
 
         for column in self.data_columns.iter() {
             if let Ok(field) = current_schema.field_with_name(&column.column_name) {
-                if let Some(alias) = column.alias.as_ref() {
-                    exposed_fields.push(field.clone().with_name(alias));
-                    renames.insert(column.column_name.clone(), alias.clone());
-                } else {
-                    exposed_fields.push(field.clone());
-                }
+                Self::insert_exposed_field(
+                    &mut exposed_fields,
+                    &mut exposed_names,
+                    &mut renames,
+                    field,
+                    &column.column_name,
+                    column.alias.as_ref(),
+                )?;
 
                 if let Some(nested_metadata_columns) = column.column_metadata_columns.as_ref() {
                     for nested_column in nested_metadata_columns.iter() {
                         if let Ok(nested_field) =
                             current_schema.field_with_name(&nested_column.column_name)
                         {
-                            if let Some(nested_alias) = nested_column.alias.as_ref() {
-                                exposed_fields.push(nested_field.clone().with_name(nested_alias));
-                                renames.insert(
-                                    nested_column.column_name.clone(),
-                                    nested_alias.clone(),
-                                );
-                            } else {
-                                exposed_fields.push(nested_field.clone());
-                            }
+                            Self::insert_exposed_field(
+                                &mut exposed_fields,
+                                &mut exposed_names,
+                                &mut renames,
+                                nested_field,
+                                &nested_column.column_name,
+                                nested_column.alias.as_ref(),
+                            )?;
                         } else {
                             return Err(TableError::GenericTableError(format!(
                                 "Nested metadata column '{}' not found in the current schema",
@@ -162,12 +195,14 @@ impl PresetTable {
 
         for column in self.metadata_columns.iter() {
             if let Ok(field) = current_schema.field_with_name(&column.column_name) {
-                if let Some(alias) = column.alias.as_ref() {
-                    exposed_fields.push(field.clone().with_name(alias));
-                    renames.insert(column.column_name.clone(), alias.clone());
-                } else {
-                    exposed_fields.push(field.clone());
-                }
+                Self::insert_exposed_field(
+                    &mut exposed_fields,
+                    &mut exposed_names,
+                    &mut renames,
+                    field,
+                    &column.column_name,
+                    column.alias.as_ref(),
+                )?;
             } else {
                 return Err(TableError::GenericTableError(format!(
                     "Metadata column '{}' not found in the current schema",
@@ -340,5 +375,159 @@ impl TableProvider for PresetTableProvider {
         filters: &[&Expr],
     ) -> datafusion::error::Result<Vec<TableProviderFilterPushDown>> {
         self.inner.supports_filters_pushdown(filters)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::{
+        array::{ArrayRef, Int32Array},
+        datatypes::{DataType, Field, Schema},
+        record_batch::RecordBatch,
+    };
+    use datafusion::{catalog::MemTable, prelude::SessionContext};
+    use futures::StreamExt;
+
+    use crate::{DataLake, TABLES_OBJECT_STORE_URL, table::Table};
+
+    fn mapping(column_name: &str, alias: Option<&str>) -> PresetColumnMapping {
+        PresetColumnMapping {
+            column_name: column_name.to_string(),
+            alias: alias.map(str::to_string),
+            description: None,
+            filter: None,
+            column_metadata_columns: None,
+            _metadata_fields: HashMap::new(),
+        }
+    }
+
+    async fn preset_provider_result(
+        preset: PresetTable,
+    ) -> Result<Arc<dyn TableProvider>, TableError> {
+        let ctx = Arc::new(SessionContext::new());
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1])) as ArrayRef,
+                Arc::new(Int32Array::from(vec![2])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+        let source = Arc::new(MemTable::try_new(schema, vec![vec![batch]]).unwrap());
+        ctx.register_table("source", source).unwrap();
+
+        preset
+            .table_provider(
+                ObjectStoreUrl::parse("file://").unwrap(),
+                ObjectStoreUrl::parse("file://").unwrap(),
+                ctx,
+            )
+            .await
+    }
+
+    fn preset_table(
+        data_columns: Vec<PresetColumnMapping>,
+        metadata_columns: Vec<PresetColumnMapping>,
+    ) -> PresetTable {
+        PresetTable {
+            table_engine: Arc::new(TableType::Merged(crate::table::merged::MergedTable {
+                table_names: vec!["source".to_string()],
+            })),
+            data_columns,
+            metadata_columns,
+        }
+    }
+
+    #[tokio::test]
+    async fn preset_table_provider_rejects_duplicate_aliases() {
+        let preset = preset_table(
+            vec![mapping("a", Some("dup")), mapping("b", Some("dup"))],
+            vec![],
+        );
+
+        let result = preset_provider_result(preset).await;
+
+        match result {
+            Err(TableError::GenericTableError(message)) => {
+                assert_eq!(message, "Preset table exposes duplicate column name 'dup'");
+            }
+            other => panic!("expected duplicate-column error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn preset_table_provider_rejects_alias_colliding_with_existing_name() {
+        let preset = preset_table(vec![mapping("a", Some("b")), mapping("b", None)], vec![]);
+
+        let result = preset_provider_result(preset).await;
+
+        match result {
+            Err(TableError::GenericTableError(message)) => {
+                assert_eq!(message, "Preset table exposes duplicate column name 'b'");
+            }
+            other => panic!("expected duplicate-column error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_table_rejects_duplicate_preset_output_columns_without_persisting() {
+        let ctx = Arc::new(SessionContext::new());
+        let data_lake = Arc::new(DataLake::new(ctx.clone()).await);
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1])) as ArrayRef,
+                Arc::new(Int32Array::from(vec![2])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+        let source = Arc::new(MemTable::try_new(schema, vec![vec![batch]]).unwrap());
+        ctx.register_table("source", source).unwrap();
+
+        let table_name = format!(
+            "invalid-preset-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+
+        let table = Table {
+            table_directory: vec![],
+            table_name: table_name.clone(),
+            table_type: TableType::Preset(preset_table(
+                vec![mapping("a", Some("dup")), mapping("b", Some("dup"))],
+                vec![],
+            )),
+            description: None,
+        };
+
+        let result = data_lake.create_table(table).await;
+
+        match result {
+            Err(TableError::GenericTableError(message)) => {
+                assert_eq!(message, "Preset table exposes duplicate column name 'dup'");
+            }
+            other => panic!("expected duplicate-column error, got {other:?}"),
+        }
+
+        assert!(data_lake.list_table(&table_name).is_none());
+
+        let object_store = ctx
+            .runtime_env()
+            .object_store(&*TABLES_OBJECT_STORE_URL)
+            .unwrap();
+        let mut entries = object_store.list(Some(&object_store::path::Path::from(table_name)));
+        assert!(entries.next().await.is_none());
     }
 }


### PR DESCRIPTION
Fixes #185 

This pull request improves the robustness of the preset table creation process by preventing duplicate column names (including aliases) in exposed columns, and adds comprehensive tests to ensure correct behavior. The changes introduce stricter validation and modularization in how preset tables expose columns, ensuring data integrity and clearer error handling.

**Preset Table Column Exposure Validation:**

* Added a new method `insert_exposed_field` in `PresetTable` to centralize logic for inserting exposed fields, ensuring no duplicate column names (including aliases) are present. If a duplicate is detected, a clear error is returned.
* Updated the preset table creation logic to use the new `insert_exposed_field` method for both data and metadata columns, enforcing the uniqueness constraint throughout all nested and top-level columns. [[1]](diffhunk://#diff-c760254bcae1edd2cb8910970b64856d95b365a1b247dbb3ffa014707b00656eR153-R179) [[2]](diffhunk://#diff-c760254bcae1edd2cb8910970b64856d95b365a1b247dbb3ffa014707b00656eL165-R205)

**Testing and Reliability:**

* Added extensive tests to `beacon-data-lake/src/table/preset/mod.rs` that verify duplicate column names and aliases are correctly rejected, and that no table is persisted when such an error occurs. These tests cover both direct alias duplication and alias collisions with existing column names.

**Code Quality and Maintenance:**

* Improved imports by adding `HashSet` for tracking exposed names and cleaning up import statements.

**DataLake Table Creation Flow:**

* Adjusted the `create_table` method in `DataLake` to ensure the table provider is created before attempting to save the table, and clarified lock handling for thread safety. [[1]](diffhunk://#diff-4e9c327c76a22001c83c7515657ea64743198b5b5b854e183de354c680c638eaL503-R514) [[2]](diffhunk://#diff-4e9c327c76a22001c83c7515657ea64743198b5b5b854e183de354c680c638eaL516-R525)