### PR TITLE
Add materialized views (CREATE MATERIALIZED VIEW / REFRESH)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beacon-api"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "arrow",

--- a/beacon-core/src/parser/beacon_parser.rs
+++ b/beacon-core/src/parser/beacon_parser.rs
@@ -8,7 +8,8 @@ use datafusion::sql::{
 
 use super::statement::{
     AlterAtlasTableStatement, AtlasOp, BeaconStatement, CreateAtlasTableStatement,
-    DeleteAtlasDatasetsStatement, IngestStatement,
+    CreateMaterializedViewStatement, DeleteAtlasDatasetsStatement, IngestStatement,
+    RefreshMaterializedViewStatement,
 };
 
 /// A parser that extends `DFParser` with custom Beacon SQL syntax.
@@ -42,9 +43,84 @@ impl<'a> BeaconParser<'a> {
         //     return self.parse_alter_atlas_table();
         // }
 
+        if self.is_refresh() {
+            return self.parse_refresh();
+        }
+
+        if self.is_create_materialized_view() {
+            return self.parse_create_materialized_view();
+        }
+
         let df_statement = Box::new(self.df_parser.parse_statement()?);
 
         Ok(BeaconStatement::DFStatement(df_statement))
+    }
+
+    /// Check if the next tokens form a REFRESH statement.
+    fn is_refresh(&self) -> bool {
+        let t1 = &self.df_parser.parser.peek_nth_token(0).token;
+        matches!(t1, Token::Word(w) if w.value.to_uppercase() == "REFRESH")
+    }
+
+    /// Parse: REFRESH <view_name>
+    fn parse_refresh(&mut self) -> Result<BeaconStatement> {
+        // Consume REFRESH
+        self.df_parser.parser.next_token();
+
+        let view_name = self
+            .df_parser
+            .parser
+            .parse_object_name(false)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        Ok(BeaconStatement::RefreshMaterializedView(
+            RefreshMaterializedViewStatement { view_name },
+        ))
+    }
+
+    /// Check if the next tokens form a CREATE MATERIALIZED VIEW statement.
+    fn is_create_materialized_view(&self) -> bool {
+        let t1 = &self.df_parser.parser.peek_nth_token(0).token;
+        let t2 = &self.df_parser.parser.peek_nth_token(1).token;
+        let t3 = &self.df_parser.parser.peek_nth_token(2).token;
+
+        matches!(t1, Token::Word(w) if w.keyword == Keyword::CREATE)
+            && matches!(t2, Token::Word(w) if w.value.to_uppercase() == "MATERIALIZED")
+            && matches!(t3, Token::Word(w) if w.keyword == Keyword::VIEW)
+    }
+
+    /// Parse: CREATE MATERIALIZED VIEW <view_name> AS <query>
+    fn parse_create_materialized_view(&mut self) -> Result<BeaconStatement> {
+        // Consume CREATE MATERIALIZED VIEW
+        for _ in 0..3 {
+            self.df_parser.parser.next_token();
+        }
+
+        let view_name = self
+            .df_parser
+            .parser
+            .parse_object_name(false)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        // Expect AS
+        self.df_parser
+            .parser
+            .expect_keyword(Keyword::AS)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        // Parse the defining query and capture its SQL text.
+        let query = self
+            .df_parser
+            .parser
+            .parse_query()
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        Ok(BeaconStatement::CreateMaterializedView(
+            CreateMaterializedViewStatement {
+                view_name,
+                query_sql: query.to_string(),
+            },
+        ))
     }
 
     /// Check if the next tokens form an INGEST statement.
@@ -549,6 +625,74 @@ mod tests {
     #[test]
     fn test_parse_alter_atlas_table_missing_partition_clause() {
         let sql = "ALTER ATLAS TABLE my_table ALTER COLUMN col SET DATA TYPE INT";
+        let mut parser = BeaconParser::new(sql).unwrap();
+        assert!(parser.parse_statement().is_err());
+    }
+
+    #[test]
+    fn test_parse_create_materialized_view() {
+        let sql = "CREATE MATERIALIZED VIEW monthly AS SELECT customer_id, SUM(amount) AS total FROM orders GROUP BY customer_id";
+        let mut parser = BeaconParser::new(sql).unwrap();
+        let stmt = parser.parse_statement().unwrap();
+
+        match stmt {
+            BeaconStatement::CreateMaterializedView(s) => {
+                assert_eq!(s.view_name.to_string(), "monthly");
+                assert!(s.query_sql.to_uppercase().contains("SELECT"));
+                assert!(s.query_sql.contains("orders"));
+            }
+            _ => panic!("Expected CreateMaterializedView statement"),
+        }
+    }
+
+    #[test]
+    fn test_parse_create_materialized_view_display() {
+        let sql = "CREATE MATERIALIZED VIEW mv AS SELECT 1 AS a";
+        let mut parser = BeaconParser::new(sql).unwrap();
+        let stmt = parser.parse_statement().unwrap();
+        assert_eq!(stmt.to_string(), "CREATE MATERIALIZED VIEW mv AS SELECT 1 AS a");
+    }
+
+    #[test]
+    fn test_parse_create_materialized_view_missing_as() {
+        let sql = "CREATE MATERIALIZED VIEW mv SELECT 1 AS a";
+        let mut parser = BeaconParser::new(sql).unwrap();
+        assert!(parser.parse_statement().is_err());
+    }
+
+    #[test]
+    fn test_parse_regular_create_view_is_df_statement() {
+        let sql = "CREATE VIEW v AS SELECT 1 AS a";
+        let mut parser = BeaconParser::new(sql).unwrap();
+        let stmt = parser.parse_statement().unwrap();
+        assert!(matches!(stmt, BeaconStatement::DFStatement(_)));
+    }
+
+    #[test]
+    fn test_parse_refresh() {
+        let sql = "REFRESH monthly_sales";
+        let mut parser = BeaconParser::new(sql).unwrap();
+        let stmt = parser.parse_statement().unwrap();
+
+        match stmt {
+            BeaconStatement::RefreshMaterializedView(s) => {
+                assert_eq!(s.view_name.to_string(), "monthly_sales");
+            }
+            _ => panic!("Expected RefreshMaterializedView statement"),
+        }
+    }
+
+    #[test]
+    fn test_parse_refresh_display() {
+        let sql = "REFRESH schema.mv";
+        let mut parser = BeaconParser::new(sql).unwrap();
+        let stmt = parser.parse_statement().unwrap();
+        assert_eq!(stmt.to_string(), "REFRESH schema.mv");
+    }
+
+    #[test]
+    fn test_parse_refresh_missing_name() {
+        let sql = "REFRESH";
         let mut parser = BeaconParser::new(sql).unwrap();
         assert!(parser.parse_statement().is_err());
     }

--- a/beacon-core/src/parser/statement.rs
+++ b/beacon-core/src/parser/statement.rs
@@ -9,6 +9,38 @@ pub enum BeaconStatement {
     DeleteAtlasDatasets(DeleteAtlasDatasetsStatement),
     CreateAtlasTable(CreateAtlasTableStatement),
     AlterAtlas(AlterAtlasTableStatement),
+    CreateMaterializedView(CreateMaterializedViewStatement),
+    RefreshMaterializedView(RefreshMaterializedViewStatement),
+}
+
+/// CREATE MATERIALIZED VIEW <view_name> AS <query>
+#[derive(Debug, Clone)]
+pub struct CreateMaterializedViewStatement {
+    pub view_name: ObjectName,
+    /// The SQL text of the defining query (everything after `AS`).
+    pub query_sql: String,
+}
+
+impl Display for CreateMaterializedViewStatement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CREATE MATERIALIZED VIEW {} AS {}",
+            self.view_name, self.query_sql
+        )
+    }
+}
+
+/// REFRESH <view_name>
+#[derive(Debug, Clone)]
+pub struct RefreshMaterializedViewStatement {
+    pub view_name: ObjectName,
+}
+
+impl Display for RefreshMaterializedViewStatement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "REFRESH {}", self.view_name)
+    }
 }
 
 /// ALTER ATLAS TABLE <table_name> ON PARTITION <partition_name> ALTER COLUMN <column_name> SET DATA TYPE <data_type>
