### PR TITLE
list datasets function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,6 +1182,7 @@ dependencies = [
  "chrono",
  "csv",
  "datafusion",
+ "futures",
  "geo",
  "geojson",
  "gsw",

--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -75,6 +75,7 @@ impl Runtime {
             session_ctx.clone(),
             file_manager.data_object_store_url(),
             beacon_object_storage::get_datasets_object_store().await,
+            file_manager.file_formats().to_vec(),
         );
 
         for table_function in table_functions.iter() {

--- a/beacon-data-lake/src/files/manager.rs
+++ b/beacon-data-lake/src/files/manager.rs
@@ -43,6 +43,10 @@ impl FileManager {
         self.data_directory_store_url.clone()
     }
 
+    pub fn file_formats(&self) -> &Vec<Arc<dyn FileFormatFactoryExt>> {
+        &self.file_formats
+    }
+
     pub fn try_create_temp_output_file(&self, extension: &str) -> TempOutputFile {
         Self::create_temp_output_file(extension)
     }

--- a/beacon-functions/Cargo.toml
+++ b/beacon-functions/Cargo.toml
@@ -24,6 +24,7 @@ lru = "0.14.0"
 ordered-float = "5.0.0"
 tracing = { workspace = true }
 tokio = { workspace = true }
+futures = { workspace = true }
 chrono = { workspace = true }
 
 beacon-common = { path = "../beacon-common" }

--- a/beacon-functions/src/file_formats/list_datasets.rs
+++ b/beacon-functions/src/file_formats/list_datasets.rs
@@ -1,0 +1,116 @@
+use std::sync::Arc;
+
+use arrow::{
+    array::StringArray,
+    datatypes::{DataType, Field, Schema},
+    record_batch::RecordBatch,
+};
+use beacon_common::listing_url::parse_listing_table_url;
+use beacon_datafusion_ext::format_ext::{DatasetMetadata, FileFormatFactoryExt};
+use datafusion::{
+    catalog::{MemTable, TableFunctionImpl, TableProvider},
+    error::DataFusionError,
+    execution::object_store::ObjectStoreUrl,
+    prelude::{Expr, SessionContext},
+};
+use futures::StreamExt;
+
+use crate::file_formats::BeaconTableFunctionImpl;
+
+pub struct ListDatasetsFunc {
+    runtime_handle: tokio::runtime::Handle,
+    session_ctx: Arc<SessionContext>,
+    data_object_store_url: ObjectStoreUrl,
+    file_formats: Vec<Arc<dyn FileFormatFactoryExt>>,
+}
+
+impl ListDatasetsFunc {
+    pub fn new(
+        runtime_handle: tokio::runtime::Handle,
+        session_ctx: Arc<SessionContext>,
+        data_object_store_url: ObjectStoreUrl,
+        file_formats: Vec<Arc<dyn FileFormatFactoryExt>>,
+    ) -> Self {
+        Self {
+            runtime_handle,
+            session_ctx,
+            data_object_store_url,
+            file_formats,
+        }
+    }
+}
+
+impl std::fmt::Debug for ListDatasetsFunc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ListDatasetsFunc")
+    }
+}
+
+impl BeaconTableFunctionImpl for ListDatasetsFunc {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> String {
+        "list_datasets".to_string()
+    }
+
+    fn description(&self) -> Option<String> {
+        Some("Lists all datasets stored in beacon, returning file name and format.".to_string())
+    }
+}
+
+impl TableFunctionImpl for ListDatasetsFunc {
+    fn call(&self, _args: &[Expr]) -> datafusion::error::Result<Arc<dyn TableProvider>> {
+        let file_formats = self.file_formats.clone();
+        let session_ctx = self.session_ctx.clone();
+        let data_object_store_url = self.data_object_store_url.clone();
+
+        let datasets: Vec<DatasetMetadata> = tokio::task::block_in_place(|| {
+            self.runtime_handle.block_on(async move {
+                let state = session_ctx.state();
+                let object_store = session_ctx
+                    .runtime_env()
+                    .object_store(data_object_store_url.clone())?;
+
+                let listing_url = parse_listing_table_url(&data_object_store_url, "**/*")?;
+                let mut objects = Vec::new();
+                let mut entry_stream = listing_url
+                    .list_all_files(&state, &object_store, "")
+                    .await?;
+
+                while let Some(entry) = entry_stream.next().await {
+                    if let Ok(entry) = entry {
+                        objects.push(entry);
+                    }
+                }
+
+                let mut datasets = vec![];
+                for file_format in file_formats.iter() {
+                    let format_datasets = file_format.discover_datasets(&objects)?;
+                    datasets.extend(format_datasets);
+                }
+
+                Ok::<Vec<DatasetMetadata>, DataFusionError>(datasets)
+            })
+        })?;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("file_name", DataType::Utf8, false),
+            Field::new("file_format", DataType::Utf8, false),
+        ]));
+
+        let file_names: StringArray = datasets
+            .iter()
+            .map(|d| Some(d.file_path.as_str()))
+            .collect();
+        let file_formats: StringArray = datasets.iter().map(|d| Some(d.format.as_str())).collect();
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(file_names), Arc::new(file_formats)],
+        )?;
+
+        Ok(Arc::new(MemTable::try_new(schema, vec![vec![batch]])?))
+    }
+}

