### PR TITLE
Add keycloak auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-time"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9622f5c6fb50377516c70f65159e70b25465409760c6bd6d4e581318bf704e83"
+dependencies = [
+ "once_cell",
+ "portable-atomic",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +737,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-keycloak-auth"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e418f474ee6cd0ba9c4ab6158f8369e29311f92ecc79cb88194b7b47de4c4ad"
+dependencies = [
+ "atomic-time",
+ "axum",
+ "educe",
+ "futures",
+ "http",
+ "jsonwebtoken",
+ "nonempty",
+ "reqwest",
+ "serde",
+ "serde-querystring",
+ "serde_json",
+ "serde_with",
+ "snafu",
+ "time",
+ "tokio",
+ "tower",
+ "tracing",
+ "try-again",
+ "typed-builder",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "axum-streams"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +810,7 @@ dependencies = [
  "arrow-flight",
  "arrow-ipc 56.2.0",
  "axum",
+ "axum-keycloak-auth",
  "axum-streams",
  "base64",
  "beacon-config",
@@ -790,6 +830,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "utoipa",
  "utoipa-axum",
  "utoipa-scalar",
@@ -2804,6 +2845,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2823,6 +2876,26 @@ name = "endian-type"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "env_home"
@@ -3698,6 +3771,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4099,6 +4173,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4129,6 +4218,15 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lexical"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc8a009b2ff1f419ccc62706f04fe0ca6e67b37460513964a3dfdb919bb37d6"
+dependencies = [
+ "lexical-core",
+]
 
 [[package]]
 name = "lexical-core"
@@ -4607,6 +4705,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4685,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-format"
@@ -4906,9 +5010,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
@@ -5072,6 +5176,16 @@ name = "pdqselect"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -5684,6 +5798,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -6013,6 +6128,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-querystring"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae1940bc2612f641456fc715125e4002cbd235d040188a1994e64b734054c2e"
+dependencies = [
+ "lexical",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6034,14 +6159,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap 2.13.0",
  "itoa",
- "ryu",
+ "memchr",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -6166,6 +6293,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.17",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -6551,9 +6690,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -6566,15 +6705,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6915,6 +7054,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-again"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7840f01e68d609b64f3d6954d52846fa42b5dad9403eaecd00d2658d85f0cbff"
+dependencies = [
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6942,6 +7091,26 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "typed-builder"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "typeid"
@@ -7308,6 +7477,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -8214,6 +8392,12 @@ name = "zlib-rs"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ utoipa-scalar = { version = "0.3.0", features = ["axum"] }
 utoipa-swagger-ui = { version = "9.0.0", features = ["axum"] }
 
 serde = { version = "^1.0.2", features = ["rc", "derive"] }
-serde_json = "=1.0.120"
+serde_json = "1.0.134"
 anyhow = "1.0.95"
 thiserror = "2.0.12"
 

--- a/beacon-api/Cargo.toml
+++ b/beacon-api/Cargo.toml
@@ -10,8 +10,10 @@ pprof = { version = "0.15", features = ["flamegraph"] }
 [dependencies]
 axum = { version = "0.8.1", features = ["tracing", "multipart", "ws"] }
 axum-streams = { version = "0.23.1", features = ["arrow"]}
+axum-keycloak-auth = { version = "0.8.3", default-features = false, features = ["rustls-tls"] }
 tower-http = { version = "0.6.1", features = ["trace", "cors"] }
 base64 = "0.22.1"
+url = "2"
 
 futures = { workspace = true }
 futures-util = { workspace = true }

--- a/beacon-api/src/auth/keycloak.rs
+++ b/beacon-api/src/auth/keycloak.rs
@@ -1,0 +1,118 @@
+//! Optional Keycloak Bearer-JWT authentication shared by the HTTP and Flight SQL transports.
+//!
+//! Construction is driven by [`beacon_config::CONFIG.keycloak`]. Two independent
+//! [`KcLayer`]s are built when Keycloak is enabled — an **admin** layer (always present
+//! when enabled) and a **query** layer (present when `protect_query=true`). The
+//! admin layer's role should be configured as a composite of the query role in
+//! Keycloak so admin tokens satisfy both gates.
+
+use std::sync::Arc;
+
+use axum_keycloak_auth::{
+    decode::KeycloakToken,
+    instance::{KeycloakAuthInstance, KeycloakConfig as KcInstanceConfig},
+    layer::KeycloakAuthLayer,
+    role::KeycloakRole,
+    PassthroughMode,
+};
+use url::Url;
+
+use crate::auth::AuthError;
+
+/// Shared Keycloak validation layer.
+///
+/// `KeycloakAuthLayer` is `Clone` and is used both as an Axum middleware and as a
+/// standalone validator (Flight SQL) via [`validate_raw_token`].
+pub(crate) type KcLayer = KeycloakAuthLayer<String>;
+
+/// Pair of Keycloak layers produced at startup.
+///
+/// `admin` is `Some` whenever Keycloak is enabled; `query` is `Some` only when
+/// `BEACON_KEYCLOAK_PROTECT_QUERY=true`. Both layers share a single
+/// [`KeycloakAuthInstance`], so JWKS discovery and caching happen once.
+pub(crate) struct KeycloakLayers {
+    pub(crate) admin: Option<KcLayer>,
+    pub(crate) query: Option<KcLayer>,
+}
+
+/// Claims extracted from a validated Keycloak token, exposed to Flight SQL so it
+/// can decide between read-only and admin (DDL) execution.
+pub(crate) struct ValidatedClaims {
+    pub(crate) is_admin: bool,
+}
+
+/// Builds the admin and (optionally) query Keycloak layers from configuration.
+///
+/// Returns `KeycloakLayers { admin: None, query: None }` when Keycloak is disabled,
+/// in which case callers fall back to HTTP Basic admin authentication and anonymous
+/// query access.
+///
+/// Must be called from within a tokio runtime: the underlying
+/// [`KeycloakAuthInstance`] spawns a background task for JWKS refresh.
+pub(crate) fn build_layers() -> anyhow::Result<KeycloakLayers> {
+    let cfg = &beacon_config::CONFIG.keycloak;
+    if !cfg.enabled {
+        return Ok(KeycloakLayers {
+            admin: None,
+            query: None,
+        });
+    }
+
+    let server = Url::parse(&cfg.server_url)
+        .map_err(|e| anyhow::anyhow!("invalid BEACON_KEYCLOAK_SERVER_URL: {e}"))?;
+
+    let instance = Arc::new(KeycloakAuthInstance::new(
+        KcInstanceConfig::builder()
+            .server(server)
+            .realm(cfg.realm.clone())
+            .build(),
+    ));
+
+    let admin = build_layer_with_role(instance.clone(), cfg.required_role.clone());
+    let query = cfg
+        .protect_query
+        .then(|| build_layer_with_role(instance, cfg.query_role.clone()));
+
+    Ok(KeycloakLayers {
+        admin: Some(admin),
+        query,
+    })
+}
+
+fn build_layer_with_role(instance: Arc<KeycloakAuthInstance>, role: String) -> KcLayer {
+    let cfg = &beacon_config::CONFIG.keycloak;
+    KeycloakAuthLayer::<String>::builder()
+        .instance(instance)
+        .passthrough_mode(PassthroughMode::Block)
+        .persist_raw_claims(false)
+        .expected_audiences(vec![cfg.expected_audience.clone()])
+        .required_roles(vec![role])
+        .build()
+}
+
+/// Validates a raw Bearer JWT against the given Keycloak layer and extracts the
+/// claims Flight SQL needs to decide whether the token represents an admin.
+///
+/// `is_admin` is `true` when the validated token carries the configured admin
+/// role (`BEACON_KEYCLOAK_REQUIRED_ROLE`) as either a realm role or any client
+/// role. Validation against `layer` enforces signature, audience, expiry, and
+/// the layer's own required role (admin layer requires admin role; query layer
+/// requires query role).
+pub(crate) async fn validate_raw_token(
+    layer: &KcLayer,
+    token: &str,
+) -> Result<ValidatedClaims, AuthError> {
+    let (_, decoded): (_, KeycloakToken<String>) =
+        layer.validate_raw_token(token).await.map_err(|e| {
+            tracing::debug!("Keycloak token validation failed: {e}");
+            AuthError
+        })?;
+
+    let admin_role = &beacon_config::CONFIG.keycloak.required_role;
+    let is_admin = decoded.roles.iter().any(|r| match r {
+        KeycloakRole::Realm { role } => role == admin_role,
+        KeycloakRole::Client { role, .. } => role == admin_role,
+    });
+
+    Ok(ValidatedClaims { is_admin })
+}

--- a/beacon-api/src/auth/mod.rs
+++ b/beacon-api/src/auth/mod.rs
@@ -2,6 +2,8 @@
 
 use base64::{engine::general_purpose, Engine as _};
 
+pub(crate) mod keycloak;
+
 /// Marker error for invalid or malformed authentication credentials
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct AuthError;

--- a/beacon-api/src/axum/admin/mod.rs
+++ b/beacon-api/src/axum/admin/mod.rs
@@ -10,6 +10,7 @@ use utoipa::{
 };
 use utoipa_axum::{router::OpenApiRouter, routes};
 
+use crate::auth::keycloak::KcLayer;
 use crate::axum::auth::basic_auth;
 
 mod check;
@@ -20,14 +21,26 @@ mod file;
 #[openapi(modifiers(&SecurityAddon))]
 pub struct AdminApiDoc;
 
-/// Builds the admin router and attaches basic-auth middleware.
-pub(crate) fn setup_admin_router() -> (Router<Arc<Runtime>>, utoipa::openapi::OpenApi) {
-    let (admin_router, admin_api) = OpenApiRouter::with_openapi(AdminApiDoc::openapi())
+/// Builds the admin router and attaches the configured auth middleware.
+///
+/// When a [`KcLayer`] is provided the admin surface validates Keycloak-issued
+/// Bearer JWTs (Basic auth is rejected). Otherwise the legacy
+/// [`basic_auth`] middleware is used.
+pub(crate) fn setup_admin_router(
+    keycloak: Option<KcLayer>,
+) -> (Router<Arc<Runtime>>, utoipa::openapi::OpenApi) {
+    let base = OpenApiRouter::with_openapi(AdminApiDoc::openapi())
         .routes(routes!(file::upload_file))
         .routes(routes!(file::download_handler))
         .routes(routes!(file::delete_file))
-        .routes(routes!(check::check))
-        .layer(::axum::middleware::from_fn(basic_auth))
+        .routes(routes!(check::check));
+
+    let with_auth = match keycloak {
+        Some(layer) => base.layer(layer),
+        None => base.layer(::axum::middleware::from_fn(basic_auth)),
+    };
+
+    let (admin_router, admin_api) = with_auth
         .layer(DefaultBodyLimit::disable())
         .split_for_parts();
 

--- a/beacon-api/src/axum/client/mod.rs
+++ b/beacon-api/src/axum/client/mod.rs
@@ -7,6 +7,8 @@ use beacon_core::runtime::Runtime;
 use utoipa::OpenApi;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
+use crate::auth::keycloak::KcLayer;
+
 mod datasets;
 mod functions;
 mod info;
@@ -19,9 +21,15 @@ mod tables;
 pub struct ClientApiDoc;
 
 /// Builds the client router and returns the generated OpenAPI document alongside it.
+///
+/// When `keycloak_query` is `Some`, the layer gates every client endpoint behind a
+/// valid Keycloak JWT carrying the configured query role. When `None`, client
+/// endpoints remain anonymous (the historical behavior).
 #[allow(deprecated)]
-pub(crate) fn setup_client_router() -> (Router<Arc<Runtime>>, utoipa::openapi::OpenApi) {
-    OpenApiRouter::with_openapi(ClientApiDoc::openapi())
+pub(crate) fn setup_client_router(
+    keycloak_query: Option<KcLayer>,
+) -> (Router<Arc<Runtime>>, utoipa::openapi::OpenApi) {
+    let base = OpenApiRouter::with_openapi(ClientApiDoc::openapi())
         .routes(routes!(query::query))
         .routes(routes!(query::parse_query))
         .routes(routes!(query::query_metrics))
@@ -39,6 +47,10 @@ pub(crate) fn setup_client_router() -> (Router<Arc<Runtime>>, utoipa::openapi::O
         .routes(routes!(tables::default_table_schema))
         .routes(routes!(functions::list_functions))
         .routes(routes!(functions::list_table_functions))
-        .routes(routes!(info::system_info))
-        .split_for_parts()
+        .routes(routes!(info::system_info));
+
+    match keycloak_query {
+        Some(layer) => base.layer(layer).split_for_parts(),
+        None => base.split_for_parts(),
+    }
 }

--- a/beacon-api/src/axum/router.rs
+++ b/beacon-api/src/axum/router.rs
@@ -29,8 +29,9 @@ const BEACON_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// contains invalid origins, methods, or headers — validated once at startup
 /// rather than on every request.
 pub(crate) fn setup_router(beacon_runtime: Arc<Runtime>) -> anyhow::Result<Router> {
-    let (client_router, mut api_docs_client) = setup_client_router();
-    let (admin_router, api_docs_admin) = setup_admin_router();
+    let layers = crate::auth::keycloak::build_layers()?;
+    let (client_router, mut api_docs_client) = setup_client_router(layers.query);
+    let (admin_router, api_docs_admin) = setup_admin_router(layers.admin);
 
     api_docs_client.merge(api_docs_admin);
     api_docs_client = set_api_docs_info(api_docs_client);
@@ -59,8 +60,9 @@ pub(crate) fn setup_router(beacon_runtime: Arc<Runtime>) -> anyhow::Result<Route
 
     // SwaggerUi is merged outside the base_path nest to avoid doubling the prefix
     // in the openapi.json URL (/{base_path}/{base_path}/openapi.json).
-    let swagger_ui = SwaggerUi::new(swagger_url)
-        .urls(vec![(Url::new("Docs", &openapi_url), docs)]);
+    // `Url::new` requires `&'static str`; the URL is built once at startup, so leak it.
+    let openapi_url: &'static str = openapi_url.leak();
+    let swagger_ui = SwaggerUi::new(swagger_url).urls(vec![(Url::new("Docs", openapi_url), docs)]);
 
     if base_path.is_empty() {
         Ok(Router::new()

--- a/beacon-api/src/flight_sql/auth.rs
+++ b/beacon-api/src/flight_sql/auth.rs
@@ -11,7 +11,39 @@ use prost::Message;
 use tonic::{Request, Status};
 use uuid::Uuid;
 
+use crate::auth::keycloak::{self, KcLayer, KeycloakLayers};
 use crate::auth::{parse_bearer_token, validate_basic_auth_credentials, verify_basic_auth_value};
+
+/// Keycloak layers held by the Flight SQL [`Authenticator`].
+///
+/// `admin_layer` is always present in Keycloak mode and used for validation when the
+/// query layer is off. `query_layer` is `Some` when `BEACON_KEYCLOAK_PROTECT_QUERY=true`;
+/// in that mode every Flight SQL request is validated against the query layer (anonymous
+/// access is disabled regardless of `BEACON_FLIGHT_SQL_ALLOW_ANONYMOUS`).
+#[derive(Clone)]
+pub(super) struct KeycloakAuth {
+    admin_layer: KcLayer,
+    query_layer: Option<KcLayer>,
+}
+
+impl KeycloakAuth {
+    /// Returns the layer used for validating incoming JWTs.
+    ///
+    /// Prefers the query layer when present so user-role tokens are accepted.
+    /// The admin role is then derived from the decoded claims by
+    /// [`keycloak::validate_raw_token`].
+    fn validation_layer(&self) -> &KcLayer {
+        self.query_layer.as_ref().unwrap_or(&self.admin_layer)
+    }
+
+    /// Whether anonymous handshake/requests are permitted.
+    ///
+    /// Anonymous is allowed only when query protection is off; in that mode the
+    /// caller's `allow_anonymous` configuration is honored.
+    fn allows_anonymous(&self) -> bool {
+        self.query_layer.is_none()
+    }
+}
 
 /// Per-request authorization context shared with the execution layer.
 #[derive(Clone)]
@@ -39,20 +71,36 @@ struct AuthToken {
 }
 
 /// Authenticates Flight SQL requests and manages short-lived bearer sessions.
+///
+/// When [`Self::keycloak`] is `Some`, all credentials are validated as
+/// Keycloak-issued Bearer JWTs (Basic auth is rejected) and the token's
+/// roles decide whether the session has admin (DDL) privileges. When `None`,
+/// the legacy hardcoded Basic admin credentials are used and short-lived UUID
+/// session tokens are issued after a successful handshake.
 #[derive(Clone)]
 pub(super) struct Authenticator {
     allow_anonymous: bool,
     token_ttl: Duration,
     auth_tokens: Arc<tokio::sync::RwLock<HashMap<String, AuthToken>>>,
+    keycloak: Option<KeycloakAuth>,
 }
 
 impl Authenticator {
     /// Creates a new authenticator with the configured anonymous-access policy and token TTL.
-    pub(super) fn new(allow_anonymous: bool, token_ttl: Duration) -> Self {
+    pub(super) fn new(
+        allow_anonymous: bool,
+        token_ttl: Duration,
+        keycloak_layers: KeycloakLayers,
+    ) -> Self {
+        let keycloak = keycloak_layers.admin.map(|admin_layer| KeycloakAuth {
+            admin_layer,
+            query_layer: keycloak_layers.query,
+        });
         Self {
             allow_anonymous,
             token_ttl,
             auth_tokens: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            keycloak,
         }
     }
 
@@ -82,23 +130,53 @@ impl Authenticator {
     }
 
     /// Authorizes an optional auth value, falling back to anonymous access when enabled.
+    ///
+    /// Anonymous access is only honored when query protection is off; with
+    /// `BEACON_KEYCLOAK_PROTECT_QUERY=true` every Flight SQL request must
+    /// present a JWT regardless of `BEACON_FLIGHT_SQL_ALLOW_ANONYMOUS`.
     pub(super) async fn authorize_optional(
         &self,
         auth_value: Option<String>,
     ) -> Result<AuthContext, Status> {
+        let anonymous_allowed = self.allow_anonymous
+            && self
+                .keycloak
+                .as_ref()
+                .map(KeycloakAuth::allows_anonymous)
+                .unwrap_or(true);
         match auth_value {
             Some(auth_value) => self.authorize_value(auth_value).await,
-            None if self.allow_anonymous => Ok(AuthContext::anonymous()),
+            None if anonymous_allowed => Ok(AuthContext::anonymous()),
             None => Err(Status::unauthenticated("missing authorization metadata")),
         }
     }
 
     /// Authenticates the Flight SQL handshake and decides whether the session is admin or anonymous.
-    pub(super) fn authorize_handshake(
+    pub(super) async fn authorize_handshake(
         &self,
         auth_value: Option<&str>,
         handshake: Option<&HandshakeRequest>,
     ) -> Result<AuthContext, Status> {
+        // Keycloak mode: only Bearer JWTs are accepted; Basic credentials are rejected.
+        if let Some(kc) = &self.keycloak {
+            if let Some(auth_value) = auth_value {
+                let token = parse_bearer_token(auth_value)
+                    .map_err(|_| Status::unauthenticated("invalid credentials"))?;
+                let claims = keycloak::validate_raw_token(kc.validation_layer(), token)
+                    .await
+                    .map_err(|_| Status::unauthenticated("invalid credentials"))?;
+                return Ok(AuthContext {
+                    is_super_user: claims.is_admin,
+                });
+            }
+            // Anonymous is only honored when query protection is off; otherwise
+            // every Flight SQL session must present a JWT.
+            if kc.allows_anonymous() && self.allow_anonymous {
+                return Ok(AuthContext::anonymous());
+            }
+            return Err(Status::unauthenticated("invalid credentials"));
+        }
+
         if let Some(auth_value) = auth_value {
             verify_basic_auth_value(auth_value)
                 .map_err(|_| Status::unauthenticated("invalid credentials"))?;
@@ -140,6 +218,20 @@ impl Authenticator {
 
     /// Resolves either bearer metadata or inline basic credentials into an auth context.
     async fn authorize_value(&self, auth_value: String) -> Result<AuthContext, Status> {
+        // Keycloak mode: bearer tokens are validated directly as Keycloak JWTs;
+        // Basic credentials are rejected. The token's roles decide whether the
+        // session has admin (DDL) privileges via `is_super_user`.
+        if let Some(kc) = &self.keycloak {
+            let token = parse_bearer_token(&auth_value)
+                .map_err(|_| Status::unauthenticated("invalid credentials"))?;
+            let claims = keycloak::validate_raw_token(kc.validation_layer(), token)
+                .await
+                .map_err(|_| Status::unauthenticated("invalid credentials"))?;
+            return Ok(AuthContext {
+                is_super_user: claims.is_admin,
+            });
+        }
+
         if let Ok(token) = parse_bearer_token(&auth_value) {
             return self.authorize_bearer(token).await;
         }

--- a/beacon-api/src/flight_sql/service.rs
+++ b/beacon-api/src/flight_sql/service.rs
@@ -49,13 +49,19 @@ pub(crate) struct BeaconFlightSqlService {
 impl BeaconFlightSqlService {
     /// Creates a service using the configured anonymous-access policy.
     pub(crate) fn new(runtime: Arc<beacon_core::runtime::Runtime>) -> anyhow::Result<Self> {
-        Self::new_with_options(runtime, beacon_config::CONFIG.flight_sql.allow_anonymous)
+        let layers = crate::auth::keycloak::build_layers()?;
+        Self::new_with_options(
+            runtime,
+            beacon_config::CONFIG.flight_sql.allow_anonymous,
+            layers,
+        )
     }
 
     /// Creates a service with an explicit anonymous-access setting, used primarily by tests.
     pub(super) fn new_with_options(
         runtime: Arc<beacon_core::runtime::Runtime>,
         allow_anonymous: bool,
+        keycloak_layers: crate::auth::keycloak::KeycloakLayers,
     ) -> anyhow::Result<Self> {
         let flight_sql = &beacon_config::CONFIG.flight_sql;
 
@@ -65,6 +71,7 @@ impl BeaconFlightSqlService {
             authenticator: Authenticator::new(
                 allow_anonymous,
                 Duration::from_secs(flight_sql.token_ttl_secs),
+                keycloak_layers,
             ),
             statements: SqlHandleStore::new(Duration::from_secs(flight_sql.statement_ttl_secs)),
             prepared_statements: SqlHandleStore::new(Duration::from_secs(
@@ -160,7 +167,8 @@ impl FlightSqlService for BeaconFlightSqlService {
             .unwrap_or_default();
         let auth = self
             .authenticator
-            .authorize_handshake(auth_value.as_deref(), first_request.as_ref())?;
+            .authorize_handshake(auth_value.as_deref(), first_request.as_ref())
+            .await?;
         // Flight SQL clients reuse the bearer token returned by the handshake for subsequent RPCs.
         let token = self.authenticator.issue_token(auth).await;
 

--- a/beacon-api/src/flight_sql/tests.rs
+++ b/beacon-api/src/flight_sql/tests.rs
@@ -16,7 +16,15 @@ async fn spawn_server(allow_anonymous: bool) -> (SocketAddr, tokio::task::JoinHa
 
     let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
     let runtime = Arc::new(beacon_core::runtime::Runtime::new().await.unwrap());
-    let service = BeaconFlightSqlService::new_with_options(runtime, allow_anonymous).unwrap();
+    let service = BeaconFlightSqlService::new_with_options(
+        runtime,
+        allow_anonymous,
+        crate::auth::keycloak::KeycloakLayers {
+            admin: None,
+            query: None,
+        },
+    )
+    .unwrap();
 
     let handle = tokio::spawn(async move {
         Server::builder()

--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -6,6 +6,7 @@ use lazy_static::lazy_static;
 #[derive(Debug)]
 pub struct Config {
     pub admin: AdminConfig,
+    pub keycloak: KeycloakConfig,
     pub server: ServerConfig,
     pub runtime: RuntimeConfig,
     pub sql: SqlConfig,
@@ -19,6 +20,29 @@ pub struct Config {
 pub struct AdminConfig {
     pub username: String,
     pub password: String,
+}
+
+/// Optional Keycloak Bearer-JWT authentication.
+///
+/// When [`KeycloakConfig::enabled`] is `true`, HTTP admin routes and the Flight SQL
+/// handshake validate `Authorization: Bearer <jwt>` tokens against the configured
+/// Keycloak realm and require [`KeycloakConfig::required_role`] in the token claims.
+/// HTTP Basic auth is rejected in this mode.
+///
+/// When additionally [`KeycloakConfig::protect_query`] is `true`, client/read endpoints
+/// (`/api/query*`, `/api/datasets*`, `/api/tables*`, `/api/functions*`, `/api/info`) and
+/// all Flight SQL traffic require a JWT carrying [`KeycloakConfig::query_role`]. The
+/// admin role should be configured as a Keycloak composite of the query role so that
+/// admin tokens also pass the query gate.
+#[derive(Debug)]
+pub struct KeycloakConfig {
+    pub enabled: bool,
+    pub server_url: String,
+    pub realm: String,
+    pub expected_audience: String,
+    pub required_role: String,
+    pub protect_query: bool,
+    pub query_role: String,
 }
 
 #[derive(Debug)]
@@ -113,6 +137,22 @@ struct RawConfig {
     admin_username: String,
     #[envconfig(from = "BEACON_ADMIN_PASSWORD", default = "beacon-password")]
     admin_password: String,
+
+    // Keycloak (optional)
+    #[envconfig(from = "BEACON_KEYCLOAK_ENABLED", default = "false")]
+    keycloak_enabled: bool,
+    #[envconfig(from = "BEACON_KEYCLOAK_SERVER_URL", default = "")]
+    keycloak_server_url: String,
+    #[envconfig(from = "BEACON_KEYCLOAK_REALM", default = "")]
+    keycloak_realm: String,
+    #[envconfig(from = "BEACON_KEYCLOAK_EXPECTED_AUDIENCE", default = "beacon-api")]
+    keycloak_expected_audience: String,
+    #[envconfig(from = "BEACON_KEYCLOAK_REQUIRED_ROLE", default = "beacon-admin")]
+    keycloak_required_role: String,
+    #[envconfig(from = "BEACON_KEYCLOAK_PROTECT_QUERY", default = "false")]
+    keycloak_protect_query: bool,
+    #[envconfig(from = "BEACON_KEYCLOAK_QUERY_ROLE", default = "beacon-user")]
+    keycloak_query_role: String,
     #[envconfig(from = "BEACON_PORT", default = "5001")]
     port: u16,
     #[envconfig(from = "BEACON_HOST", default = "0.0.0.0")]
@@ -226,6 +266,15 @@ impl From<RawConfig> for Config {
                 username: raw.admin_username,
                 password: raw.admin_password,
             },
+            keycloak: KeycloakConfig {
+                enabled: raw.keycloak_enabled,
+                server_url: raw.keycloak_server_url,
+                realm: raw.keycloak_realm,
+                expected_audience: raw.keycloak_expected_audience,
+                required_role: raw.keycloak_required_role,
+                protect_query: raw.keycloak_protect_query,
+                query_role: raw.keycloak_query_role,
+            },
             server: ServerConfig {
                 port: raw.port,
                 host: raw.host,
@@ -291,9 +340,24 @@ impl From<RawConfig> for Config {
 
 impl Config {
     pub fn init() -> Config {
-        RawConfig::init_from_env()
+        let config: Config = RawConfig::init_from_env()
             .map(Into::into)
-            .expect("Failed to load config")
+            .expect("Failed to load config");
+        if config.keycloak.enabled {
+            assert!(
+                !config.keycloak.server_url.trim().is_empty(),
+                "BEACON_KEYCLOAK_SERVER_URL must be set when BEACON_KEYCLOAK_ENABLED=true"
+            );
+            assert!(
+                !config.keycloak.realm.trim().is_empty(),
+                "BEACON_KEYCLOAK_REALM must be set when BEACON_KEYCLOAK_ENABLED=true"
+            );
+        } else if config.keycloak.protect_query {
+            eprintln!(
+                "warning: BEACON_KEYCLOAK_PROTECT_QUERY=true ignored because BEACON_KEYCLOAK_ENABLED=false"
+            );
+        }
+        config
     }
 }
 


### PR DESCRIPTION
This pull request introduces optional Keycloak Bearer-JWT authentication for both HTTP (Axum) and Flight SQL transports, allowing for more robust and configurable authentication and authorization. The changes are backward-compatible: if Keycloak is not enabled in the configuration, the system continues to use legacy Basic authentication and anonymous access as before. When enabled, Keycloak authentication enforces role-based access control for both admin and query endpoints.

**Keycloak Authentication Integration:**

* Added a new `keycloak` module (`beacon-api/src/auth/keycloak.rs`) that provides shared Keycloak JWT validation logic, builds admin and query layers based on configuration, and exposes claims for downstream authorization decisions.
* Updated the main router setup (`beacon-api/src/axum/router.rs`) to build Keycloak layers at startup and pass them to the admin and client routers, enabling or disabling JWT validation as configured.
* Modified the admin and client routers (`beacon-api/src/axum/admin/mod.rs`, `beacon-api/src/axum/client/mod.rs`) to accept optional Keycloak layers, applying them as middleware if present, or falling back to Basic/anonymous auth. 

**Flight SQL Authentication Enhancements:**

* Extended the Flight SQL authenticator (`beacon-api/src/flight_sql/auth.rs`) to support Keycloak JWT validation, including role-based admin/DDL privilege checks and correct handling of anonymous access based on configuration. 
* Updated the Flight SQL service construction and tests to pass in Keycloak layers, ensuring consistent authentication logic across transports. 
**Dependency and Configuration Updates:**

* Added new dependencies for Keycloak and JWT validation (`axum-keycloak-auth`, `url`) and updated `serde_json` version.
* Extended the main configuration struct to include Keycloak settings.

These changes provide a flexible, secure foundation for authentication and authorization, supporting both modern (Keycloak/JWT) and legacy (Basic/anonymous) modes as needed.