@@ -99,6 +131,8 @@ impl Display for BeaconStatement {
             Self::DeleteAtlasDatasets(s) => write!(f, "{s}"),
             Self::CreateAtlasTable(s) => write!(f, "{s}"),
             Self::AlterAtlas(s) => write!(f, "{s}"),
+            Self::CreateMaterializedView(s) => write!(f, "{s}"),
+            Self::RefreshMaterializedView(s) => write!(f, "{s}"),
         }
     }
 }

--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -533,3 +533,126 @@ impl Runtime {
         }
     }
 }
+
+#[cfg(test)]
+mod materialized_view_tests {
+    use super::Runtime;
+    use futures::TryStreamExt;
+
+    async fn collect_sql(
+        runtime: &Runtime,
+        sql: &str,
+    ) -> anyhow::Result<Vec<arrow::record_batch::RecordBatch>> {
+        let stream = runtime.run_sql(sql.to_string(), true).await?;
+        let batches = stream.try_collect::<Vec<_>>().await?;
+        Ok(batches)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn materialized_view_create_query_refresh_and_drop() {
+        let runtime = Runtime::new().await.expect("runtime should start");
+
+        let suffix = uuid::Uuid::new_v4().simple();
+        let mv = format!("mv_test_{suffix}");
+        let rv = format!("rv_test_{suffix}");
+
+        // CREATE
+        collect_sql(
+            &runtime,
+            &format!("CREATE MATERIALIZED VIEW {mv} AS SELECT 1 AS a, 2 AS b"),
+        )
+        .await
+        .expect("create materialized view should succeed");
+
+        // QUERY reads from the persisted Parquet result.
+        let batches = collect_sql(&runtime, &format!("SELECT * FROM {mv}"))
+            .await
+            .expect("query of materialized view should succeed");
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(rows, 1);
+        assert_eq!(batches[0].num_columns(), 2);
+
+        // REFRESH recomputes and replaces the stored data.
+        collect_sql(&runtime, &format!("REFRESH {mv}"))
+            .await
+            .expect("refresh should succeed");
+        let rows: usize = collect_sql(&runtime, &format!("SELECT * FROM {mv}"))
+            .await
+            .expect("query after refresh should succeed")
+            .iter()
+            .map(|b| b.num_rows())
+            .sum();
+        assert_eq!(rows, 1);
+
+        // REFRESH of an unknown view fails clearly.
+        let err = collect_sql(&runtime, &format!("REFRESH {mv}_missing"))
+            .await
+            .expect_err("refresh of unknown view should fail");
+        assert!(
+            err.to_string().contains("does not exist"),
+            "unexpected error: {err}"
+        );
+
+        // REFRESH of a regular view fails clearly.
+        collect_sql(&runtime, &format!("CREATE VIEW {rv} AS SELECT 1 AS a"))
+            .await
+            .expect("create regular view should succeed");
+        let err = collect_sql(&runtime, &format!("REFRESH {rv}"))
+            .await
+            .expect_err("refresh of a regular view should fail");
+        assert!(
+            err.to_string().contains("is not a materialized view"),
+            "unexpected error: {err}"
+        );
+
+        // DROP removes the materialized view; it is no longer queryable.
+        collect_sql(&runtime, &format!("DROP TABLE {mv}"))
+            .await
+            .expect("drop should succeed");
+        assert!(
+            collect_sql(&runtime, &format!("SELECT * FROM {mv}"))
+                .await
+                .is_err(),
+            "materialized view should not be queryable after drop"
+        );
+
+        // Cleanup the regular view.
+        let _ = collect_sql(&runtime, &format!("DROP VIEW {rv}")).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn materialized_view_handles_zero_row_result() {
+        let runtime = Runtime::new().await.expect("runtime should start");
+        let mv = format!("mv_empty_{}", uuid::Uuid::new_v4().simple());
+
+        // A query with no rows must still create a queryable, Parquet-backed view.
+        collect_sql(
+            &runtime,
+            &format!("CREATE MATERIALIZED VIEW {mv} AS SELECT 1 AS a WHERE false"),
+        )
+        .await
+        .expect("create materialized view with empty result should succeed");
+
+        let batches = collect_sql(&runtime, &format!("SELECT * FROM {mv}"))
+            .await
+            .expect("query of empty materialized view should succeed");
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(rows, 0);
+
+        // Refresh of an empty result must also succeed and stay empty.
+        collect_sql(&runtime, &format!("REFRESH {mv}"))
+            .await
+            .expect("refresh of empty materialized view should succeed");
+        let rows: usize = collect_sql(&runtime, &format!("SELECT * FROM {mv}"))
+            .await
+            .expect("query after refresh should succeed")
+            .iter()
+            .map(|b| b.num_rows())
+            .sum();
+        assert_eq!(rows, 0);
+
+        collect_sql(&runtime, &format!("DROP TABLE {mv}"))
+            .await
+            .expect("drop should succeed");
+    }
+}

--- a/beacon-core/src/statement_handlers/handlers/create_materialized_view.rs
+++ b/beacon-core/src/statement_handlers/handlers/create_materialized_view.rs
@@ -1,0 +1,68 @@
+use beacon_data_lake::DATASETS_OBJECT_STORE_URL;
+use beacon_datafusion_ext::table_ext::{MaterializedViewDefinition, TableDefinition};
+use datafusion::{execution::SendableRecordBatchStream, prelude::SQLOptions, sql::TableReference};
+
+use async_trait::async_trait;
+
+use crate::statement_handlers::{
+    context::HandlerContext,
+    payload::{StatementKind, StatementPayload},
+    traits::StatementHandler,
+};
+
+use super::materialized_view::{now_millis, write_query_to_datasets_parquet};
+
+pub(crate) struct CreateMaterializedViewStatementHandler;
+
+#[async_trait]
+impl StatementHandler for CreateMaterializedViewStatementHandler {
+    fn kind(&self) -> StatementKind {
+        StatementKind::CreateMaterializedView
+    }
+
+    async fn execute(
+        &self,
+        payload: StatementPayload,
+        context: &HandlerContext,
+        _sql_options: &SQLOptions,
+    ) -> anyhow::Result<SendableRecordBatchStream> {
+        let statement = payload.into_create_materialized_view()?;
+        let session_ctx = context.session_ctx();
+        let name = statement.view_name.to_string();
+        let table_ref = TableReference::parse_str(&name);
+
+        if session_ctx.table_exist(table_ref.clone())? {
+            return Err(anyhow::anyhow!(
+                "Materialized view '{name}' already exists"
+            ));
+        }
+
+        // Execute the defining query and persist its result as Parquet.
+        let df = session_ctx.sql(&statement.query_sql).await?;
+        let dir_path = format!("__beacon__/{}/{}", name, uuid::Uuid::new_v4());
+        let schema = write_query_to_datasets_parquet(&session_ctx, df, &dir_path).await?;
+        let storage_location = format!("{dir_path}/");
+
+        let now = now_millis();
+        let definition = MaterializedViewDefinition {
+            name: name.clone(),
+            definition: statement.query_sql,
+            schema,
+            storage_location,
+            created_at: now,
+            last_refreshed: Some(now),
+        };
+
+        let store_url = DATASETS_OBJECT_STORE_URL.clone();
+        let provider = definition
+            .build_provider(session_ctx.clone(), &store_url)
+            .await?;
+
+        // Registering through the session context persists the definition to the
+        // catalog (tables://<name>/table.json) via the schema provider.
+        session_ctx.register_table(table_ref, provider)?;
+
+        tracing::info!("Created materialized view '{name}'");
+        Ok(context.empty_record_batch_stream())
+    }
+}

--- a/beacon-core/src/statement_handlers/handlers/df_statement.rs
+++ b/beacon-core/src/statement_handlers/handlers/df_statement.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use beacon_data_lake::DATASETS_OBJECT_STORE_URL;
+use beacon_datafusion_ext::table_ext::MaterializedView;
 use beacon_table::BeaconTable;
 use datafusion::{
     catalog::{TableProvider, TableProviderFactory},
@@ -219,7 +220,26 @@ impl StatementHandler for DFStatementHandler {
         match &plan {
             LogicalPlan::Ddl(DdlStatement::DropTable(drop_table_statement)) => {
                 Self::ensure_drop_table_exists(&session_ctx, drop_table_statement)?;
+
+                // If this is a materialized view, capture its data prefix so the
+                // persisted Parquet can be reclaimed after deregistering.
+                let materialized_prefix = session_ctx
+                    .table_provider(drop_table_statement.name.clone())
+                    .await
+                    .ok()
+                    .and_then(|provider| {
+                        provider
+                            .as_any()
+                            .downcast_ref::<MaterializedView>()
+                            .map(|mv| mv.base_storage_prefix())
+                    });
+
                 session_ctx.deregister_table(drop_table_statement.name.clone())?;
+
+                if let Some(prefix) = materialized_prefix {
+                    super::materialized_view::delete_datasets_prefix(&session_ctx, &prefix).await;
+                }
+
                 Ok(Self::empty_ddl_stream(&plan))
             }
             LogicalPlan::Ddl(DdlStatement::CreateExternalTable(create_external)) => {

--- a/beacon-core/src/statement_handlers/handlers/materialized_view.rs
+++ b/beacon-core/src/statement_handlers/handlers/materialized_view.rs
@@ -1,0 +1,109 @@
+//! Shared helpers for materialized-view statement handling.
+
+use std::sync::Arc;
+
+use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use beacon_data_lake::DATASETS_OBJECT_STORE_URL;
+use datafusion::{
+    config::TableParquetOptions,
+    datasource::{
+        file_format::parquet::ParquetSink,
+        listing::ListingTableUrl,
+        physical_plan::{FileGroup, FileSinkConfig},
+        sink::DataSinkExec,
+    },
+    logical_expr::dml::InsertOp,
+    parquet::arrow::ArrowWriter,
+    prelude::{DataFrame, SessionContext},
+};
+use futures::StreamExt;
+
+/// Current time as Unix epoch milliseconds (0 if the clock is before the epoch).
+pub(crate) fn now_millis() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Writes a query's result to Parquet under `dir_path` (relative to the datasets
+/// object store) and returns the output schema.
+///
+/// Uses an explicit `object_store_url` in the sink config — the same pattern as
+/// `BeaconTable` — so the store is resolved by scheme (`datasets://`) rather than
+/// from the URL authority, which would otherwise be parsed from the path prefix.
+pub(crate) async fn write_query_to_datasets_parquet(
+    session_ctx: &SessionContext,
+    df: DataFrame,
+    dir_path: &str,
+) -> anyhow::Result<SchemaRef> {
+    let store_url = DATASETS_OBJECT_STORE_URL.clone();
+    let physical_plan = df.create_physical_plan().await?;
+    let output_schema = physical_plan.schema();
+
+    let original_url = format!("{store_url}{dir_path}");
+    let parsed_url = ListingTableUrl::parse(&original_url)?;
+
+    let sink_config = FileSinkConfig {
+        original_url,
+        object_store_url: store_url.clone(),
+        file_group: FileGroup::default(),
+        table_paths: vec![parsed_url],
+        output_schema: output_schema.clone(),
+        table_partition_cols: vec![],
+        insert_op: InsertOp::Append,
+        keep_partition_by_columns: false,
+        file_extension: "parquet".to_string(),
+    };
+
+    let sink = Arc::new(ParquetSink::new(sink_config, TableParquetOptions::default()));
+    let sink_exec = Arc::new(DataSinkExec::new(physical_plan, sink, None));
+    let task_ctx = session_ctx.task_ctx();
+    datafusion::physical_plan::collect(sink_exec, task_ctx).await?;
+
+    // Guarantee at least one Parquet file exists, even when the query produced zero
+    // rows (DataFusion's sink writes no file for an empty result). Otherwise the
+    // view's ListingTable would have no file to infer a schema from, and reads /
+    // refresh would fail. The empty file carries the schema, so reads return zero rows.
+    let store = session_ctx.runtime_env().object_store(&store_url)?;
+    let prefix = object_store::path::Path::from(dir_path.trim_end_matches('/'));
+    let wrote_any = store.list(Some(&prefix)).next().await.is_some();
+    if !wrote_any {
+        let mut buffer: Vec<u8> = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buffer, output_schema.clone(), None)?;
+        writer.write(&RecordBatch::new_empty(output_schema.clone()))?;
+        writer.close()?;
+        store.put(&prefix.child("part-0.parquet"), buffer.into()).await?;
+    }
+
+    Ok(output_schema)
+}
+
+/// Best-effort recursive delete of every object under `prefix` in the datasets
+/// object store. Failures are logged rather than propagated, since this is only
+/// used to reclaim space for replaced/dropped materialized-view data.
+pub(crate) async fn delete_datasets_prefix(session_ctx: &SessionContext, prefix: &str) {
+    let store_url = DATASETS_OBJECT_STORE_URL.clone();
+    let store = match session_ctx.runtime_env().object_store(&store_url) {
+        Ok(store) => store,
+        Err(error) => {
+            tracing::warn!("Failed to resolve datasets object store for cleanup of '{prefix}': {error}");
+            return;
+        }
+    };
+
+    let path = object_store::path::Path::from(prefix.trim_end_matches('/'));
+    let mut listing = store.list(Some(&path));
+    while let Some(entry) = listing.next().await {
+        match entry {
+            Ok(meta) => {
+                if let Err(error) = store.delete(&meta.location).await {
+                    tracing::warn!("Failed to delete '{}' during cleanup: {error}", meta.location);
+                }
+            }
+            Err(error) => {
+                tracing::warn!("Failed to list '{prefix}' during cleanup: {error}");
+            }
+        }
+    }
+}

--- a/beacon-core/src/statement_handlers/handlers/mod.rs
+++ b/beacon-core/src/statement_handlers/handlers/mod.rs
@@ -1,21 +1,28 @@
 mod alter_atlas;
 mod create_atlas_table;
+mod create_materialized_view;
 mod delete_atlas_datasets;
 mod df_statement;
 mod ingest;
+mod materialized_view;
+mod refresh_materialized_view;
 
 use std::sync::Arc;
 
 use alter_atlas::AlterAtlasStatementHandler;
 use create_atlas_table::CreateAtlasTableStatementHandler;
+use create_materialized_view::CreateMaterializedViewStatementHandler;
 use delete_atlas_datasets::DeleteAtlasDatasetsStatementHandler;
 use df_statement::DFStatementHandler;
 use ingest::IngestStatementHandler;
+use refresh_materialized_view::RefreshMaterializedViewStatementHandler;
 
 use crate::statement_handlers::registry::StatementRegistry;
 
 pub(crate) fn register_default_statement_handlers(registry: &mut StatementRegistry) {
     registry.register_handler(Arc::new(DFStatementHandler));
+    registry.register_handler(Arc::new(CreateMaterializedViewStatementHandler));
+    registry.register_handler(Arc::new(RefreshMaterializedViewStatementHandler));
     // ToDo: Re-enable when the handlers are implemented
     // registry.register_handler(Arc::new(IngestStatementHandler));
     // registry.register_handler(Arc::new(DeleteAtlasDatasetsStatementHandler));

--- a/beacon-core/src/statement_handlers/handlers/refresh_materialized_view.rs
+++ b/beacon-core/src/statement_handlers/handlers/refresh_materialized_view.rs
@@ -1,0 +1,79 @@
+use async_trait::async_trait;
+use beacon_data_lake::DATASETS_OBJECT_STORE_URL;
+use beacon_datafusion_ext::table_ext::{
+    MaterializedView, MaterializedViewDefinition, TableDefinition,
+};
+use datafusion::{execution::SendableRecordBatchStream, prelude::SQLOptions, sql::TableReference};
+
+use crate::statement_handlers::{
+    context::HandlerContext,
+    payload::{StatementKind, StatementPayload},
+    traits::StatementHandler,
+};
+
+use super::materialized_view::{
+    delete_datasets_prefix, now_millis, write_query_to_datasets_parquet,
+};
+
+pub(crate) struct RefreshMaterializedViewStatementHandler;
+
+#[async_trait]
+impl StatementHandler for RefreshMaterializedViewStatementHandler {
+    fn kind(&self) -> StatementKind {
+        StatementKind::RefreshMaterializedView
+    }
+
+    async fn execute(
+        &self,
+        payload: StatementPayload,
+        context: &HandlerContext,
+        _sql_options: &SQLOptions,
+    ) -> anyhow::Result<SendableRecordBatchStream> {
+        let statement = payload.into_refresh_materialized_view()?;
+        let session_ctx = context.session_ctx();
+        let name = statement.view_name.to_string();
+        let table_ref = TableReference::parse_str(&name);
+
+        let provider = session_ctx
+            .table_provider(table_ref.clone())
+            .await
+            .map_err(|_| anyhow::anyhow!("Materialized view '{name}' does not exist"))?;
+
+        let old_definition = provider
+            .as_any()
+            .downcast_ref::<MaterializedView>()
+            .ok_or_else(|| anyhow::anyhow!("Object '{name}' is not a materialized view"))?
+            .definition()
+            .clone();
+
+        // Recompute the query into a fresh versioned directory so the existing data
+        // remains usable if this fails before the catalog pointer is swapped.
+        let df = session_ctx.sql(&old_definition.definition).await?;
+        let dir_path = format!("__beacon__/{}/{}", name, uuid::Uuid::new_v4());
+        let schema = write_query_to_datasets_parquet(&session_ctx, df, &dir_path).await?;
+        let new_storage_location = format!("{dir_path}/");
+
+        let new_definition = MaterializedViewDefinition {
+            name: name.clone(),
+            definition: old_definition.definition.clone(),
+            schema,
+            storage_location: new_storage_location,
+            created_at: old_definition.created_at,
+            last_refreshed: Some(now_millis()),
+        };
+
+        let store_url = DATASETS_OBJECT_STORE_URL.clone();
+        let new_provider = new_definition
+            .build_provider(session_ctx.clone(), &store_url)
+            .await?;
+
+        // Atomically swap the catalog pointer (single table.json PUT) and the provider.
+        session_ctx.register_table(table_ref, new_provider)?;
+
+        // The pointer now references the new data; reclaim the old directory.
+        delete_datasets_prefix(&session_ctx, &old_definition.storage_location).await;
+
+        tracing::info!("Refreshed materialized view '{name}'");
+        Ok(context.empty_record_batch_stream())
+    }
+}

--- a/beacon-core/src/statement_handlers/payload.rs
+++ b/beacon-core/src/statement_handlers/payload.rs
@@ -1,6 +1,7 @@
 use crate::parser::statement::{
     AlterAtlasTableStatement, BeaconStatement, CreateAtlasTableStatement,
-    DeleteAtlasDatasetsStatement, IngestStatement,
+    CreateMaterializedViewStatement, DeleteAtlasDatasetsStatement, IngestStatement,
+    RefreshMaterializedViewStatement,
 };
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -11,6 +12,8 @@ pub(crate) enum StatementKind {
     CreateAtlasTable,
     AlterAtlas,
     CreateTable,
+    CreateMaterializedView,
+    RefreshMaterializedView,
 }
 
 pub(crate) enum StatementPayload {
@@ -19,6 +22,8 @@ pub(crate) enum StatementPayload {
     DeleteAtlasDatasets(DeleteAtlasDatasetsStatement),
     CreateAtlasTable(CreateAtlasTableStatement),
     AlterAtlas(AlterAtlasTableStatement),
+    CreateMaterializedView(CreateMaterializedViewStatement),
+    RefreshMaterializedView(RefreshMaterializedViewStatement),
 }
 
 impl StatementPayload {
@@ -29,6 +34,8 @@ impl StatementPayload {
             Self::DeleteAtlasDatasets(_) => StatementKind::DeleteAtlasDatasets,
             Self::CreateAtlasTable(_) => StatementKind::CreateAtlasTable,
             Self::AlterAtlas(_) => StatementKind::AlterAtlas,
+            Self::CreateMaterializedView(_) => StatementKind::CreateMaterializedView,
+            Self::RefreshMaterializedView(_) => StatementKind::RefreshMaterializedView,
         }
     }
 
@@ -66,6 +73,24 @@ impl StatementPayload {
             _ => Err(anyhow::anyhow!("Expected AlterAtlas payload")),
         }
     }
+
+    pub(crate) fn into_create_materialized_view(
+        self,
+    ) -> anyhow::Result<CreateMaterializedViewStatement> {
+        match self {
+            Self::CreateMaterializedView(statement) => Ok(statement),
+            _ => Err(anyhow::anyhow!("Expected CreateMaterializedView payload")),
+        }
+    }
+
+    pub(crate) fn into_refresh_materialized_view(
+        self,
+    ) -> anyhow::Result<RefreshMaterializedViewStatement> {
+        match self {
+            Self::RefreshMaterializedView(statement) => Ok(statement),
+            _ => Err(anyhow::anyhow!("Expected RefreshMaterializedView payload")),
+        }
+    }
 }
 
 impl From<BeaconStatement> for StatementPayload {
@@ -76,6 +101,12 @@ impl From<BeaconStatement> for StatementPayload {
             BeaconStatement::DeleteAtlasDatasets(statement) => Self::DeleteAtlasDatasets(statement),
             BeaconStatement::CreateAtlasTable(statement) => Self::CreateAtlasTable(statement),
             BeaconStatement::AlterAtlas(statement) => Self::AlterAtlas(statement),
+            BeaconStatement::CreateMaterializedView(statement) => {
+                Self::CreateMaterializedView(statement)
+            }
+            BeaconStatement::RefreshMaterializedView(statement) => {
+                Self::RefreshMaterializedView(statement)
+            }
         }
     }
 }

--- a/beacon-data-lake/src/files/manager.rs
+++ b/beacon-data-lake/src/files/manager.rs
@@ -77,6 +77,11 @@ impl FileManager {
 
         while let Some(entry) = entry_stream.next().await {
             if let Ok(entry) = entry {
+                // Skip Beacon-internal storage (e.g. materialized view data) so it is
+                // not surfaced as a user dataset.
+                if entry.location.as_ref().starts_with("__beacon__/") {
+                    continue;
+                }
                 objects.push(entry);
             }
         }

--- a/beacon-data-lake/src/table_runtime/schema_persistence.rs
+++ b/beacon-data-lake/src/table_runtime/schema_persistence.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use beacon_datafusion_ext::table_ext::{ExternalTable, TableDefinition, ViewTableDefinition};
+use beacon_datafusion_ext::table_ext::{
+    ExternalTable, MaterializedView, TableDefinition, ViewTableDefinition,
+};
 use beacon_table::BeaconTable;
 use datafusion::{
     catalog::TableProvider, datasource::ViewTable, error::DataFusionError,
@@ -83,6 +85,9 @@ impl SchemaPersistenceService {
                 let definition = table.definition();
                 Arc::new(definition)
             } else if let Some(table) = table.as_any().downcast_ref::<ExternalTable>() {
+                let definition = table.definition();
+                Arc::new(definition.clone())
+            } else if let Some(table) = table.as_any().downcast_ref::<MaterializedView>() {
                 let definition = table.definition();
                 Arc::new(definition.clone())
             } else if let Some(table) = table.as_any().downcast_ref::<ViewTable>() {

--- a/beacon-datafusion-ext/src/table_ext.rs
+++ b/beacon-datafusion-ext/src/table_ext.rs
@@ -494,10 +494,174 @@ impl TableDefinition for ViewTableDefinition {
     }
 }
 
+/// A materialized view: a query whose result set is persisted as Parquet files
+/// and served directly from disk instead of being recomputed on every read.
+///
+/// Wraps an inner [`ListingTable`] built over the persisted Parquet, mirroring how
+/// [`ExternalTable`] wraps a listing table. The wrapper is the downcast target used
+/// by catalog persistence and by refresh/drop detection.
+#[derive(Clone, Debug)]
+pub struct MaterializedView {
+    definition: MaterializedViewDefinition,
+    inner: ListingTable,
+}
+
+impl MaterializedView {
+    pub fn new(definition: MaterializedViewDefinition, inner: ListingTable) -> Self {
+        Self { definition, inner }
+    }
+
+    pub fn definition(&self) -> &MaterializedViewDefinition {
+        &self.definition
+    }
+
+    /// Storage prefix (relative to the datasets object store) that holds all
+    /// versioned data directories for this materialized view.
+    pub fn base_storage_prefix(&self) -> String {
+        format!("__beacon__/{}", self.definition.name)
+    }
+}
+
+#[async_trait::async_trait]
+impl TableProvider for MaterializedView {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.inner.schema()
+    }
+
+    fn constraints(&self) -> Option<&Constraints> {
+        self.inner.constraints()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn get_table_definition(&self) -> Option<&str> {
+        Some(self.definition.definition.as_str())
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        self.inner
+            .scan(state, projection, filters, limit)
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("MaterializedView scan error: {e}")))
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> datafusion::error::Result<Vec<TableProviderFilterPushDown>> {
+        self.inner.supports_filters_pushdown(filters)
+    }
+
+    fn statistics(&self) -> Option<Statistics> {
+        self.inner.statistics()
+    }
+
+    async fn insert_into(
+        &self,
+        _state: &dyn Session,
+        _input: Arc<dyn ExecutionPlan>,
+        _insert_op: InsertOp,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        not_impl_err!("Insert into MaterializedView is not supported")
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+/// Persisted configuration for a materialized view.
+pub struct MaterializedViewDefinition {
+    /// Logical view name.
+    pub name: String,
+    /// Original SQL query that produces the materialized result.
+    pub definition: String,
+    /// Output schema of the query, recorded for catalog/metadata purposes.
+    pub schema: SchemaRef,
+    /// Active data directory (relative to the datasets object store) holding the
+    /// persisted Parquet files, e.g. `__beacon__/<name>/<uuid>/`.
+    pub storage_location: String,
+    /// Creation timestamp (Unix epoch milliseconds).
+    pub created_at: i64,
+    /// Timestamp of the last successful refresh (Unix epoch milliseconds), if any.
+    #[serde(default)]
+    pub last_refreshed: Option<i64>,
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "materialized_view")]
+impl TableDefinition for MaterializedViewDefinition {
+    /// Builds a [`MaterializedView`] provider backed by a [`ListingTable`] over the
+    /// persisted Parquet at `storage_location`. The schema is inferred from the
+    /// written Parquet to avoid drift between the recorded schema and the files.
+    async fn build_provider(
+        &self,
+        context: Arc<SessionContext>,
+        data_store_url: &ObjectStoreUrl,
+    ) -> anyhow::Result<Arc<dyn TableProvider>> {
+        let session_state = context.state();
+        let file_format_factory = session_state
+            .get_file_format_factory("parquet")
+            .ok_or(config_datafusion_err!(
+                "Unable to build materialized view '{}': parquet FileFormat not found.",
+                self.name
+            ))?;
+        let file_format =
+            file_format_factory.create(&session_state, &std::collections::HashMap::new())?;
+
+        let mut listing_table_url = parse_listing_table_url(data_store_url, &self.storage_location)?;
+
+        let options = ListingOptions::new(file_format)
+            .with_file_extension("")
+            .with_session_config_options(session_state.config())
+            .with_table_partition_cols(vec![]);
+
+        options
+            .validate_partitions(&session_state, &listing_table_url)
+            .await?;
+
+        listing_table_url = maybe_apply_default_glob(listing_table_url, &options, "parquet")?;
+        let resolved_schema = options
+            .infer_schema(&session_state, &listing_table_url)
+            .await?;
+
+        let config = ListingTableConfig::new(listing_table_url)
+            .with_listing_options(options)
+            .with_schema(resolved_schema);
+        let provider = ListingTable::try_new(config)?.with_cache(
+            session_state
+                .runtime_env()
+                .cache_manager
+                .get_file_statistic_cache(),
+        );
+
+        Ok(Arc::new(MaterializedView::new(self.clone(), provider)))
+    }
+
+    fn table_name(&self) -> &str {
+        &self.name
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+}
+
 #[cfg(test)]
 /// Unit tests covering listing-table and view-table definition behavior.
 mod tests {
-    use super::{ExternalTableDefinition, TableDefinition, ViewTableDefinition};
+    use super::{
+        ExternalTableDefinition, MaterializedViewDefinition, TableDefinition, ViewTableDefinition,
+    };
     use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::datasource::{MemTable, TableType, ViewTable};
@@ -788,5 +952,86 @@ mod tests {
             dependencies,
             vec!["t1".to_string(), "t2".to_string(), "t3".to_string()]
         );
+    }
+
+    #[test]
+    /// Verifies a materialized view definition round-trips through typetag JSON.
+    fn materialized_view_definition_serde_round_trip() {
+        let definition = MaterializedViewDefinition {
+            name: "mv".to_string(),
+            definition: "SELECT 1 AS a".to_string(),
+            schema: Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)])),
+            storage_location: "__beacon__/mv/abc/".to_string(),
+            created_at: 42,
+            last_refreshed: Some(43),
+        };
+        let boxed: Arc<dyn TableDefinition> = Arc::new(definition);
+
+        let json = serde_json::to_string(&boxed).expect("definition should serialize");
+        assert!(json.contains("\"materialized_view\""));
+
+        let restored: Arc<dyn TableDefinition> =
+            serde_json::from_str(&json).expect("definition should deserialize");
+        assert_eq!(restored.table_name(), "mv");
+        assert_eq!(restored.table_type(), TableType::Base);
+    }
+
+    #[tokio::test]
+    /// Verifies a materialized view definition scans the persisted Parquet result.
+    async fn materialized_view_definition_build_provider_scans_parquet() {
+        use super::MaterializedView;
+        use datafusion::dataframe::DataFrameWriteOptions;
+
+        let root = create_temp_dir("table_ext_materialized_view");
+
+        // Write the query result to Parquet under the temp directory.
+        let writer_ctx = SessionContext::new();
+        let df = writer_ctx
+            .sql("SELECT 1 AS a, 2 AS b")
+            .await
+            .expect("query should plan");
+        let write_url = format!("file://{}/", root.to_string_lossy());
+        df.write_parquet(&write_url, DataFrameWriteOptions::new(), None)
+            .await
+            .expect("parquet result should be written");
+
+        let definition = MaterializedViewDefinition {
+            name: "mv".to_string(),
+            definition: "SELECT 1 AS a, 2 AS b".to_string(),
+            schema: Arc::new(Schema::empty()),
+            storage_location: format!("{}/", to_store_relative_location(&root)),
+            created_at: 0,
+            last_refreshed: None,
+        };
+
+        let context = Arc::new(SessionContext::new());
+        let store_url = ObjectStoreUrl::parse("file://").unwrap();
+
+        let provider = definition
+            .build_provider(context.clone(), &store_url)
+            .await
+            .expect("materialized view provider should be built");
+
+        let materialized = provider
+            .as_any()
+            .downcast_ref::<MaterializedView>()
+            .expect("provider should be a MaterializedView");
+        assert_eq!(materialized.base_storage_prefix(), "__beacon__/mv");
+
+        let schema = provider.schema();
+        assert_eq!(schema.fields().len(), 2);
+
+        let state = context.state();
+        let plan = provider
+            .scan(&state, None, &[], None)
+            .await
+            .expect("scan plan should be built");
+        let batches = datafusion::physical_plan::collect(plan, context.task_ctx())
+            .await
+            .expect("scan should execute");
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(rows, 1);
+
+        fs::remove_dir_all(&root).expect("temporary directory should be cleaned up");
     }
 }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -261,6 +261,16 @@ export default defineConfig({
                   text: 'CREATE VIEW',
                   link: '/docs/1.6.0/sql/create-view',
                 },
+                {
+                  text: 'CREATE MATERIALIZED VIEW',
+                  link: '/docs/1.6.0/sql/create-materialized-view',
+                  collapsed: true,
+                  items: [
+                    { text: 'Querying', link: '/docs/1.6.0/sql/create-materialized-view#querying' },
+                    { text: 'REFRESH', link: '/docs/1.6.0/sql/create-materialized-view#refresh' },
+                    { text: 'DROP', link: '/docs/1.6.0/sql/create-materialized-view#drop' },
+                  ]
+                },
               ]
             },
             {

--- a/docs/docs/1.6.0/sql/create-materialized-view.md
+++ b/docs/docs/1.6.0/sql/create-materialized-view.md
@@ -1,0 +1,99 @@
+# CREATE MATERIALIZED VIEW
+
+```sql
+CREATE MATERIALIZED VIEW monthly_sales AS
+    SELECT
+        customer_id,
+        date_trunc('month', order_date) AS month,
+        SUM(amount) AS total_amount
+    FROM orders
+    GROUP BY customer_id, date_trunc('month', order_date)
+```
+
+A materialized view runs its defining query **once**, at creation time, and persists the result
+set as Parquet files. Querying the view reads straight from the persisted Parquet instead of
+recomputing the original query — useful for expensive, repeated, or aggregation-heavy queries.
+
+Unlike a regular [view](./create-view.md) (which recomputes on every reference), a materialized
+view only changes when you explicitly [`REFRESH`](#refresh) it.
+
+## Syntax
+
+```sql
+CREATE MATERIALIZED VIEW <view_name> AS
+    <select_statement>
+```
+
+When the statement runs, Beacon:
+
+1. Stores the materialized view definition in the catalog as a table provider.
+2. Executes the defining query immediately.
+3. Writes the result as one or more Parquet files under the reserved
+   `__beacon__/<view_name>/` prefix in the datasets object store.
+4. Serves future reads from the persisted Parquet result.
+
+The catalog records the view name, original SQL query, output schema, storage location, creation
+timestamp, and last-refresh timestamp.
+
+## Querying
+
+```sql
+SELECT * FROM monthly_sales
+```
+
+This scans the Parquet-backed result and benefits from columnar projection and predicate
+pushdown — it does **not** re-run the original query.
+
+## REFRESH
+
+```sql
+REFRESH monthly_sales
+```
+
+A refresh recomputes the original query and replaces the stored Parquet data with the new result
+(full refresh). The new data is written to a fresh directory and the catalog pointer is swapped
+atomically, so a failed refresh leaves the previous result intact and queryable.
+
+::: info
+Only **full refresh** is supported in this version. Incremental refresh, scheduled refresh, and
+dependency-based invalidation are planned for later releases.
+:::
+
+### Errors
+
+Refreshing a name that is not a materialized view fails clearly:
+
+```text
+Materialized view 'unknown_view' does not exist
+```
+
+```text
+Object 'orders' is not a materialized view
+```
+
+## DROP
+
+```sql
+DROP TABLE monthly_sales
+
+DROP TABLE IF EXISTS monthly_sales
+```
+
+Dropping a materialized view removes it from the catalog and deletes its persisted Parquet data.
+
+## Example
+
+```sql
+CREATE MATERIALIZED VIEW top_customers AS
+    SELECT
+        customer_id,
+        SUM(total) AS lifetime_value
+    FROM orders
+    GROUP BY customer_id
+    ORDER BY lifetime_value DESC
+    LIMIT 100;
+
+SELECT * FROM top_customers;
+
+REFRESH top_customers;
+```


### PR DESCRIPTION
## Summary

Implements materialized views (issue #216): a query's result set is persisted to Parquet once and served directly from disk, instead of recomputing the source query on every reference. An explicit `REFRESH` recomputes and replaces the stored result (full refresh).

```sql
CREATE MATERIALIZED VIEW monthly_sales AS
    SELECT customer_id, date_trunc('month', order_date) AS month, SUM(amount) AS total
    FROM orders
    GROUP BY customer_id, date_trunc('month', order_date);

SELECT * FROM monthly_sales;   -- scans the persisted Parquet, not `orders`
REFRESH monthly_sales;         -- recompute + replace
DROP TABLE monthly_sales;      -- removes catalog entry + Parquet
```

## What changed

- **Provider + definition** (`beacon-datafusion-ext/src/table_ext.rs`): new `MaterializedView` provider wrapping a `ListingTable` (so reads get projection/predicate pushdown) plus a serializable `MaterializedViewDefinition` (typetag `materialized_view`) storing name, SQL, schema, storage location, and created/last-refreshed timestamps.
- **Catalog persistence** (`beacon-data-lake/.../schema_persistence.rs`): downcast branch so registration auto-persists the definition to `tables://<view>/table.json` (loaded at startup like other tables).
- **Parser** (`beacon-core/src/parser/*`): `CREATE MATERIALIZED VIEW <name> AS <query>` and `REFRESH <name>`, modeled on the existing custom-statement handling.
- **Handlers** (`beacon-core/src/statement_handlers/handlers/*`): create, refresh, and drop cleanup. Writes use an explicit `object_store_url` sink (the `BeaconTable` pattern).
- **Dataset listing** (`beacon-data-lake/.../files/manager.rs`): hides the reserved `__beacon__/` prefix from user dataset listings.
- **Docs**: `sql/create-materialized-view.md` + VitePress sidebar entry.

## Storage & atomicity

```
datasets://__beacon__/<view>/<uuid>/part-*.parquet   <- active data (one versioned dir per refresh)
tables://<view>/table.json                           <- definition (atomic pointer)
```

`REFRESH` writes a **new** `<uuid>` dir, then atomically swaps the pointer via a single `table.json` PUT, then deletes the old dir. A crash before the swap leaves the previous data and pointer fully usable.

## Notes for reviewers

- **Full refresh only** for this version; incremental/scheduled refresh and dependency-based invalidation are explicitly out of scope (follow-ups).
- **Zero-row results** still write an empty, schema-only Parquet file so the view remains creatable, refreshable, and queryable (returns 0 rows).
- Error messages match the issue: `Materialized view '<name>' does not exist`, `Object '<name>' is not a materialized view`.
- `Cargo.lock` contains a 1-line sync (`beacon-api` 1.6.0 -> 1.6.1) matching the already-committed version bump.

## Test plan

- [x] `cargo test -p beacon-core --lib -- materialized_view` (parser, definition, and end-to-end create/query/refresh/error/drop, plus the zero-row case) — all green.
- [x] `cargo test -p beacon-datafusion-ext` materialized-view definition tests (serde round-trip + scan persisted Parquet) — green.
- [ ] Manual: run the server, `CREATE`/`SELECT`/`REFRESH`/`DROP`, restart and confirm the view reloads from `table.json`.

Pre-existing, unrelated test failures (INGEST/ATLAS parser tests with detection still commented out, and a couple of `ViewTable` tests) fail identically on `main` and are untouched here.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)