--- a/beacon-functions/src/file_formats/mod.rs
+++ b/beacon-functions/src/file_formats/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use arrow::datatypes::Field;
+use beacon_datafusion_ext::format_ext::FileFormatFactoryExt;
 use beacon_object_storage::DatasetsStore;
 use datafusion::{
     catalog::TableFunctionImpl,
@@ -9,6 +10,7 @@ use datafusion::{
     prelude::SessionContext,
 };
 
+pub mod list_datasets;
 pub mod read_arrow;
 pub mod read_bbf;
 pub mod read_csv;
@@ -23,6 +25,7 @@ pub fn register_table_functions(
     session_ctx: Arc<SessionContext>,
     data_object_store_url: ObjectStoreUrl,
     datasets_object_store: Arc<DatasetsStore>,
+    file_formats: Vec<Arc<dyn FileFormatFactoryExt>>,
 ) -> Vec<Arc<dyn BeaconTableFunctionImpl>> {
     vec![
         Arc::new(read_parquet::ReadParquetFunc::new(
@@ -63,10 +66,16 @@ pub fn register_table_functions(
             data_object_store_url.clone(),
         )),
         Arc::new(read_schema::ReadSchemaFunc::new(
+            runtime_handle.clone(),
+            session_ctx.clone(),
+            data_object_store_url.clone(),
+            datasets_object_store,
+        )),
+        Arc::new(list_datasets::ListDatasetsFunc::new(
             runtime_handle,
             session_ctx,
             data_object_store_url,
-            datasets_object_store,
+            file_formats,
         )),
     ]
 }


### PR DESCRIPTION
This pull request introduces a new `list_datasets` table function to the beacon system, which enables users to list all datasets stored in beacon, including their file names and formats. To support this, the codebase is updated to pass file format factories throughout the relevant components, and dependencies are updated accordingly.

**New functionality:**

* Added a new `ListDatasetsFunc` table function in `beacon-functions/src/file_formats/list_datasets.rs`, which lists all datasets (file names and formats) by discovering datasets using all available file format factories.

**Codebase integration and plumbing:**

* Updated the `register_table_functions` function in `beacon-functions/src/file_formats/mod.rs` to include the new `ListDatasetsFunc` and to accept and pass the list of file format factories (`file_formats`) to all relevant table functions. 
* Modified the `Runtime` and `FileManager` implementations to expose and pass the available file format factories, ensuring they are available where needed for table function registration.

**Dependency updates:**

* Added the `futures` crate to `beacon-functions/Cargo.toml` to support asynchronous streaming in the new table function.

**Module organization:**

* Registered the new `list_datasets` module in `beacon-functions/src/file_formats/mod.rs` for use in the system.