### PR TITLE
Arrow Atlas Format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ source = "git+https://github.com/robinskil/array-format.git#97245fffdaf700a29c00
 dependencies = [
  "bytes",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 1.9.3",
  "lz4_flex 0.11.5",
  "moka",
  "ndarray",
@@ -624,20 +624,25 @@ dependencies = [
 
 [[package]]
 name = "atlas"
-version = "0.7.0"
-source = "git+https://github.com/robinskil/atlas.git#5e695efa45623d4953286c56620ef22a2c582b83"
+version = "0.8.0"
+source = "git+https://github.com/robinskil/atlas.git#dbd673e8cccf44bd8b663456e2be25928e97322c"
 dependencies = [
  "array-format",
  "chrono",
+ "futures",
  "indexmap 2.13.0",
+ "lz4_flex 0.11.5",
  "ndarray",
+ "num_cpus",
  "object_store 0.13.2",
  "parking_lot",
+ "rmp-serde",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -837,13 +842,17 @@ dependencies = [
  "datafusion",
  "futures",
  "indexmap 2.13.0",
+ "lz4_flex 0.11.5",
+ "moka",
  "ndarray",
  "object_store 0.12.4",
+ "rmp-serde",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -2890,7 +2899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4023,7 +4032,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4636,7 +4645,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5419,7 +5428,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5740,6 +5749,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "robust"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5871,7 +5899,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6311,6 +6339,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -6447,7 +6476,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7325,7 +7354,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,15 +137,15 @@ dependencies = [
 
 [[package]]
 name = "array-format"
-version = "0.5.0"
-source = "git+https://github.com/robinskil/array-format.git#ca7d02bafbd14062b2a5bd9df4ca9804d670a4bb"
+version = "0.7.0"
+source = "git+https://github.com/robinskil/array-format.git#f516d2c71b197105e9708eaf8abc9e4c49b8fd93"
 dependencies = [
  "bytes",
  "futures",
- "indexmap 1.9.3",
- "lz4_flex",
+ "indexmap 2.13.0",
+ "lz4_flex 0.11.5",
  "moka",
- "ndarray 0.17.2",
+ "ndarray",
  "object_store 0.13.2",
  "rkyv",
  "tempfile",
@@ -389,7 +389,7 @@ dependencies = [
  "arrow-schema 56.2.0",
  "arrow-select 56.2.0",
  "flatbuffers",
- "lz4_flex",
+ "lz4_flex 0.11.5",
  "zstd",
 ]
 
@@ -624,19 +624,20 @@ dependencies = [
 
 [[package]]
 name = "atlas"
-version = "0.2.0"
-source = "git+https://github.com/robinskil/atlas.git#412b5835b2a74d498736ff536294fe12d0be1ca9"
+version = "0.2.2"
+source = "git+https://github.com/robinskil/atlas.git#de99752f0a31b43add0e7861b1d0c406f3a02e6d"
 dependencies = [
  "array-format",
  "chrono",
  "indexmap 2.13.0",
- "ndarray 0.17.2",
+ "ndarray",
  "object_store 0.13.2",
  "parking_lot",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -835,7 +836,7 @@ dependencies = [
  "datafusion",
  "futures",
  "indexmap 2.13.0",
- "ndarray 0.17.2",
+ "ndarray",
  "object_store 0.12.4",
  "serde",
  "serde_json",
@@ -864,7 +865,7 @@ dependencies = [
  "hifitime",
  "indexmap 2.13.0",
  "moka",
- "ndarray 0.17.2",
+ "ndarray",
  "netcdf",
  "netcdf-sys",
  "num-traits",
@@ -893,7 +894,7 @@ dependencies = [
  "futures",
  "futures-util",
  "indexmap 2.13.0",
- "lz4_flex",
+ "lz4_flex 0.11.5",
  "object_store 0.12.4",
  "quick-xml 0.37.5",
  "regex",
@@ -926,7 +927,7 @@ dependencies = [
  "datafusion",
  "futures",
  "indexmap 2.13.0",
- "ndarray 0.17.2",
+ "ndarray",
  "object_store 0.12.4",
  "serde",
  "tokio",
@@ -972,7 +973,7 @@ dependencies = [
  "futures",
  "indexmap 2.13.0",
  "itertools 0.14.0",
- "lz4_flex",
+ "lz4_flex 0.11.5",
  "lzzzz",
  "moka",
  "munge_macro",
@@ -1152,7 +1153,7 @@ dependencies = [
  "lru 0.16.3",
  "moka",
  "nd-arrow-array",
- "ndarray 0.17.2",
+ "ndarray",
  "num-traits",
  "num_cpus",
  "object_store 0.12.4",
@@ -1184,6 +1185,7 @@ version = "1.6.0"
 dependencies = [
  "anyhow",
  "arrow",
+ "beacon-arrow-atlas",
  "beacon-arrow-netcdf",
  "beacon-arrow-tiff",
  "beacon-common",
@@ -1227,7 +1229,7 @@ dependencies = [
  "datafusion",
  "futures",
  "indexmap 2.13.0",
- "ndarray 0.17.2",
+ "ndarray",
  "pin-project",
  "rand 0.8.5",
  "rkyv",
@@ -1252,7 +1254,7 @@ dependencies = [
  "chrono",
  "criterion 0.5.1",
  "futures",
- "ndarray 0.17.2",
+ "ndarray",
  "pin-project",
  "rand 0.8.5",
  "serde",
@@ -1446,6 +1448,19 @@ dependencies = [
  "lz4-sys",
  "snappy_src",
  "zstd-sys",
+]
+
+[[package]]
+name = "blusc"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4e0c17eaa785d2673fe58c22fc817946c2330ed47f3d9f79835d65950d32a45"
+dependencies = [
+ "flate2",
+ "lz4_flex 0.12.2",
+ "pkg-config",
+ "snap",
+ "zstd",
 ]
 
 [[package]]
@@ -2874,7 +2889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3711,7 +3726,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -4007,7 +4022,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4299,6 +4314,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "lzma-rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4438,9 +4462,9 @@ dependencies = [
 
 [[package]]
 name = "monostate"
-version = "0.1.18"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+checksum = "bb4cc965c89dd0615a9e822ff8002f7633d2466143d51bd58693e4b2c75aabad"
 dependencies = [
  "monostate-impl",
  "serde",
@@ -4449,9 +4473,9 @@ dependencies = [
 
 [[package]]
 name = "monostate-impl"
-version = "0.1.18"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+checksum = "23f5b99488110875b5904839d396c2cdfaf241ff6622638acb879cc7effad5de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4515,21 +4539,6 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
-]
-
-[[package]]
-name = "ndarray"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
@@ -4550,7 +4559,7 @@ source = "git+https://github.com/robinskil/netcdf.git#35cc74866e5f337f883fe8b70c
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "ndarray 0.17.2",
+ "ndarray",
  "netcdf-sys",
  "semver",
 ]
@@ -4626,7 +4635,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4976,7 +4985,7 @@ dependencies = [
  "flate2",
  "half",
  "hashbrown 0.15.5",
- "lz4_flex",
+ "lz4_flex 0.11.5",
  "num",
  "num-bigint",
  "paste",
@@ -5010,7 +5019,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.16.1",
- "lz4_flex",
+ "lz4_flex 0.11.5",
  "num",
  "num-bigint",
  "object_store 0.12.4",
@@ -5272,7 +5281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -5370,7 +5379,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -5407,9 +5416,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5861,7 +5870,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6437,7 +6446,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7315,7 +7324,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7880,15 +7889,16 @@ dependencies = [
 
 [[package]]
 name = "zarrs"
-version = "0.22.10"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfbcfd7f9ae28f00972fcc4ca97e88c161d98ff8fde6959dc4955bb223eb9205"
+checksum = "251f4ec1a9e60ca9c693ade9b29a0b981a61e68ea3e2ae85fa9da31bcdca5dbe"
 dependencies = [
  "async-generic",
  "async-lock",
  "async-trait",
  "base64",
  "blosc-src",
+ "blusc",
  "bytemuck",
  "bytes",
  "crc32c",
@@ -7900,12 +7910,14 @@ dependencies = [
  "inventory",
  "itertools 0.14.0",
  "itoa",
+ "libz-sys",
  "log",
  "lru 0.16.3",
  "moka",
- "ndarray 0.16.1",
+ "ndarray",
  "num",
  "num-complex",
+ "paste",
  "quick_cache",
  "rayon",
  "rayon_iter_concurrent_limit",
@@ -7915,26 +7927,82 @@ dependencies = [
  "thread_local",
  "unsafe_cell_slice",
  "uuid",
+ "zarrs_chunk_grid",
+ "zarrs_chunk_key_encoding",
+ "zarrs_codec",
  "zarrs_data_type",
  "zarrs_filesystem",
  "zarrs_metadata",
  "zarrs_metadata_ext",
  "zarrs_plugin",
- "zarrs_registry",
  "zarrs_storage",
  "zstd",
 ]
 
 [[package]]
-name = "zarrs_data_type"
-version = "0.4.2"
+name = "zarrs_chunk_grid"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff78d0d99d9a9ab702460adf5f95f4a0538d0c100bbe34bddd238211e30ae3f4"
+checksum = "1cf67386fd96a0336cd3e5ab5ca6cb14e0e05aee80f1acae8c4d3cf562a8bb65"
+dependencies = [
+ "derive_more",
+ "inventory",
+ "itertools 0.14.0",
+ "rayon",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "zarrs_metadata",
+ "zarrs_plugin",
+]
+
+[[package]]
+name = "zarrs_chunk_key_encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9040e7feaa92d1904d492acd0cd91b97214f1791c5b5738e6c05b2ca4145a382"
+dependencies = [
+ "derive_more",
+ "inventory",
+ "zarrs_metadata",
+ "zarrs_plugin",
+ "zarrs_storage",
+]
+
+[[package]]
+name = "zarrs_codec"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383a129a6a0cbb2c80cdba23809e5cab85159756464b7d0f112468a495c128da"
+dependencies = [
+ "async-trait",
+ "bytemuck",
+ "derive_more",
+ "futures",
+ "inventory",
+ "itertools 0.14.0",
+ "rayon",
+ "thiserror 2.0.17",
+ "unsafe_cell_slice",
+ "zarrs_chunk_grid",
+ "zarrs_data_type",
+ "zarrs_metadata",
+ "zarrs_plugin",
+ "zarrs_storage",
+]
+
+[[package]]
+name = "zarrs_data_type"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc7c594c9363278fcd9db4c205514f009944206eb093ea7ad40b85f50009f31"
 dependencies = [
  "derive_more",
  "half",
  "inventory",
  "num",
+ "paste",
+ "serde",
+ "serde_json",
  "thiserror 2.0.17",
  "zarrs_metadata",
  "zarrs_plugin",
@@ -7960,9 +8028,9 @@ dependencies = [
 
 [[package]]
 name = "zarrs_metadata"
-version = "0.6.2"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579803c6537c827b366fcd6cb0d78469f6a2978e6ab9768ce67526fdb85d7205"
+checksum = "d60c4c363a8a302d7babb3c29017850a7b4e0af6ca5f9ba2946263a185b62fea"
 dependencies = [
  "derive_more",
  "half",
@@ -7974,13 +8042,11 @@ dependencies = [
 
 [[package]]
 name = "zarrs_metadata_ext"
-version = "0.2.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5522075a04b3a6ea09c0fb1c98e34a1be7385e91d3d0ffe4fc621f8329f9cd79"
+checksum = "2048e07848ca99c7450518e0584929300b1b6a3cf442f18b26ffd3520814bd5b"
 dependencies = [
  "derive_more",
- "half",
- "log",
  "monostate",
  "num",
  "serde",
@@ -7988,7 +8054,6 @@ dependencies = [
  "serde_repr",
  "thiserror 2.0.17",
  "zarrs_metadata",
- "zarrs_registry",
 ]
 
 [[package]]
@@ -8005,27 +8070,21 @@ dependencies = [
 
 [[package]]
 name = "zarrs_plugin"
-version = "0.2.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da996f69dd0f1a22486cc9a25081dbd382034bed2659e04fb4bb7a57da5da227"
+checksum = "5cbe0ed432aee86856f70ca33be36eaf4a0dae21ab730750d9280a7ca1e95046"
 dependencies = [
+ "paste",
+ "regex",
+ "serde_json",
  "thiserror 2.0.17",
 ]
 
 [[package]]
-name = "zarrs_registry"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82282c3a6b1be79662d92594319584c6efee313654fd6cee59d5b958497a4e1c"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "zarrs_storage"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6151db6a755786bdafe905cb51b5f9d87c2818b75d3977025ed9e9d1571ed144"
+checksum = "7d098796d2ed4cf94896569615101e0432e870a7665396da5cc32300fb68f7c1"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,6 +833,7 @@ dependencies = [
  "beacon-nd-array",
  "beacon-object-storage",
  "chrono",
+ "crossbeam",
  "datafusion",
  "futures",
  "indexmap 2.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,8 +137,8 @@ dependencies = [
 
 [[package]]
 name = "array-format"
-version = "0.7.0"
-source = "git+https://github.com/robinskil/array-format.git#f516d2c71b197105e9708eaf8abc9e4c49b8fd93"
+version = "0.8.0"
+source = "git+https://github.com/robinskil/array-format.git#97245fffdaf700a29c004dc8644e46297259d6e7"
 dependencies = [
  "bytes",
  "futures",
@@ -624,8 +624,8 @@ dependencies = [
 
 [[package]]
 name = "atlas"
-version = "0.2.2"
-source = "git+https://github.com/robinskil/atlas.git#de99752f0a31b43add0e7861b1d0c406f3a02e6d"
+version = "0.7.0"
+source = "git+https://github.com/robinskil/atlas.git#5e695efa45623d4953286c56620ef22a2c582b83"
 dependencies = [
  "array-format",
  "chrono",
@@ -2889,7 +2889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3726,7 +3726,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4022,7 +4022,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4635,7 +4635,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5281,7 +5281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -5379,7 +5379,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -5416,9 +5416,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5870,7 +5870,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6446,7 +6446,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7324,7 +7324,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,17 +137,21 @@ dependencies = [
 
 [[package]]
 name = "array-format"
-version = "0.2.0"
-source = "git+https://github.com/robinskil/array-format.git#95a99a03c54d9ecdc37d0e3a510c7afcbe7cdd0e"
+version = "0.5.0"
+source = "git+https://github.com/robinskil/array-format.git#ca7d02bafbd14062b2a5bd9df4ca9804d670a4bb"
 dependencies = [
  "bytes",
  "futures",
+ "indexmap 1.9.3",
  "lz4_flex",
  "moka",
+ "ndarray 0.17.2",
  "object_store 0.13.2",
  "rkyv",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
+ "zerocopy",
  "zstd",
 ]
 
@@ -619,6 +623,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "atlas"
+version = "0.2.0"
+source = "git+https://github.com/robinskil/atlas.git#412b5835b2a74d498736ff536294fe12d0be1ca9"
+dependencies = [
+ "array-format",
+ "chrono",
+ "indexmap 2.13.0",
+ "ndarray 0.17.2",
+ "object_store 0.13.2",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +819,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "beacon-arrow-atlas"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "arrow",
+ "async-trait",
+ "atlas",
+ "beacon-common",
+ "beacon-config",
+ "beacon-datafusion-ext",
+ "beacon-nd-array",
+ "beacon-object-storage",
+ "chrono",
+ "datafusion",
+ "futures",
+ "indexmap 2.13.0",
+ "ndarray 0.17.2",
+ "object_store 0.12.4",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "beacon-arrow-netcdf"
 version = "1.6.0"
 dependencies = [
@@ -909,42 +956,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "beacon-atlas"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "array-format",
- "arrow",
- "async-trait",
- "beacon-common",
- "beacon-datafusion-ext",
- "beacon-nd-array",
- "beacon-nd-arrow",
- "bincode",
- "bloomfilter",
- "bytes",
- "chrono",
- "crossbeam",
- "datafusion",
- "flume",
- "futures",
- "indexmap 2.13.0",
- "moka",
- "ndarray 0.17.2",
- "object_store 0.12.4",
- "once_cell",
- "ordered-float 5.1.0",
- "parking_lot",
- "serde",
- "serde_json",
- "tempfile",
- "tokio",
- "tokio-test",
- "typetag",
- "zstd",
-]
-
-[[package]]
 name = "beacon-binary-format"
 version = "2.1.3"
 dependencies = [
@@ -1018,7 +1029,6 @@ dependencies = [
  "async-trait",
  "beacon-arrow-netcdf",
  "beacon-arrow-odv",
- "beacon-atlas",
  "beacon-common",
  "beacon-config",
  "beacon-data-lake",
@@ -1060,7 +1070,6 @@ dependencies = [
  "arrow",
  "async-trait",
  "beacon-arrow-zarr",
- "beacon-atlas",
  "beacon-binary-format",
  "beacon-common",
  "beacon-config",
@@ -1121,11 +1130,11 @@ dependencies = [
  "arrow-flight",
  "async-trait",
  "async_zip",
+ "beacon-arrow-atlas",
  "beacon-arrow-netcdf",
  "beacon-arrow-odv",
  "beacon-arrow-tiff",
  "beacon-arrow-zarr",
- "beacon-atlas",
  "beacon-binary-format",
  "beacon-common",
  "beacon-config",
@@ -1383,24 +1392,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,17 +1433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.7",
-]
-
-[[package]]
-name = "bloomfilter"
-version = "1.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c541c70a910b485670304fd420f0eab8f7bde68439db6a8d98819c3d2774d7e2"
-dependencies = [
- "bit-vec",
- "getrandom 0.2.17",
- "siphasher",
 ]
 
 [[package]]
@@ -2894,7 +2874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3731,7 +3711,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4027,7 +4007,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4646,7 +4626,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5292,7 +5272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -5390,7 +5370,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -5427,9 +5407,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5881,7 +5861,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6172,9 +6152,6 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "slab"
@@ -6460,7 +6437,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6671,17 +6648,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -7349,7 +7315,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["beacon-api", "beacon-arrow-netcdf", "beacon-arrow-odv", "beacon-common", "beacon-config", "beacon-core", "beacon-functions", "beacon-query", "beacon-planner", "beacon-data-lake", "beacon-formats", "beacon-arrow-zarr", "beacon-binary-format", "beacon-object-storage", "beacon-nd-arrow", "beacon-atlas", "beacon-datafusion-ext", "beacon-table", "beacon-nd-array", "beacon-statistics-index", "beacon-arrow-tiff"]
+members = ["beacon-api", "beacon-arrow-netcdf", "beacon-arrow-odv", "beacon-common", "beacon-config", "beacon-core", "beacon-functions", "beacon-query", "beacon-planner", "beacon-data-lake", "beacon-formats", "beacon-arrow-zarr", "beacon-binary-format", "beacon-object-storage", "beacon-nd-arrow", "beacon-datafusion-ext", "beacon-table", "beacon-nd-array", "beacon-statistics-index", "beacon-arrow-tiff", "beacon-arrow-atlas"]
 exclude = ["beacon-binary-format-toolbox"]
 
 [workspace.dependencies]

--- a/beacon-api/src/axum/router.rs
+++ b/beacon-api/src/axum/router.rs
@@ -59,8 +59,9 @@ pub(crate) fn setup_router(beacon_runtime: Arc<Runtime>) -> anyhow::Result<Route
 
     // SwaggerUi is merged outside the base_path nest to avoid doubling the prefix
     // in the openapi.json URL (/{base_path}/{base_path}/openapi.json).
-    let swagger_ui = SwaggerUi::new(swagger_url)
-        .urls(vec![(Url::new("Docs", &openapi_url), docs)]);
+    let openapi_url_static: &'static str = openapi_url.leak();
+    let swagger_ui =
+        SwaggerUi::new(swagger_url).urls(vec![(Url::new("Docs", openapi_url_static), docs)]);
 
     if base_path.is_empty() {
         Ok(Router::new()

--- a/beacon-api/src/main.rs
+++ b/beacon-api/src/main.rs
@@ -92,7 +92,7 @@ fn setup_tracing() {
             // built-in extractors with the `axum::rejection` target at `TRACE` level.
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
                 format!(
-                    "info,{}=debug,tower_http=debug,axum::rejection=trace,beacon_core=debug,beacon_arrow_odv=debug,beacon_arrow_netcdf=debug,beacon_data_lake=debug,beacon_api=debug,beacon_formats=debug,beacon_common=debug,beacon_table=debug,beacon_functions=debug,beacon_nd_array=debug",
+                    "info,{}=debug,tower_http=debug,axum::rejection=trace,beacon_core=debug,beacon_arrow_odv=debug,beacon_arrow_netcdf=debug,beacon_data_lake=debug,beacon_api=debug,beacon_formats=debug,beacon_common=debug,beacon_table=debug,beacon_functions=debug,beacon_nd_array=debug,beacon_arrow_atlas=debug",
                     env!("CARGO_CRATE_NAME")
                 )
                 .into()

--- a/beacon-arrow-atlas/Cargo.toml
+++ b/beacon-arrow-atlas/Cargo.toml
@@ -16,9 +16,13 @@ chrono = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+rmp-serde = "1"
+zstd = "0.13"
+lz4_flex = "0.11"
 ndarray = "0.17"
-atlas = { git = "https://github.com/robinskil/atlas.git", version = "0.7.0" }
+atlas = { git = "https://github.com/robinskil/atlas.git", version = "0.8.0" }
 crossbeam = { workspace = true }
+moka = { workspace = true }
 
 beacon-object-storage = { path = "../beacon-object-storage" }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }

--- a/beacon-arrow-atlas/Cargo.toml
+++ b/beacon-arrow-atlas/Cargo.toml
@@ -17,7 +17,7 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 ndarray = "0.17"
-atlas = { git = "https://github.com/robinskil/atlas.git", version = "0.2.2" }
+atlas = { git = "https://github.com/robinskil/atlas.git", version = "0.7.0" }
 
 beacon-object-storage = { path = "../beacon-object-storage" }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }

--- a/beacon-arrow-atlas/Cargo.toml
+++ b/beacon-arrow-atlas/Cargo.toml
@@ -16,8 +16,8 @@ chrono = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-ndarray = "0.17.1"
-atlas = { git = "https://github.com/robinskil/atlas.git", version = "0.2.0" }
+ndarray = "0.17"
+atlas = { git = "https://github.com/robinskil/atlas.git", version = "0.2.2" }
 
 beacon-object-storage = { path = "../beacon-object-storage" }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }

--- a/beacon-arrow-atlas/Cargo.toml
+++ b/beacon-arrow-atlas/Cargo.toml
@@ -18,6 +18,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 ndarray = "0.17"
 atlas = { git = "https://github.com/robinskil/atlas.git", version = "0.7.0" }
+crossbeam = { workspace = true }
 
 beacon-object-storage = { path = "../beacon-object-storage" }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }

--- a/beacon-arrow-atlas/Cargo.toml
+++ b/beacon-arrow-atlas/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "beacon-arrow-atlas"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+object_store = { workspace = true }
+datafusion = { workspace = true }
+arrow = { workspace = true }
+async-trait = { workspace = true }
+anyhow = { workspace = true }
+futures = { workspace = true }
+indexmap = { workspace = true }
+tracing = { workspace = true }
+chrono = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+ndarray = "0.17.1"
+atlas = { git = "https://github.com/robinskil/atlas.git", version = "0.2.0" }
+
+beacon-object-storage = { path = "../beacon-object-storage" }
+beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }
+beacon-nd-array = { path = "../beacon-nd-array" }
+beacon-config = { path = "../beacon-config" }
+beacon-common = { path = "../beacon-common" }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/beacon-arrow-atlas/src/backend.rs
+++ b/beacon-arrow-atlas/src/backend.rs
@@ -1,0 +1,343 @@
+//! Array backend implementations used by the Atlas reader.
+
+use std::sync::Arc;
+
+use beacon_nd_array::{
+    array::{backend::ArrayBackend, subset::ArraySubset},
+    datatypes::{NdArrayType, TimestampNanosecond},
+};
+use ndarray::ArrayD;
+
+/// Trait implemented for `T: NdArrayType` values that can be read from an
+/// atlas `DatasetView` as a typed `ArrayD<T>`.
+///
+/// Atlas's `read_array::<E>` is generic over `array_format::ArrayElement`.
+/// Most `NdArrayType` impls are also `ArrayElement` (numeric primitives,
+/// `String`, `Vec<u8>`), but a few — notably
+/// [`TimestampNanosecond`] — are layout-compatible newtypes that need a
+/// thin element-wise conversion. This trait hides the difference behind
+/// a single `read` entry point so [`AtlasArrayBackend`] stays generic.
+#[async_trait::async_trait]
+pub trait AtlasReadable: NdArrayType {
+    async fn read(
+        dataset: &atlas::DatasetView,
+        array_name: &str,
+        start: Vec<usize>,
+        shape: Vec<usize>,
+    ) -> anyhow::Result<ArrayD<Self>>;
+}
+
+macro_rules! impl_atlas_readable_passthrough {
+    ($ty:ty) => {
+        #[async_trait::async_trait]
+        impl AtlasReadable for $ty {
+            async fn read(
+                dataset: &atlas::DatasetView,
+                array_name: &str,
+                start: Vec<usize>,
+                shape: Vec<usize>,
+            ) -> anyhow::Result<ArrayD<Self>> {
+                let arr = dataset
+                    .read_array::<$ty>(array_name, start, shape)
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "Failed to read atlas array '{}': {}",
+                            array_name,
+                            e
+                        )
+                    })?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Atlas array '{}' not found in dataset '{}'",
+                            array_name,
+                            dataset.name()
+                        )
+                    })?;
+                Ok(arr.to_owned())
+            }
+        }
+    };
+}
+
+impl_atlas_readable_passthrough!(i8);
+impl_atlas_readable_passthrough!(i16);
+impl_atlas_readable_passthrough!(i32);
+impl_atlas_readable_passthrough!(i64);
+impl_atlas_readable_passthrough!(u8);
+impl_atlas_readable_passthrough!(u16);
+impl_atlas_readable_passthrough!(u32);
+impl_atlas_readable_passthrough!(u64);
+impl_atlas_readable_passthrough!(f32);
+impl_atlas_readable_passthrough!(f64);
+impl_atlas_readable_passthrough!(String);
+impl_atlas_readable_passthrough!(Vec<u8>);
+
+#[async_trait::async_trait]
+impl AtlasReadable for TimestampNanosecond {
+    async fn read(
+        dataset: &atlas::DatasetView,
+        array_name: &str,
+        start: Vec<usize>,
+        shape: Vec<usize>,
+    ) -> anyhow::Result<ArrayD<Self>> {
+        let arr = dataset
+            .read_array::<atlas::TimestampNs>(array_name, start, shape)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to read atlas timestamp array '{}': {}",
+                    array_name,
+                    e
+                )
+            })?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Atlas array '{}' not found in dataset '{}'",
+                    array_name,
+                    dataset.name()
+                )
+            })?;
+        // Map element-wise: TimestampNs(i64) -> TimestampNanosecond(i64).
+        // Both are #[repr(transparent)] over i64.
+        Ok(arr.to_owned().mapv(|ts| TimestampNanosecond(ts.0)))
+    }
+}
+
+/// Backend that reads atlas array data lazily.
+pub struct AtlasArrayBackend<T: NdArrayType> {
+    atlas: Arc<atlas::Atlas>,
+    dataset_name: String,
+    array_name: String,
+    shape: Vec<usize>,
+    dimensions: Vec<String>,
+    chunk_shape: Vec<usize>,
+    fill_value: Option<T>,
+}
+
+impl<T: NdArrayType> std::fmt::Debug for AtlasArrayBackend<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AtlasArrayBackend")
+            .field("dataset_name", &self.dataset_name)
+            .field("array_name", &self.array_name)
+            .field("shape", &self.shape)
+            .field("dimensions", &self.dimensions)
+            .field("chunk_shape", &self.chunk_shape)
+            .finish()
+    }
+}
+
+impl<T: NdArrayType> AtlasArrayBackend<T> {
+    pub fn new(
+        atlas: Arc<atlas::Atlas>,
+        dataset_name: String,
+        array_name: String,
+        shape: Vec<usize>,
+        dimensions: Vec<String>,
+        chunk_shape: Vec<usize>,
+        fill_value: Option<T>,
+    ) -> Self {
+        Self {
+            atlas,
+            dataset_name,
+            array_name,
+            shape,
+            dimensions,
+            chunk_shape,
+            fill_value,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: NdArrayType + AtlasReadable> ArrayBackend<T> for AtlasArrayBackend<T> {
+    fn len(&self) -> usize {
+        self.shape.iter().product()
+    }
+
+    fn shape(&self) -> Vec<usize> {
+        self.shape.clone()
+    }
+
+    fn dimensions(&self) -> Vec<String> {
+        self.dimensions.clone()
+    }
+
+    fn chunk_shape(&self) -> Vec<usize> {
+        self.chunk_shape.clone()
+    }
+
+    fn fill_value(&self) -> Option<T> {
+        self.fill_value.clone()
+    }
+
+    async fn read_subset(&self, subset: ArraySubset) -> anyhow::Result<ArrayD<T>> {
+        let view = self.atlas.open_dataset(&self.dataset_name).await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to open atlas dataset '{}': {}",
+                self.dataset_name,
+                e
+            )
+        })?;
+        T::read(&view, &self.array_name, subset.start, subset.shape).await
+    }
+}
+
+/// Backend for scalar attribute values surfaced as rank-0 arrays.
+#[derive(Debug)]
+pub struct AttributeBackend<T: NdArrayType> {
+    value: T,
+}
+
+impl<T: NdArrayType> AttributeBackend<T> {
+    pub fn new(value: T) -> Self {
+        Self { value }
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: NdArrayType> ArrayBackend<T> for AttributeBackend<T> {
+    fn len(&self) -> usize {
+        1
+    }
+
+    fn shape(&self) -> Vec<usize> {
+        vec![]
+    }
+
+    fn dimensions(&self) -> Vec<String> {
+        vec![]
+    }
+
+    fn fill_value(&self) -> Option<T> {
+        None
+    }
+
+    async fn read_subset(&self, _subset: ArraySubset) -> anyhow::Result<ArrayD<T>> {
+        Ok(ndarray::arr0(self.value.clone()).into_dyn())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reader::test_support::build_two_dataset_store;
+    use atlas::Atlas;
+
+    // ── AttributeBackend ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn attribute_backend_is_rank_zero() {
+        let backend = AttributeBackend::new("hello".to_string());
+        assert_eq!(backend.len(), 1);
+        assert!(ArrayBackend::<String>::shape(&backend).is_empty());
+        assert!(ArrayBackend::<String>::dimensions(&backend).is_empty());
+    }
+
+    #[tokio::test]
+    async fn attribute_backend_read_subset_returns_value() {
+        let backend = AttributeBackend::new(42i32);
+        let arr = backend
+            .read_subset(ArraySubset {
+                start: vec![],
+                shape: vec![],
+            })
+            .await
+            .expect("read");
+        assert_eq!(arr.ndim(), 0);
+        let raw = arr.into_raw_vec_and_offset().0;
+        assert_eq!(raw, vec![42i32]);
+    }
+
+    // ── AtlasArrayBackend ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn atlas_array_backend_reports_metadata() {
+        let backend = AtlasArrayBackend::<f32>::new(
+            Arc::new(dummy_atlas().await),
+            "winter".into(),
+            "temperature".into(),
+            vec![4],
+            vec!["obs".into()],
+            vec![4],
+            Some(-1.0f32),
+        );
+        assert_eq!(<AtlasArrayBackend<f32> as ArrayBackend<f32>>::shape(&backend), vec![4]);
+        assert_eq!(
+            <AtlasArrayBackend<f32> as ArrayBackend<f32>>::dimensions(&backend),
+            vec!["obs".to_string()]
+        );
+        assert_eq!(
+            <AtlasArrayBackend<f32> as ArrayBackend<f32>>::chunk_shape(&backend),
+            vec![4]
+        );
+        assert_eq!(
+            <AtlasArrayBackend<f32> as ArrayBackend<f32>>::fill_value(&backend),
+            Some(-1.0f32)
+        );
+        assert_eq!(backend.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn atlas_array_backend_read_subset_full_range() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        build_two_dataset_store(tmp.path()).await;
+        let atlas = Atlas::open_path(tmp.path()).await.expect("open atlas");
+
+        let backend = AtlasArrayBackend::<f32>::new(
+            Arc::new(atlas),
+            "winter".into(),
+            "temperature".into(),
+            vec![4],
+            vec!["obs".into()],
+            vec![4],
+            None,
+        );
+        let arr = backend
+            .read_subset(ArraySubset {
+                start: vec![0],
+                shape: vec![4],
+            })
+            .await
+            .expect("read full");
+        let raw = arr.into_raw_vec_and_offset().0;
+        assert_eq!(raw, vec![1.0f32, 2.0, 3.0, 4.0]);
+    }
+
+    #[tokio::test]
+    async fn atlas_array_backend_read_subset_partial_range() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        build_two_dataset_store(tmp.path()).await;
+        let atlas = Atlas::open_path(tmp.path()).await.expect("open atlas");
+
+        let backend = AtlasArrayBackend::<i32>::new(
+            Arc::new(atlas),
+            "winter".into(),
+            "cycle".into(),
+            vec![4],
+            vec!["obs".into()],
+            vec![4],
+            None,
+        );
+        let arr = backend
+            .read_subset(ArraySubset {
+                start: vec![1],
+                shape: vec![2],
+            })
+            .await
+            .expect("read partial");
+        let raw = arr.into_raw_vec_and_offset().0;
+        assert_eq!(raw, vec![20i32, 30]);
+    }
+
+    /// Helper: build a fresh empty atlas store in a (leaked) temp dir for
+    /// metadata-only tests that don't need the data to survive the test.
+    async fn dummy_atlas() -> Atlas {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let atlas = Atlas::create_path(tmp.path(), atlas::StoreConfig::default())
+            .await
+            .expect("create dummy atlas");
+        std::mem::forget(tmp);
+        atlas
+    }
+}

--- a/beacon-arrow-atlas/src/backend.rs
+++ b/beacon-arrow-atlas/src/backend.rs
@@ -25,6 +25,11 @@ pub trait AtlasReadable: NdArrayType {
         start: Vec<usize>,
         shape: Vec<usize>,
     ) -> anyhow::Result<ArrayD<Self>>;
+
+    /// Convert an atlas `FillValue` into this type's per-element fill,
+    /// using the same widening/sentinel rules `array_format` applies when
+    /// materializing missing chunks.
+    fn fill_element(fill: Option<&atlas::FillValue>) -> Self;
 }
 
 macro_rules! impl_atlas_readable_passthrough {
@@ -55,6 +60,10 @@ macro_rules! impl_atlas_readable_passthrough {
                         )
                     })?;
                 Ok(arr.to_owned())
+            }
+
+            fn fill_element(fill: Option<&atlas::FillValue>) -> Self {
+                <$ty as atlas::ArrayElement>::fill_element(fill)
             }
         }
     };
@@ -101,6 +110,11 @@ impl AtlasReadable for TimestampNanosecond {
         // Map element-wise: TimestampNs(i64) -> TimestampNanosecond(i64).
         // Both are #[repr(transparent)] over i64.
         Ok(arr.to_owned().mapv(|ts| TimestampNanosecond(ts.0)))
+    }
+
+    fn fill_element(fill: Option<&atlas::FillValue>) -> Self {
+        let ts = <atlas::TimestampNs as atlas::ArrayElement>::fill_element(fill);
+        TimestampNanosecond(ts.0)
     }
 }
 
@@ -247,6 +261,34 @@ mod tests {
         assert_eq!(arr.ndim(), 0);
         let raw = arr.into_raw_vec_and_offset().0;
         assert_eq!(raw, vec![42i32]);
+    }
+
+    // ── AtlasReadable::fill_element ────────────────────────────────────
+
+    #[test]
+    fn fill_element_passthrough_numeric() {
+        use atlas::FillValue;
+        assert_eq!(
+            <i32 as AtlasReadable>::fill_element(Some(&FillValue::Int(-7))),
+            -7i32
+        );
+        let nan = <f64 as AtlasReadable>::fill_element(Some(&FillValue::Float(f64::NAN)));
+        assert!(nan.is_nan(), "NaN fill must round-trip as NaN");
+        assert_eq!(<i32 as AtlasReadable>::fill_element(None), 0i32);
+    }
+
+    #[test]
+    fn fill_element_timestamp_newtype_unwraps() {
+        use atlas::FillValue;
+        // The TimestampNanosecond impl goes through atlas::TimestampNs and
+        // must end up wrapping the same i64.
+        let ts = <TimestampNanosecond as AtlasReadable>::fill_element(Some(
+            &FillValue::TimestampNs(123),
+        ));
+        assert_eq!(ts, TimestampNanosecond(123));
+        let from_int =
+            <TimestampNanosecond as AtlasReadable>::fill_element(Some(&FillValue::Int(456)));
+        assert_eq!(from_int, TimestampNanosecond(456));
     }
 
     // ── AtlasArrayBackend ──────────────────────────────────────────────

--- a/beacon-arrow-atlas/src/compat.rs
+++ b/beacon-arrow-atlas/src/compat.rs
@@ -1,0 +1,229 @@
+//! Compatibility helpers between atlas types and Beacon ND arrays.
+
+use std::sync::Arc;
+
+use atlas::{Attr, DType};
+use beacon_nd_array::{NdArray, NdArrayD, datatypes::TimestampNanosecond};
+
+use crate::backend::{AtlasArrayBackend, AttributeBackend};
+
+/// Convert an atlas array (described by its [`atlas::ArraySchema`]) into a
+/// lazy [`NdArrayD`] backed by [`AtlasArrayBackend`].
+///
+/// `FixedSizeList` and `List` dtypes are rejected with an explicit error —
+/// they have no analogue in Beacon's ND array model and silently skipping
+/// them would propagate dimension mismatches.
+///
+/// Fill values are not exposed on `ArraySchema` and are therefore left as
+/// `None` here; atlas's storage applies fill values to absent chunks
+/// during `read_array`, so the data returned by the backend is already
+/// fill-substituted at the boundary.
+pub fn array_to_nd_array(
+    atlas: Arc<atlas::Atlas>,
+    dataset_name: &str,
+    array_name: &str,
+    schema: &atlas::ArraySchema,
+) -> anyhow::Result<Arc<dyn NdArrayD>> {
+    let shape = schema.shape.clone();
+    let dimensions = schema.dimension_names.clone();
+    let chunk_shape = schema.chunk_shape.clone();
+
+    macro_rules! mk {
+        ($ty:ty) => {{
+            let backend = AtlasArrayBackend::<$ty>::new(
+                atlas.clone(),
+                dataset_name.to_string(),
+                array_name.to_string(),
+                shape.clone(),
+                dimensions.clone(),
+                chunk_shape.clone(),
+                None,
+            );
+            let nd = NdArray::new_with_backend(backend)?;
+            Ok::<Arc<dyn NdArrayD>, anyhow::Error>(Arc::new(nd))
+        }};
+    }
+
+    match &schema.dtype {
+        DType::Bool => Err(anyhow::anyhow!(
+            "Atlas array '{}' has dtype Bool which is not currently readable through Beacon \
+             (atlas's ArrayElement does not yet impl bool)",
+            array_name
+        )),
+        DType::Int8 => mk!(i8),
+        DType::Int16 => mk!(i16),
+        DType::Int32 => mk!(i32),
+        DType::Int64 => mk!(i64),
+        DType::UInt8 => mk!(u8),
+        DType::UInt16 => mk!(u16),
+        DType::UInt32 => mk!(u32),
+        DType::UInt64 => mk!(u64),
+        DType::Float32 => mk!(f32),
+        DType::Float64 => mk!(f64),
+        DType::String => mk!(String),
+        DType::Binary => mk!(Vec<u8>),
+        DType::TimestampNs => mk!(TimestampNanosecond),
+        DType::FixedSizeList { .. } => Err(anyhow::anyhow!(
+            "Atlas array '{}' has unsupported dtype FixedSizeList — Beacon does not currently model fixed-size lists",
+            array_name
+        )),
+        DType::List { .. } => Err(anyhow::anyhow!(
+            "Atlas array '{}' has unsupported dtype List — Beacon does not currently model variable-length lists",
+            array_name
+        )),
+    }
+}
+
+/// Convert an atlas attribute value into a rank-0 ND array.
+pub fn attribute_to_nd_array(_name: &str, attr: Attr) -> anyhow::Result<Arc<dyn NdArrayD>> {
+    match attr {
+        Attr::Bool(v) => Ok(Arc::new(NdArray::new_with_backend(AttributeBackend::new(v))?)),
+        Attr::Int64(v) => Ok(Arc::new(NdArray::new_with_backend(AttributeBackend::new(v))?)),
+        Attr::Float64(v) => Ok(Arc::new(NdArray::new_with_backend(AttributeBackend::new(v))?)),
+        Attr::String(v) => Ok(Arc::new(NdArray::new_with_backend(AttributeBackend::new(v))?)),
+        Attr::TimestampNanoseconds(v) => Ok(Arc::new(NdArray::new_with_backend(
+            AttributeBackend::new(TimestampNanosecond(v)),
+        )?)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use atlas::{ArraySchema, Codec, DType};
+    use beacon_nd_array::{NdArray, datatypes::NdArrayDataType};
+
+    fn schema_with_dtype(dtype: DType) -> ArraySchema {
+        ArraySchema {
+            dtype,
+            shape: vec![2],
+            chunk_shape: vec![2],
+            dimension_names: vec!["x".into()],
+            codec: Codec::default(),
+        }
+    }
+
+    // We can't actually open an atlas for the type-dispatch happy paths
+    // without a real store; instead exercise the rejection branches and
+    // the attribute conversion (which has no atlas dependency).
+
+    #[test]
+    fn array_to_nd_array_rejects_bool() {
+        let dummy_atlas = dummy_atlas();
+        let err = array_to_nd_array(
+            dummy_atlas,
+            "ds",
+            "flag",
+            &schema_with_dtype(DType::Bool),
+        )
+        .expect_err("Bool should be rejected");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Bool"), "{msg}");
+        assert!(msg.contains("flag"), "{msg}");
+    }
+
+    #[test]
+    fn array_to_nd_array_rejects_fixed_size_list() {
+        let dummy_atlas = dummy_atlas();
+        let err = array_to_nd_array(
+            dummy_atlas,
+            "ds",
+            "vectors",
+            &schema_with_dtype(DType::FixedSizeList {
+                child: Box::new(DType::Float32),
+                size: 4,
+            }),
+        )
+        .expect_err("FixedSizeList should be rejected");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("FixedSizeList"), "{msg}");
+        assert!(msg.contains("vectors"), "{msg}");
+    }
+
+    #[test]
+    fn array_to_nd_array_rejects_list() {
+        let dummy_atlas = dummy_atlas();
+        let err = array_to_nd_array(
+            dummy_atlas,
+            "ds",
+            "events",
+            &schema_with_dtype(DType::List {
+                child: Box::new(DType::Int32),
+            }),
+        )
+        .expect_err("List should be rejected");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("List"), "{msg}");
+        assert!(msg.contains("events"), "{msg}");
+    }
+
+    fn dummy_atlas() -> Arc<atlas::Atlas> {
+        // The rejection branches return before touching the atlas handle,
+        // so we need a value but never invoke it. Build one on a fresh
+        // temp dir to keep the type system honest.
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let atlas = rt.block_on(async {
+            atlas::Atlas::create_path(tmp.path(), atlas::StoreConfig::default())
+                .await
+                .expect("create dummy atlas")
+        });
+        // Leak the tempdir so it stays alive for the duration of the test;
+        // the rejection paths never touch the filesystem so this is safe.
+        std::mem::forget(tmp);
+        Arc::new(atlas)
+    }
+
+    // ── attribute_to_nd_array ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn attribute_bool_round_trips() {
+        let nd = attribute_to_nd_array("flag", Attr::Bool(true)).expect("convert");
+        assert_eq!(nd.datatype(), NdArrayDataType::Bool);
+        assert!(nd.shape().is_empty());
+        let typed = nd.as_any().downcast_ref::<NdArray<bool>>().expect("downcast");
+        assert_eq!(typed.clone_into_raw_vec().await, vec![true]);
+    }
+
+    #[tokio::test]
+    async fn attribute_int64_round_trips() {
+        let nd = attribute_to_nd_array("count", Attr::Int64(42)).expect("convert");
+        assert_eq!(nd.datatype(), NdArrayDataType::I64);
+        let typed = nd.as_any().downcast_ref::<NdArray<i64>>().expect("downcast");
+        assert_eq!(typed.clone_into_raw_vec().await, vec![42i64]);
+    }
+
+    #[tokio::test]
+    async fn attribute_float64_round_trips() {
+        let nd = attribute_to_nd_array("scale", Attr::Float64(1.5)).expect("convert");
+        assert_eq!(nd.datatype(), NdArrayDataType::F64);
+        let typed = nd.as_any().downcast_ref::<NdArray<f64>>().expect("downcast");
+        assert_eq!(typed.clone_into_raw_vec().await, vec![1.5f64]);
+    }
+
+    #[tokio::test]
+    async fn attribute_string_round_trips() {
+        let nd = attribute_to_nd_array("season", Attr::String("winter".into())).expect("convert");
+        assert_eq!(nd.datatype(), NdArrayDataType::String);
+        let typed = nd
+            .as_any()
+            .downcast_ref::<NdArray<String>>()
+            .expect("downcast");
+        assert_eq!(typed.clone_into_raw_vec().await, vec!["winter".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn attribute_timestamp_round_trips() {
+        let nanos = 1_700_000_000_000_000_000i64;
+        let nd = attribute_to_nd_array("ts", Attr::TimestampNanoseconds(nanos)).expect("convert");
+        assert_eq!(nd.datatype(), NdArrayDataType::Timestamp);
+        let typed = nd
+            .as_any()
+            .downcast_ref::<NdArray<TimestampNanosecond>>()
+            .expect("downcast");
+        assert_eq!(
+            typed.clone_into_raw_vec().await,
+            vec![TimestampNanosecond(nanos)]
+        );
+    }
+}

--- a/beacon-arrow-atlas/src/compat.rs
+++ b/beacon-arrow-atlas/src/compat.rs
@@ -2,10 +2,112 @@
 
 use std::sync::Arc;
 
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use atlas::{Attr, DType};
 use beacon_nd_array::{NdArray, NdArrayD, datatypes::TimestampNanosecond};
 
-use crate::backend::{AtlasArrayBackend, AttributeBackend};
+use crate::backend::{AtlasArrayBackend, AtlasReadable, AttributeBackend};
+
+/// Arrow data type for an atlas array dtype, or `None` for dtypes that
+/// cannot be read through Beacon (`Bool`, `FixedSizeList`, `List`).
+///
+/// Kept in lock-step with [`array_to_nd_array`] so the two paths produce
+/// matching field sets — every dtype that yields `Some(_)` here is one
+/// that `array_to_nd_array` will build a backend for.
+pub fn atlas_array_dtype_to_arrow(dtype: &DType) -> Option<DataType> {
+    Some(match dtype {
+        DType::Bool => return None,
+        DType::Int8 => DataType::Int8,
+        DType::Int16 => DataType::Int16,
+        DType::Int32 => DataType::Int32,
+        DType::Int64 => DataType::Int64,
+        DType::UInt8 => DataType::UInt8,
+        DType::UInt16 => DataType::UInt16,
+        DType::UInt32 => DataType::UInt32,
+        DType::UInt64 => DataType::UInt64,
+        DType::Float32 => DataType::Float32,
+        DType::Float64 => DataType::Float64,
+        DType::String => DataType::Utf8,
+        DType::Binary => DataType::Binary,
+        DType::TimestampNs => DataType::Timestamp(TimeUnit::Nanosecond, None),
+        DType::FixedSizeList { .. } | DType::List { .. } => return None,
+    })
+}
+
+/// Arrow data type for an atlas attribute value.
+pub fn atlas_attr_to_arrow(attr: &Attr) -> DataType {
+    match attr {
+        Attr::Bool(_) => DataType::Boolean,
+        Attr::Int64(_) => DataType::Int64,
+        Attr::Float64(_) => DataType::Float64,
+        Attr::String(_) => DataType::Utf8,
+        Attr::TimestampNanoseconds(_) => DataType::Timestamp(TimeUnit::Nanosecond, None),
+    }
+}
+
+/// Build the Arrow schema for an atlas dataset directly from its metadata
+/// — no NdArray backends are constructed.
+///
+/// Fields are sorted alphabetically by name to match the post-`sort_keys`
+/// ordering produced by [`crate::reader::dataset_from_atlas`], so the
+/// indices returned by `SchemaAdapter::map_schema` line up with the
+/// arrays/attributes a subsequent `dataset_from_atlas` call will include.
+///
+/// Arrays whose dtype is unsupported (see [`atlas_array_dtype_to_arrow`])
+/// are silently skipped, mirroring the runtime behavior of
+/// `dataset_from_atlas` which `warn!`-skips them.
+///
+/// When `read_dimensions` is `Some`, the result keeps only arrays whose
+/// dimensions are a subset of the requested list (attributes are rank-0
+/// and always survive). This mirrors
+/// `Dataset::project_with_dimensions`: requested dimensions must exist
+/// in the dataset, otherwise the function errors.
+pub fn atlas_view_arrow_schema(
+    view: &atlas::DatasetView,
+    read_dimensions: Option<&[String]>,
+) -> anyhow::Result<Schema> {
+    let meta = view.meta();
+
+    if let Some(requested) = read_dimensions {
+        let available: std::collections::HashSet<&str> = meta
+            .arrays
+            .values()
+            .flat_map(|s| s.dimension_names.iter().map(String::as_str))
+            .collect();
+        for dim in requested {
+            if !available.contains(dim.as_str()) {
+                anyhow::bail!(
+                    "dimension '{dim}' not found in atlas dataset '{}'",
+                    view.name()
+                );
+            }
+        }
+    }
+
+    let mut fields: Vec<Field> = Vec::with_capacity(meta.arrays.len() + meta.attributes.len());
+
+    for (name, schema) in &meta.arrays {
+        let Some(dtype) = atlas_array_dtype_to_arrow(&schema.dtype) else {
+            continue;
+        };
+        if let Some(requested) = read_dimensions {
+            if !schema
+                .dimension_names
+                .iter()
+                .all(|d| requested.iter().any(|r| r == d))
+            {
+                continue;
+            }
+        }
+        fields.push(Field::new(name, dtype, true));
+    }
+    for (name, attr) in &meta.attributes {
+        fields.push(Field::new(name, atlas_attr_to_arrow(attr), true));
+    }
+
+    fields.sort_by(|a, b| a.name().cmp(b.name()));
+    Ok(Schema::new(fields))
+}
 
 /// Convert an atlas array (described by its [`atlas::ArraySchema`]) into a
 /// lazy [`NdArrayD`] backed by [`AtlasArrayBackend`].
@@ -14,15 +116,14 @@ use crate::backend::{AtlasArrayBackend, AttributeBackend};
 /// they have no analogue in Beacon's ND array model and silently skipping
 /// them would propagate dimension mismatches.
 ///
-/// Fill values are not exposed on `ArraySchema` and are therefore left as
-/// `None` here; atlas's storage applies fill values to absent chunks
-/// during `read_array`, so the data returned by the backend is already
-/// fill-substituted at the boundary.
+/// `fill_value` comes from [`atlas::DatasetView::array_fill_value`] and is
+/// converted to the per-dtype `T` via [`AtlasReadable::fill_element`].
 pub fn array_to_nd_array(
     atlas: Arc<atlas::Atlas>,
     dataset_name: &str,
     array_name: &str,
     schema: &atlas::ArraySchema,
+    fill_value: Option<atlas::FillValue>,
 ) -> anyhow::Result<Arc<dyn NdArrayD>> {
     let shape = schema.shape.clone();
     let dimensions = schema.dimension_names.clone();
@@ -30,6 +131,9 @@ pub fn array_to_nd_array(
 
     macro_rules! mk {
         ($ty:ty) => {{
+            let fill: Option<$ty> = fill_value
+                .as_ref()
+                .map(|fv| <$ty as AtlasReadable>::fill_element(Some(fv)));
             let backend = AtlasArrayBackend::<$ty>::new(
                 atlas.clone(),
                 dataset_name.to_string(),
@@ -37,7 +141,7 @@ pub fn array_to_nd_array(
                 shape.clone(),
                 dimensions.clone(),
                 chunk_shape.clone(),
-                None,
+                fill,
             );
             let nd = NdArray::new_with_backend(backend)?;
             Ok::<Arc<dyn NdArrayD>, anyhow::Error>(Arc::new(nd))
@@ -115,6 +219,7 @@ mod tests {
             "ds",
             "flag",
             &schema_with_dtype(DType::Bool),
+            None,
         )
         .expect_err("Bool should be rejected");
         let msg = format!("{err:#}");
@@ -133,6 +238,7 @@ mod tests {
                 child: Box::new(DType::Float32),
                 size: 4,
             }),
+            None,
         )
         .expect_err("FixedSizeList should be rejected");
         let msg = format!("{err:#}");
@@ -150,6 +256,7 @@ mod tests {
             &schema_with_dtype(DType::List {
                 child: Box::new(DType::Int32),
             }),
+            None,
         )
         .expect_err("List should be rejected");
         let msg = format!("{err:#}");

--- a/beacon-arrow-atlas/src/datafusion/cache.rs
+++ b/beacon-arrow-atlas/src/datafusion/cache.rs
@@ -1,0 +1,141 @@
+//! Centralized cache of opened atlas stores keyed by marker path
+//! plus freshness (`last_modified` + `size`). Every caller that wants
+//! an `Arc<Atlas>` should go through [`get_or_open_atlas`] so a single
+//! `atlas.json` is opened exactly once across the process for as long
+//! as its on-disk metadata is unchanged.
+
+use std::sync::{Arc, LazyLock};
+
+use atlas::Atlas;
+use beacon_object_storage::DatasetsStore;
+use moka::future::Cache;
+use object_store::ObjectMeta;
+use object_store::path::Path as OsPath;
+
+use crate::datafusion::reader;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CacheKey {
+    path: OsPath,
+    last_modified: chrono::DateTime<chrono::Utc>,
+    size: u64,
+}
+
+static ATLAS_CACHE: LazyLock<Cache<CacheKey, Arc<Atlas>>> = LazyLock::new(|| {
+    Cache::builder()
+        .max_capacity(beacon_config::CONFIG.atlas.reader_cache_size)
+        .build()
+});
+
+/// Return a cached [`Arc<Atlas>`] for `marker`, opening from disk on
+/// miss. Freshness is encoded in the cache key — a marker whose
+/// `last_modified` or `size` differs from the cached entry produces a
+/// new key, forcing a re-open. The previous entry lingers until evicted
+/// by the LRU bound.
+///
+/// Concurrent first-readers for the same key coalesce inside
+/// [`moka::future::Cache::try_get_with`].
+pub async fn get_or_open_atlas(
+    store: Arc<DatasetsStore>,
+    marker: &ObjectMeta,
+) -> datafusion::error::Result<Arc<Atlas>> {
+    if !beacon_config::CONFIG.atlas.use_reader_cache {
+        return reader::open_atlas_store(store, &marker.location).await;
+    }
+
+    let key = CacheKey {
+        path: marker.location.clone(),
+        last_modified: marker.last_modified,
+        size: marker.size,
+    };
+    let path = marker.location.clone();
+
+    ATLAS_CACHE
+        .try_get_with(key, async move { reader::open_atlas_store(store, &path).await })
+        .await
+        .map_err(|e: Arc<datafusion::error::DataFusionError>| {
+            datafusion::error::DataFusionError::Execution(format!(
+                "Failed to open atlas store via cache: {e}"
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datafusion::test_support::{ensure_fixture, fixture_marker_object_meta, test_store};
+    use object_store::path::Path as OsPath;
+
+    fn marker_with(path: OsPath, last_modified: chrono::DateTime<chrono::Utc>, size: u64) -> ObjectMeta {
+        ObjectMeta {
+            location: path,
+            last_modified,
+            size,
+            e_tag: None,
+            version: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn cache_returns_same_arc_for_identical_marker() {
+        ensure_fixture().await;
+        let store = test_store().await;
+        let marker = fixture_marker_object_meta();
+
+        let first = get_or_open_atlas(store.clone(), &marker)
+            .await
+            .expect("first open");
+        let second = get_or_open_atlas(store, &marker)
+            .await
+            .expect("second open");
+
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "identical marker must hit the cache",
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_reopens_when_last_modified_changes() {
+        ensure_fixture().await;
+        let store = test_store().await;
+        let base = fixture_marker_object_meta();
+        let bumped = marker_with(
+            base.location.clone(),
+            base.last_modified + chrono::Duration::seconds(1),
+            base.size,
+        );
+
+        let first = get_or_open_atlas(store.clone(), &base)
+            .await
+            .expect("first open");
+        let second = get_or_open_atlas(store, &bumped)
+            .await
+            .expect("second open");
+
+        assert!(
+            !Arc::ptr_eq(&first, &second),
+            "bumped last_modified must invalidate the cache",
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_reopens_when_size_changes() {
+        ensure_fixture().await;
+        let store = test_store().await;
+        let base = fixture_marker_object_meta();
+        let bumped = marker_with(base.location.clone(), base.last_modified, base.size + 1);
+
+        let first = get_or_open_atlas(store.clone(), &base)
+            .await
+            .expect("first open");
+        let second = get_or_open_atlas(store, &bumped)
+            .await
+            .expect("second open");
+
+        assert!(
+            !Arc::ptr_eq(&first, &second),
+            "bumped size must invalidate the cache",
+        );
+    }
+}

--- a/beacon-arrow-atlas/src/datafusion/mod.rs
+++ b/beacon-arrow-atlas/src/datafusion/mod.rs
@@ -255,36 +255,17 @@ impl FileFormat for AtlasFormat {
         for marker in markers {
             let atlas =
                 open_atlas_store(self.datasets_object_store.clone(), &marker.location).await?;
+            let read_dimensions = self.options.read_dimensions.as_deref();
             for dataset_name in atlas.list_datasets() {
-                let dataset =
-                    crate::reader::dataset_from_atlas(atlas.clone(), &dataset_name)
-                        .await
-                        .map_err(|e| {
-                            exec_datafusion_err!(
-                                "Failed to derive schema for atlas dataset '{}' at {}: {}",
-                                dataset_name,
-                                marker.location,
-                                e
-                            )
-                        })?;
-                // Honor the dimension filter so the inferred schema only contains
-                // arrays whose dimensions match the user's `read_dimensions` selection.
-                let dataset = if let Some(dims) = self.options.read_dimensions.clone() {
-                    let proj = beacon_nd_array::projection::DatasetProjection {
-                        dimension_projection: Some(dims),
-                        index_projection: None,
-                    };
-                    dataset.project(&proj).map_err(|e| {
-                        exec_datafusion_err!(
-                            "Failed to apply dimension projection to atlas dataset '{}': {}",
-                            dataset_name,
-                            e
-                        )
-                    })?
-                } else {
-                    dataset
-                };
-                let schema = beacon_nd_array::arrow::schema::any_dataset_to_arrow_schema(&dataset)
+                let view = atlas.open_dataset(&dataset_name).await.map_err(|e| {
+                    exec_datafusion_err!(
+                        "Failed to open atlas dataset '{}' at {}: {}",
+                        dataset_name,
+                        marker.location,
+                        e
+                    )
+                })?;
+                let schema = crate::compat::atlas_view_arrow_schema(&view, read_dimensions)
                     .map_err(|e| {
                         exec_datafusion_err!(
                             "Failed to derive Arrow schema for atlas dataset '{}': {}",

--- a/beacon-arrow-atlas/src/datafusion/mod.rs
+++ b/beacon-arrow-atlas/src/datafusion/mod.rs
@@ -23,7 +23,7 @@ use object_store::{ObjectMeta, ObjectStore};
 use crate::datafusion::{
     options::AtlasOptions,
     reader::open_atlas_store,
-    source::{AtlasFileInfo, AtlasSource},
+    source::{AtlasSource, AtlasStreamDatasets},
 };
 
 pub mod options;

--- a/beacon-arrow-atlas/src/datafusion/mod.rs
+++ b/beacon-arrow-atlas/src/datafusion/mod.rs
@@ -267,6 +267,23 @@ impl FileFormat for AtlasFormat {
                                 e
                             )
                         })?;
+                // Honor the dimension filter so the inferred schema only contains
+                // arrays whose dimensions match the user's `read_dimensions` selection.
+                let dataset = if let Some(dims) = self.options.read_dimensions.clone() {
+                    let proj = beacon_nd_array::projection::DatasetProjection {
+                        dimension_projection: Some(dims),
+                        index_projection: None,
+                    };
+                    dataset.project(&proj).map_err(|e| {
+                        exec_datafusion_err!(
+                            "Failed to apply dimension projection to atlas dataset '{}': {}",
+                            dataset_name,
+                            e
+                        )
+                    })?
+                } else {
+                    dataset
+                };
                 let schema = beacon_nd_array::arrow::schema::any_dataset_to_arrow_schema(&dataset)
                     .map_err(|e| {
                         exec_datafusion_err!(
@@ -336,7 +353,10 @@ impl FileFormat for AtlasFormat {
             }
         }
 
-        let source = AtlasSource::new(self.datasets_object_store.clone());
+        let source = AtlasSource::new(
+            self.datasets_object_store.clone(),
+            self.options.read_dimensions.clone(),
+        );
         let conf = FileScanConfigBuilder::from(conf)
             .with_file_groups(new_groups)
             .with_source(Arc::new(source))
@@ -357,7 +377,10 @@ impl FileFormat for AtlasFormat {
     }
 
     fn file_source(&self) -> Arc<dyn FileSource> {
-        Arc::new(AtlasSource::new(self.datasets_object_store.clone()))
+        Arc::new(AtlasSource::new(
+            self.datasets_object_store.clone(),
+            self.options.read_dimensions.clone(),
+        ))
     }
 }
 

--- a/beacon-arrow-atlas/src/datafusion/mod.rs
+++ b/beacon-arrow-atlas/src/datafusion/mod.rs
@@ -11,7 +11,9 @@ use datafusion::{
     datasource::{
         file_format::{FileFormat, FileFormatFactory, file_compression_type::FileCompressionType},
         listing::PartitionedFile,
-        physical_plan::{FileGroup, FileScanConfig, FileScanConfigBuilder, FileSinkConfig, FileSource},
+        physical_plan::{
+            FileGroup, FileScanConfig, FileScanConfigBuilder, FileSinkConfig, FileSource,
+        },
     },
     physical_expr::LexRequirement,
     physical_plan::ExecutionPlan,
@@ -282,7 +284,10 @@ impl FileFormat for AtlasFormat {
         }
 
         let schema = super_type_schema(&schemas).map_err(|e| {
-            exec_datafusion_err!("Failed to compute super type schema for atlas datasets: {}", e)
+            exec_datafusion_err!(
+                "Failed to compute super type schema for atlas datasets: {}",
+                e
+            )
         })?;
         Ok(Arc::new(schema))
     }
@@ -302,44 +307,11 @@ impl FileFormat for AtlasFormat {
         _state: &dyn Session,
         conf: FileScanConfig,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        // Rebuild file_groups: explode each atlas.json marker into one
-        // PartitionedFile per atlas dataset, carrying the dataset name in
-        // `extensions`.
-        let mut object_metas: Vec<ObjectMeta> = Vec::new();
-        for group in &conf.file_groups {
-            for file in group.files() {
-                object_metas.push(file.object_meta.clone());
-            }
-        }
-        let markers = top_level_atlas_markers(&object_metas);
-
-        let mut new_groups: Vec<FileGroup> = Vec::new();
-        for marker in markers {
-            let atlas =
-                open_atlas_store(self.datasets_object_store.clone(), &marker.location).await?;
-            let mut files = Vec::new();
-            for dataset_name in atlas.list_datasets() {
-                let pf = PartitionedFile {
-                    object_meta: marker.clone(),
-                    partition_values: vec![],
-                    range: None,
-                    statistics: None,
-                    extensions: Some(Arc::new(AtlasFileInfo { dataset_name })),
-                    metadata_size_hint: None,
-                };
-                files.push(pf);
-            }
-            if !files.is_empty() {
-                new_groups.push(FileGroup::new(files));
-            }
-        }
-
         let source = AtlasSource::new(
             self.datasets_object_store.clone(),
             self.options.read_dimensions.clone(),
         );
         let conf = FileScanConfigBuilder::from(conf)
-            .with_file_groups(new_groups)
             .with_source(Arc::new(source))
             .build();
         Ok(DataSourceExec::from_data_source(conf))
@@ -534,14 +506,21 @@ mod tests {
         let ctx = SessionContext::new();
 
         let schema = format
-            .infer_schema(&ctx.state(), &dummy_object_store(), &[fixture_marker_object_meta()])
+            .infer_schema(
+                &ctx.state(),
+                &dummy_object_store(),
+                &[fixture_marker_object_meta()],
+            )
             .await
             .expect("infer");
 
         let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
         // Winter has cycle, season, temperature, year; summer has season, temperature.
         // The super-typed schema should include all of them.
-        assert!(names.contains(&"temperature"), "missing temperature in {names:?}");
+        assert!(
+            names.contains(&"temperature"),
+            "missing temperature in {names:?}"
+        );
         assert!(names.contains(&"cycle"), "missing cycle in {names:?}");
         assert!(names.contains(&"season"), "missing season in {names:?}");
         assert!(names.contains(&"year"), "missing year in {names:?}");
@@ -574,13 +553,13 @@ mod tests {
         let store = test_store().await;
         let format = AtlasFormat::new(store, AtlasOptions::default());
         let ctx = SessionContext::new();
-        let empty_schema: arrow::datatypes::SchemaRef =
-            Arc::new(arrow::datatypes::Schema::empty());
+        let empty_schema: arrow::datatypes::SchemaRef = Arc::new(arrow::datatypes::Schema::empty());
         let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(empty_schema.clone()));
 
         let conf = FileSinkConfig {
             original_url: String::new(),
-            object_store_url: datafusion::execution::object_store::ObjectStoreUrl::local_filesystem(),
+            object_store_url: datafusion::execution::object_store::ObjectStoreUrl::local_filesystem(
+            ),
             table_paths: vec![],
             file_group: FileGroup::new(vec![]),
             output_schema: empty_schema,

--- a/beacon-arrow-atlas/src/datafusion/mod.rs
+++ b/beacon-arrow-atlas/src/datafusion/mod.rs
@@ -22,16 +22,70 @@ use object_store::{ObjectMeta, ObjectStore};
 
 use crate::datafusion::{
     options::AtlasOptions,
-    reader::open_atlas_store,
     source::{AtlasSource, AtlasStreamDatasets},
 };
 
+pub mod cache;
 pub mod options;
+pub mod pushdown;
 pub mod reader;
 pub mod source;
 
-/// The extension used for atlas store marker files.
+/// Canonical marker filename used as the format identifier with
+/// DataFusion. Kept stable across atlas versions so the registered
+/// `FileFormat` lookup key doesn't churn even though the on-disk
+/// filename may be any of [`ATLAS_MARKER_NAMES`].
 const ATLAS_MARKER: &str = "atlas.json";
+
+/// All marker filenames atlas 0.8.0 may emit at the root of a store.
+/// Order matches atlas's own `META_VARIANTS` — uncompressed first within
+/// each format, JSON before MsgPack overall — so when multiple are
+/// present the priority tie-break mirrors atlas.
+const ATLAS_MARKER_NAMES: [&str; 6] = [
+    "atlas.json",
+    "atlas.json.zst",
+    "atlas.json.lz4",
+    "atlas.msgpack",
+    "atlas.msgpack.zst",
+    "atlas.msgpack.lz4",
+];
+
+#[derive(Copy, Clone)]
+enum MetaFormat {
+    Json,
+    MsgPack,
+}
+
+#[derive(Copy, Clone)]
+enum Codec {
+    None,
+    Zstd,
+    Lz4,
+}
+
+/// Map a marker filename to its `(format, compression)` encoding.
+fn atlas_marker_encoding(filename: &str) -> Option<(MetaFormat, Codec)> {
+    match filename {
+        "atlas.json" => Some((MetaFormat::Json, Codec::None)),
+        "atlas.json.zst" => Some((MetaFormat::Json, Codec::Zstd)),
+        "atlas.json.lz4" => Some((MetaFormat::Json, Codec::Lz4)),
+        "atlas.msgpack" => Some((MetaFormat::MsgPack, Codec::None)),
+        "atlas.msgpack.zst" => Some((MetaFormat::MsgPack, Codec::Zstd)),
+        "atlas.msgpack.lz4" => Some((MetaFormat::MsgPack, Codec::Lz4)),
+        _ => None,
+    }
+}
+
+/// If `p` ends in one of the known atlas marker filenames, return that
+/// filename. Used both to recognize markers and to recover the actual
+/// on-disk filename for path manipulation.
+fn atlas_marker_filename(p: &object_store::path::Path) -> Option<&'static str> {
+    let s = p.as_ref();
+    ATLAS_MARKER_NAMES
+        .iter()
+        .copied()
+        .find(|name| s == *name || s.ends_with(&format!("/{name}")))
+}
 
 #[derive(Debug, Clone)]
 pub struct AtlasFormatFactory {
@@ -123,18 +177,20 @@ impl FileFormatFactoryExt for AtlasFormatFactory {
                 }
             };
 
+            let marker_name = atlas_marker_filename(&marker.location)
+                .expect("top_level_atlas_markers only yields recognized markers");
             let store_path = marker
                 .location
                 .as_ref()
-                .strip_suffix(ATLAS_MARKER)
+                .strip_suffix(marker_name)
                 .unwrap_or(marker.location.as_ref())
                 .trim_end_matches('/');
 
             for dataset_name in dataset_names {
                 let file_path = if store_path.is_empty() {
-                    format!("{ATLAS_MARKER}/{dataset_name}")
+                    format!("{marker_name}/{dataset_name}")
                 } else {
-                    format!("{store_path}/{ATLAS_MARKER}/{dataset_name}")
+                    format!("{store_path}/{marker_name}/{dataset_name}")
                 };
                 out.push(DatasetMetadata::new(file_path, ext.clone()));
             }
@@ -148,29 +204,52 @@ impl FileFormatFactoryExt for AtlasFormatFactory {
     }
 }
 
-/// Parse an `atlas.json` file from disk and return the names of the
-/// datasets it registers.
+/// Parse an atlas store metadata file from disk and return the names of
+/// the datasets it registers.
 ///
-/// Atlas's on-disk layout has a stable shape:
-/// `{ "version": <u32>, "codec": ..., "datasets": { "<name>": {...}, ... } }`.
+/// Format and compression are derived from the filename — atlas 0.8.0
+/// encodes both in the on-disk name (`atlas.{json,msgpack}{,.zst,.lz4}`).
 /// We deliberately only read the `datasets` object's keys to stay
 /// compatible across minor schema additions.
 fn read_atlas_dataset_names(local_path: &str) -> anyhow::Result<Vec<String>> {
     let bytes = std::fs::read(local_path)
-        .map_err(|e| anyhow::anyhow!("Failed to read atlas.json at {local_path}: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("Failed to read atlas marker at {local_path}: {e}"))?;
+
+    let filename = std::path::Path::new(local_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| anyhow::anyhow!("Atlas marker path has no filename: {local_path}"))?;
+
+    let (format, codec) = atlas_marker_encoding(filename)
+        .ok_or_else(|| anyhow::anyhow!("Unknown atlas marker filename: {filename}"))?;
+
+    let raw = match codec {
+        Codec::None => bytes,
+        Codec::Zstd => zstd::stream::decode_all(bytes.as_slice())
+            .map_err(|e| anyhow::anyhow!("Failed to zstd-decode {local_path}: {e}"))?,
+        Codec::Lz4 => lz4_flex::decompress_size_prepended(&bytes)
+            .map_err(|e| anyhow::anyhow!("Failed to lz4-decode {local_path}: {e}"))?,
+    };
+
+    // `IgnoredAny` deserializes from any value shape, so this struct
+    // works against both JSON and MsgPack without per-format variants.
     #[derive(serde::Deserialize)]
     struct Doc {
         #[serde(default)]
-        datasets: std::collections::BTreeMap<String, serde_json::Value>,
+        datasets: std::collections::BTreeMap<String, serde::de::IgnoredAny>,
     }
-    let doc: Doc = serde_json::from_slice(&bytes)
-        .map_err(|e| anyhow::anyhow!("Failed to parse atlas.json at {local_path}: {e}"))?;
+
+    let doc: Doc = match format {
+        MetaFormat::Json => serde_json::from_slice(&raw)
+            .map_err(|e| anyhow::anyhow!("Failed to JSON-parse {local_path}: {e}"))?,
+        MetaFormat::MsgPack => rmp_serde::from_slice(&raw)
+            .map_err(|e| anyhow::anyhow!("Failed to MsgPack-parse {local_path}: {e}"))?,
+    };
     Ok(doc.datasets.into_keys().collect())
 }
 
 fn is_atlas_marker(obj: &ObjectMeta) -> bool {
-    let loc = obj.location.to_string();
-    loc == ATLAS_MARKER || loc.ends_with(&format!("/{ATLAS_MARKER}"))
+    atlas_marker_filename(&obj.location).is_some()
 }
 
 /// Filter `objects` down to the unique top-level `atlas.json` files.
@@ -202,8 +281,8 @@ fn top_level_atlas_markers(objects: &[ObjectMeta]) -> Vec<ObjectMeta> {
 
 fn marker_parent(p: &object_store::path::Path) -> Option<String> {
     let s = p.as_ref();
-    s.strip_suffix(ATLAS_MARKER)
-        .map(|s| s.trim_end_matches('/').to_string())
+    let name = atlas_marker_filename(p)?;
+    Some(s.strip_suffix(name)?.trim_end_matches('/').to_string())
 }
 
 #[derive(Debug, Clone)]
@@ -256,7 +335,7 @@ impl FileFormat for AtlasFormat {
         let mut schemas = Vec::new();
         for marker in markers {
             let atlas =
-                open_atlas_store(self.datasets_object_store.clone(), &marker.location).await?;
+                cache::get_or_open_atlas(self.datasets_object_store.clone(), &marker).await?;
             let read_dimensions = self.options.read_dimensions.as_deref();
             for dataset_name in atlas.list_datasets() {
                 let view = atlas.open_dataset(&dataset_name).await.map_err(|e| {
@@ -394,8 +473,10 @@ pub(crate) mod test_support {
 mod tests {
     use super::test_support::{ensure_fixture, fixture_marker_object_meta, test_store};
     use super::*;
+    use beacon_object_storage::get_datasets_object_store;
     use datafusion::prelude::SessionContext;
     use object_store::local::LocalFileSystem;
+    use object_store::path::Path as OsPath;
 
     fn dummy_object_store() -> Arc<dyn ObjectStore> {
         Arc::new(LocalFileSystem::new())
@@ -574,5 +655,260 @@ mod tests {
             .expect_err("writing should be unsupported");
         let msg = format!("{err}");
         assert!(msg.to_lowercase().contains("not"), "{msg}");
+    }
+
+    // ── Atlas 0.8.0 marker variants ────────────────────────────────────
+
+    fn marker_obj(path: &str) -> ObjectMeta {
+        ObjectMeta {
+            location: object_store::path::Path::from(path),
+            last_modified: chrono::Utc::now(),
+            size: 0,
+            e_tag: None,
+            version: None,
+        }
+    }
+
+    #[test]
+    fn is_atlas_marker_matches_all_six_variants() {
+        for name in &ATLAS_MARKER_NAMES {
+            assert!(
+                is_atlas_marker(&marker_obj(name)),
+                "bare {name} should be recognized",
+            );
+            assert!(
+                is_atlas_marker(&marker_obj(&format!("store/{name}"))),
+                "store/{name} should be recognized",
+            );
+            assert!(
+                is_atlas_marker(&marker_obj(&format!("a/b/c/{name}"))),
+                "a/b/c/{name} should be recognized",
+            );
+        }
+
+        // Lookalikes must not match.
+        for negative in [
+            "foo/data.af",
+            "store/atlas.json.tmp",
+            "store/atlas.jsona",
+            "store/atlas.msgpack.bak",
+            "atlas.json/inner",
+        ] {
+            assert!(
+                !is_atlas_marker(&marker_obj(negative)),
+                "{negative} should NOT be recognized",
+            );
+        }
+    }
+
+    #[test]
+    fn marker_parent_strips_each_variant() {
+        for name in &ATLAS_MARKER_NAMES {
+            assert_eq!(
+                marker_parent(&object_store::path::Path::from(format!("store/{name}"))),
+                Some("store".to_string()),
+                "marker_parent should strip {name}",
+            );
+            assert_eq!(
+                marker_parent(&object_store::path::Path::from(*name)),
+                Some(String::new()),
+                "marker_parent of bare {name} is empty",
+            );
+        }
+        assert_eq!(
+            marker_parent(&object_store::path::Path::from("foo.txt")),
+            None,
+            "marker_parent of a non-marker is None",
+        );
+    }
+
+    // ── read_atlas_dataset_names: one test per variant ─────────────────
+
+    /// Atlas's on-disk meta shape, mirrored just well enough to encode
+    /// fixtures. We don't import atlas's own `StoreMeta` because it's
+    /// `pub(crate)`.
+    #[derive(serde::Serialize)]
+    struct FixtureMeta {
+        version: u32,
+        codec: &'static str,
+        datasets: std::collections::BTreeMap<String, FixtureDataset>,
+    }
+
+    #[derive(serde::Serialize, Default)]
+    struct FixtureDataset {
+        arrays: std::collections::BTreeMap<String, serde_json::Value>,
+        attributes: std::collections::BTreeMap<String, serde_json::Value>,
+    }
+
+    fn sample_meta() -> FixtureMeta {
+        let mut datasets = std::collections::BTreeMap::new();
+        datasets.insert("a".to_string(), FixtureDataset::default());
+        datasets.insert("b".to_string(), FixtureDataset::default());
+        FixtureMeta {
+            version: 1,
+            codec: "Zstd",
+            datasets,
+        }
+    }
+
+    fn encode_meta(meta: &FixtureMeta, format: MetaFormat) -> Vec<u8> {
+        match format {
+            MetaFormat::Json => serde_json::to_vec(meta).expect("encode json"),
+            MetaFormat::MsgPack => rmp_serde::to_vec_named(meta).expect("encode msgpack"),
+        }
+    }
+
+    fn compress_meta(bytes: Vec<u8>, codec: Codec) -> Vec<u8> {
+        match codec {
+            Codec::None => bytes,
+            Codec::Zstd => zstd::stream::encode_all(bytes.as_slice(), 0).expect("zstd"),
+            Codec::Lz4 => lz4_flex::compress_prepend_size(&bytes),
+        }
+    }
+
+    fn write_fixture_marker(filename: &str, format: MetaFormat, codec: Codec) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bytes = compress_meta(encode_meta(&sample_meta(), format), codec);
+        std::fs::write(dir.path().join(filename), bytes).expect("write fixture");
+        dir
+    }
+
+    fn assert_dataset_names(dir: &std::path::Path, filename: &str) {
+        let path = dir.join(filename);
+        let names =
+            read_atlas_dataset_names(path.to_str().expect("utf-8 path")).expect("read names");
+        assert_eq!(names, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn read_atlas_dataset_names_json_uncompressed() {
+        let dir = write_fixture_marker("atlas.json", MetaFormat::Json, Codec::None);
+        assert_dataset_names(dir.path(), "atlas.json");
+    }
+
+    #[test]
+    fn read_atlas_dataset_names_json_zstd() {
+        let dir = write_fixture_marker("atlas.json.zst", MetaFormat::Json, Codec::Zstd);
+        assert_dataset_names(dir.path(), "atlas.json.zst");
+    }
+
+    #[test]
+    fn read_atlas_dataset_names_json_lz4() {
+        let dir = write_fixture_marker("atlas.json.lz4", MetaFormat::Json, Codec::Lz4);
+        assert_dataset_names(dir.path(), "atlas.json.lz4");
+    }
+
+    #[test]
+    fn read_atlas_dataset_names_msgpack_uncompressed() {
+        let dir = write_fixture_marker("atlas.msgpack", MetaFormat::MsgPack, Codec::None);
+        assert_dataset_names(dir.path(), "atlas.msgpack");
+    }
+
+    #[test]
+    fn read_atlas_dataset_names_msgpack_zstd() {
+        let dir = write_fixture_marker("atlas.msgpack.zst", MetaFormat::MsgPack, Codec::Zstd);
+        assert_dataset_names(dir.path(), "atlas.msgpack.zst");
+    }
+
+    #[test]
+    fn read_atlas_dataset_names_msgpack_lz4() {
+        let dir = write_fixture_marker("atlas.msgpack.lz4", MetaFormat::MsgPack, Codec::Lz4);
+        assert_dataset_names(dir.path(), "atlas.msgpack.lz4");
+    }
+
+    #[test]
+    fn read_atlas_dataset_names_rejects_unknown_filename() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("not_an_atlas_marker");
+        std::fs::write(&path, b"{}").expect("write");
+        let err =
+            read_atlas_dataset_names(path.to_str().expect("utf-8")).expect_err("should reject");
+        assert!(
+            format!("{err}").contains("Unknown atlas marker filename"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn top_level_markers_dedupes_across_different_formats() {
+        // Outer store uses atlas.json; nested store uses atlas.msgpack.zst.
+        // The nested one must be dropped even though the filenames differ.
+        let objs = vec![
+            marker_obj("a/atlas.json"),
+            marker_obj("a/b/atlas.msgpack.zst"),
+            marker_obj("c/atlas.msgpack"),
+        ];
+        let kept: Vec<String> = top_level_atlas_markers(&objs)
+            .iter()
+            .map(|m| m.location.to_string())
+            .collect();
+        assert!(kept.contains(&"a/atlas.json".to_string()));
+        assert!(kept.contains(&"c/atlas.msgpack".to_string()));
+        assert!(!kept.iter().any(|p| p == "a/b/atlas.msgpack.zst"));
+    }
+
+    // ── End-to-end: discover_datasets against a non-default marker ─────
+
+    const MSGPACK_ZST_FIXTURE_DIR: &str = "beacon-arrow-atlas-tests/two_datasets.msgpack.zst.atlas";
+
+    /// Build the msgpack.zst fixture once per test run.
+    async fn ensure_msgpack_zst_fixture() -> std::path::PathBuf {
+        use crate::reader::test_support::build_two_dataset_store_with_config;
+        use atlas::{Codec as AtlasCodec, MetaFormat as AtlasMetaFormat, StoreConfig};
+
+        static FIXTURE: tokio::sync::OnceCell<std::path::PathBuf> =
+            tokio::sync::OnceCell::const_new();
+        FIXTURE
+            .get_or_init(|| async {
+                let dst = beacon_config::DATASETS_DIR_PATH.join(MSGPACK_ZST_FIXTURE_DIR);
+                let marker = dst.join("atlas.msgpack.zst");
+                if !marker.exists() {
+                    if dst.exists() {
+                        std::fs::remove_dir_all(&dst).expect("cleanup partial fixture");
+                    }
+                    std::fs::create_dir_all(&dst).expect("create fixture dir");
+                    let config = StoreConfig {
+                        meta_format: AtlasMetaFormat::MsgPack,
+                        meta_compression: AtlasCodec::Zstd,
+                        ..Default::default()
+                    };
+                    build_two_dataset_store_with_config(&dst, config).await;
+                }
+                dst
+            })
+            .await
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn discover_datasets_finds_msgpack_zst_store() {
+        ensure_msgpack_zst_fixture().await;
+        let store = get_datasets_object_store().await;
+        let factory = AtlasFormatFactory::new(store, AtlasOptions::default());
+
+        let marker = ObjectMeta {
+            location: OsPath::from(format!("{MSGPACK_ZST_FIXTURE_DIR}/atlas.msgpack.zst")),
+            last_modified: chrono::Utc::now(),
+            size: 0,
+            e_tag: None,
+            version: None,
+        };
+        let datasets = factory.discover_datasets(&[marker]).expect("discover");
+
+        assert_eq!(datasets.len(), 2, "expected 2 datasets, got {datasets:?}");
+        let paths: Vec<&str> = datasets.iter().map(|d| d.file_path.as_str()).collect();
+        // Synthetic paths must preserve the actual on-disk marker name.
+        assert!(
+            paths
+                .iter()
+                .any(|p| p.ends_with("/atlas.msgpack.zst/winter")),
+            "missing winter in {paths:?}",
+        );
+        assert!(
+            paths
+                .iter()
+                .any(|p| p.ends_with("/atlas.msgpack.zst/summer")),
+            "missing summer in {paths:?}",
+        );
     }
 }

--- a/beacon-arrow-atlas/src/datafusion/mod.rs
+++ b/beacon-arrow-atlas/src/datafusion/mod.rs
@@ -1,0 +1,595 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow::datatypes::SchemaRef;
+use beacon_common::super_typing::super_type_schema;
+use beacon_datafusion_ext::format_ext::{DatasetMetadata, FileFormatFactoryExt};
+use beacon_object_storage::DatasetsStore;
+use datafusion::{
+    catalog::{Session, memory::DataSourceExec},
+    common::{GetExt, Statistics, exec_datafusion_err},
+    datasource::{
+        file_format::{FileFormat, FileFormatFactory, file_compression_type::FileCompressionType},
+        listing::PartitionedFile,
+        physical_plan::{FileGroup, FileScanConfig, FileScanConfigBuilder, FileSinkConfig, FileSource},
+    },
+    physical_expr::LexRequirement,
+    physical_plan::ExecutionPlan,
+};
+use object_store::{ObjectMeta, ObjectStore};
+
+use crate::datafusion::{
+    options::AtlasOptions,
+    reader::open_atlas_store,
+    source::{AtlasFileInfo, AtlasSource},
+};
+
+pub mod options;
+pub mod reader;
+pub mod source;
+
+/// The extension used for atlas store marker files.
+const ATLAS_MARKER: &str = "atlas.json";
+
+#[derive(Debug, Clone)]
+pub struct AtlasFormatFactory {
+    pub datasets_object_store: Arc<DatasetsStore>,
+    pub options: AtlasOptions,
+}
+
+impl AtlasFormatFactory {
+    pub fn new(datasets_object_store: Arc<DatasetsStore>, options: AtlasOptions) -> Self {
+        Self {
+            datasets_object_store,
+            options,
+        }
+    }
+}
+
+impl FileFormatFactory for AtlasFormatFactory {
+    fn create(
+        &self,
+        _state: &dyn Session,
+        _format_options: &std::collections::HashMap<String, String>,
+    ) -> datafusion::error::Result<Arc<dyn FileFormat>> {
+        Ok(Arc::new(AtlasFormat::new(
+            self.datasets_object_store.clone(),
+            self.options.clone(),
+        )))
+    }
+
+    fn default(&self) -> Arc<dyn FileFormat> {
+        Arc::new(AtlasFormat::new(
+            self.datasets_object_store.clone(),
+            self.options.clone(),
+        ))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl GetExt for AtlasFormatFactory {
+    fn get_ext(&self) -> String {
+        ATLAS_MARKER.to_string()
+    }
+}
+
+impl FileFormatFactoryExt for AtlasFormatFactory {
+    fn discover_datasets(
+        &self,
+        objects: &[ObjectMeta],
+    ) -> datafusion::error::Result<Vec<DatasetMetadata>> {
+        let markers = top_level_atlas_markers(objects);
+        let ext = self.get_ext();
+        let mut out = Vec::new();
+
+        for marker in markers {
+            // Read atlas.json directly with sync I/O. This is the cheap
+            // shape we want for the catalog scan — we only need the
+            // dataset names, not the full atlas open path (which is async
+            // and would deadlock when discover_datasets is called from
+            // inside a tokio runtime).
+            let local_path = match self
+                .datasets_object_store
+                .translate_netcdf_url_path(&marker.location)
+            {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to translate atlas marker path {}: {e}",
+                        marker.location
+                    );
+                    continue;
+                }
+            };
+
+            if local_path.starts_with("http://") || local_path.starts_with("https://") {
+                tracing::warn!(
+                    "Skipping atlas marker at {} — remote object stores are not yet supported",
+                    marker.location
+                );
+                continue;
+            }
+
+            let dataset_names = match read_atlas_dataset_names(&local_path) {
+                Ok(names) => names,
+                Err(e) => {
+                    tracing::warn!("Failed to read atlas marker at {local_path}: {e}");
+                    continue;
+                }
+            };
+
+            let store_path = marker
+                .location
+                .as_ref()
+                .strip_suffix(ATLAS_MARKER)
+                .unwrap_or(marker.location.as_ref())
+                .trim_end_matches('/');
+
+            for dataset_name in dataset_names {
+                let file_path = if store_path.is_empty() {
+                    format!("{ATLAS_MARKER}/{dataset_name}")
+                } else {
+                    format!("{store_path}/{ATLAS_MARKER}/{dataset_name}")
+                };
+                out.push(DatasetMetadata::new(file_path, ext.clone()));
+            }
+        }
+
+        Ok(out)
+    }
+
+    fn file_format_name(&self) -> String {
+        self.get_ext()
+    }
+}
+
+/// Parse an `atlas.json` file from disk and return the names of the
+/// datasets it registers.
+///
+/// Atlas's on-disk layout has a stable shape:
+/// `{ "version": <u32>, "codec": ..., "datasets": { "<name>": {...}, ... } }`.
+/// We deliberately only read the `datasets` object's keys to stay
+/// compatible across minor schema additions.
+fn read_atlas_dataset_names(local_path: &str) -> anyhow::Result<Vec<String>> {
+    let bytes = std::fs::read(local_path)
+        .map_err(|e| anyhow::anyhow!("Failed to read atlas.json at {local_path}: {e}"))?;
+    #[derive(serde::Deserialize)]
+    struct Doc {
+        #[serde(default)]
+        datasets: std::collections::BTreeMap<String, serde_json::Value>,
+    }
+    let doc: Doc = serde_json::from_slice(&bytes)
+        .map_err(|e| anyhow::anyhow!("Failed to parse atlas.json at {local_path}: {e}"))?;
+    Ok(doc.datasets.into_keys().collect())
+}
+
+fn is_atlas_marker(obj: &ObjectMeta) -> bool {
+    let loc = obj.location.to_string();
+    loc == ATLAS_MARKER || loc.ends_with(&format!("/{ATLAS_MARKER}"))
+}
+
+/// Filter `objects` down to the unique top-level `atlas.json` files.
+///
+/// If two `atlas.json` files appear at different levels of a nested
+/// directory tree we keep only the outermost one (the ancestor) — atlas
+/// stores never contain other atlas stores, so any deeper marker is
+/// spurious. This mirrors zarr's `top_level_zarr_meta_v3`.
+fn top_level_atlas_markers(objects: &[ObjectMeta]) -> Vec<ObjectMeta> {
+    let mut markers: Vec<&ObjectMeta> = objects.iter().filter(|o| is_atlas_marker(o)).collect();
+    markers.sort_by(|a, b| a.location.as_ref().cmp(b.location.as_ref()));
+
+    let mut kept: Vec<ObjectMeta> = Vec::new();
+    'outer: for meta in &markers {
+        let dir = match marker_parent(&meta.location) {
+            Some(p) => p,
+            None => String::new(),
+        };
+        for already in &kept {
+            let already_dir = marker_parent(&already.location).unwrap_or_default();
+            if !already_dir.is_empty() && dir.starts_with(&format!("{already_dir}/")) {
+                continue 'outer;
+            }
+        }
+        kept.push((*meta).clone());
+    }
+    kept
+}
+
+fn marker_parent(p: &object_store::path::Path) -> Option<String> {
+    let s = p.as_ref();
+    s.strip_suffix(ATLAS_MARKER)
+        .map(|s| s.trim_end_matches('/').to_string())
+}
+
+#[derive(Debug, Clone)]
+pub struct AtlasFormat {
+    pub datasets_object_store: Arc<DatasetsStore>,
+    pub options: AtlasOptions,
+}
+
+impl AtlasFormat {
+    pub fn new(datasets_object_store: Arc<DatasetsStore>, options: AtlasOptions) -> Self {
+        Self {
+            datasets_object_store,
+            options,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl FileFormat for AtlasFormat {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn compression_type(&self) -> Option<FileCompressionType> {
+        None
+    }
+
+    fn get_ext(&self) -> String {
+        ATLAS_MARKER.to_string()
+    }
+
+    fn get_ext_with_compression(
+        &self,
+        _file_compression_type: &FileCompressionType,
+    ) -> datafusion::error::Result<String> {
+        Ok(ATLAS_MARKER.to_string())
+    }
+
+    async fn infer_schema(
+        &self,
+        _state: &dyn Session,
+        _store: &Arc<dyn ObjectStore>,
+        objects: &[ObjectMeta],
+    ) -> datafusion::error::Result<SchemaRef> {
+        let markers = top_level_atlas_markers(objects);
+        if markers.is_empty() {
+            return Ok(Arc::new(arrow::datatypes::Schema::empty()));
+        }
+
+        let mut schemas = Vec::new();
+        for marker in markers {
+            let atlas =
+                open_atlas_store(self.datasets_object_store.clone(), &marker.location).await?;
+            for dataset_name in atlas.list_datasets() {
+                let dataset =
+                    crate::reader::dataset_from_atlas(atlas.clone(), &dataset_name)
+                        .await
+                        .map_err(|e| {
+                            exec_datafusion_err!(
+                                "Failed to derive schema for atlas dataset '{}' at {}: {}",
+                                dataset_name,
+                                marker.location,
+                                e
+                            )
+                        })?;
+                let schema = beacon_nd_array::arrow::schema::any_dataset_to_arrow_schema(&dataset)
+                    .map_err(|e| {
+                        exec_datafusion_err!(
+                            "Failed to derive Arrow schema for atlas dataset '{}': {}",
+                            dataset_name,
+                            e
+                        )
+                    })?;
+                schemas.push(Arc::new(schema));
+            }
+        }
+
+        if schemas.is_empty() {
+            return Ok(Arc::new(arrow::datatypes::Schema::empty()));
+        }
+
+        let schema = super_type_schema(&schemas).map_err(|e| {
+            exec_datafusion_err!("Failed to compute super type schema for atlas datasets: {}", e)
+        })?;
+        Ok(Arc::new(schema))
+    }
+
+    async fn infer_stats(
+        &self,
+        _state: &dyn Session,
+        _store: &Arc<dyn ObjectStore>,
+        table_schema: SchemaRef,
+        _object: &ObjectMeta,
+    ) -> datafusion::error::Result<Statistics> {
+        Ok(Statistics::new_unknown(&table_schema))
+    }
+
+    async fn create_physical_plan(
+        &self,
+        _state: &dyn Session,
+        conf: FileScanConfig,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        // Rebuild file_groups: explode each atlas.json marker into one
+        // PartitionedFile per atlas dataset, carrying the dataset name in
+        // `extensions`.
+        let mut object_metas: Vec<ObjectMeta> = Vec::new();
+        for group in &conf.file_groups {
+            for file in group.files() {
+                object_metas.push(file.object_meta.clone());
+            }
+        }
+        let markers = top_level_atlas_markers(&object_metas);
+
+        let mut new_groups: Vec<FileGroup> = Vec::new();
+        for marker in markers {
+            let atlas =
+                open_atlas_store(self.datasets_object_store.clone(), &marker.location).await?;
+            let mut files = Vec::new();
+            for dataset_name in atlas.list_datasets() {
+                let pf = PartitionedFile {
+                    object_meta: marker.clone(),
+                    partition_values: vec![],
+                    range: None,
+                    statistics: None,
+                    extensions: Some(Arc::new(AtlasFileInfo { dataset_name })),
+                    metadata_size_hint: None,
+                };
+                files.push(pf);
+            }
+            if !files.is_empty() {
+                new_groups.push(FileGroup::new(files));
+            }
+        }
+
+        let source = AtlasSource::new(self.datasets_object_store.clone());
+        let conf = FileScanConfigBuilder::from(conf)
+            .with_file_groups(new_groups)
+            .with_source(Arc::new(source))
+            .build();
+        Ok(DataSourceExec::from_data_source(conf))
+    }
+
+    async fn create_writer_physical_plan(
+        &self,
+        _input: Arc<dyn ExecutionPlan>,
+        _state: &dyn Session,
+        _conf: FileSinkConfig,
+        _order_requirements: Option<LexRequirement>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Err(datafusion::error::DataFusionError::NotImplemented(
+            "Writing atlas datasets is not supported".to_string(),
+        ))
+    }
+
+    fn file_source(&self) -> Arc<dyn FileSource> {
+        Arc::new(AtlasSource::new(self.datasets_object_store.clone()))
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    //! Shared helpers for integration tests across the datafusion module.
+
+    use super::ATLAS_MARKER;
+    use crate::reader::test_support::build_two_dataset_store;
+    use beacon_object_storage::{DatasetsStore, get_datasets_object_store};
+    use object_store::{ObjectMeta, path::Path as OsPath};
+    use std::sync::Arc;
+
+    /// Fixture directory under [`beacon_config::DATASETS_DIR_PATH`].
+    pub const FIXTURE_DIR: &str = "beacon-arrow-atlas-tests/two_datasets.atlas";
+
+    /// Ensure the `two_datasets.atlas` fixture exists under the global
+    /// datasets directory. Idempotent and race-free across concurrent
+    /// `#[tokio::test]` invocations.
+    pub async fn ensure_fixture() -> std::path::PathBuf {
+        static FIXTURE: tokio::sync::OnceCell<std::path::PathBuf> =
+            tokio::sync::OnceCell::const_new();
+        FIXTURE
+            .get_or_init(|| async {
+                let dst = beacon_config::DATASETS_DIR_PATH.join(FIXTURE_DIR);
+                let marker = dst.join(ATLAS_MARKER);
+                if !marker.exists() {
+                    if dst.exists() {
+                        std::fs::remove_dir_all(&dst).expect("cleanup partial fixture");
+                    }
+                    std::fs::create_dir_all(&dst).expect("create fixture dir");
+                    build_two_dataset_store(&dst).await;
+                }
+                dst
+            })
+            .await
+            .clone()
+    }
+
+    pub async fn test_store() -> Arc<DatasetsStore> {
+        ensure_fixture().await;
+        get_datasets_object_store().await
+    }
+
+    /// `ObjectMeta` for the fixture's `atlas.json` marker.
+    pub fn fixture_marker_object_meta() -> ObjectMeta {
+        ObjectMeta {
+            location: OsPath::from(format!("{FIXTURE_DIR}/{ATLAS_MARKER}")),
+            last_modified: chrono::Utc::now(),
+            size: 0,
+            e_tag: None,
+            version: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::{ensure_fixture, fixture_marker_object_meta, test_store};
+    use super::*;
+    use datafusion::prelude::SessionContext;
+    use object_store::local::LocalFileSystem;
+
+    fn dummy_object_store() -> Arc<dyn ObjectStore> {
+        Arc::new(LocalFileSystem::new())
+    }
+
+    // ── is_atlas_marker / top_level_atlas_markers ──────────────────────
+
+    #[test]
+    fn is_atlas_marker_matches_only_marker_file() {
+        let yes = ObjectMeta {
+            location: object_store::path::Path::from("foo/atlas.json"),
+            last_modified: chrono::Utc::now(),
+            size: 0,
+            e_tag: None,
+            version: None,
+        };
+        let no = ObjectMeta {
+            location: object_store::path::Path::from("foo/data.af"),
+            last_modified: chrono::Utc::now(),
+            size: 0,
+            e_tag: None,
+            version: None,
+        };
+        assert!(is_atlas_marker(&yes));
+        assert!(!is_atlas_marker(&no));
+    }
+
+    #[test]
+    fn top_level_markers_drops_nested_stores() {
+        let objs = vec![
+            ObjectMeta {
+                location: object_store::path::Path::from("a/atlas.json"),
+                last_modified: chrono::Utc::now(),
+                size: 0,
+                e_tag: None,
+                version: None,
+            },
+            ObjectMeta {
+                location: object_store::path::Path::from("a/b/atlas.json"),
+                last_modified: chrono::Utc::now(),
+                size: 0,
+                e_tag: None,
+                version: None,
+            },
+            ObjectMeta {
+                location: object_store::path::Path::from("c/atlas.json"),
+                last_modified: chrono::Utc::now(),
+                size: 0,
+                e_tag: None,
+                version: None,
+            },
+        ];
+        let kept = top_level_atlas_markers(&objs);
+        let kept_paths: Vec<String> = kept.iter().map(|m| m.location.to_string()).collect();
+        assert!(kept_paths.contains(&"a/atlas.json".to_string()));
+        assert!(kept_paths.contains(&"c/atlas.json".to_string()));
+        assert!(!kept_paths.iter().any(|p| p == "a/b/atlas.json"));
+    }
+
+    // ── AtlasFormatFactory ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn factory_get_ext_returns_atlas_json() {
+        let store = test_store().await;
+        let factory = AtlasFormatFactory::new(store, AtlasOptions::default());
+        assert_eq!(factory.get_ext(), "atlas.json");
+        assert_eq!(factory.file_format_name(), "atlas.json");
+    }
+
+    #[tokio::test]
+    async fn discover_datasets_emits_one_entry_per_atlas_dataset() {
+        let store = test_store().await;
+        let factory = AtlasFormatFactory::new(store, AtlasOptions::default());
+
+        let objects = vec![fixture_marker_object_meta()];
+        let datasets = factory.discover_datasets(&objects).expect("discover");
+
+        assert_eq!(datasets.len(), 2, "expected 2 datasets, got {datasets:?}");
+        let paths: Vec<&str> = datasets.iter().map(|d| d.file_path.as_str()).collect();
+        assert!(paths.iter().any(|p| p.ends_with("/atlas.json/winter")));
+        assert!(paths.iter().any(|p| p.ends_with("/atlas.json/summer")));
+        for ds in &datasets {
+            assert_eq!(ds.format, "atlas.json");
+        }
+    }
+
+    #[tokio::test]
+    async fn discover_datasets_ignores_non_marker_objects() {
+        let store = test_store().await;
+        let factory = AtlasFormatFactory::new(store, AtlasOptions::default());
+        let objects = vec![ObjectMeta {
+            location: object_store::path::Path::from("some/other.nc"),
+            last_modified: chrono::Utc::now(),
+            size: 0,
+            e_tag: None,
+            version: None,
+        }];
+        let datasets = factory.discover_datasets(&objects).expect("discover");
+        assert!(datasets.is_empty());
+    }
+
+    // ── AtlasFormat ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn infer_schema_unions_columns_across_datasets() {
+        let store = test_store().await;
+        let format = AtlasFormat::new(store, AtlasOptions::default());
+        let ctx = SessionContext::new();
+
+        let schema = format
+            .infer_schema(&ctx.state(), &dummy_object_store(), &[fixture_marker_object_meta()])
+            .await
+            .expect("infer");
+
+        let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        // Winter has cycle, season, temperature, year; summer has season, temperature.
+        // The super-typed schema should include all of them.
+        assert!(names.contains(&"temperature"), "missing temperature in {names:?}");
+        assert!(names.contains(&"cycle"), "missing cycle in {names:?}");
+        assert!(names.contains(&"season"), "missing season in {names:?}");
+        assert!(names.contains(&"year"), "missing year in {names:?}");
+    }
+
+    #[tokio::test]
+    async fn infer_schema_empty_objects_returns_empty_schema() {
+        let store = test_store().await;
+        let format = AtlasFormat::new(store, AtlasOptions::default());
+        let ctx = SessionContext::new();
+
+        let schema = format
+            .infer_schema(&ctx.state(), &dummy_object_store(), &[])
+            .await
+            .expect("infer");
+        assert!(schema.fields().is_empty());
+    }
+
+    #[tokio::test]
+    async fn file_source_returns_atlas_type() {
+        let store = test_store().await;
+        ensure_fixture().await;
+        let format = AtlasFormat::new(store, AtlasOptions::default());
+        assert_eq!(format.file_source().file_type(), "atlas");
+    }
+
+    #[tokio::test]
+    async fn writer_path_not_implemented() {
+        use datafusion::physical_plan::empty::EmptyExec;
+        let store = test_store().await;
+        let format = AtlasFormat::new(store, AtlasOptions::default());
+        let ctx = SessionContext::new();
+        let empty_schema: arrow::datatypes::SchemaRef =
+            Arc::new(arrow::datatypes::Schema::empty());
+        let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(empty_schema.clone()));
+
+        let conf = FileSinkConfig {
+            original_url: String::new(),
+            object_store_url: datafusion::execution::object_store::ObjectStoreUrl::local_filesystem(),
+            table_paths: vec![],
+            file_group: FileGroup::new(vec![]),
+            output_schema: empty_schema,
+            table_partition_cols: vec![],
+            insert_op: datafusion::logical_expr::dml::InsertOp::Append,
+            keep_partition_by_columns: false,
+            file_extension: "atlas.json".to_string(),
+        };
+        let err = format
+            .create_writer_physical_plan(input, &ctx.state(), conf, None)
+            .await
+            .expect_err("writing should be unsupported");
+        let msg = format!("{err}");
+        assert!(msg.to_lowercase().contains("not"), "{msg}");
+    }
+}

--- a/beacon-arrow-atlas/src/datafusion/options.rs
+++ b/beacon-arrow-atlas/src/datafusion/options.rs
@@ -1,0 +1,6 @@
+/// Configuration options for the atlas file format in DataFusion queries.
+///
+/// Reserved for future expansion. The current read path has no tunables
+/// (atlas already maintains its own internal array-file cache).
+#[derive(Debug, Default, Clone)]
+pub struct AtlasOptions {}

--- a/beacon-arrow-atlas/src/datafusion/options.rs
+++ b/beacon-arrow-atlas/src/datafusion/options.rs
@@ -1,6 +1,10 @@
 /// Configuration options for the atlas file format in DataFusion queries.
-///
-/// Reserved for future expansion. The current read path has no tunables
-/// (atlas already maintains its own internal array-file cache).
 #[derive(Debug, Default, Clone)]
-pub struct AtlasOptions {}
+pub struct AtlasOptions {
+    /// Optional list of dimension names used to filter which arrays are read.
+    ///
+    /// When `Some`, only arrays whose dimensions match the listed dimensions
+    /// are kept (applied via [`beacon_nd_array::projection::DatasetProjection`]).
+    /// When `None` (default), all arrays are read.
+    pub read_dimensions: Option<Vec<String>>,
+}

--- a/beacon-arrow-atlas/src/datafusion/pushdown.rs
+++ b/beacon-arrow-atlas/src/datafusion/pushdown.rs
@@ -1,0 +1,341 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, BooleanArray, UInt64Array};
+use arrow::datatypes::{DataType, SchemaRef};
+use atlas::{Atlas, Attr, StatValue};
+use datafusion::common::Column;
+use datafusion::common::pruning::PruningStatistics;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::utils::collect_columns;
+use datafusion::physical_optimizer::pruning::PruningPredicate;
+use datafusion::scalar::ScalarValue;
+
+/// Prune atlas datasets whose statistics cannot satisfy `predicate`.
+///
+/// Walks every dataset in `store`, gathers per-column statistics
+/// (`view.array_stats` for array variables; the attribute value itself for
+/// metadata attributes, which are scalars), and runs them through
+/// DataFusion's [`PruningPredicate`] to drop datasets that cannot match.
+///
+/// On any error path that prevents pruning — predicate unsupported,
+/// schema derivation failure on an individual dataset, etc. — the
+/// function falls back to keeping all datasets so callers never lose
+/// rows due to a pruning hiccup.
+pub async fn pushdown_with_statistics(
+    store: Arc<Atlas>,
+    predicate: Arc<dyn PhysicalExpr>,
+    table_schema: SchemaRef,
+) -> datafusion::error::Result<Vec<String>> {
+    let dataset_names = store.list_datasets();
+    if dataset_names.is_empty() {
+        return Ok(dataset_names);
+    }
+
+    let mut views = Vec::with_capacity(dataset_names.len());
+    for name in &dataset_names {
+        let view = store.open_dataset(name).await.map_err(|e| {
+            datafusion::error::DataFusionError::Execution(format!(
+                "Failed to open atlas dataset '{name}' for pruning: {e}"
+            ))
+        })?;
+        views.push(view);
+    }
+
+    let pruning_predicate = match PruningPredicate::try_new(predicate, table_schema.clone()) {
+        Ok(p) => p,
+        Err(_) => return Ok(dataset_names),
+    };
+
+    let referenced = collect_columns(pruning_predicate.orig_expr());
+
+    let mut columns: HashMap<String, ColumnPackedStats> = HashMap::new();
+    for col in &referenced {
+        let col_name = col.name();
+        let Ok(field) = table_schema.field_with_name(col_name) else {
+            continue;
+        };
+        let target_dtype = field.data_type().clone();
+        let null_scalar = ScalarValue::try_from(&target_dtype).unwrap_or(ScalarValue::Null);
+
+        let mut mins: Vec<ScalarValue> = Vec::with_capacity(views.len());
+        let mut maxes: Vec<ScalarValue> = Vec::with_capacity(views.len());
+        let mut null_counts: Vec<Option<u64>> = Vec::with_capacity(views.len());
+        let mut row_counts: Vec<Option<u64>> = Vec::with_capacity(views.len());
+
+        for view in &views {
+            let meta = view.meta();
+            if meta.arrays.contains_key(col_name) {
+                match view.array_stats(col_name).await {
+                    Some(stats) => {
+                        mins.push(stat_value_to_scalar(
+                            stats.min.as_ref(),
+                            &target_dtype,
+                            &null_scalar,
+                        ));
+                        maxes.push(stat_value_to_scalar(
+                            stats.max.as_ref(),
+                            &target_dtype,
+                            &null_scalar,
+                        ));
+                        null_counts.push(Some(stats.null_count));
+                        row_counts.push(Some(stats.row_count));
+                    }
+                    None => {
+                        // Stats not computed (e.g. unflushed write). Treat
+                        // as "unknown" so the predicate cannot prune this
+                        // dataset on this column.
+                        mins.push(null_scalar.clone());
+                        maxes.push(null_scalar.clone());
+                        null_counts.push(None);
+                        row_counts.push(None);
+                    }
+                }
+            } else if let Some(attr) = meta.attributes.get(col_name) {
+                let scalar = attr_to_scalar(attr, &target_dtype, &null_scalar);
+                mins.push(scalar.clone());
+                maxes.push(scalar);
+                null_counts.push(Some(0));
+                row_counts.push(Some(1));
+            } else {
+                // Column is absent from this dataset — at read time the
+                // SchemaAdapter fills it with NULLs, so the dataset's
+                // contribution for this column really is "all null".
+                mins.push(null_scalar.clone());
+                maxes.push(null_scalar.clone());
+                null_counts.push(Some(1));
+                row_counts.push(Some(1));
+            }
+        }
+
+        let Ok(min_arr) = ScalarValue::iter_to_array(mins) else {
+            continue;
+        };
+        let Ok(max_arr) = ScalarValue::iter_to_array(maxes) else {
+            continue;
+        };
+        let null_arr: ArrayRef = Arc::new(UInt64Array::from(null_counts));
+        let row_arr: ArrayRef = Arc::new(UInt64Array::from(row_counts));
+
+        columns.insert(
+            col_name.to_string(),
+            ColumnPackedStats {
+                min: min_arr,
+                max: max_arr,
+                null_count: null_arr,
+                row_count: row_arr,
+            },
+        );
+    }
+
+    let pruning_stats = AtlasDatasetPruningStatistics {
+        num_datasets: views.len(),
+        columns,
+    };
+    let mask = pruning_predicate.prune(&pruning_stats).map_err(|e| {
+        datafusion::error::DataFusionError::Execution(format!(
+            "Failed to prune atlas datasets: {e}"
+        ))
+    })?;
+
+    Ok(dataset_names
+        .into_iter()
+        .zip(mask)
+        .filter_map(|(name, keep)| keep.then_some(name))
+        .collect())
+}
+
+struct ColumnPackedStats {
+    min: ArrayRef,
+    max: ArrayRef,
+    null_count: ArrayRef,
+    row_count: ArrayRef,
+}
+
+struct AtlasDatasetPruningStatistics {
+    num_datasets: usize,
+    columns: HashMap<String, ColumnPackedStats>,
+}
+
+impl PruningStatistics for AtlasDatasetPruningStatistics {
+    fn min_values(&self, column: &Column) -> Option<ArrayRef> {
+        self.columns.get(column.name()).map(|c| c.min.clone())
+    }
+
+    fn max_values(&self, column: &Column) -> Option<ArrayRef> {
+        self.columns.get(column.name()).map(|c| c.max.clone())
+    }
+
+    fn null_counts(&self, column: &Column) -> Option<ArrayRef> {
+        self.columns
+            .get(column.name())
+            .map(|c| c.null_count.clone())
+    }
+
+    fn row_counts(&self, column: &Column) -> Option<ArrayRef> {
+        self.columns.get(column.name()).map(|c| c.row_count.clone())
+    }
+
+    fn num_containers(&self) -> usize {
+        self.num_datasets
+    }
+
+    fn contained(
+        &self,
+        _column: &Column,
+        _values: &std::collections::HashSet<ScalarValue>,
+    ) -> Option<BooleanArray> {
+        None
+    }
+}
+
+/// Convert an `atlas::StatValue` into a `ScalarValue` of `target` type.
+///
+/// Goes through a canonical wide form (`Int64`/`UInt64`/`Float64`/
+/// `Utf8`/`Binary`/`TimestampNanosecond`) and then casts to the target.
+/// Returns `null_scalar` on any conversion failure.
+fn stat_value_to_scalar(
+    value: Option<&StatValue>,
+    target: &DataType,
+    null_scalar: &ScalarValue,
+) -> ScalarValue {
+    let canonical = match value {
+        Some(StatValue::Int(x)) => ScalarValue::Int64(Some(*x)),
+        Some(StatValue::UInt(x)) => ScalarValue::UInt64(Some(*x)),
+        Some(StatValue::Float(x)) => ScalarValue::Float64(Some(*x)),
+        Some(StatValue::Bytes(b)) => match std::str::from_utf8(b) {
+            Ok(s) => ScalarValue::Utf8(Some(s.to_string())),
+            Err(_) => ScalarValue::Binary(Some(b.clone())),
+        },
+        Some(StatValue::TimestampNs(x)) => ScalarValue::TimestampNanosecond(Some(*x), None),
+        None => return null_scalar.clone(),
+    };
+    canonical
+        .cast_to(target)
+        .unwrap_or_else(|_| null_scalar.clone())
+}
+
+/// Convert an `atlas::Attr` into a `ScalarValue` of `target` type.
+fn attr_to_scalar(attr: &Attr, target: &DataType, null_scalar: &ScalarValue) -> ScalarValue {
+    let canonical = match attr {
+        Attr::Bool(v) => ScalarValue::Boolean(Some(*v)),
+        Attr::Int64(v) => ScalarValue::Int64(Some(*v)),
+        Attr::Float64(v) => ScalarValue::Float64(Some(*v)),
+        Attr::String(v) => ScalarValue::Utf8(Some(v.clone())),
+        Attr::TimestampNanoseconds(v) => ScalarValue::TimestampNanosecond(Some(*v), None),
+    };
+    canonical
+        .cast_to(target)
+        .unwrap_or_else(|_| null_scalar.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compat::atlas_view_arrow_schema;
+    use crate::datafusion::cache::get_or_open_atlas;
+    use crate::datafusion::test_support::{fixture_marker_object_meta, test_store};
+    use beacon_common::super_typing::super_type_schema;
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_expr::expressions::{self, BinaryExpr};
+    use datafusion::scalar::ScalarValue;
+
+    async fn fixture_atlas() -> (Arc<Atlas>, SchemaRef) {
+        let store = test_store().await;
+        let marker = fixture_marker_object_meta();
+        let atlas = get_or_open_atlas(store, &marker).await.expect("open atlas");
+
+        let names = atlas.list_datasets();
+        let mut schemas = Vec::with_capacity(names.len());
+        for name in &names {
+            let view = atlas.open_dataset(name).await.expect("open ds");
+            schemas.push(Arc::new(
+                atlas_view_arrow_schema(&view, None).expect("schema"),
+            ));
+        }
+        let table_schema: SchemaRef =
+            Arc::new(super_type_schema(&schemas).expect("super type schema"));
+        (atlas, table_schema)
+    }
+
+    fn binary(
+        left: Arc<dyn PhysicalExpr>,
+        op: Operator,
+        right: Arc<dyn PhysicalExpr>,
+    ) -> Arc<dyn PhysicalExpr> {
+        Arc::new(BinaryExpr::new(left, op, right))
+    }
+
+    #[tokio::test]
+    async fn prune_drops_dataset_when_array_range_excludes_predicate() {
+        let (atlas, schema) = fixture_atlas().await;
+        // winter.temperature ∈ [1, 4], summer.temperature ∈ [20, 22]
+        let col = expressions::col("temperature", &schema).expect("col");
+        let lit = expressions::lit(ScalarValue::Float32(Some(10.0)));
+        let predicate = binary(col, Operator::Gt, lit);
+
+        let kept = pushdown_with_statistics(atlas, predicate, schema)
+            .await
+            .expect("prune");
+        assert_eq!(kept, vec!["summer".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn prune_uses_attribute_value_for_metadata_columns() {
+        let (atlas, schema) = fixture_atlas().await;
+        let col = expressions::col("season", &schema).expect("col");
+        let lit = expressions::lit(ScalarValue::Utf8(Some("winter".into())));
+        let predicate = binary(col, Operator::Eq, lit);
+
+        let kept = pushdown_with_statistics(atlas, predicate, schema)
+            .await
+            .expect("prune");
+        assert_eq!(kept, vec!["winter".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn prune_treats_missing_column_as_all_null() {
+        // `cycle` exists in winter (values 10..40) but not in summer.
+        // Predicate `cycle = 1` excludes winter (range [10,40] doesn't
+        // contain 1) and excludes summer (all-null can't equal 1).
+        let (atlas, schema) = fixture_atlas().await;
+        let col = expressions::col("cycle", &schema).expect("col");
+        let lit = expressions::lit(ScalarValue::Int32(Some(1)));
+        let predicate = binary(col, Operator::Eq, lit);
+
+        let kept = pushdown_with_statistics(atlas, predicate, schema)
+            .await
+            .expect("prune");
+        assert!(kept.is_empty(), "expected both pruned, got {kept:?}");
+    }
+
+    #[tokio::test]
+    async fn prune_keeps_dataset_when_missing_only_in_one() {
+        // Predicate `cycle = 20` keeps winter ([10,40] could contain 20)
+        // and prunes summer (no cycle column).
+        let (atlas, schema) = fixture_atlas().await;
+        let col = expressions::col("cycle", &schema).expect("col");
+        let lit = expressions::lit(ScalarValue::Int32(Some(20)));
+        let predicate = binary(col, Operator::Eq, lit);
+
+        let kept = pushdown_with_statistics(atlas, predicate, schema)
+            .await
+            .expect("prune");
+        assert_eq!(kept, vec!["winter".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn prune_returns_all_when_no_datasets_match_or_predicate_trivial() {
+        // `temperature >= -1000` keeps everything.
+        let (atlas, schema) = fixture_atlas().await;
+        let col = expressions::col("temperature", &schema).expect("col");
+        let lit = expressions::lit(ScalarValue::Float32(Some(-1000.0)));
+        let predicate = binary(col, Operator::GtEq, lit);
+
+        let mut kept = pushdown_with_statistics(atlas, predicate, schema)
+            .await
+            .expect("prune");
+        kept.sort();
+        assert_eq!(kept, vec!["summer".to_string(), "winter".to_string()]);
+    }
+}

--- a/beacon-arrow-atlas/src/datafusion/reader.rs
+++ b/beacon-arrow-atlas/src/datafusion/reader.rs
@@ -1,0 +1,56 @@
+//! Helpers for opening atlas stores from beacon-managed object paths.
+
+use std::sync::Arc;
+
+use atlas::Atlas;
+use beacon_object_storage::DatasetsStore;
+use object_store::path::Path as OsPath;
+
+/// Resolve the parent directory of an `atlas.json` object path to a
+/// local filesystem path suitable for [`Atlas::open_path`].
+///
+/// Atlas requires an `Arc<dyn ObjectStore>` from object_store **0.13**,
+/// while beacon's `DatasetsStore` is wired against object_store **0.12**.
+/// Until the two version pins converge we restrict reads to local-FS
+/// datasets and rely on `DatasetsStore::translate_netcdf_url_path` to
+/// produce the plain filesystem path.
+fn store_dir_for_object(
+    datasets_object_store: &Arc<DatasetsStore>,
+    object_path: &OsPath,
+) -> datafusion::error::Result<std::path::PathBuf> {
+    let local_marker = datasets_object_store
+        .translate_netcdf_url_path(object_path)
+        .map_err(|e| {
+            datafusion::error::DataFusionError::Execution(format!(
+                "Failed to translate atlas object path {object_path} to local path: {e}"
+            ))
+        })?;
+
+    if local_marker.starts_with("http://") || local_marker.starts_with("https://") {
+        return Err(datafusion::error::DataFusionError::NotImplemented(
+            "Atlas datasets on remote object stores are not yet supported — only local filesystem stores are readable".to_string(),
+        ));
+    }
+
+    let marker = std::path::PathBuf::from(local_marker);
+    let dir = marker.parent().ok_or_else(|| {
+        datafusion::error::DataFusionError::Execution(format!(
+            "Atlas marker path {marker:?} has no parent directory"
+        ))
+    })?;
+    Ok(dir.to_path_buf())
+}
+
+/// Open the atlas store whose `atlas.json` lives at `object_path`.
+pub async fn open_atlas_store(
+    datasets_object_store: Arc<DatasetsStore>,
+    object_path: &OsPath,
+) -> datafusion::error::Result<Arc<Atlas>> {
+    let dir = store_dir_for_object(&datasets_object_store, object_path)?;
+    let atlas = Atlas::open_path(&dir).await.map_err(|e| {
+        datafusion::error::DataFusionError::Execution(format!(
+            "Failed to open atlas store at {dir:?}: {e}"
+        ))
+    })?;
+    Ok(Arc::new(atlas))
+}

--- a/beacon-arrow-atlas/src/datafusion/source.rs
+++ b/beacon-arrow-atlas/src/datafusion/source.rs
@@ -21,10 +21,13 @@ use datafusion::{
         metrics::ExecutionPlanMetricsSet,
     },
 };
+use futures::future;
 use futures::{StreamExt, TryStreamExt, stream::BoxStream};
 use tokio::sync::Mutex;
 
 use crate::datafusion::reader;
+
+const ATLAS_DATASET_CONCURRENCY: usize = 8;
 
 /// Per-opener cache of opened atlas stores keyed by `atlas.json` path.
 ///
@@ -61,8 +64,18 @@ pub async fn get_or_open_atlas(
 /// `PartitionedFile`s belonging to one atlas store; the dataset name
 /// stored here selects which atlas dataset the opener should read.
 #[derive(Debug, Clone)]
-pub struct AtlasFileInfo {
-    pub dataset_name: String,
+pub struct AtlasStreamDatasets {
+    pub stream: Arc<crossbeam::queue::SegQueue<String>>,
+}
+
+impl AtlasStreamDatasets {
+    pub fn new(dataset_names: Vec<String>) -> Self {
+        let stream = Arc::new(crossbeam::queue::SegQueue::new());
+        for name in dataset_names {
+            stream.push(name);
+        }
+        Self { stream }
+    }
 }
 
 /// DataFusion [`FileSource`] for atlas stores.
@@ -76,6 +89,8 @@ pub struct AtlasSource {
     batch_size: usize,
     predicate: Option<Arc<dyn PhysicalExpr>>,
     read_dimensions: Option<Vec<String>>,
+
+    stream_cache: Arc<Mutex<HashMap<String, AtlasStreamDatasets>>>,
 }
 
 impl AtlasSource {
@@ -92,6 +107,7 @@ impl AtlasSource {
             batch_size: usize::MAX,
             predicate: None,
             read_dimensions,
+            stream_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -122,6 +138,7 @@ impl FileSource for AtlasSource {
             metrics: self.execution_plan_metrics.clone(),
             partition,
             read_dimensions: self.read_dimensions.clone(),
+            stream_cache: self.stream_cache.clone(),
         })
     }
 
@@ -213,74 +230,118 @@ struct AtlasOpener {
     metrics: ExecutionPlanMetricsSet,
     partition: usize,
     read_dimensions: Option<Vec<String>>,
+
+    stream_cache: Arc<Mutex<HashMap<String, AtlasStreamDatasets>>>,
 }
 
 impl AtlasOpener {
     async fn read_task(
-        object_path: object_store::path::Path,
-        dataset_name: String,
         datasets_object_store: Arc<DatasetsStore>,
+        object_path: object_store::path::Path,
+        stream_cache: Arc<Mutex<HashMap<String, AtlasStreamDatasets>>>,
         schema_adapter: Arc<dyn SchemaAdapter>,
         batch_size: usize,
         metrics: Option<DatasetReadMetrics>,
         read_dimensions: Option<Vec<String>>,
     ) -> datafusion::error::Result<BoxStream<'static, datafusion::error::Result<RecordBatch>>> {
         let atlas = get_or_open_atlas(datasets_object_store, &object_path).await?;
-        let view = atlas.open_dataset(&dataset_name).await.map_err(|e| {
-            datafusion::error::DataFusionError::Execution(format!(
-                "Failed to open atlas dataset '{dataset_name}' at {object_path}: {e}"
-            ))
-        })?;
 
-        // Derive the file schema from atlas metadata alone (no backends),
-        // then ask the schema adapter which fields the query needs.
-        let file_schema: SchemaRef =
-            crate::compat::atlas_view_arrow_schema(&view, read_dimensions.as_deref())
-                .map_err(|e| {
-                    datafusion::error::DataFusionError::Execution(format!(
-                        "Failed to derive Arrow schema for atlas dataset '{dataset_name}': {e}"
-                    ))
-                })?
-                .into();
-
-        let (schema_mapper, projection) = schema_adapter.map_schema(&file_schema)?;
-
-        if projection.is_empty() {
-            return Ok(futures::stream::empty().boxed());
-        }
-
-        // Build the AnyDataset with only the queried-and-available columns.
-        let projected_names: Vec<String> = projection
-            .iter()
-            .map(|i| file_schema.field(*i).name().clone())
-            .collect();
-        let dataset =
-            crate::reader::dataset_from_atlas(atlas, &dataset_name, Some(&projected_names))
-                .await
-                .map_err(|e| {
-                    datafusion::error::DataFusionError::Execution(format!(
-                        "Failed to load atlas dataset '{dataset_name}': {e}"
-                    ))
-                })?;
-
-        // Atlas has no filter pushdown today.
-        let pushdown_filter: Option<PushdownFilter> = None;
-        let stream =
-            any_dataset_as_record_batch_stream(dataset, batch_size, pushdown_filter, metrics)
-                .map_err(|e| {
-                    datafusion::error::DataFusionError::Execution(format!(
-                        "Error reading atlas dataset as Arrow stream: {e}"
-                    ))
+        let stream_datasets_handle = {
+            let mut guard = stream_cache.lock().await;
+            guard
+                .entry(object_path.to_string())
+                .or_insert_with(|| {
+                    let dataset_names = atlas.list_datasets();
+                    AtlasStreamDatasets::new(dataset_names)
                 })
-                .and_then(move |batch| {
-                    let mapped = schema_mapper.map_batch(batch).map_err(|e| {
+                .clone()
+        };
+
+        let queue = stream_datasets_handle.stream;
+        let futures_stream = futures::stream::iter(std::iter::from_fn(move || queue.pop()));
+
+        let stream = futures_stream
+            .map(move |dataset_name| {
+                let atlas = atlas.clone();
+                let schema_adapter = schema_adapter.clone();
+                let read_dimensions = read_dimensions.clone();
+                let metrics = metrics.clone();
+                let object_path = object_path.clone();
+                async move {
+                    let view = atlas.open_dataset(&dataset_name).await.map_err(|e| {
                         datafusion::error::DataFusionError::Execution(format!(
-                            "Failed to map atlas batch schema: {e}"
+                            "Failed to open atlas dataset '{dataset_name}' at {object_path}: {e}"
                         ))
-                    });
-                    futures::future::ready(mapped)
-                })
-                .boxed();
+                    })?;
+
+                    // Derive the file schema from atlas metadata alone (no backends),
+                    // then ask the schema adapter which fields the query needs.
+                    let file_schema: SchemaRef = crate::compat::atlas_view_arrow_schema(
+                        &view,
+                        read_dimensions.as_deref(),
+                    )
+                    .map_err(|e| {
+                        datafusion::error::DataFusionError::Execution(format!(
+                            "Failed to derive Arrow schema for atlas dataset '{dataset_name}': {e}"
+                        ))
+                    })?
+                    .into();
+
+                    let (schema_mapper, projection) = schema_adapter.map_schema(&file_schema)?;
+
+                    if projection.is_empty() {
+                        return Ok::<
+                            BoxStream<'static, datafusion::error::Result<RecordBatch>>,
+                            datafusion::error::DataFusionError,
+                        >(futures::stream::empty().boxed());
+                    }
+
+                    // Build the AnyDataset with only the queried-and-available columns.
+                    let projected_names: Vec<String> = projection
+                        .iter()
+                        .map(|i| file_schema.field(*i).name().clone())
+                        .collect();
+                    let dataset = crate::reader::dataset_from_atlas(
+                        atlas,
+                        &dataset_name,
+                        Some(&projected_names),
+                    )
+                    .await
+                    .map_err(|e| {
+                        datafusion::error::DataFusionError::Execution(format!(
+                            "Failed to load atlas dataset '{dataset_name}': {e}"
+                        ))
+                    })?;
+
+                    // Atlas has no filter pushdown today.
+                    let pushdown_filter: Option<PushdownFilter> = None;
+                    let dataset_stream = any_dataset_as_record_batch_stream(
+                        dataset,
+                        batch_size,
+                        pushdown_filter,
+                        metrics,
+                    )
+                    .map_err(|e| {
+                        datafusion::error::DataFusionError::Execution(format!(
+                            "Error reading atlas dataset as Arrow stream: {e}"
+                        ))
+                    })
+                    .and_then(move |batch| {
+                        let mapped = schema_mapper.map_batch(batch).map_err(|e| {
+                            datafusion::error::DataFusionError::Execution(format!(
+                                "Failed to map atlas batch schema: {e}"
+                            ))
+                        });
+                        future::ready(mapped)
+                    })
+                    .boxed();
+
+                    Ok(dataset_stream)
+                }
+            })
+            .buffer_unordered(ATLAS_DATASET_CONCURRENCY)
+            .try_flatten()
+            .boxed();
 
         Ok(stream)
     }
@@ -290,26 +351,13 @@ impl FileOpener for AtlasOpener {
     fn open(
         &self,
         file_meta: FileMeta,
-        file: datafusion::datasource::listing::PartitionedFile,
+        _file: datafusion::datasource::listing::PartitionedFile,
     ) -> datafusion::error::Result<FileOpenFuture> {
-        let dataset_name = file
-            .extensions
-            .as_ref()
-            .and_then(|ext| ext.downcast_ref::<AtlasFileInfo>())
-            .map(|info| info.dataset_name.clone())
-            .ok_or_else(|| {
-                datafusion::error::DataFusionError::Execution(
-                    "Atlas PartitionedFile is missing AtlasFileInfo extensions — dataset name unavailable"
-                        .to_string(),
-                )
-            })?;
-
         let metrics = Some(DatasetReadMetrics::new(&self.metrics, self.partition));
         let fut = Self::read_task(
-            file_meta.object_meta.location,
-            dataset_name,
             self.datasets_object_store.clone(),
-            self.atlas_cache.clone(),
+            file_meta.object_meta.location,
+            self.stream_cache.clone(),
             self.schema_adapter.clone(),
             self.batch_size,
             metrics,
@@ -365,83 +413,53 @@ mod tests {
         (opener, table_schema, object)
     }
 
-    fn pf_for(dataset_name: &str, object: object_store::ObjectMeta) -> PartitionedFile {
+    fn pf_for(object: object_store::ObjectMeta) -> PartitionedFile {
         PartitionedFile {
             object_meta: object,
             partition_values: vec![],
             range: None,
             statistics: None,
-            extensions: Some(Arc::new(AtlasFileInfo {
-                dataset_name: dataset_name.to_string(),
-            })),
+            extensions: None,
             metadata_size_hint: None,
         }
     }
 
-    #[tokio::test]
-    async fn opener_streams_batches_for_winter() {
-        let (opener, _schema, object) = build_opener_with_schema().await;
-        let pf = pf_for("winter", object.clone());
-
-        let file_meta = FileMeta {
-            object_meta: object,
-            range: None,
-            extensions: pf.extensions.clone(),
-            metadata_size_hint: None,
-        };
-
-        let stream = opener
-            .open(file_meta, pf)
-            .expect("open")
-            .await
-            .expect("stream");
-        let batches: Vec<_> = stream.collect().await;
-        assert!(!batches.is_empty(), "expected at least one batch");
-
-        let first = batches[0].as_ref().expect("batch ok");
-        assert!(first.num_rows() > 0);
-        assert!(first.num_columns() > 0);
-    }
-
-    #[tokio::test]
-    async fn opener_missing_extensions_errors() {
-        let (opener, _schema, object) = build_opener_with_schema().await;
-
-        // PartitionedFile without AtlasFileInfo extensions.
-        let pf = PartitionedFile {
-            object_meta: object.clone(),
-            partition_values: vec![],
-            range: None,
-            statistics: None,
-            extensions: None,
-            metadata_size_hint: None,
-        };
-        let file_meta = FileMeta {
+    fn file_meta_for(object: object_store::ObjectMeta) -> FileMeta {
+        FileMeta {
             object_meta: object,
             range: None,
             extensions: None,
             metadata_size_hint: None,
-        };
-        let result = opener.open(file_meta, pf);
-        assert!(
-            result.is_err(),
-            "missing AtlasFileInfo should produce error"
-        );
+        }
+    }
+
+    fn collect_temperatures(
+        batches: &[arrow::record_batch::RecordBatch],
+        temp_idx: usize,
+    ) -> Vec<f32> {
+        let mut out = Vec::new();
+        for batch in batches {
+            let arr = batch
+                .column(temp_idx)
+                .as_any()
+                .downcast_ref::<arrow::array::Float32Array>()
+                .expect("temperature is Float32");
+            for i in 0..arr.len() {
+                if arr.is_valid(i) {
+                    out.push(arr.value(i));
+                }
+            }
+        }
+        out
     }
 
     #[tokio::test]
-    async fn opener_summer_null_fills_missing_columns() {
-        // Summer has only `temperature` + `season` — querying with the full
-        // union schema must still produce batches whose width matches the
-        // table schema, with NULLs in the columns summer doesn't carry.
+    async fn opener_drains_queue_streaming_all_datasets() {
+        // One open() call must drain the shared dataset queue and stream
+        // batches from every dataset in the atlas (winter + summer).
         let (opener, schema, object) = build_opener_with_schema().await;
-        let pf = pf_for("summer", object.clone());
-        let file_meta = FileMeta {
-            object_meta: object,
-            range: None,
-            extensions: pf.extensions.clone(),
-            metadata_size_hint: None,
-        };
+        let pf = pf_for(object.clone());
+        let file_meta = file_meta_for(object);
 
         let stream = opener
             .open(file_meta, pf)
@@ -450,57 +468,68 @@ mod tests {
             .expect("stream");
         let batches: Vec<arrow::record_batch::RecordBatch> =
             stream.filter_map(|b| async move { b.ok() }).collect().await;
-        assert!(
-            !batches.is_empty(),
-            "expected at least one batch from summer"
-        );
+        assert!(!batches.is_empty(), "expected batches from drained queue");
 
+        // Every batch must honor the union table schema width.
         for batch in &batches {
-            assert_eq!(
-                batch.schema().fields().len(),
-                schema.fields().len(),
-                "table-schema width must be honored even when columns are missing",
-            );
+            assert_eq!(batch.schema().fields().len(), schema.fields().len());
         }
 
+        // The merged stream must contain temperature values from BOTH
+        // datasets: winter contributes [1, 2, 3, 4]; summer contributes
+        // [20, 21, 22]. Order is unspecified (buffer_unordered).
         let temp_idx = schema.index_of("temperature").expect("temperature column");
-        let cycle_idx = schema.index_of("cycle").expect("cycle column");
-        let year_idx = schema.index_of("year").expect("year column");
-
-        let mut temps = Vec::new();
-        for batch in &batches {
-            let arr = batch
-                .column(temp_idx)
-                .as_any()
-                .downcast_ref::<arrow::array::Float32Array>()
-                .expect("temperature is Float32");
-            for i in 0..arr.len() {
-                if arr.is_valid(i) {
-                    temps.push(arr.value(i));
-                }
-            }
-
-            let cycle = batch.column(cycle_idx);
-            assert_eq!(
-                cycle.null_count(),
-                cycle.len(),
-                "summer's `cycle` column should be all-null"
-            );
-            let year = batch.column(year_idx);
-            assert_eq!(
-                year.null_count(),
-                year.len(),
-                "summer's `year` column should be all-null"
-            );
-        }
-        assert_eq!(temps, vec![20.0f32, 21.0, 22.0]);
+        let mut temps = collect_temperatures(&batches, temp_idx);
+        temps.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_eq!(temps, vec![1.0f32, 2.0, 3.0, 4.0, 20.0, 21.0, 22.0]);
     }
 
     #[tokio::test]
-    async fn opener_projection_only_missing_column_yields_empty_stream() {
-        // Project the table schema down to just `cycle` and read summer,
-        // which has no `cycle`. The schema adapter's projection comes back
-        // empty so the stream must be empty (no rows of all-NULL).
+    async fn opener_honors_union_schema_with_nulls_for_missing_columns() {
+        // Reading drains both datasets. Summer's batches must carry the
+        // full union width with NULLs in `cycle` and `year`; winter's
+        // batches must have real values there.
+        let (opener, schema, object) = build_opener_with_schema().await;
+        let pf = pf_for(object.clone());
+        let file_meta = file_meta_for(object);
+
+        let stream = opener
+            .open(file_meta, pf)
+            .expect("open")
+            .await
+            .expect("stream");
+        let batches: Vec<arrow::record_batch::RecordBatch> =
+            stream.filter_map(|b| async move { b.ok() }).collect().await;
+        assert!(!batches.is_empty());
+
+        let cycle_idx = schema.index_of("cycle").expect("cycle column");
+        let year_idx = schema.index_of("year").expect("year column");
+
+        let total_cycle_nulls: usize = batches
+            .iter()
+            .map(|b| b.column(cycle_idx).null_count())
+            .sum();
+        let total_year_nulls: usize = batches
+            .iter()
+            .map(|b| b.column(year_idx).null_count())
+            .sum();
+        // Summer has 3 rows and no cycle/year, so at least 3 null entries
+        // must appear in each of those columns across the merged stream.
+        assert!(
+            total_cycle_nulls >= 3,
+            "expected at least summer's 3 null cycle entries, got {total_cycle_nulls}",
+        );
+        assert!(
+            total_year_nulls >= 3,
+            "expected at least summer's 3 null year entries, got {total_year_nulls}",
+        );
+    }
+
+    #[tokio::test]
+    async fn opener_projection_skips_datasets_missing_the_column() {
+        // Project only to `cycle` — winter has it, summer doesn't.
+        // Summer's per-dataset stream short-circuits to empty (empty
+        // projection); winter's batches still flow through.
         ensure_fixture().await;
         let store = test_store().await;
         let format = AtlasFormat::new(store.clone(), AtlasOptions::default());
@@ -526,96 +555,8 @@ mod tests {
         .build();
 
         let opener = source.create_file_opener(dummy_store, &conf, 0);
-        let pf = pf_for("summer", object.clone());
-        let file_meta = FileMeta {
-            object_meta: object,
-            range: None,
-            extensions: pf.extensions.clone(),
-            metadata_size_hint: None,
-        };
-
-        let stream = opener
-            .open(file_meta, pf)
-            .expect("open")
-            .await
-            .expect("stream");
-        let batches: Vec<_> = stream.collect().await;
-        assert!(
-            batches.is_empty(),
-            "summer has no `cycle`; empty projection must yield no batches"
-        );
-    }
-
-    #[tokio::test]
-    async fn opener_reuses_atlas_across_datasets() {
-        use datafusion::datasource::schema_adapter::{
-            DefaultSchemaAdapterFactory, SchemaAdapterFactory,
-        };
-
-        ensure_fixture().await;
-        let store = test_store().await;
-        let format = AtlasFormat::new(store.clone(), AtlasOptions::default());
-        let ctx = SessionContext::new();
-        let object = fixture_marker_object_meta();
-
-        let dummy_store: Arc<dyn object_store::ObjectStore> =
-            Arc::new(object_store::local::LocalFileSystem::new());
-        let table_schema = format
-            .infer_schema(&ctx.state(), &dummy_store, &[object.clone()])
-            .await
-            .expect("infer schema");
-
-        let projected_schema = table_schema.clone();
-        let schema_adapter =
-            Arc::new(DefaultSchemaAdapterFactory).create(projected_schema, table_schema.clone());
-        let atlas_cache: AtlasCache = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-
-        let opener = AtlasOpener {
-            datasets_object_store: store,
-            schema_adapter: Arc::from(schema_adapter),
-            batch_size: usize::MAX,
-            metrics: ExecutionPlanMetricsSet::new(),
-            partition: 0,
-            read_dimensions: None,
-            atlas_cache: atlas_cache.clone(),
-        };
-
-        for name in ["winter", "summer"] {
-            let pf = pf_for(name, object.clone());
-            let file_meta = FileMeta {
-                object_meta: object.clone(),
-                range: None,
-                extensions: pf.extensions.clone(),
-                metadata_size_hint: None,
-            };
-            let stream = opener
-                .open(file_meta, pf)
-                .expect("open")
-                .await
-                .expect("stream");
-            let batches: Vec<_> = stream.collect().await;
-            assert!(!batches.is_empty(), "expected batches for dataset {name}");
-        }
-
-        let guard = atlas_cache.lock().await;
-        assert_eq!(
-            guard.len(),
-            1,
-            "atlas store must be opened exactly once across both datasets, cache: {:?}",
-            guard.keys().collect::<Vec<_>>(),
-        );
-    }
-
-    #[tokio::test]
-    async fn opener_winter_has_temperature_column() {
-        let (opener, schema, object) = build_opener_with_schema().await;
-        let pf = pf_for("winter", object.clone());
-        let file_meta = FileMeta {
-            object_meta: object,
-            range: None,
-            extensions: pf.extensions.clone(),
-            metadata_size_hint: None,
-        };
+        let pf = pf_for(object.clone());
+        let file_meta = file_meta_for(object);
 
         let stream = opener
             .open(file_meta, pf)
@@ -624,29 +565,45 @@ mod tests {
             .expect("stream");
         let batches: Vec<arrow::record_batch::RecordBatch> =
             stream.filter_map(|b| async move { b.ok() }).collect().await;
-        assert!(!batches.is_empty());
 
-        // Verify the union schema is honored: even though winter has all
-        // four columns, the projected output must match table_schema.
+        // Winter contributes the only batches — summer's empty projection
+        // produces an empty stream that flat-flattens away.
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert!(total_rows > 0, "expected winter's cycle rows");
+        // Projected schema width is 1 (just `cycle`).
         for batch in &batches {
-            assert_eq!(batch.schema().fields().len(), schema.fields().len());
+            assert_eq!(batch.schema().fields().len(), 1);
         }
+    }
 
-        // Concatenate temperature column values across batches.
-        let temp_idx = schema.index_of("temperature").expect("temperature column");
-        let mut all = Vec::new();
-        for batch in &batches {
-            let col = batch.column(temp_idx);
-            let arr = col
-                .as_any()
-                .downcast_ref::<arrow::array::Float32Array>()
-                .expect("Float32Array");
-            for i in 0..arr.len() {
-                if arr.is_valid(i) {
-                    all.push(arr.value(i));
-                }
-            }
-        }
-        assert_eq!(all, vec![1.0f32, 2.0, 3.0, 4.0]);
+    #[tokio::test]
+    async fn opener_opens_each_atlas_marker_once_per_source() {
+        // The opener's stream_cache holds one AtlasStreamDatasets per
+        // atlas marker path. After draining via open(), a second open()
+        // on the same atlas finds an empty queue and yields no batches.
+        let (opener, _schema, object) = build_opener_with_schema().await;
+
+        // First open drains the queue.
+        let stream = opener
+            .open(file_meta_for(object.clone()), pf_for(object.clone()))
+            .expect("open")
+            .await
+            .expect("stream");
+        let first_batches: Vec<_> = stream.collect().await;
+        assert!(!first_batches.is_empty(), "first open must produce batches");
+
+        // Second open sees an empty queue (same stream_cache entry) and
+        // therefore produces no batches.
+        let stream = opener
+            .open(file_meta_for(object.clone()), pf_for(object))
+            .expect("open")
+            .await
+            .expect("stream");
+        let second_batches: Vec<_> = stream.collect().await;
+        assert!(
+            second_batches.is_empty(),
+            "second open must observe a drained queue, got {} batches",
+            second_batches.len(),
+        );
     }
 }

--- a/beacon-arrow-atlas/src/datafusion/source.rs
+++ b/beacon-arrow-atlas/src/datafusion/source.rs
@@ -46,10 +46,14 @@ pub struct AtlasSource {
     projected_statistics: Option<Statistics>,
     batch_size: usize,
     predicate: Option<Arc<dyn PhysicalExpr>>,
+    read_dimensions: Option<Vec<String>>,
 }
 
 impl AtlasSource {
-    pub fn new(datasets_object_store: Arc<DatasetsStore>) -> Self {
+    pub fn new(
+        datasets_object_store: Arc<DatasetsStore>,
+        read_dimensions: Option<Vec<String>>,
+    ) -> Self {
         Self {
             datasets_object_store,
             schema_adapter_factory: None,
@@ -58,6 +62,7 @@ impl AtlasSource {
             projected_statistics: None,
             batch_size: usize::MAX,
             predicate: None,
+            read_dimensions,
         }
     }
 }
@@ -87,6 +92,7 @@ impl FileSource for AtlasSource {
             batch_size: self.batch_size,
             metrics: self.execution_plan_metrics.clone(),
             partition,
+            read_dimensions: self.read_dimensions.clone(),
         })
     }
 
@@ -188,6 +194,7 @@ struct AtlasOpener {
     batch_size: usize,
     metrics: ExecutionPlanMetricsSet,
     partition: usize,
+    read_dimensions: Option<Vec<String>>,
 }
 
 impl AtlasOpener {
@@ -198,6 +205,7 @@ impl AtlasOpener {
         schema_adapter: Arc<dyn SchemaAdapter>,
         batch_size: usize,
         metrics: Option<DatasetReadMetrics>,
+        read_dimensions: Option<Vec<String>>,
     ) -> datafusion::error::Result<BoxStream<'static, datafusion::error::Result<RecordBatch>>> {
         let atlas = reader::open_atlas_store(datasets_object_store, &object_path).await?;
 
@@ -208,6 +216,22 @@ impl AtlasOpener {
                     "Failed to open atlas dataset '{dataset_name}' at {object_path}: {e}"
                 ))
             })?;
+
+        // Apply dimension projection before deriving the file schema, so the
+        // schema reflects only arrays whose dimensions match the user's filter.
+        let dataset = if let Some(dims) = read_dimensions {
+            let proj = DatasetProjection {
+                dimension_projection: Some(dims),
+                index_projection: None,
+            };
+            dataset.project(&proj).map_err(|e| {
+                datafusion::error::DataFusionError::Execution(format!(
+                    "Failed to apply dimension projection to atlas dataset '{dataset_name}': {e}"
+                ))
+            })?
+        } else {
+            dataset
+        };
 
         let file_schema: SchemaRef =
             beacon_nd_array::arrow::schema::any_dataset_to_arrow_schema(&dataset)
@@ -287,6 +311,7 @@ impl FileOpener for AtlasOpener {
             self.schema_adapter.clone(),
             self.batch_size,
             metrics,
+            self.read_dimensions.clone(),
         );
         Ok(Box::pin(fut))
     }
@@ -325,7 +350,7 @@ mod tests {
             .await
             .expect("infer schema");
 
-        let source = AtlasSource::new(store);
+        let source = AtlasSource::new(store, None);
         let conf = FileScanConfigBuilder::new(
             ObjectStoreUrl::local_filesystem(),
             table_schema.clone(),

--- a/beacon-arrow-atlas/src/datafusion/source.rs
+++ b/beacon-arrow-atlas/src/datafusion/source.rs
@@ -1,8 +1,7 @@
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::{collections::HashMap, sync::LazyLock};
 
 use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
-use atlas::Atlas;
 use beacon_nd_array::arrow::{
     batch::any_dataset_as_record_batch_stream, metrics::DatasetReadMetrics,
     pushdown_filter::PushdownFilter,
@@ -23,40 +22,10 @@ use datafusion::{
 };
 use futures::future;
 use futures::{StreamExt, TryStreamExt, stream::BoxStream};
+use object_store::ObjectMeta;
 use tokio::sync::Mutex;
 
-use crate::datafusion::reader;
-
 const ATLAS_DATASET_CONCURRENCY: usize = 8;
-
-/// Per-opener cache of opened atlas stores keyed by `atlas.json` path.
-///
-/// All `read_task` futures spawned by one `AtlasOpener` share this
-/// map, so the N datasets in a single atlas store pay `Atlas::open_path`
-/// exactly once. The mutex is held across the open so concurrent first
-/// reads of the same marker coalesce instead of double-opening.
-static ATLAS_CACHE: LazyLock<Mutex<HashMap<object_store::path::Path, Arc<Atlas>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-pub async fn get_or_open_atlas(
-    datasets_object_store: Arc<DatasetsStore>,
-    object_path: &object_store::path::Path,
-) -> datafusion::error::Result<Arc<Atlas>> {
-    let mut guard = ATLAS_CACHE.lock().await;
-    if let Some(atlas) = guard.get(object_path) {
-        return Ok(atlas.clone());
-    }
-    let atlas = reader::open_atlas_store(datasets_object_store, object_path)
-        .await
-        .map_err(|e| {
-            datafusion::error::DataFusionError::Execution(format!(
-                "Failed to open atlas store at {}: {e}",
-                object_path
-            ))
-        })?;
-    guard.insert(object_path.clone(), atlas.clone());
-    Ok(atlas)
-}
 
 /// Per-file payload attached to each `PartitionedFile.extensions`.
 ///
@@ -138,6 +107,7 @@ impl FileSource for AtlasSource {
             metrics: self.execution_plan_metrics.clone(),
             partition,
             read_dimensions: self.read_dimensions.clone(),
+            predicate: self.predicate.clone(),
             stream_cache: self.stream_cache.clone(),
         })
     }
@@ -230,6 +200,7 @@ struct AtlasOpener {
     metrics: ExecutionPlanMetricsSet,
     partition: usize,
     read_dimensions: Option<Vec<String>>,
+    predicate: Option<Arc<dyn PhysicalExpr>>,
 
     stream_cache: Arc<Mutex<HashMap<String, AtlasStreamDatasets>>>,
 }
@@ -237,14 +208,18 @@ struct AtlasOpener {
 impl AtlasOpener {
     async fn read_task(
         datasets_object_store: Arc<DatasetsStore>,
-        object_path: object_store::path::Path,
+        object_meta: ObjectMeta,
         stream_cache: Arc<Mutex<HashMap<String, AtlasStreamDatasets>>>,
         schema_adapter: Arc<dyn SchemaAdapter>,
         batch_size: usize,
         metrics: Option<DatasetReadMetrics>,
         read_dimensions: Option<Vec<String>>,
+        predicate: Option<Arc<dyn PhysicalExpr>>,
     ) -> datafusion::error::Result<BoxStream<'static, datafusion::error::Result<RecordBatch>>> {
-        let atlas = get_or_open_atlas(datasets_object_store, &object_path).await?;
+        let atlas =
+            crate::datafusion::cache::get_or_open_atlas(datasets_object_store, &object_meta)
+                .await?;
+        let object_path = object_meta.location.clone();
 
         let stream_datasets_handle = {
             let mut guard = stream_cache.lock().await;
@@ -267,16 +242,18 @@ impl AtlasOpener {
                 let read_dimensions = read_dimensions.clone();
                 let metrics = metrics.clone();
                 let object_path = object_path.clone();
-                async move {
-                    let view = atlas.open_dataset(&dataset_name).await.map_err(|e| {
+                {
+                    let predicate_cloned = predicate.clone();
+                    async move {
+                        let view = atlas.open_dataset(&dataset_name).await.map_err(|e| {
                         datafusion::error::DataFusionError::Execution(format!(
                             "Failed to open atlas dataset '{dataset_name}' at {object_path}: {e}"
                         ))
                     })?;
 
-                    // Derive the file schema from atlas metadata alone (no backends),
-                    // then ask the schema adapter which fields the query needs.
-                    let file_schema: SchemaRef = crate::compat::atlas_view_arrow_schema(
+                        // Derive the file schema from atlas metadata alone (no backends),
+                        // then ask the schema adapter which fields the query needs.
+                        let file_schema: SchemaRef = crate::compat::atlas_view_arrow_schema(
                         &view,
                         read_dimensions.as_deref(),
                     )
@@ -287,56 +264,59 @@ impl AtlasOpener {
                     })?
                     .into();
 
-                    let (schema_mapper, projection) = schema_adapter.map_schema(&file_schema)?;
+                        let (schema_mapper, projection) =
+                            schema_adapter.map_schema(&file_schema)?;
 
-                    if projection.is_empty() {
-                        return Ok::<
-                            BoxStream<'static, datafusion::error::Result<RecordBatch>>,
-                            datafusion::error::DataFusionError,
-                        >(futures::stream::empty().boxed());
-                    }
+                        if projection.is_empty() {
+                            return Ok::<
+                                BoxStream<'static, datafusion::error::Result<RecordBatch>>,
+                                datafusion::error::DataFusionError,
+                            >(futures::stream::empty().boxed());
+                        }
 
-                    // Build the AnyDataset with only the queried-and-available columns.
-                    let projected_names: Vec<String> = projection
-                        .iter()
-                        .map(|i| file_schema.field(*i).name().clone())
-                        .collect();
-                    let dataset = crate::reader::dataset_from_atlas(
-                        atlas,
-                        &dataset_name,
-                        Some(&projected_names),
-                    )
-                    .await
-                    .map_err(|e| {
-                        datafusion::error::DataFusionError::Execution(format!(
-                            "Failed to load atlas dataset '{dataset_name}': {e}"
-                        ))
-                    })?;
-
-                    // Atlas has no filter pushdown today.
-                    let pushdown_filter: Option<PushdownFilter> = None;
-                    let dataset_stream = any_dataset_as_record_batch_stream(
-                        dataset,
-                        batch_size,
-                        pushdown_filter,
-                        metrics,
-                    )
-                    .map_err(|e| {
-                        datafusion::error::DataFusionError::Execution(format!(
-                            "Error reading atlas dataset as Arrow stream: {e}"
-                        ))
-                    })
-                    .and_then(move |batch| {
-                        let mapped = schema_mapper.map_batch(batch).map_err(|e| {
+                        // Build the AnyDataset with only the queried-and-available columns.
+                        let projected_names: Vec<String> = projection
+                            .iter()
+                            .map(|i| file_schema.field(*i).name().clone())
+                            .collect();
+                        let dataset = crate::reader::dataset_from_atlas(
+                            atlas,
+                            &dataset_name,
+                            Some(&projected_names),
+                        )
+                        .await
+                        .map_err(|e| {
                             datafusion::error::DataFusionError::Execution(format!(
-                                "Failed to map atlas batch schema: {e}"
+                                "Failed to load atlas dataset '{dataset_name}': {e}"
                             ))
-                        });
-                        future::ready(mapped)
-                    })
-                    .boxed();
+                        })?;
 
-                    Ok(dataset_stream)
+                        // Atlas has no filter pushdown today.
+                        let pushdown_filter: Option<PushdownFilter> =
+                            predicate_cloned.map(PushdownFilter::new);
+                        let dataset_stream = any_dataset_as_record_batch_stream(
+                            dataset,
+                            batch_size,
+                            pushdown_filter,
+                            metrics,
+                        )
+                        .map_err(|e| {
+                            datafusion::error::DataFusionError::Execution(format!(
+                                "Error reading atlas dataset as Arrow stream: {e}"
+                            ))
+                        })
+                        .and_then(move |batch| {
+                            let mapped = schema_mapper.map_batch(batch).map_err(|e| {
+                                datafusion::error::DataFusionError::Execution(format!(
+                                    "Failed to map atlas batch schema: {e}"
+                                ))
+                            });
+                            future::ready(mapped)
+                        })
+                        .boxed();
+
+                        Ok(dataset_stream)
+                    }
                 }
             })
             .buffer_unordered(ATLAS_DATASET_CONCURRENCY)
@@ -356,12 +336,13 @@ impl FileOpener for AtlasOpener {
         let metrics = Some(DatasetReadMetrics::new(&self.metrics, self.partition));
         let fut = Self::read_task(
             self.datasets_object_store.clone(),
-            file_meta.object_meta.location,
+            file_meta.object_meta,
             self.stream_cache.clone(),
             self.schema_adapter.clone(),
             self.batch_size,
             metrics,
             self.read_dimensions.clone(),
+            self.predicate.clone(),
         );
         Ok(Box::pin(fut))
     }

--- a/beacon-arrow-atlas/src/datafusion/source.rs
+++ b/beacon-arrow-atlas/src/datafusion/source.rs
@@ -1,0 +1,439 @@
+use std::sync::Arc;
+
+use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use beacon_nd_array::{
+    arrow::{
+        batch::any_dataset_as_record_batch_stream, metrics::DatasetReadMetrics,
+        pushdown_filter::PushdownFilter,
+    },
+    projection::DatasetProjection,
+};
+use beacon_object_storage::DatasetsStore;
+use datafusion::{
+    common::Statistics,
+    config::ConfigOptions,
+    datasource::{
+        physical_plan::{FileMeta, FileOpenFuture, FileOpener, FileSource},
+        schema_adapter::{DefaultSchemaAdapterFactory, SchemaAdapter, SchemaAdapterFactory},
+    },
+    physical_expr::{PhysicalExpr, conjunction},
+    physical_plan::{
+        filter_pushdown::{FilterPushdownPropagation, PushedDown},
+        metrics::ExecutionPlanMetricsSet,
+    },
+};
+use futures::{StreamExt, TryStreamExt, stream::BoxStream};
+
+use crate::datafusion::reader;
+
+/// Per-file payload attached to each `PartitionedFile.extensions`.
+///
+/// The same `atlas.json` ObjectMeta is reused across all
+/// `PartitionedFile`s belonging to one atlas store; the dataset name
+/// stored here selects which atlas dataset the opener should read.
+#[derive(Debug, Clone)]
+pub struct AtlasFileInfo {
+    pub dataset_name: String,
+}
+
+/// DataFusion [`FileSource`] for atlas stores.
+#[derive(Debug, Clone)]
+pub struct AtlasSource {
+    datasets_object_store: Arc<DatasetsStore>,
+    schema_adapter_factory: Option<Arc<dyn SchemaAdapterFactory>>,
+    override_schema: Option<SchemaRef>,
+    execution_plan_metrics: ExecutionPlanMetricsSet,
+    projected_statistics: Option<Statistics>,
+    batch_size: usize,
+    predicate: Option<Arc<dyn PhysicalExpr>>,
+}
+
+impl AtlasSource {
+    pub fn new(datasets_object_store: Arc<DatasetsStore>) -> Self {
+        Self {
+            datasets_object_store,
+            schema_adapter_factory: None,
+            override_schema: None,
+            execution_plan_metrics: ExecutionPlanMetricsSet::new(),
+            projected_statistics: None,
+            batch_size: usize::MAX,
+            predicate: None,
+        }
+    }
+}
+
+impl FileSource for AtlasSource {
+    fn create_file_opener(
+        &self,
+        _object_store: Arc<dyn object_store::ObjectStore>,
+        base_config: &datafusion::datasource::physical_plan::FileScanConfig,
+        partition: usize,
+    ) -> Arc<dyn FileOpener> {
+        let table_schema = self
+            .override_schema
+            .clone()
+            .unwrap_or_else(|| base_config.file_schema.clone());
+        let projected_schema = base_config.projected_schema();
+        let schema_adapter_factory = self
+            .schema_adapter_factory
+            .clone()
+            .unwrap_or_else(|| Arc::new(DefaultSchemaAdapterFactory));
+
+        let schema_adapter = schema_adapter_factory.create(projected_schema, table_schema.clone());
+
+        Arc::new(AtlasOpener {
+            datasets_object_store: self.datasets_object_store.clone(),
+            schema_adapter: Arc::from(schema_adapter),
+            batch_size: self.batch_size,
+            metrics: self.execution_plan_metrics.clone(),
+            partition,
+        })
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn with_batch_size(&self, batch_size: usize) -> Arc<dyn FileSource> {
+        Arc::new(Self {
+            batch_size,
+            ..self.clone()
+        })
+    }
+
+    fn with_schema(&self, schema: SchemaRef) -> Arc<dyn FileSource> {
+        Arc::new(Self {
+            override_schema: Some(schema),
+            ..self.clone()
+        })
+    }
+
+    fn with_projection(
+        &self,
+        _config: &datafusion::datasource::physical_plan::FileScanConfig,
+    ) -> Arc<dyn FileSource> {
+        Arc::new(self.clone())
+    }
+
+    fn with_statistics(&self, statistics: Statistics) -> Arc<dyn FileSource> {
+        Arc::new(Self {
+            projected_statistics: Some(statistics),
+            ..self.clone()
+        })
+    }
+
+    fn repartitioned(
+        &self,
+        _target_partitions: usize,
+        _repartition_file_min_size: usize,
+        _output_ordering: Option<datafusion::physical_expr::LexOrdering>,
+        _config: &datafusion::datasource::physical_plan::FileScanConfig,
+    ) -> datafusion::error::Result<Option<datafusion::datasource::physical_plan::FileScanConfig>>
+    {
+        Ok(None)
+    }
+
+    fn metrics(&self) -> &ExecutionPlanMetricsSet {
+        &self.execution_plan_metrics
+    }
+
+    fn statistics(&self) -> datafusion::error::Result<Statistics> {
+        if let Some(statistics) = &self.projected_statistics {
+            Ok(statistics.clone())
+        } else if let Some(schema) = self.override_schema.as_ref() {
+            Ok(Statistics::new_unknown(schema))
+        } else {
+            Err(datafusion::error::DataFusionError::Execution(
+                "Schema must be set to compute statistics".to_string(),
+            ))
+        }
+    }
+
+    fn file_type(&self) -> &str {
+        "atlas"
+    }
+
+    fn schema_adapter_factory(&self) -> Option<Arc<dyn SchemaAdapterFactory>> {
+        self.schema_adapter_factory.clone()
+    }
+
+    fn try_pushdown_filters(
+        &self,
+        filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> datafusion::error::Result<FilterPushdownPropagation<Arc<dyn FileSource>>> {
+        let predicate = match self.predicate.clone() {
+            Some(existing) => conjunction(std::iter::once(existing).chain(filters.clone())),
+            None => conjunction(filters.clone()),
+        };
+
+        let source = Self {
+            predicate: Some(predicate),
+            ..self.clone()
+        };
+
+        Ok(FilterPushdownPropagation::with_parent_pushdown_result(vec![
+            PushedDown::No;
+            filters.len()
+        ])
+        .with_updated_node(Arc::new(source)))
+    }
+}
+
+// ─── FileOpener ────────────────────────────────────────────────────────────
+
+struct AtlasOpener {
+    datasets_object_store: Arc<DatasetsStore>,
+    schema_adapter: Arc<dyn SchemaAdapter>,
+    batch_size: usize,
+    metrics: ExecutionPlanMetricsSet,
+    partition: usize,
+}
+
+impl AtlasOpener {
+    async fn read_task(
+        object_path: object_store::path::Path,
+        dataset_name: String,
+        datasets_object_store: Arc<DatasetsStore>,
+        schema_adapter: Arc<dyn SchemaAdapter>,
+        batch_size: usize,
+        metrics: Option<DatasetReadMetrics>,
+    ) -> datafusion::error::Result<BoxStream<'static, datafusion::error::Result<RecordBatch>>> {
+        let atlas = reader::open_atlas_store(datasets_object_store, &object_path).await?;
+
+        let dataset = crate::reader::dataset_from_atlas(atlas, &dataset_name)
+            .await
+            .map_err(|e| {
+                datafusion::error::DataFusionError::Execution(format!(
+                    "Failed to open atlas dataset '{dataset_name}' at {object_path}: {e}"
+                ))
+            })?;
+
+        let file_schema: SchemaRef =
+            beacon_nd_array::arrow::schema::any_dataset_to_arrow_schema(&dataset)
+                .map_err(|e| {
+                    datafusion::error::DataFusionError::Execution(format!(
+                        "Failed to derive Arrow schema from atlas dataset '{dataset_name}': {e}"
+                    ))
+                })?
+                .into();
+
+        let (schema_mapper, projection) = schema_adapter.map_schema(&file_schema)?;
+
+        if projection.is_empty() {
+            return Ok(futures::stream::empty().boxed());
+        }
+
+        let dataset = if projection.len() < file_schema.fields().len() {
+            let proj = DatasetProjection {
+                dimension_projection: None,
+                index_projection: Some(projection),
+            };
+            dataset.project(&proj).map_err(|e| {
+                datafusion::error::DataFusionError::Execution(format!(
+                    "Failed to project atlas dataset '{dataset_name}': {e}"
+                ))
+            })?
+        } else {
+            dataset
+        };
+
+        // Atlas has no filter pushdown today.
+        let pushdown_filter: Option<PushdownFilter> = None;
+        let stream =
+            any_dataset_as_record_batch_stream(dataset, batch_size, pushdown_filter, metrics)
+                .map_err(|e| {
+                    datafusion::error::DataFusionError::Execution(format!(
+                        "Error reading atlas dataset as Arrow stream: {e}"
+                    ))
+                })
+                .and_then(move |batch| {
+                    let mapped = schema_mapper.map_batch(batch).map_err(|e| {
+                        datafusion::error::DataFusionError::Execution(format!(
+                            "Failed to map atlas batch schema: {e}"
+                        ))
+                    });
+                    futures::future::ready(mapped)
+                })
+                .boxed();
+
+        Ok(stream)
+    }
+}
+
+impl FileOpener for AtlasOpener {
+    fn open(
+        &self,
+        file_meta: FileMeta,
+        file: datafusion::datasource::listing::PartitionedFile,
+    ) -> datafusion::error::Result<FileOpenFuture> {
+        let dataset_name = file
+            .extensions
+            .as_ref()
+            .and_then(|ext| ext.downcast_ref::<AtlasFileInfo>())
+            .map(|info| info.dataset_name.clone())
+            .ok_or_else(|| {
+                datafusion::error::DataFusionError::Execution(
+                    "Atlas PartitionedFile is missing AtlasFileInfo extensions — dataset name unavailable"
+                        .to_string(),
+                )
+            })?;
+
+        let metrics = Some(DatasetReadMetrics::new(&self.metrics, self.partition));
+        let fut = Self::read_task(
+            file_meta.object_meta.location,
+            dataset_name,
+            self.datasets_object_store.clone(),
+            self.schema_adapter.clone(),
+            self.batch_size,
+            metrics,
+        );
+        Ok(Box::pin(fut))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datafusion::AtlasFormat;
+    use crate::datafusion::options::AtlasOptions;
+    use crate::datafusion::test_support::{ensure_fixture, fixture_marker_object_meta, test_store};
+    use arrow::array::Array;
+    use datafusion::datasource::file_format::FileFormat;
+    use datafusion::datasource::listing::PartitionedFile;
+    use datafusion::datasource::physical_plan::{
+        FileMeta, FileScanConfigBuilder, FileSource,
+    };
+    use datafusion::execution::object_store::ObjectStoreUrl;
+    use datafusion::prelude::SessionContext;
+    use futures::StreamExt;
+    use std::sync::Arc;
+
+    async fn build_opener_with_schema()
+    -> (Arc<dyn FileOpener>, arrow::datatypes::SchemaRef, object_store::ObjectMeta) {
+        ensure_fixture().await;
+        let store = test_store().await;
+        let format = AtlasFormat::new(store.clone(), AtlasOptions::default());
+        let ctx = SessionContext::new();
+        let object = fixture_marker_object_meta();
+
+        let dummy_store: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::local::LocalFileSystem::new());
+
+        let table_schema = format
+            .infer_schema(&ctx.state(), &dummy_store, &[object.clone()])
+            .await
+            .expect("infer schema");
+
+        let source = AtlasSource::new(store);
+        let conf = FileScanConfigBuilder::new(
+            ObjectStoreUrl::local_filesystem(),
+            table_schema.clone(),
+            Arc::new(source.clone()) as Arc<dyn FileSource>,
+        )
+        .build();
+
+        let opener = source.create_file_opener(dummy_store, &conf, 0);
+        (opener, table_schema, object)
+    }
+
+    fn pf_for(dataset_name: &str, object: object_store::ObjectMeta) -> PartitionedFile {
+        PartitionedFile {
+            object_meta: object,
+            partition_values: vec![],
+            range: None,
+            statistics: None,
+            extensions: Some(Arc::new(AtlasFileInfo {
+                dataset_name: dataset_name.to_string(),
+            })),
+            metadata_size_hint: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn opener_streams_batches_for_winter() {
+        let (opener, _schema, object) = build_opener_with_schema().await;
+        let pf = pf_for("winter", object.clone());
+
+        let file_meta = FileMeta {
+            object_meta: object,
+            range: None,
+            extensions: pf.extensions.clone(),
+            metadata_size_hint: None,
+        };
+
+        let stream = opener.open(file_meta, pf).expect("open").await.expect("stream");
+        let batches: Vec<_> = stream.collect().await;
+        assert!(!batches.is_empty(), "expected at least one batch");
+
+        let first = batches[0].as_ref().expect("batch ok");
+        assert!(first.num_rows() > 0);
+        assert!(first.num_columns() > 0);
+    }
+
+    #[tokio::test]
+    async fn opener_missing_extensions_errors() {
+        let (opener, _schema, object) = build_opener_with_schema().await;
+
+        // PartitionedFile without AtlasFileInfo extensions.
+        let pf = PartitionedFile {
+            object_meta: object.clone(),
+            partition_values: vec![],
+            range: None,
+            statistics: None,
+            extensions: None,
+            metadata_size_hint: None,
+        };
+        let file_meta = FileMeta {
+            object_meta: object,
+            range: None,
+            extensions: None,
+            metadata_size_hint: None,
+        };
+        let result = opener.open(file_meta, pf);
+        assert!(result.is_err(), "missing AtlasFileInfo should produce error");
+    }
+
+    #[tokio::test]
+    async fn opener_winter_has_temperature_column() {
+        let (opener, schema, object) = build_opener_with_schema().await;
+        let pf = pf_for("winter", object.clone());
+        let file_meta = FileMeta {
+            object_meta: object,
+            range: None,
+            extensions: pf.extensions.clone(),
+            metadata_size_hint: None,
+        };
+
+        let stream = opener.open(file_meta, pf).expect("open").await.expect("stream");
+        let batches: Vec<arrow::record_batch::RecordBatch> = stream
+            .filter_map(|b| async move { b.ok() })
+            .collect()
+            .await;
+        assert!(!batches.is_empty());
+
+        // Verify the union schema is honored: even though winter has all
+        // four columns, the projected output must match table_schema.
+        for batch in &batches {
+            assert_eq!(batch.schema().fields().len(), schema.fields().len());
+        }
+
+        // Concatenate temperature column values across batches.
+        let temp_idx = schema.index_of("temperature").expect("temperature column");
+        let mut all = Vec::new();
+        for batch in &batches {
+            let col = batch.column(temp_idx);
+            let arr = col
+                .as_any()
+                .downcast_ref::<arrow::array::Float32Array>()
+                .expect("Float32Array");
+            for i in 0..arr.len() {
+                if arr.is_valid(i) {
+                    all.push(arr.value(i));
+                }
+            }
+        }
+        assert_eq!(all, vec![1.0f32, 2.0, 3.0, 4.0]);
+    }
+}
+

--- a/beacon-arrow-atlas/src/datafusion/source.rs
+++ b/beacon-arrow-atlas/src/datafusion/source.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
+use std::{collections::HashMap, sync::LazyLock};
 
 use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use atlas::Atlas;
 use beacon_nd_array::arrow::{
     batch::any_dataset_as_record_batch_stream, metrics::DatasetReadMetrics,
     pushdown_filter::PushdownFilter,
@@ -20,8 +22,38 @@ use datafusion::{
     },
 };
 use futures::{StreamExt, TryStreamExt, stream::BoxStream};
+use tokio::sync::Mutex;
 
 use crate::datafusion::reader;
+
+/// Per-opener cache of opened atlas stores keyed by `atlas.json` path.
+///
+/// All `read_task` futures spawned by one `AtlasOpener` share this
+/// map, so the N datasets in a single atlas store pay `Atlas::open_path`
+/// exactly once. The mutex is held across the open so concurrent first
+/// reads of the same marker coalesce instead of double-opening.
+static ATLAS_CACHE: LazyLock<Mutex<HashMap<object_store::path::Path, Arc<Atlas>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub async fn get_or_open_atlas(
+    datasets_object_store: Arc<DatasetsStore>,
+    object_path: &object_store::path::Path,
+) -> datafusion::error::Result<Arc<Atlas>> {
+    let mut guard = ATLAS_CACHE.lock().await;
+    if let Some(atlas) = guard.get(object_path) {
+        return Ok(atlas.clone());
+    }
+    let atlas = reader::open_atlas_store(datasets_object_store, object_path)
+        .await
+        .map_err(|e| {
+            datafusion::error::DataFusionError::Execution(format!(
+                "Failed to open atlas store at {}: {e}",
+                object_path
+            ))
+        })?;
+    guard.insert(object_path.clone(), atlas.clone());
+    Ok(atlas)
+}
 
 /// Per-file payload attached to each `PartitionedFile.extensions`.
 ///
@@ -125,17 +157,6 @@ impl FileSource for AtlasSource {
         })
     }
 
-    fn repartitioned(
-        &self,
-        _target_partitions: usize,
-        _repartition_file_min_size: usize,
-        _output_ordering: Option<datafusion::physical_expr::LexOrdering>,
-        _config: &datafusion::datasource::physical_plan::FileScanConfig,
-    ) -> datafusion::error::Result<Option<datafusion::datasource::physical_plan::FileScanConfig>>
-    {
-        Ok(None)
-    }
-
     fn metrics(&self) -> &ExecutionPlanMetricsSet {
         &self.execution_plan_metrics
     }
@@ -204,8 +225,7 @@ impl AtlasOpener {
         metrics: Option<DatasetReadMetrics>,
         read_dimensions: Option<Vec<String>>,
     ) -> datafusion::error::Result<BoxStream<'static, datafusion::error::Result<RecordBatch>>> {
-        let atlas = reader::open_atlas_store(datasets_object_store, &object_path).await?;
-
+        let atlas = get_or_open_atlas(datasets_object_store, &object_path).await?;
         let view = atlas.open_dataset(&dataset_name).await.map_err(|e| {
             datafusion::error::DataFusionError::Execution(format!(
                 "Failed to open atlas dataset '{dataset_name}' at {object_path}: {e}"
@@ -214,16 +234,14 @@ impl AtlasOpener {
 
         // Derive the file schema from atlas metadata alone (no backends),
         // then ask the schema adapter which fields the query needs.
-        let file_schema: SchemaRef = crate::compat::atlas_view_arrow_schema(
-            &view,
-            read_dimensions.as_deref(),
-        )
-        .map_err(|e| {
-            datafusion::error::DataFusionError::Execution(format!(
-                "Failed to derive Arrow schema for atlas dataset '{dataset_name}': {e}"
-            ))
-        })?
-        .into();
+        let file_schema: SchemaRef =
+            crate::compat::atlas_view_arrow_schema(&view, read_dimensions.as_deref())
+                .map_err(|e| {
+                    datafusion::error::DataFusionError::Execution(format!(
+                        "Failed to derive Arrow schema for atlas dataset '{dataset_name}': {e}"
+                    ))
+                })?
+                .into();
 
         let (schema_mapper, projection) = schema_adapter.map_schema(&file_schema)?;
 
@@ -236,17 +254,14 @@ impl AtlasOpener {
             .iter()
             .map(|i| file_schema.field(*i).name().clone())
             .collect();
-        let dataset = crate::reader::dataset_from_atlas(
-            atlas,
-            &dataset_name,
-            Some(&projected_names),
-        )
-        .await
-        .map_err(|e| {
-            datafusion::error::DataFusionError::Execution(format!(
-                "Failed to load atlas dataset '{dataset_name}': {e}"
-            ))
-        })?;
+        let dataset =
+            crate::reader::dataset_from_atlas(atlas, &dataset_name, Some(&projected_names))
+                .await
+                .map_err(|e| {
+                    datafusion::error::DataFusionError::Execution(format!(
+                        "Failed to load atlas dataset '{dataset_name}': {e}"
+                    ))
+                })?;
 
         // Atlas has no filter pushdown today.
         let pushdown_filter: Option<PushdownFilter> = None;
@@ -294,6 +309,7 @@ impl FileOpener for AtlasOpener {
             file_meta.object_meta.location,
             dataset_name,
             self.datasets_object_store.clone(),
+            self.atlas_cache.clone(),
             self.schema_adapter.clone(),
             self.batch_size,
             metrics,
@@ -312,16 +328,17 @@ mod tests {
     use arrow::array::Array;
     use datafusion::datasource::file_format::FileFormat;
     use datafusion::datasource::listing::PartitionedFile;
-    use datafusion::datasource::physical_plan::{
-        FileMeta, FileScanConfigBuilder, FileSource,
-    };
+    use datafusion::datasource::physical_plan::{FileMeta, FileScanConfigBuilder, FileSource};
     use datafusion::execution::object_store::ObjectStoreUrl;
     use datafusion::prelude::SessionContext;
     use futures::StreamExt;
     use std::sync::Arc;
 
-    async fn build_opener_with_schema()
-    -> (Arc<dyn FileOpener>, arrow::datatypes::SchemaRef, object_store::ObjectMeta) {
+    async fn build_opener_with_schema() -> (
+        Arc<dyn FileOpener>,
+        arrow::datatypes::SchemaRef,
+        object_store::ObjectMeta,
+    ) {
         ensure_fixture().await;
         let store = test_store().await;
         let format = AtlasFormat::new(store.clone(), AtlasOptions::default());
@@ -373,7 +390,11 @@ mod tests {
             metadata_size_hint: None,
         };
 
-        let stream = opener.open(file_meta, pf).expect("open").await.expect("stream");
+        let stream = opener
+            .open(file_meta, pf)
+            .expect("open")
+            .await
+            .expect("stream");
         let batches: Vec<_> = stream.collect().await;
         assert!(!batches.is_empty(), "expected at least one batch");
 
@@ -402,7 +423,10 @@ mod tests {
             metadata_size_hint: None,
         };
         let result = opener.open(file_meta, pf);
-        assert!(result.is_err(), "missing AtlasFileInfo should produce error");
+        assert!(
+            result.is_err(),
+            "missing AtlasFileInfo should produce error"
+        );
     }
 
     #[tokio::test]
@@ -419,12 +443,17 @@ mod tests {
             metadata_size_hint: None,
         };
 
-        let stream = opener.open(file_meta, pf).expect("open").await.expect("stream");
-        let batches: Vec<arrow::record_batch::RecordBatch> = stream
-            .filter_map(|b| async move { b.ok() })
-            .collect()
-            .await;
-        assert!(!batches.is_empty(), "expected at least one batch from summer");
+        let stream = opener
+            .open(file_meta, pf)
+            .expect("open")
+            .await
+            .expect("stream");
+        let batches: Vec<arrow::record_batch::RecordBatch> =
+            stream.filter_map(|b| async move { b.ok() }).collect().await;
+        assert!(
+            !batches.is_empty(),
+            "expected at least one batch from summer"
+        );
 
         for batch in &batches {
             assert_eq!(
@@ -505,11 +534,75 @@ mod tests {
             metadata_size_hint: None,
         };
 
-        let stream = opener.open(file_meta, pf).expect("open").await.expect("stream");
+        let stream = opener
+            .open(file_meta, pf)
+            .expect("open")
+            .await
+            .expect("stream");
         let batches: Vec<_> = stream.collect().await;
         assert!(
             batches.is_empty(),
             "summer has no `cycle`; empty projection must yield no batches"
+        );
+    }
+
+    #[tokio::test]
+    async fn opener_reuses_atlas_across_datasets() {
+        use datafusion::datasource::schema_adapter::{
+            DefaultSchemaAdapterFactory, SchemaAdapterFactory,
+        };
+
+        ensure_fixture().await;
+        let store = test_store().await;
+        let format = AtlasFormat::new(store.clone(), AtlasOptions::default());
+        let ctx = SessionContext::new();
+        let object = fixture_marker_object_meta();
+
+        let dummy_store: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::local::LocalFileSystem::new());
+        let table_schema = format
+            .infer_schema(&ctx.state(), &dummy_store, &[object.clone()])
+            .await
+            .expect("infer schema");
+
+        let projected_schema = table_schema.clone();
+        let schema_adapter =
+            Arc::new(DefaultSchemaAdapterFactory).create(projected_schema, table_schema.clone());
+        let atlas_cache: AtlasCache = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+
+        let opener = AtlasOpener {
+            datasets_object_store: store,
+            schema_adapter: Arc::from(schema_adapter),
+            batch_size: usize::MAX,
+            metrics: ExecutionPlanMetricsSet::new(),
+            partition: 0,
+            read_dimensions: None,
+            atlas_cache: atlas_cache.clone(),
+        };
+
+        for name in ["winter", "summer"] {
+            let pf = pf_for(name, object.clone());
+            let file_meta = FileMeta {
+                object_meta: object.clone(),
+                range: None,
+                extensions: pf.extensions.clone(),
+                metadata_size_hint: None,
+            };
+            let stream = opener
+                .open(file_meta, pf)
+                .expect("open")
+                .await
+                .expect("stream");
+            let batches: Vec<_> = stream.collect().await;
+            assert!(!batches.is_empty(), "expected batches for dataset {name}");
+        }
+
+        let guard = atlas_cache.lock().await;
+        assert_eq!(
+            guard.len(),
+            1,
+            "atlas store must be opened exactly once across both datasets, cache: {:?}",
+            guard.keys().collect::<Vec<_>>(),
         );
     }
 
@@ -524,11 +617,13 @@ mod tests {
             metadata_size_hint: None,
         };
 
-        let stream = opener.open(file_meta, pf).expect("open").await.expect("stream");
-        let batches: Vec<arrow::record_batch::RecordBatch> = stream
-            .filter_map(|b| async move { b.ok() })
-            .collect()
-            .await;
+        let stream = opener
+            .open(file_meta, pf)
+            .expect("open")
+            .await
+            .expect("stream");
+        let batches: Vec<arrow::record_batch::RecordBatch> =
+            stream.filter_map(|b| async move { b.ok() }).collect().await;
         assert!(!batches.is_empty());
 
         // Verify the union schema is honored: even though winter has all
@@ -555,4 +650,3 @@ mod tests {
         assert_eq!(all, vec![1.0f32, 2.0, 3.0, 4.0]);
     }
 }
-

--- a/beacon-arrow-atlas/src/datafusion/source.rs
+++ b/beacon-arrow-atlas/src/datafusion/source.rs
@@ -1,12 +1,9 @@
 use std::sync::Arc;
 
 use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
-use beacon_nd_array::{
-    arrow::{
-        batch::any_dataset_as_record_batch_stream, metrics::DatasetReadMetrics,
-        pushdown_filter::PushdownFilter,
-    },
-    projection::DatasetProjection,
+use beacon_nd_array::arrow::{
+    batch::any_dataset_as_record_batch_stream, metrics::DatasetReadMetrics,
+    pushdown_filter::PushdownFilter,
 };
 use beacon_object_storage::DatasetsStore;
 use datafusion::{
@@ -209,38 +206,24 @@ impl AtlasOpener {
     ) -> datafusion::error::Result<BoxStream<'static, datafusion::error::Result<RecordBatch>>> {
         let atlas = reader::open_atlas_store(datasets_object_store, &object_path).await?;
 
-        let dataset = crate::reader::dataset_from_atlas(atlas, &dataset_name)
-            .await
-            .map_err(|e| {
-                datafusion::error::DataFusionError::Execution(format!(
-                    "Failed to open atlas dataset '{dataset_name}' at {object_path}: {e}"
-                ))
-            })?;
+        let view = atlas.open_dataset(&dataset_name).await.map_err(|e| {
+            datafusion::error::DataFusionError::Execution(format!(
+                "Failed to open atlas dataset '{dataset_name}' at {object_path}: {e}"
+            ))
+        })?;
 
-        // Apply dimension projection before deriving the file schema, so the
-        // schema reflects only arrays whose dimensions match the user's filter.
-        let dataset = if let Some(dims) = read_dimensions {
-            let proj = DatasetProjection {
-                dimension_projection: Some(dims),
-                index_projection: None,
-            };
-            dataset.project(&proj).map_err(|e| {
-                datafusion::error::DataFusionError::Execution(format!(
-                    "Failed to apply dimension projection to atlas dataset '{dataset_name}': {e}"
-                ))
-            })?
-        } else {
-            dataset
-        };
-
-        let file_schema: SchemaRef =
-            beacon_nd_array::arrow::schema::any_dataset_to_arrow_schema(&dataset)
-                .map_err(|e| {
-                    datafusion::error::DataFusionError::Execution(format!(
-                        "Failed to derive Arrow schema from atlas dataset '{dataset_name}': {e}"
-                    ))
-                })?
-                .into();
+        // Derive the file schema from atlas metadata alone (no backends),
+        // then ask the schema adapter which fields the query needs.
+        let file_schema: SchemaRef = crate::compat::atlas_view_arrow_schema(
+            &view,
+            read_dimensions.as_deref(),
+        )
+        .map_err(|e| {
+            datafusion::error::DataFusionError::Execution(format!(
+                "Failed to derive Arrow schema for atlas dataset '{dataset_name}': {e}"
+            ))
+        })?
+        .into();
 
         let (schema_mapper, projection) = schema_adapter.map_schema(&file_schema)?;
 
@@ -248,19 +231,22 @@ impl AtlasOpener {
             return Ok(futures::stream::empty().boxed());
         }
 
-        let dataset = if projection.len() < file_schema.fields().len() {
-            let proj = DatasetProjection {
-                dimension_projection: None,
-                index_projection: Some(projection),
-            };
-            dataset.project(&proj).map_err(|e| {
-                datafusion::error::DataFusionError::Execution(format!(
-                    "Failed to project atlas dataset '{dataset_name}': {e}"
-                ))
-            })?
-        } else {
-            dataset
-        };
+        // Build the AnyDataset with only the queried-and-available columns.
+        let projected_names: Vec<String> = projection
+            .iter()
+            .map(|i| file_schema.field(*i).name().clone())
+            .collect();
+        let dataset = crate::reader::dataset_from_atlas(
+            atlas,
+            &dataset_name,
+            Some(&projected_names),
+        )
+        .await
+        .map_err(|e| {
+            datafusion::error::DataFusionError::Execution(format!(
+                "Failed to load atlas dataset '{dataset_name}': {e}"
+            ))
+        })?;
 
         // Atlas has no filter pushdown today.
         let pushdown_filter: Option<PushdownFilter> = None;
@@ -417,6 +403,114 @@ mod tests {
         };
         let result = opener.open(file_meta, pf);
         assert!(result.is_err(), "missing AtlasFileInfo should produce error");
+    }
+
+    #[tokio::test]
+    async fn opener_summer_null_fills_missing_columns() {
+        // Summer has only `temperature` + `season` — querying with the full
+        // union schema must still produce batches whose width matches the
+        // table schema, with NULLs in the columns summer doesn't carry.
+        let (opener, schema, object) = build_opener_with_schema().await;
+        let pf = pf_for("summer", object.clone());
+        let file_meta = FileMeta {
+            object_meta: object,
+            range: None,
+            extensions: pf.extensions.clone(),
+            metadata_size_hint: None,
+        };
+
+        let stream = opener.open(file_meta, pf).expect("open").await.expect("stream");
+        let batches: Vec<arrow::record_batch::RecordBatch> = stream
+            .filter_map(|b| async move { b.ok() })
+            .collect()
+            .await;
+        assert!(!batches.is_empty(), "expected at least one batch from summer");
+
+        for batch in &batches {
+            assert_eq!(
+                batch.schema().fields().len(),
+                schema.fields().len(),
+                "table-schema width must be honored even when columns are missing",
+            );
+        }
+
+        let temp_idx = schema.index_of("temperature").expect("temperature column");
+        let cycle_idx = schema.index_of("cycle").expect("cycle column");
+        let year_idx = schema.index_of("year").expect("year column");
+
+        let mut temps = Vec::new();
+        for batch in &batches {
+            let arr = batch
+                .column(temp_idx)
+                .as_any()
+                .downcast_ref::<arrow::array::Float32Array>()
+                .expect("temperature is Float32");
+            for i in 0..arr.len() {
+                if arr.is_valid(i) {
+                    temps.push(arr.value(i));
+                }
+            }
+
+            let cycle = batch.column(cycle_idx);
+            assert_eq!(
+                cycle.null_count(),
+                cycle.len(),
+                "summer's `cycle` column should be all-null"
+            );
+            let year = batch.column(year_idx);
+            assert_eq!(
+                year.null_count(),
+                year.len(),
+                "summer's `year` column should be all-null"
+            );
+        }
+        assert_eq!(temps, vec![20.0f32, 21.0, 22.0]);
+    }
+
+    #[tokio::test]
+    async fn opener_projection_only_missing_column_yields_empty_stream() {
+        // Project the table schema down to just `cycle` and read summer,
+        // which has no `cycle`. The schema adapter's projection comes back
+        // empty so the stream must be empty (no rows of all-NULL).
+        ensure_fixture().await;
+        let store = test_store().await;
+        let format = AtlasFormat::new(store.clone(), AtlasOptions::default());
+        let ctx = SessionContext::new();
+        let object = fixture_marker_object_meta();
+
+        let dummy_store: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::local::LocalFileSystem::new());
+
+        let table_schema = format
+            .infer_schema(&ctx.state(), &dummy_store, &[object.clone()])
+            .await
+            .expect("infer schema");
+        let cycle_idx = table_schema.index_of("cycle").expect("cycle column");
+
+        let source = AtlasSource::new(store, None);
+        let conf = FileScanConfigBuilder::new(
+            ObjectStoreUrl::local_filesystem(),
+            table_schema.clone(),
+            Arc::new(source.clone()) as Arc<dyn FileSource>,
+        )
+        .with_projection(Some(vec![cycle_idx]))
+        .build();
+
+        let opener = source.create_file_opener(dummy_store, &conf, 0);
+        let pf = pf_for("summer", object.clone());
+        let file_meta = FileMeta {
+            object_meta: object,
+            range: None,
+            extensions: pf.extensions.clone(),
+            metadata_size_hint: None,
+        };
+
+        let stream = opener.open(file_meta, pf).expect("open").await.expect("stream");
+        let batches: Vec<_> = stream.collect().await;
+        assert!(
+            batches.is_empty(),
+            "summer has no `cycle`; empty projection must yield no batches"
+        );
     }
 
     #[tokio::test]

--- a/beacon-arrow-atlas/src/lib.rs
+++ b/beacon-arrow-atlas/src/lib.rs
@@ -1,0 +1,15 @@
+//! `beacon-arrow-atlas` bridges Atlas array stores and Beacon ND Arrow arrays.
+//!
+//! Atlas (<https://github.com/robinskil/atlas>) is a directory-based store
+//! where a single `atlas.json` registry describes one or more named
+//! datasets, each containing its own set of arrays. This crate exposes
+//! each atlas dataset as a Beacon `AnyDataset` via lazy `NdArrayD`
+//! backends and registers an `AtlasFormat` / `AtlasFormatFactory` so the
+//! datasets are queryable through DataFusion.
+
+pub use atlas;
+
+pub mod backend;
+pub mod compat;
+pub mod datafusion;
+pub mod reader;

--- a/beacon-arrow-atlas/src/lib.rs
+++ b/beacon-arrow-atlas/src/lib.rs
@@ -13,3 +13,19 @@ pub mod backend;
 pub mod compat;
 pub mod datafusion;
 pub mod reader;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_name() {
+        let store = atlas::Atlas::open_path("data/datasets/example")
+            .await
+            .unwrap();
+
+        println!("Store name: {:?}", store.list_datasets());
+
+        let dataset = store.open_dataset("GL_PR_CT_2FGX5").await.unwrap();
+    }
+}

--- a/beacon-arrow-atlas/src/reader.rs
+++ b/beacon-arrow-atlas/src/reader.rs
@@ -1,0 +1,272 @@
+//! High-level atlas reader that produces [`AnyDataset`] values.
+//!
+//! Each atlas store may hold multiple named datasets. [`open_dataset`]
+//! returns the contents of **one** atlas dataset as a Beacon
+//! [`AnyDataset`], wrapping every array and attribute in a lazy
+//! [`NdArrayD`](beacon_nd_array::NdArrayD) backend.
+
+use std::{path::Path, sync::Arc};
+
+use atlas::Atlas;
+use beacon_nd_array::{NdArrayD, dataset::{AnyDataset, Dataset}};
+use indexmap::IndexMap;
+
+use crate::compat;
+
+/// Open an atlas store on the local filesystem and read the named
+/// dataset into an [`AnyDataset`].
+///
+/// This is a convenience for tests and standalone callers; the
+/// DataFusion code path opens the [`Atlas`] handle separately and calls
+/// [`dataset_from_atlas`] directly.
+pub async fn open_dataset<P: AsRef<Path>>(
+    store_path: P,
+    dataset_name: &str,
+) -> anyhow::Result<AnyDataset> {
+    let atlas = Atlas::open_path(store_path.as_ref())
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to open atlas store at {:?}: {}", store_path.as_ref(), e))?;
+    dataset_from_atlas(Arc::new(atlas), dataset_name).await
+}
+
+/// Build an [`AnyDataset`] from an already-open atlas handle.
+pub async fn dataset_from_atlas(
+    atlas: Arc<Atlas>,
+    dataset_name: &str,
+) -> anyhow::Result<AnyDataset> {
+    let view = atlas
+        .open_dataset(dataset_name)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to open atlas dataset '{}': {}", dataset_name, e))?;
+
+    let mut arrays: IndexMap<String, Arc<dyn NdArrayD>> = IndexMap::new();
+
+    for array_name in view.list_arrays() {
+        let schema = view
+            .array_meta(&array_name)
+            .map_err(|e| anyhow::anyhow!(
+                "Failed to read atlas schema for array '{}' in dataset '{}': {}",
+                array_name,
+                dataset_name,
+                e
+            ))?;
+        match compat::array_to_nd_array(atlas.clone(), dataset_name, &array_name, &schema) {
+            Ok(nd) => {
+                arrays.insert(array_name, nd);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Skipping atlas array '{}' in dataset '{}': {}",
+                    array_name,
+                    dataset_name,
+                    e
+                );
+            }
+        }
+    }
+
+    for (attr_name, attr_value) in view.meta().attributes {
+        match compat::attribute_to_nd_array(&attr_name, attr_value) {
+            Ok(nd) => {
+                arrays.insert(attr_name, nd);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Skipping atlas attribute '{}' in dataset '{}': {}",
+                    attr_name,
+                    dataset_name,
+                    e
+                );
+            }
+        }
+    }
+
+    arrays.sort_keys();
+
+    let dataset = Dataset::new(dataset_name.to_string(), arrays).await;
+    AnyDataset::try_from_dataset(dataset)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to wrap atlas dataset as AnyDataset: {}", e))
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    //! Helpers for building atlas store fixtures in tests across the crate.
+
+    use atlas::{Atlas, Attr, StoreConfig};
+    use std::path::Path;
+
+    /// Build a two-dataset atlas store at `path`.
+    ///
+    /// Layout:
+    /// - `winter`: arrays `temperature: Float32[4]`, `cycle: Int32[4]`;
+    ///   attribute `season: String("winter")`, `year: Int64(2024)`.
+    /// - `summer`: arrays `temperature: Float32[3]`;
+    ///   attribute `season: String("summer")`.
+    pub async fn build_two_dataset_store(path: &Path) {
+        let mut atlas = Atlas::create_path(path, StoreConfig::default())
+            .await
+            .expect("create atlas store");
+
+        // ── winter ────────────────────────────────────────────────────
+        let mut winter = atlas
+            .create_dataset("winter")
+            .await
+            .expect("create winter");
+        winter
+            .define_array::<f32>("temperature", vec!["obs".into()], vec![4], None, None)
+            .await
+            .expect("define winter.temperature");
+        winter
+            .define_array::<i32>("cycle", vec!["obs".into()], vec![4], None, None)
+            .await
+            .expect("define winter.cycle");
+        winter.set_attribute("season", Attr::String("winter".into()));
+        winter.set_attribute("year", Attr::Int64(2024));
+
+        let temps = ndarray::arr1(&[1.0f32, 2.0, 3.0, 4.0]).into_dyn();
+        winter
+            .write_array("temperature", vec![0], temps.view())
+            .await
+            .expect("write winter.temperature");
+        let cycles = ndarray::arr1(&[10i32, 20, 30, 40]).into_dyn();
+        winter
+            .write_array("cycle", vec![0], cycles.view())
+            .await
+            .expect("write winter.cycle");
+
+        // ── summer ────────────────────────────────────────────────────
+        let mut summer = atlas
+            .create_dataset("summer")
+            .await
+            .expect("create summer");
+        summer
+            .define_array::<f32>("temperature", vec!["obs".into()], vec![3], None, None)
+            .await
+            .expect("define summer.temperature");
+        summer.set_attribute("season", Attr::String("summer".into()));
+
+        let temps = ndarray::arr1(&[20.0f32, 21.0, 22.0]).into_dyn();
+        summer
+            .write_array("temperature", vec![0], temps.view())
+            .await
+            .expect("write summer.temperature");
+
+        // Persist `atlas.json` + array files to disk.
+        atlas.flush().await.expect("flush atlas store");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::build_two_dataset_store;
+    use super::*;
+    use beacon_nd_array::NdArray;
+
+    #[tokio::test]
+    async fn open_dataset_lists_arrays_and_attributes() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        build_two_dataset_store(tmp.path()).await;
+
+        let winter = open_dataset(tmp.path(), "winter").await.expect("open winter");
+        assert_eq!(winter.name(), "winter");
+
+        let ds = winter.dataset();
+        let names: Vec<&str> = ds.arrays.keys().map(|s| s.as_str()).collect();
+        // Sorted insertion: season, temperature, year, cycle - then sorted to:
+        // cycle, season, temperature, year
+        assert!(names.contains(&"temperature"));
+        assert!(names.contains(&"cycle"));
+        assert!(names.contains(&"season"));
+        assert!(names.contains(&"year"));
+    }
+
+    #[tokio::test]
+    async fn open_dataset_reads_array_values() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        build_two_dataset_store(tmp.path()).await;
+
+        let winter = open_dataset(tmp.path(), "winter").await.expect("open winter");
+        let temp = winter
+            .get_array("temperature")
+            .expect("temperature array")
+            .as_any()
+            .downcast_ref::<NdArray<f32>>()
+            .expect("downcast f32");
+        let raw = temp.clone_into_raw_vec().await;
+        assert_eq!(raw, vec![1.0f32, 2.0, 3.0, 4.0]);
+
+        let cycle = winter
+            .get_array("cycle")
+            .expect("cycle array")
+            .as_any()
+            .downcast_ref::<NdArray<i32>>()
+            .expect("downcast i32");
+        let raw = cycle.clone_into_raw_vec().await;
+        assert_eq!(raw, vec![10i32, 20, 30, 40]);
+    }
+
+    #[tokio::test]
+    async fn open_dataset_reads_attributes_as_rank_zero() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        build_two_dataset_store(tmp.path()).await;
+
+        let winter = open_dataset(tmp.path(), "winter").await.expect("open winter");
+        let season = winter
+            .get_array("season")
+            .expect("season attribute")
+            .as_any()
+            .downcast_ref::<NdArray<String>>()
+            .expect("downcast string");
+        assert!(season.shape().is_empty(), "attribute should be rank-0");
+        let raw = season.clone_into_raw_vec().await;
+        assert_eq!(raw, vec!["winter".to_string()]);
+
+        let year = winter
+            .get_array("year")
+            .expect("year attribute")
+            .as_any()
+            .downcast_ref::<NdArray<i64>>()
+            .expect("downcast i64");
+        let raw = year.clone_into_raw_vec().await;
+        assert_eq!(raw, vec![2024i64]);
+    }
+
+    #[tokio::test]
+    async fn open_dataset_distinguishes_between_dataset_views() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        build_two_dataset_store(tmp.path()).await;
+
+        let winter = open_dataset(tmp.path(), "winter").await.expect("open winter");
+        let summer = open_dataset(tmp.path(), "summer").await.expect("open summer");
+
+        assert_eq!(winter.dataset().get_array("temperature").unwrap().shape(), &[4]);
+        assert_eq!(summer.dataset().get_array("temperature").unwrap().shape(), &[3]);
+        // summer doesn't define `cycle` or `year`.
+        assert!(summer.dataset().get_array("cycle").is_none());
+        assert!(summer.dataset().get_array("year").is_none());
+    }
+
+    #[tokio::test]
+    async fn open_dataset_unknown_returns_error() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        build_two_dataset_store(tmp.path()).await;
+
+        let err = open_dataset(tmp.path(), "ghost")
+            .await
+            .expect_err("should fail for unknown dataset");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("ghost") || msg.contains("DatasetNotFound"),
+            "error should mention missing dataset name: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn open_dataset_missing_store_path_errors() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        // No store created — atlas.json absent.
+        let result = open_dataset(tmp.path(), "winter").await;
+        assert!(result.is_err());
+    }
+}

--- a/beacon-arrow-atlas/src/reader.rs
+++ b/beacon-arrow-atlas/src/reader.rs
@@ -8,7 +8,10 @@
 use std::{path::Path, sync::Arc};
 
 use atlas::Atlas;
-use beacon_nd_array::{NdArrayD, dataset::{AnyDataset, Dataset}};
+use beacon_nd_array::{
+    NdArrayD,
+    dataset::{AnyDataset, Dataset},
+};
 use indexmap::IndexMap;
 
 use crate::compat;
@@ -23,34 +26,64 @@ pub async fn open_dataset<P: AsRef<Path>>(
     store_path: P,
     dataset_name: &str,
 ) -> anyhow::Result<AnyDataset> {
-    let atlas = Atlas::open_path(store_path.as_ref())
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to open atlas store at {:?}: {}", store_path.as_ref(), e))?;
-    dataset_from_atlas(Arc::new(atlas), dataset_name).await
+    let atlas = Atlas::open_path(store_path.as_ref()).await.map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to open atlas store at {:?}: {}",
+            store_path.as_ref(),
+            e
+        )
+    })?;
+    dataset_from_atlas(Arc::new(atlas), dataset_name, None).await
 }
 
 /// Build an [`AnyDataset`] from an already-open atlas handle.
+///
+/// `projected_names`:
+/// - `None` — include every array and attribute in the dataset.
+/// - `Some(names)` — include only arrays/attributes whose name appears in
+///   `names`. Names not present in the dataset are silently ignored.
+///   This lets the DataFusion source skip building `NdArrayD` backends
+///   for columns the query won't use.
 pub async fn dataset_from_atlas(
     atlas: Arc<Atlas>,
     dataset_name: &str,
+    projected_names: Option<&[String]>,
 ) -> anyhow::Result<AnyDataset> {
     let view = atlas
         .open_dataset(dataset_name)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to open atlas dataset '{}': {}", dataset_name, e))?;
 
+    let included = |name: &str| projected_names.map_or(true, |names| names.iter().any(|n| n == name));
+
     let mut arrays: IndexMap<String, Arc<dyn NdArrayD>> = IndexMap::new();
 
     for array_name in view.list_arrays() {
-        let schema = view
-            .array_meta(&array_name)
-            .map_err(|e| anyhow::anyhow!(
-                "Failed to read atlas schema for array '{}' in dataset '{}': {}",
+        if !included(&array_name) {
+            continue;
+        }
+        let schema = view.array_meta(&array_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Atlas schema missing for array '{}' in dataset '{}'",
+                array_name,
+                dataset_name,
+            )
+        })?;
+        let fill_value = view.array_fill_value(&array_name).await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to read fill value for atlas array '{}' in dataset '{}': {}",
                 array_name,
                 dataset_name,
                 e
-            ))?;
-        match compat::array_to_nd_array(atlas.clone(), dataset_name, &array_name, &schema) {
+            )
+        })?;
+        match compat::array_to_nd_array(
+            atlas.clone(),
+            dataset_name,
+            &array_name,
+            &schema,
+            fill_value,
+        ) {
             Ok(nd) => {
                 arrays.insert(array_name, nd);
             }
@@ -66,6 +99,9 @@ pub async fn dataset_from_atlas(
     }
 
     for (attr_name, attr_value) in view.meta().attributes {
+        if !included(&attr_name) {
+            continue;
+        }
         match compat::attribute_to_nd_array(&attr_name, attr_value) {
             Ok(nd) => {
                 arrays.insert(attr_name, nd);
@@ -93,13 +129,14 @@ pub async fn dataset_from_atlas(
 pub(crate) mod test_support {
     //! Helpers for building atlas store fixtures in tests across the crate.
 
-    use atlas::{Atlas, Attr, StoreConfig};
+    use atlas::{Atlas, Attr, FillValue, StoreConfig};
     use std::path::Path;
 
     /// Build a two-dataset atlas store at `path`.
     ///
     /// Layout:
-    /// - `winter`: arrays `temperature: Float32[4]`, `cycle: Int32[4]`;
+    /// - `winter`: arrays `temperature: Float32[4]`, `cycle: Int32[4]`
+    ///   (fill_value = -1, lets us assert fill propagation end-to-end);
     ///   attribute `season: String("winter")`, `year: Int64(2024)`.
     /// - `summer`: arrays `temperature: Float32[3]`;
     ///   attribute `season: String("summer")`.
@@ -109,16 +146,19 @@ pub(crate) mod test_support {
             .expect("create atlas store");
 
         // ── winter ────────────────────────────────────────────────────
-        let mut winter = atlas
-            .create_dataset("winter")
-            .await
-            .expect("create winter");
+        let mut winter = atlas.create_dataset("winter").await.expect("create winter");
         winter
             .define_array::<f32>("temperature", vec!["obs".into()], vec![4], None, None)
             .await
             .expect("define winter.temperature");
         winter
-            .define_array::<i32>("cycle", vec!["obs".into()], vec![4], None, None)
+            .define_array::<i32>(
+                "cycle",
+                vec!["obs".into()],
+                vec![4],
+                None,
+                Some(FillValue::Int(-1)),
+            )
             .await
             .expect("define winter.cycle");
         winter.set_attribute("season", Attr::String("winter".into()));
@@ -136,10 +176,7 @@ pub(crate) mod test_support {
             .expect("write winter.cycle");
 
         // ── summer ────────────────────────────────────────────────────
-        let mut summer = atlas
-            .create_dataset("summer")
-            .await
-            .expect("create summer");
+        let mut summer = atlas.create_dataset("summer").await.expect("create summer");
         summer
             .define_array::<f32>("temperature", vec!["obs".into()], vec![3], None, None)
             .await
@@ -168,7 +205,9 @@ mod tests {
         let tmp = tempfile::tempdir().expect("temp dir");
         build_two_dataset_store(tmp.path()).await;
 
-        let winter = open_dataset(tmp.path(), "winter").await.expect("open winter");
+        let winter = open_dataset(tmp.path(), "winter")
+            .await
+            .expect("open winter");
         assert_eq!(winter.name(), "winter");
 
         let ds = winter.dataset();
@@ -186,7 +225,9 @@ mod tests {
         let tmp = tempfile::tempdir().expect("temp dir");
         build_two_dataset_store(tmp.path()).await;
 
-        let winter = open_dataset(tmp.path(), "winter").await.expect("open winter");
+        let winter = open_dataset(tmp.path(), "winter")
+            .await
+            .expect("open winter");
         let temp = winter
             .get_array("temperature")
             .expect("temperature array")
@@ -211,7 +252,9 @@ mod tests {
         let tmp = tempfile::tempdir().expect("temp dir");
         build_two_dataset_store(tmp.path()).await;
 
-        let winter = open_dataset(tmp.path(), "winter").await.expect("open winter");
+        let winter = open_dataset(tmp.path(), "winter")
+            .await
+            .expect("open winter");
         let season = winter
             .get_array("season")
             .expect("season attribute")
@@ -233,15 +276,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn open_dataset_propagates_array_fill_value() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        build_two_dataset_store(tmp.path()).await;
+
+        let winter = open_dataset(tmp.path(), "winter")
+            .await
+            .expect("open winter");
+        let cycle = winter
+            .get_array("cycle")
+            .expect("cycle array")
+            .as_any()
+            .downcast_ref::<NdArray<i32>>()
+            .expect("downcast i32");
+        assert_eq!(cycle.fill_value().await, Some(-1i32));
+
+        // temperature was defined without a fill value.
+        let temperature = winter
+            .get_array("temperature")
+            .expect("temperature array")
+            .as_any()
+            .downcast_ref::<NdArray<f32>>()
+            .expect("downcast f32");
+        assert_eq!(temperature.fill_value().await, None);
+    }
+
+    #[tokio::test]
     async fn open_dataset_distinguishes_between_dataset_views() {
         let tmp = tempfile::tempdir().expect("temp dir");
         build_two_dataset_store(tmp.path()).await;
 
-        let winter = open_dataset(tmp.path(), "winter").await.expect("open winter");
-        let summer = open_dataset(tmp.path(), "summer").await.expect("open summer");
+        let winter = open_dataset(tmp.path(), "winter")
+            .await
+            .expect("open winter");
+        let summer = open_dataset(tmp.path(), "summer")
+            .await
+            .expect("open summer");
 
-        assert_eq!(winter.dataset().get_array("temperature").unwrap().shape(), &[4]);
-        assert_eq!(summer.dataset().get_array("temperature").unwrap().shape(), &[3]);
+        assert_eq!(
+            winter.dataset().get_array("temperature").unwrap().shape(),
+            &[4]
+        );
+        assert_eq!(
+            summer.dataset().get_array("temperature").unwrap().shape(),
+            &[3]
+        );
         // summer doesn't define `cycle` or `year`.
         assert!(summer.dataset().get_array("cycle").is_none());
         assert!(summer.dataset().get_array("year").is_none());

--- a/beacon-arrow-atlas/src/reader.rs
+++ b/beacon-arrow-atlas/src/reader.rs
@@ -141,7 +141,14 @@ pub(crate) mod test_support {
     /// - `summer`: arrays `temperature: Float32[3]`;
     ///   attribute `season: String("summer")`.
     pub async fn build_two_dataset_store(path: &Path) {
-        let mut atlas = Atlas::create_path(path, StoreConfig::default())
+        build_two_dataset_store_with_config(path, StoreConfig::default()).await;
+    }
+
+    /// Same as [`build_two_dataset_store`] but lets the caller pick the
+    /// metadata format / compression so tests can exercise non-default
+    /// atlas marker filenames (e.g. `atlas.msgpack.zst`).
+    pub async fn build_two_dataset_store_with_config(path: &Path, config: StoreConfig) {
+        let mut atlas = Atlas::create_path(path, config)
             .await
             .expect("create atlas store");
 

--- a/beacon-arrow-odv/Cargo.toml
+++ b/beacon-arrow-odv/Cargo.toml
@@ -20,7 +20,7 @@ tar = "0.4.44"
 zstd = "0.13.3"
 lz4_flex = "0.11.3"
 zip = "2.2.3"
-async_zip = { version = "0.0.18", features = ["tokio", "zstd"] }
+async_zip = { version = "0.0.18", features = ["tokio", "zstd", "deflate"] }
 tokio-util = "0.7.16"
 walkdir = "2.5.0"
 regex = "1.11.1"

--- a/beacon-arrow-odv/src/reader.rs
+++ b/beacon-arrow-odv/src/reader.rs
@@ -334,7 +334,7 @@ impl AsyncOdvDecoder {
         schema_mapper: Arc<OdvSchemaMapper>,
     ) -> impl Stream<Item = Result<RecordBatch, ArrowError>> {
         let decoder = arrow::csv::reader::ReaderBuilder::new(schema_mapper.input_schema.clone())
-            .with_batch_size(16 * 1024)
+            .with_batch_size(32 * 1024)
             .with_comment(b'/')
             .with_delimiter(b'\t')
             .with_header(true)
@@ -446,7 +446,7 @@ mod tests {
     async fn test_full_file_compressed() {
         let object_store =
             object_store::local::LocalFileSystem::new_with_prefix("./test-data/").unwrap();
-        let path = object_store::path::Path::from("test.txt.zst");
+        let path = object_store::path::Path::from("large_test_odv.txt");
 
         let reader = OdvObjectReader::try_new(Arc::new(object_store), path)
             .await
@@ -456,9 +456,14 @@ mod tests {
         let output_file = std::fs::File::create("./test-data/test_output_compressed.csv").unwrap();
         let mut writer = arrow::csv::Writer::new(output_file);
 
+        let mut counter = 0;
         while let Some(batch) = async_stream.next().await {
             let batch = batch.unwrap();
+            counter += batch.num_rows();
+            println!("Writing batch: {}", batch.num_rows());
             writer.write(&batch).unwrap();
+            println!("Total rows written so far: {}", counter);
         }
+        println!("Total rows written: {}", counter);
     }
 }

--- a/beacon-arrow-odv/src/reader.rs
+++ b/beacon-arrow-odv/src/reader.rs
@@ -440,4 +440,25 @@ mod tests {
             writer.write(&batch).unwrap();
         }
     }
+
+    #[tokio::test]
+    #[ignore = "This needs to be fixed"]
+    async fn test_full_file_compressed() {
+        let object_store =
+            object_store::local::LocalFileSystem::new_with_prefix("./test-data/").unwrap();
+        let path = object_store::path::Path::from("test.txt.zst");
+
+        let reader = OdvObjectReader::try_new(Arc::new(object_store), path)
+            .await
+            .unwrap();
+        let mut async_stream = reader.read_async(None).await;
+
+        let output_file = std::fs::File::create("./test-data/test_output_compressed.csv").unwrap();
+        let mut writer = arrow::csv::Writer::new(output_file);
+
+        while let Some(batch) = async_stream.next().await {
+            let batch = batch.unwrap();
+            writer.write(&batch).unwrap();
+        }
+    }
 }

--- a/beacon-arrow-tiff/Cargo.toml
+++ b/beacon-arrow-tiff/Cargo.toml
@@ -22,7 +22,7 @@ beacon-common = { path = "../beacon-common" }
 beacon-config = { path = "../beacon-config" }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }
 beacon-nd-array = { path = "../beacon-nd-array" }
-ndarray = { version = "0.17.1" }
+ndarray = { version = "0.17" }
 beacon-object-storage = { path = "../beacon-object-storage" }
 
 [dev-dependencies]

--- a/beacon-arrow-zarr/Cargo.toml
+++ b/beacon-arrow-zarr/Cargo.toml
@@ -4,9 +4,12 @@ version = "1.6.0"
 edition = "2024"
 
 [dependencies]
-zarrs = {"version" = "0.22.2", features = ["async"]}
+zarrs = {"version" = "0.23.12", features = ["async"]}
+# zarrs_object_store stays on 0.5.x: 0.6.x requires object_store ^0.13 but
+# the workspace pins object_store 0.12.x. Both 0.5.x and 0.6.x share
+# zarrs_storage 0.4.x so the trait composition with zarrs 0.23 still works.
 zarrs_object_store = "0.5.0"
-zarrs_storage = "0.4.0"
+zarrs_storage = "0.4.2"
 object_store = { workspace = true }
 tokio = { workspace = true }
 arrow = { workspace = true }

--- a/beacon-arrow-zarr/src/data_types.rs
+++ b/beacon-arrow-zarr/src/data_types.rs
@@ -1,20 +1,83 @@
+//! Classification of `zarrs::array::DataType` (a struct in zarrs >= 0.23) into a
+//! match-friendly enum so call sites can dispatch by built-in dtype.
+
+use zarrs::array::DataType;
+use zarrs::array::data_type::{
+    BoolDataType, BytesDataType, Float32DataType, Float64DataType, Int8DataType, Int16DataType,
+    Int32DataType, Int64DataType, StringDataType, UInt8DataType, UInt16DataType, UInt32DataType,
+    UInt64DataType,
+};
+
+/// Built-in zarrs data types we have explicit Arrow mappings for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZarrDtypeKind {
+    Bool,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    Float32,
+    Float64,
+    String,
+    Bytes,
+    /// Any data type not covered above (custom / extension types).
+    Other,
+}
+
+/// Discriminates a [`DataType`] into a [`ZarrDtypeKind`].
+pub fn classify(data_type: &DataType) -> ZarrDtypeKind {
+    if data_type.is::<BoolDataType>() {
+        ZarrDtypeKind::Bool
+    } else if data_type.is::<Int8DataType>() {
+        ZarrDtypeKind::Int8
+    } else if data_type.is::<Int16DataType>() {
+        ZarrDtypeKind::Int16
+    } else if data_type.is::<Int32DataType>() {
+        ZarrDtypeKind::Int32
+    } else if data_type.is::<Int64DataType>() {
+        ZarrDtypeKind::Int64
+    } else if data_type.is::<UInt8DataType>() {
+        ZarrDtypeKind::UInt8
+    } else if data_type.is::<UInt16DataType>() {
+        ZarrDtypeKind::UInt16
+    } else if data_type.is::<UInt32DataType>() {
+        ZarrDtypeKind::UInt32
+    } else if data_type.is::<UInt64DataType>() {
+        ZarrDtypeKind::UInt64
+    } else if data_type.is::<Float32DataType>() {
+        ZarrDtypeKind::Float32
+    } else if data_type.is::<Float64DataType>() {
+        ZarrDtypeKind::Float64
+    } else if data_type.is::<StringDataType>() {
+        ZarrDtypeKind::String
+    } else if data_type.is::<BytesDataType>() {
+        ZarrDtypeKind::Bytes
+    } else {
+        ZarrDtypeKind::Other
+    }
+}
+
 pub fn try_zarrs_dtype_to_arrow(
-    data_type: zarrs::array::DataType,
+    data_type: &DataType,
 ) -> Result<arrow::datatypes::DataType, String> {
-    match data_type {
-        zarrs::array::DataType::Bool => Ok(arrow::datatypes::DataType::Boolean),
-        zarrs::array::DataType::Int8 => Ok(arrow::datatypes::DataType::Int8),
-        zarrs::array::DataType::Int16 => Ok(arrow::datatypes::DataType::Int16),
-        zarrs::array::DataType::Int32 => Ok(arrow::datatypes::DataType::Int32),
-        zarrs::array::DataType::Int64 => Ok(arrow::datatypes::DataType::Int64),
-        zarrs::array::DataType::UInt8 => Ok(arrow::datatypes::DataType::UInt8),
-        zarrs::array::DataType::UInt16 => Ok(arrow::datatypes::DataType::UInt16),
-        zarrs::array::DataType::UInt32 => Ok(arrow::datatypes::DataType::UInt32),
-        zarrs::array::DataType::UInt64 => Ok(arrow::datatypes::DataType::UInt64),
-        zarrs::array::DataType::Float32 => Ok(arrow::datatypes::DataType::Float32),
-        zarrs::array::DataType::Float64 => Ok(arrow::datatypes::DataType::Float64),
-        zarrs::array::DataType::String => Ok(arrow::datatypes::DataType::Utf8),
-        zarrs::array::DataType::Bytes => Ok(arrow::datatypes::DataType::Binary),
-        _ => Err(format!("Unsupported Zarrs data type: {:?}", data_type)),
+    match classify(data_type) {
+        ZarrDtypeKind::Bool => Ok(arrow::datatypes::DataType::Boolean),
+        ZarrDtypeKind::Int8 => Ok(arrow::datatypes::DataType::Int8),
+        ZarrDtypeKind::Int16 => Ok(arrow::datatypes::DataType::Int16),
+        ZarrDtypeKind::Int32 => Ok(arrow::datatypes::DataType::Int32),
+        ZarrDtypeKind::Int64 => Ok(arrow::datatypes::DataType::Int64),
+        ZarrDtypeKind::UInt8 => Ok(arrow::datatypes::DataType::UInt8),
+        ZarrDtypeKind::UInt16 => Ok(arrow::datatypes::DataType::UInt16),
+        ZarrDtypeKind::UInt32 => Ok(arrow::datatypes::DataType::UInt32),
+        ZarrDtypeKind::UInt64 => Ok(arrow::datatypes::DataType::UInt64),
+        ZarrDtypeKind::Float32 => Ok(arrow::datatypes::DataType::Float32),
+        ZarrDtypeKind::Float64 => Ok(arrow::datatypes::DataType::Float64),
+        ZarrDtypeKind::String => Ok(arrow::datatypes::DataType::Utf8),
+        ZarrDtypeKind::Bytes => Ok(arrow::datatypes::DataType::Binary),
+        ZarrDtypeKind::Other => Err(format!("Unsupported Zarrs data type: {:?}", data_type)),
     }
 }

--- a/beacon-arrow-zarr/src/decoder.rs
+++ b/beacon-arrow-zarr/src/decoder.rs
@@ -128,45 +128,45 @@ impl ArrowFillValue {
         array_data_type: &zarrs::array::DataType,
         fill_value_attr: Option<&AttributeValue>,
     ) -> Option<Self> {
-        match array_data_type {
-            zarrs::array::DataType::Bool => fill_value_attr
+        match crate::data_types::classify(array_data_type) {
+            crate::data_types::ZarrDtypeKind::Bool => fill_value_attr
                 .and_then(|attr| attr.as_bool())
                 .map(ArrowFillValue::Bool),
-            zarrs::array::DataType::Int8 => fill_value_attr
+            crate::data_types::ZarrDtypeKind::Int8 => fill_value_attr
                 .and_then(|attr| attr.as_f64().and_then(|v| i8::try_from(v as i64).ok()))
                 .map(ArrowFillValue::Int8),
-            zarrs::array::DataType::Int16 => fill_value_attr
+            crate::data_types::ZarrDtypeKind::Int16 => fill_value_attr
                 .and_then(|attr| attr.as_f64().and_then(|v| i16::try_from(v as i64).ok()))
                 .map(ArrowFillValue::Int16),
-            zarrs::array::DataType::Int32 => fill_value_attr
+            crate::data_types::ZarrDtypeKind::Int32 => fill_value_attr
                 .and_then(|attr| attr.as_f64().and_then(|v| i32::try_from(v as i64).ok()))
                 .map(ArrowFillValue::Int32),
-            zarrs::array::DataType::Int64 => fill_value_attr
+            crate::data_types::ZarrDtypeKind::Int64 => fill_value_attr
                 .and_then(|attr| attr.as_f64().map(|v| v as i64).or(None))
                 .map(ArrowFillValue::Int64),
-            zarrs::array::DataType::UInt8 => fill_value_attr
+            crate::data_types::ZarrDtypeKind::UInt8 => fill_value_attr
                 .and_then(|attr| attr.as_f64().and_then(|v| u8::try_from(v as u64).ok()))
                 .map(ArrowFillValue::UInt8),
-            zarrs::array::DataType::UInt16 => fill_value_attr
+            crate::data_types::ZarrDtypeKind::UInt16 => fill_value_attr
                 .and_then(|attr| attr.as_f64().and_then(|v| u16::try_from(v as u64).ok()))
                 .map(ArrowFillValue::UInt16),
-            zarrs::array::DataType::UInt32 => fill_value_attr
+            crate::data_types::ZarrDtypeKind::UInt32 => fill_value_attr
                 .and_then(|attr| attr.as_f64().and_then(|v| u32::try_from(v as u64).ok()))
                 .map(ArrowFillValue::UInt32),
 
-            zarrs::array::DataType::UInt64 => fill_value_attr
+            crate::data_types::ZarrDtypeKind::UInt64 => fill_value_attr
                 .and_then(|attr| attr.as_f64().map(|v| v as u64).or(None))
                 .map(ArrowFillValue::UInt64),
 
-            zarrs::array::DataType::Float32 => fill_value_attr
+            crate::data_types::ZarrDtypeKind::Float32 => fill_value_attr
                 .and_then(|attr| attr.as_f64().map(|v| v as f32).or(None))
                 .map(ArrowFillValue::Float32),
 
-            zarrs::array::DataType::Float64 => fill_value_attr
+            crate::data_types::ZarrDtypeKind::Float64 => fill_value_attr
                 .and_then(|attr| attr.as_f64())
                 .map(ArrowFillValue::Float64),
 
-            zarrs::array::DataType::String => {
+            crate::data_types::ZarrDtypeKind::String => {
                 // Interpret fill_bytes as UTF-8 string
                 fill_value_attr
                     .and_then(|attr| attr.as_str().map(|s| s.to_string()))

--- a/beacon-arrow-zarr/src/reader.rs
+++ b/beacon-arrow-zarr/src/reader.rs
@@ -9,7 +9,10 @@ use nd_arrow_array::{
     NdArrowArray,
     dimensions::{Dimension, Dimensions},
 };
-use zarrs::{array::Array, array_subset::ArraySubset, group::Group};
+use zarrs::{
+    array::{Array, ArraySubset},
+    group::Group,
+};
 use zarrs_storage::AsyncReadableListableStorageTraits;
 
 use crate::{
@@ -79,7 +82,7 @@ impl AsyncArrowZarrGroupReader {
 
             let zarr_data_type = array.data_type();
             if let Ok(arrow_data_type) =
-                crate::data_types::try_zarrs_dtype_to_arrow(zarr_data_type.clone())
+                crate::data_types::try_zarrs_dtype_to_arrow(zarr_data_type)
             {
                 fields.push(arrow::datatypes::Field::new(
                     array_name,
@@ -184,8 +187,9 @@ impl AsyncArrowZarrGroupReader {
             .collect::<Vec<_>>();
         let dimensions = Dimensions::new(dimensions);
 
-        let mut maybe_nd_array = match array_reader.data_type() {
-            zarrs::array::DataType::Bool => {
+        let zarr_data_type = array_reader.data_type();
+        let mut maybe_nd_array = match crate::data_types::classify(zarr_data_type) {
+            crate::data_types::ZarrDtypeKind::Bool => {
                 let array = array_reader
                     .async_retrieve_array_subset_ndarray::<bool>(subset)
                     .await
@@ -197,7 +201,7 @@ impl AsyncArrowZarrGroupReader {
                     .map_err(|e| e.to_string())?;
                 Ok(Some(nd_array))
             }
-            zarrs::array::DataType::Int8 => {
+            crate::data_types::ZarrDtypeKind::Int8 => {
                 let array = array_reader
                     .async_retrieve_array_subset_ndarray::<i8>(subset)
                     .await
@@ -210,7 +214,7 @@ impl AsyncArrowZarrGroupReader {
                     .map_err(|e| e.to_string())?;
                 Ok(Some(nd_array))
             }
-            zarrs::array::DataType::Int16 => {
+            crate::data_types::ZarrDtypeKind::Int16 => {
                 let array = array_reader
                     .async_retrieve_array_subset_ndarray::<i16>(subset)
                     .await
@@ -223,7 +227,7 @@ impl AsyncArrowZarrGroupReader {
                     .map_err(|e| e.to_string())?;
                 Ok(Some(nd_array))
             }
-            zarrs::array::DataType::Int32 => {
+            crate::data_types::ZarrDtypeKind::Int32 => {
                 let array = array_reader
                     .async_retrieve_array_subset_ndarray::<i32>(subset)
                     .await
@@ -236,7 +240,7 @@ impl AsyncArrowZarrGroupReader {
                     .map_err(|e| e.to_string())?;
                 Ok(Some(nd_array))
             }
-            zarrs::array::DataType::Int64 => {
+            crate::data_types::ZarrDtypeKind::Int64 => {
                 let array = array_reader
                     .async_retrieve_array_subset_ndarray::<i64>(subset)
                     .await
@@ -249,7 +253,7 @@ impl AsyncArrowZarrGroupReader {
                     .map_err(|e| e.to_string())?;
                 Ok(Some(nd_array))
             }
-            zarrs::array::DataType::UInt8 => {
+            crate::data_types::ZarrDtypeKind::UInt8 => {
                 let array = array_reader
                     .async_retrieve_array_subset_ndarray::<u8>(subset)
                     .await
@@ -262,7 +266,7 @@ impl AsyncArrowZarrGroupReader {
                     .map_err(|e| e.to_string())?;
                 Ok(Some(nd_array))
             }
-            zarrs::array::DataType::UInt16 => {
+            crate::data_types::ZarrDtypeKind::UInt16 => {
                 let array = array_reader
                     .async_retrieve_array_subset_ndarray::<u16>(subset)
                     .await
@@ -275,7 +279,7 @@ impl AsyncArrowZarrGroupReader {
                     .map_err(|e| e.to_string())?;
                 Ok(Some(nd_array))
             }
-            zarrs::array::DataType::UInt32 => {
+            crate::data_types::ZarrDtypeKind::UInt32 => {
                 let array = array_reader
                     .async_retrieve_array_subset_ndarray::<u32>(subset)
                     .await
@@ -288,7 +292,7 @@ impl AsyncArrowZarrGroupReader {
                     .map_err(|e| e.to_string())?;
                 Ok(Some(nd_array))
             }
-            zarrs::array::DataType::UInt64 => {
+            crate::data_types::ZarrDtypeKind::UInt64 => {
                 let array = array_reader
                     .async_retrieve_array_subset_ndarray::<u64>(subset)
                     .await
@@ -301,7 +305,7 @@ impl AsyncArrowZarrGroupReader {
                     .map_err(|e| e.to_string())?;
                 Ok(Some(nd_array))
             }
-            zarrs::array::DataType::Float32 => {
+            crate::data_types::ZarrDtypeKind::Float32 => {
                 let array = array_reader
                     .async_retrieve_array_subset_ndarray::<f32>(subset)
                     .await
@@ -314,7 +318,7 @@ impl AsyncArrowZarrGroupReader {
                     .map_err(|e| e.to_string())?;
                 Ok(Some(nd_array))
             }
-            zarrs::array::DataType::Float64 => {
+            crate::data_types::ZarrDtypeKind::Float64 => {
                 let array = array_reader
                     .async_retrieve_array_subset_ndarray::<f64>(subset)
                     .await
@@ -327,7 +331,7 @@ impl AsyncArrowZarrGroupReader {
                     .map_err(|e| e.to_string())?;
                 Ok(Some(nd_array))
             }
-            zarrs::array::DataType::String => {
+            crate::data_types::ZarrDtypeKind::String => {
                 let array = array_reader
                     .async_retrieve_array_subset_ndarray::<String>(subset)
                     .await
@@ -340,7 +344,7 @@ impl AsyncArrowZarrGroupReader {
                     .map_err(|e| e.to_string())?;
                 Ok(Some(nd_array))
             }
-            zarrs::array::DataType::Bytes => {
+            crate::data_types::ZarrDtypeKind::Bytes => {
                 let array = array_reader
                     .async_retrieve_array_subset_ndarray::<Vec<u8>>(subset)
                     .await
@@ -353,7 +357,9 @@ impl AsyncArrowZarrGroupReader {
                     .map_err(|e| e.to_string())?;
                 Ok(Some(nd_array))
             }
-            zarr_data_type => Err(format!("Unsupported Zarrs data type: {:?}", zarr_data_type)),
+            crate::data_types::ZarrDtypeKind::Other => {
+                Err(format!("Unsupported Zarrs data type: {:?}", zarr_data_type))
+            }
         };
 
         maybe_nd_array = if let Ok(Some(mut nd_array)) = maybe_nd_array {
@@ -378,7 +384,10 @@ mod tests {
 
     use futures::StreamExt;
     use object_store::local::LocalFileSystem;
-    use zarrs::{array::Array, array_subset::ArraySubset, group::Group};
+    use zarrs::{
+    array::{Array, ArraySubset},
+    group::Group,
+};
     use zarrs_object_store::AsyncObjectStore;
     use zarrs_storage::AsyncReadableListableStorage;
 

--- a/beacon-arrow-zarr/src/stream.rs
+++ b/beacon-arrow-zarr/src/stream.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, pin::Pin, sync::Arc, task::Poll};
 use futures::{Future, Stream};
 use indexmap::IndexMap;
 use nd_arrow_array::{NdArrowArray, batch::NdRecordBatch};
-use zarrs::{array::ChunkGrid, array_subset::ArraySubset};
+use zarrs::array::{ArraySubset, ChunkGrid};
 
 use crate::{array_slice_pushdown::ArraySlicePushDown, reader::AsyncArrowZarrGroupReader};
 
@@ -73,9 +73,10 @@ impl ArrowZarrStreamComposer {
         }
 
         if let Some(chunk_grid) = &chunk_grid {
-            // Generate all chunk indices
+            // Generate all chunk indices. zarrs 0.23 yields `TinyVec<[u64; 4]>`
+            // from `iter_chunk_indices`; the queue stores `Vec<u64>` (ChunkIndices).
             for chunk_indices in chunk_grid.iter_chunk_indices() {
-                queue.push(chunk_indices);
+                queue.push(chunk_indices.to_vec());
             }
         } else {
             // We should at least have one chunk to read, we can add an empty as it should only contain scalar attributes and arrays

--- a/beacon-atlas/Cargo.toml
+++ b/beacon-atlas/Cargo.toml
@@ -24,7 +24,7 @@ once_cell = { workspace = true }
 futures = { workspace = true }
 async-trait = { workspace = true }
 flume = { workspace = true }
-ndarray = "0.17.1"
+ndarray = "0.17"
 chrono = { workspace = true }
 crossbeam = { workspace = true }
 typetag = { workspace = true }

--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -13,6 +13,7 @@ pub struct Config {
     pub storage: StorageConfig,
     pub cors: CorsConfig,
     pub netcdf: NetcdfConfig,
+    pub atlas: AtlasConfig,
 }
 
 #[derive(Debug)]
@@ -99,6 +100,12 @@ pub struct NetcdfConfig {
     pub use_reader_cache: bool,
     pub reader_cache_size: usize,
     pub enable_statistics: bool,
+}
+
+#[derive(Debug)]
+pub struct AtlasConfig {
+    pub use_reader_cache: bool,
+    pub reader_cache_size: u64,
 }
 
 #[derive(Debug)]
@@ -210,6 +217,11 @@ struct RawConfig {
     #[envconfig(from = "BEACON_NETCDF_READER_CACHE_SIZE", default = "128")]
     netcdf_reader_cache_size: usize,
 
+    #[envconfig(from = "BEACON_ATLAS_USE_READER_CACHE", default = "true")]
+    atlas_use_reader_cache: bool,
+    #[envconfig(from = "BEACON_ATLAS_READER_CACHE_SIZE", default = "32")]
+    atlas_reader_cache_size: u64,
+
     /// The batch size for NetCDF reads, in number of rows. This is used for both local and MPIO reads.
     #[envconfig(from = "BEACON_BATCH_SIZE", default = "64000")]
     beacon_batch_size: usize,
@@ -284,6 +296,10 @@ impl From<RawConfig> for Config {
                 use_reader_cache: raw.netcdf_use_reader_cache,
                 reader_cache_size: raw.netcdf_reader_cache_size,
                 enable_statistics: raw.netcdf_enable_statistics,
+            },
+            atlas: AtlasConfig {
+                use_reader_cache: raw.atlas_use_reader_cache,
+                reader_cache_size: raw.atlas_reader_cache_size,
             },
         }
     }

--- a/beacon-core/Cargo.toml
+++ b/beacon-core/Cargo.toml
@@ -40,7 +40,6 @@ beacon-data-lake = { path = "../beacon-data-lake" }
 beacon-formats = { path = "../beacon-formats" }
 beacon-object-storage = { path = "../beacon-object-storage" }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }
-beacon-atlas = { path = "../beacon-atlas" }
 beacon-common = { path = "../beacon-common" }
 beacon-table = { path = "../beacon-table" }
 beacon-nd-array = { path = "../beacon-nd-array" }

--- a/beacon-data-lake/Cargo.toml
+++ b/beacon-data-lake/Cargo.toml
@@ -41,6 +41,5 @@ beacon-config = { path = "../beacon-config" }
 beacon-formats = { path = "../beacon-formats" }
 beacon-arrow-zarr = { path = "../beacon-arrow-zarr" }
 beacon-binary-format = { path = "../beacon-binary-format" }
-beacon-atlas = { path = "../beacon-atlas" }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }
 beacon-table = { path = "../beacon-table" }

--- a/beacon-data-lake/src/files/manager.rs
+++ b/beacon-data-lake/src/files/manager.rs
@@ -103,6 +103,8 @@ impl FileManager {
         let session_state = self.session_context.state();
         let extension = if file_pattern.ends_with("zarr.json") {
             "zarr.json".to_string()
+        } else if file_pattern.contains("/atlas.json") {
+            "atlas.json".to_string()
         } else {
             match Path::new(file_pattern).extension() {
                 Some(ext) => ext.to_string_lossy().to_string(),

--- a/beacon-formats/Cargo.toml
+++ b/beacon-formats/Cargo.toml
@@ -32,14 +32,14 @@ lru = { workspace = true }
 async_zip = { version = "0.0.18", features = ["tokio", "zstd", "deflate"] }
 tokio-util = "0.7.16"
 zarrs_object_store = "0.5.0"
-zarrs_storage = "0.4.0"
-zarrs = {"version" = "0.22.2", features = ["async"]}
+zarrs_storage = "0.4.2"
+zarrs = {"version" = "0.23.12", features = ["async"]}
 
 url = "2.5.4"
 glob = "0.3.3"
 which = "8.0.0"
 num-traits = "0.2.19"
-ndarray = { version = "0.17.1" }
+ndarray = { version = "0.17" }
 once_cell = "1.21.3"
 rlimit = "0.11.0"
 chrono = { workspace = true }

--- a/beacon-formats/Cargo.toml
+++ b/beacon-formats/Cargo.toml
@@ -45,6 +45,7 @@ rlimit = "0.11.0"
 chrono = { workspace = true }
 
 beacon-common = { path = "../beacon-common" }
+beacon-arrow-atlas = { path = "../beacon-arrow-atlas" }
 beacon-arrow-netcdf = { path = "../beacon-arrow-netcdf" }
 beacon-arrow-odv = { path = "../beacon-arrow-odv" }
 beacon-arrow-tiff = { path = "../beacon-arrow-tiff" }
@@ -56,7 +57,6 @@ nd-arrow-array = { git = "https://github.com/maris-development/nd-arrow-array.gi
 
 # Add beacon binary format
 beacon-binary-format = { path = "../beacon-binary-format" }
-beacon-atlas = { path = "../beacon-atlas" }
 arrow-flight = { workspace = true }
 tonic = "0.13"
 prost = "0.13"

--- a/beacon-formats/src/lib.rs
+++ b/beacon-formats/src/lib.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use beacon_arrow_atlas::datafusion::{AtlasFormatFactory, options::AtlasOptions};
 use beacon_arrow_netcdf::datafusion::{NetCDFFormatFactory, options::NetcdfOptions};
 use beacon_arrow_tiff::datafusion::TiffFormatFactory;
 use beacon_datafusion_ext::format_ext::FileFormatFactoryExt;
@@ -34,6 +35,10 @@ pub fn file_formats(
         Arc::new(NetCDFFormatFactory::new(
             datasets_object_store.clone(),
             NetcdfOptions::default(),
+        )),
+        Arc::new(AtlasFormatFactory::new(
+            datasets_object_store.clone(),
+            AtlasOptions::default(),
         )),
         Arc::new(TiffFormatFactory::new(Default::default())),
         Arc::new(ZarrFormatFactory),

--- a/beacon-formats/src/odv_ascii/source.rs
+++ b/beacon-formats/src/odv_ascii/source.rs
@@ -15,6 +15,7 @@ use datafusion::{
         physical_plan::{FileMeta, FileOpenFuture, FileOpener, FileScanConfig, FileSource},
         schema_adapter::{DefaultSchemaAdapterFactory, SchemaAdapter, SchemaAdapterFactory},
     },
+    physical_expr::LexOrdering,
     physical_plan::metrics::ExecutionPlanMetricsSet,
 };
 use futures::{StreamExt, TryFutureExt, TryStreamExt};
@@ -85,6 +86,16 @@ impl FileSource for OdvSource {
             schema_adapter: Arc::from(schema_adapter),
             object_store,
         })
+    }
+
+    fn repartitioned(
+        &self,
+        _target_partitions: usize,
+        _repartition_file_min_size: usize,
+        _output_ordering: Option<LexOrdering>,
+        _config: &FileScanConfig,
+    ) -> datafusion::error::Result<Option<FileScanConfig>> {
+        Ok(None)
     }
 
     /// Returns a reference to self as [`Any`].

--- a/beacon-functions/Cargo.toml
+++ b/beacon-functions/Cargo.toml
@@ -31,6 +31,7 @@ beacon-common = { path = "../beacon-common" }
 beacon-config = { path = "../beacon-config" }
 beacon-formats = { path = "../beacon-formats" }
 beacon-object-storage = { path = "../beacon-object-storage" }
+beacon-arrow-atlas = { path = "../beacon-arrow-atlas" }
 beacon-arrow-netcdf = { path = "../beacon-arrow-netcdf" }
 beacon-arrow-tiff = { path = "../beacon-arrow-tiff" }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }

--- a/beacon-functions/src/file_formats/mod.rs
+++ b/beacon-functions/src/file_formats/mod.rs
@@ -12,6 +12,7 @@ use datafusion::{
 
 pub mod list_datasets;
 pub mod read_arrow;
+pub mod read_atlas;
 pub mod read_bbf;
 pub mod read_csv;
 pub mod read_netcdf;
@@ -70,12 +71,18 @@ pub fn register_table_functions(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
-            datasets_object_store,
+            datasets_object_store.clone(),
         )),
         Arc::new(read_odv_ascii::ReadOdvAsciiFunc::new(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
+        )),
+        Arc::new(read_atlas::ReadAtlasFunc::new(
+            runtime_handle.clone(),
+            session_ctx.clone(),
+            data_object_store_url.clone(),
+            datasets_object_store,
         )),
         Arc::new(list_datasets::ListDatasetsFunc::new(
             runtime_handle,

--- a/beacon-functions/src/file_formats/read_atlas.rs
+++ b/beacon-functions/src/file_formats/read_atlas.rs
@@ -1,0 +1,168 @@
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Field};
+use beacon_arrow_atlas::datafusion::{options::AtlasOptions, AtlasFormat};
+use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
+use beacon_object_storage::DatasetsStore;
+use datafusion::{
+    catalog::TableFunctionImpl,
+    common::plan_err,
+    execution::object_store::ObjectStoreUrl,
+    prelude::{Expr, SessionContext},
+    scalar::ScalarValue,
+};
+
+use crate::file_formats::BeaconTableFunctionImpl;
+
+pub struct ReadAtlasFunc {
+    // Session Reference
+    runtime_handle: tokio::runtime::Handle,
+    session_ctx: Arc<SessionContext>,
+    data_object_store_url: ObjectStoreUrl,
+    datasets_object_store: Arc<DatasetsStore>,
+}
+
+impl ReadAtlasFunc {
+    pub fn new(
+        runtime_handle: tokio::runtime::Handle,
+        session_ctx: Arc<SessionContext>,
+        data_object_store_url: ObjectStoreUrl,
+        datasets_object_store: Arc<DatasetsStore>,
+    ) -> Self {
+        Self {
+            runtime_handle,
+            session_ctx,
+            data_object_store_url,
+            datasets_object_store,
+        }
+    }
+}
+
+impl std::fmt::Debug for ReadAtlasFunc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ReadAtlasFunc")
+    }
+}
+
+impl BeaconTableFunctionImpl for ReadAtlasFunc {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn description(&self) -> Option<String> {
+        Some(
+            "Reads atlas stores. Each path must point to an atlas.json marker file \
+             (exact path or glob like **/atlas.json). Optional second arg filters \
+             arrays to those matching the listed dimensions."
+                .to_string(),
+        )
+    }
+
+    fn name(&self) -> String {
+        "read_atlas".to_string()
+    }
+
+    fn arguments(&self) -> Option<Vec<arrow::datatypes::Field>> {
+        Some(vec![
+            Field::new(
+                "glob_paths",
+                DataType::List(Arc::new(Field::new("glob_path", DataType::Utf8, false))),
+                false,
+            ),
+            Field::new(
+                "dimensions",
+                DataType::List(Arc::new(Field::new("dimension", DataType::Utf8, false))),
+                false,
+            ),
+        ])
+    }
+}
+
+impl TableFunctionImpl for ReadAtlasFunc {
+    fn call(
+        &self,
+        args: &[datafusion::prelude::Expr],
+    ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
+        let mut glob_paths: Vec<String> = vec![];
+        if let Some(glob_path_arg) = args.first() {
+            match glob_path_arg {
+                Expr::Literal(ScalarValue::List(values), _) => {
+                    let string_array = values.as_ref().values();
+                    match string_array
+                        .as_any()
+                        .downcast_ref::<arrow::array::StringArray>()
+                    {
+                        Some(str_arr) => {
+                            str_arr.iter().for_each(|opt_str| {
+                                if let Some(s) = opt_str {
+                                    glob_paths.push(s.to_string());
+                                }
+                            });
+                        }
+                        None => {
+                            return plan_err!(
+                                "read_atlas first argument must be a List<Utf8> of glob paths"
+                            );
+                        }
+                    }
+                }
+                _ => {
+                    return plan_err!(
+                        "read_atlas first argument must be a List<Utf8> of glob paths"
+                    );
+                }
+            }
+        } else {
+            return plan_err!("read_atlas requires at least 1 argument: glob_paths : List<Utf8>");
+        }
+
+        let mut dimensions: Option<Vec<String>> = None;
+        if let Some(dimensions_arg) = args.get(1) {
+            if let Expr::Literal(ScalarValue::List(values), _) = dimensions_arg {
+                let string_array = values.as_ref().values();
+                match string_array
+                    .as_any()
+                    .downcast_ref::<arrow::array::StringArray>()
+                {
+                    Some(str_arr) => {
+                        let dims: Vec<String> = str_arr
+                            .iter()
+                            .filter_map(|opt_str| opt_str.map(|s| s.to_string()))
+                            .collect();
+                        dimensions = Some(dims);
+                    }
+                    None => {
+                        return plan_err!(
+                            "read_atlas second argument must be a List<Utf8> of dimension names"
+                        );
+                    }
+                }
+            }
+        }
+
+        tracing::debug!("read_atlas glob paths: {:?}", glob_paths);
+
+        let mut listing_urls = vec![];
+        for path in &glob_paths {
+            tracing::debug!("read_atlas processing path: {}", path);
+            listing_urls.push(parse_listing_table_url(&self.data_object_store_url, path)?);
+        }
+
+        let atlas_options = AtlasOptions {
+            read_dimensions: dimensions,
+        };
+        let file_format = AtlasFormat::new(self.datasets_object_store.clone(), atlas_options);
+        let super_listing_table = tokio::task::block_in_place(|| {
+            self.runtime_handle.block_on(async move {
+                SuperListingTable::new(
+                    &self.session_ctx.state(),
+                    Arc::new(file_format),
+                    listing_urls,
+                )
+                .await
+            })
+        })?;
+
+        Ok(Arc::new(super_listing_table))
+    }
+}

--- a/beacon-nd-array/Cargo.toml
+++ b/beacon-nd-array/Cargo.toml
@@ -12,7 +12,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true }
-ndarray = { version = "0.17.1" }
+ndarray = { version = "0.17" }
 anyhow = { workspace=true }
 async-trait = { workspace=true }
 futures = { workspace=true }

--- a/beacon-nd-array/src/arrow/batch.rs
+++ b/beacon-nd-array/src/arrow/batch.rs
@@ -578,7 +578,7 @@ pub fn dataset_as_record_batch_stream(
                                     m.output_rows.add(batch.num_rows());
                                     m.output_batches.add(1);
                                 }
-                                tracing::debug!("Emitting batch with {} rows", batch.num_rows());
+                                // tracing::debug!("Emitting batch with {} rows", batch.num_rows());
                                 Some(Ok(batch))
                             }
                             Ok(_) => None,

--- a/beacon-nd-arrow/Cargo.toml
+++ b/beacon-nd-arrow/Cargo.toml
@@ -15,7 +15,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true, optional = true }
-ndarray = { version = "0.17.1", optional = true }
+ndarray = { version = "0.17", optional = true }
 anyhow = { workspace=true }
 async-trait = { workspace=true }
 futures = { workspace=true }


### PR DESCRIPTION
This pull request introduces the new `beacon-arrow-atlas` crate to the workspace, providing integration with the Atlas data format and supporting lazy array reading for Beacon. It also updates tracing and workspace configuration to support the new crate.

**New crate: `beacon-arrow-atlas` integration**

* Added the `beacon-arrow-atlas` crate, which implements backends for reading arrays from Atlas datasets, including generic support for numeric types, strings, and timestamps, as well as a backend for scalar attributes. The crate includes thorough tests for its functionality.
**Workspace and configuration updates**

* Registered `beacon-arrow-atlas` as a workspace member in `Cargo.toml` to enable building and dependency management.
* Updated the tracing configuration in `beacon-api/src/main.rs` to add debug-level logging for `beacon_arrow_atlas`.

**API stability and bugfixes**

* Fixed a potential lifetime issue in the Swagger UI setup by leaking the `openapi_url` string to a `'static` lifetime in `beacon-api/src/axum/router.rs`.