### PR TITLE
Upgrade/datafusion 53 arrow 58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
  "lz4_flex 0.11.6",
  "moka",
  "ndarray",
- "object_store",
+ "object_store 0.13.2",
  "rkyv",
  "tempfile",
  "thiserror 2.0.18",
@@ -962,7 +962,7 @@ dependencies = [
  "lz4_flex 0.11.6",
  "ndarray",
  "num_cpus",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot",
  "rmp-serde",
  "serde",
@@ -1173,7 +1173,7 @@ dependencies = [
  "lz4_flex 0.11.6",
  "moka",
  "ndarray",
- "object_store",
+ "object_store 0.13.2",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -1207,7 +1207,7 @@ dependencies = [
  "netcdf",
  "netcdf-sys",
  "num-traits",
- "object_store",
+ "object_store 0.13.2",
  "ordered-float 5.3.0",
  "regex",
  "serde",
@@ -1233,7 +1233,7 @@ dependencies = [
  "futures-util",
  "indexmap 2.14.0",
  "lz4_flex 0.11.6",
- "object_store",
+ "object_store 0.13.2",
  "quick-xml 0.37.5",
  "regex",
  "serde",
@@ -1266,7 +1266,7 @@ dependencies = [
  "futures",
  "indexmap 2.14.0",
  "ndarray",
- "object_store",
+ "object_store 0.13.2",
  "serde",
  "tokio",
  "tracing",
@@ -1288,7 +1288,7 @@ dependencies = [
  "hifitime",
  "indexmap 2.14.0",
  "ndarray",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot",
  "regex",
  "serde_json",
@@ -1322,7 +1322,8 @@ dependencies = [
  "moka",
  "munge_macro",
  "nd-arrow-array",
- "object_store",
+ "object_store 0.12.5",
+ "object_store 0.13.2",
  "parking_lot",
  "rand 0.9.4",
  "rkyv",
@@ -1348,7 +1349,7 @@ dependencies = [
  "futures-util",
  "glob",
  "indexmap 2.14.0",
- "object_store",
+ "object_store 0.13.2",
  "regex",
  "thiserror 2.0.18",
  "tracing",
@@ -1361,7 +1362,7 @@ version = "1.6.0"
 dependencies = [
  "envconfig",
  "lazy_static",
- "object_store",
+ "object_store 0.13.2",
 ]
 
 [[package]]
@@ -1393,7 +1394,7 @@ dependencies = [
  "glob",
  "indexmap 2.14.0",
  "inventory",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot",
  "pathdiff",
  "serde",
@@ -1431,7 +1432,7 @@ dependencies = [
  "geoparquet",
  "glob",
  "indexmap 2.14.0",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot",
  "parquet",
  "serde",
@@ -1459,7 +1460,7 @@ dependencies = [
  "futures",
  "indexmap 2.14.0",
  "moka",
- "object_store",
+ "object_store 0.13.2",
  "ordered-float 5.3.0",
  "parking_lot",
  "serde",
@@ -1503,7 +1504,7 @@ dependencies = [
  "ndarray",
  "num-traits",
  "num_cpus",
- "object_store",
+ "object_store 0.13.2",
  "once_cell",
  "ordered-float 5.3.0",
  "parking_lot",
@@ -1547,7 +1548,7 @@ dependencies = [
  "inventory",
  "lazy_static",
  "lru 0.14.0",
- "object_store",
+ "object_store 0.13.2",
  "once_cell",
  "ordered-float 5.3.0",
  "serde",
@@ -1619,7 +1620,7 @@ dependencies = [
  "flume",
  "futures",
  "notify",
- "object_store",
+ "object_store 0.13.2",
  "once_cell",
  "parking_lot",
  "radix_trie",
@@ -1693,7 +1694,7 @@ dependencies = [
  "datafusion",
  "indexmap 2.14.0",
  "moka",
- "object_store",
+ "object_store 0.13.2",
  "serde",
  "serde_json",
  "tracing",
@@ -1711,7 +1712,7 @@ dependencies = [
  "bytes",
  "datafusion",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot",
  "parquet",
  "serde",
@@ -2442,7 +2443,7 @@ dependencies = [
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot",
  "parquet",
  "rand 0.9.4",
@@ -2475,7 +2476,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot",
  "tokio",
 ]
@@ -2500,7 +2501,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
 ]
 
 [[package]]
@@ -2519,7 +2520,7 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parquet",
  "paste",
  "recursive",
@@ -2566,7 +2567,7 @@ dependencies = [
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "rand 0.9.4",
  "tokio",
  "tokio-util",
@@ -2594,7 +2595,7 @@ dependencies = [
  "datafusion-session",
  "futures",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.13.2",
  "tokio",
 ]
 
@@ -2616,7 +2617,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "regex",
  "tokio",
 ]
@@ -2639,7 +2640,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -2669,7 +2670,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot",
  "parquet",
  "tokio",
@@ -2697,7 +2698,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "futures",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot",
  "rand 0.9.4",
  "tempfile",
@@ -5101,6 +5102,42 @@ dependencies = [
 
 [[package]]
 name = "object_store"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures",
+ "http",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools 0.14.0",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml 0.38.4",
+ "rand 0.9.4",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "object_store"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
@@ -5245,7 +5282,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "object_store",
+ "object_store 0.13.2",
  "paste",
  "seq-macro",
  "simdutf8",
@@ -5548,6 +5585,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -8300,7 +8347,7 @@ checksum = "ba1662bcdc585be1923a8b98ee5d6314d19af8c5775d6516a69ca33fd88b46af"
 dependencies = [
  "async-trait",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "zarrs_storage",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,17 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,15 +87,15 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
@@ -119,11 +108,11 @@ dependencies = [
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
- "object 0.32.2",
+ "object",
 ]
 
 [[package]]
@@ -137,19 +126,20 @@ dependencies = [
 
 [[package]]
 name = "array-format"
-version = "0.8.0"
-source = "git+https://github.com/robinskil/array-format.git#97245fffdaf700a29c004dc8644e46297259d6e7"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91c6d4d26f667272f8930d41bc95118716e12858baf115940a626510e7b5873"
 dependencies = [
  "bytes",
  "futures",
- "indexmap 2.13.0",
- "lz4_flex 0.11.5",
+ "indexmap 2.14.0",
+ "lz4_flex 0.11.6",
  "moka",
  "ndarray",
- "object_store 0.13.2",
+ "object_store",
  "rkyv",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "zerocopy",
  "zstd",
@@ -169,23 +159,23 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "56.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
+checksum = "4fb98341a7e051bb79731ecb33ec00cbd6e0e315a542d6732b46d462c9215ea2"
 dependencies = [
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-csv 56.2.0",
- "arrow-data 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-json 56.2.0",
- "arrow-ord 56.2.0",
- "arrow-row 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
- "arrow-string 56.2.0",
+ "arrow-arith 56.2.1",
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-cast 56.2.1",
+ "arrow-csv 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-ipc 56.2.1",
+ "arrow-json 56.2.1",
+ "arrow-ord 56.2.1",
+ "arrow-row 56.2.1",
+ "arrow-schema 56.2.1",
+ "arrow-select 56.2.1",
+ "arrow-string 56.2.1",
 ]
 
 [[package]]
@@ -232,14 +222,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "56.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
+checksum = "6ce4751cbc4bcccfeeea79df9571ff1dc066d61e44723c7604d11c7937f5b560"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
  "chrono",
  "num",
 ]
@@ -274,32 +264,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "55.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70732f04d285d49054a48b72c54f791bb3424abae92d27aafdf776c98af161c8"
+checksum = "b02ccba2e977a3aabb4384036109ca32f552399a2bc0588f925f91ed073ce70c"
 dependencies = [
  "ahash",
- "arrow-buffer 55.2.0",
- "arrow-data 55.2.0",
- "arrow-schema 55.2.0",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
  "chrono",
- "half",
- "hashbrown 0.15.5",
- "num",
-]
-
-[[package]]
-name = "arrow-array"
-version = "56.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
-dependencies = [
- "ahash",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "chrono",
- "chrono-tz",
  "half",
  "hashbrown 0.16.1",
  "num",
@@ -334,6 +307,7 @@ dependencies = [
  "arrow-data 58.3.0",
  "arrow-schema 58.3.0",
  "chrono",
+ "chrono-tz",
  "half",
  "hashbrown 0.17.1",
  "num-complex",
@@ -343,20 +317,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "55.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169b1d5d6cb390dd92ce582b06b23815c7953e9dfaaea75556e89d890d19993d"
-dependencies = [
- "bytes",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-buffer"
-version = "56.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+checksum = "a90f8bece6a9ee316a699fbbfde368a206676a1206ce89b50f07937648e76c3c"
 dependencies = [
  "bytes",
  "half",
@@ -389,35 +352,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "55.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f12eccc3e1c05a766cafb31f6a60a46c2f8efec9b74c6e0648766d30686af8"
+checksum = "61ffe645cfb4e80b1ca37a3a106ce7b4af66ccdd60c655a57e6b9aab096164a7"
 dependencies = [
- "arrow-array 55.2.0",
- "arrow-buffer 55.2.0",
- "arrow-data 55.2.0",
- "arrow-schema 55.2.0",
- "arrow-select 55.2.0",
- "atoi",
- "base64",
- "chrono",
- "half",
- "lexical-core",
- "num",
- "ryu",
-]
-
-[[package]]
-name = "arrow-cast"
-version = "56.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
-dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
+ "arrow-select 56.2.1",
  "atoi",
  "base64",
  "chrono",
@@ -474,13 +417,13 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "56.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa9bf02705b5cf762b6f764c65f04ae9082c7cfc4e96e0c33548ee3f67012eb"
+checksum = "d376e82c15a6298b49a53fbb0d89348db1d5dd3a5147977d62d5516d430cfed3"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 56.2.1",
+ "arrow-cast 56.2.1",
+ "arrow-schema 56.2.1",
  "chrono",
  "csv",
  "csv-core",
@@ -519,24 +462,12 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "55.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de1ce212d803199684b658fc4ba55fb2d7e87b213de5af415308d2fee3619c2"
+checksum = "78468c813909465dd0f858950c8a0614eb63608134acf95c602ec21381258b28"
 dependencies = [
- "arrow-buffer 55.2.0",
- "arrow-schema 55.2.0",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-data"
-version = "56.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
-dependencies = [
- "arrow-buffer 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-buffer 56.2.1",
+ "arrow-schema 56.2.1",
  "half",
  "num",
 ]
@@ -569,21 +500,21 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "56.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c8b0ba0784d56bc6266b79f5de7a24b47024e7b3a0045d2ad4df3d9b686099f"
+checksum = "28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704"
 dependencies = [
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-ord 56.2.0",
- "arrow-row 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
- "arrow-string 56.2.0",
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-row 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "arrow-string 58.3.0",
  "base64",
  "bytes",
  "futures",
@@ -592,35 +523,21 @@ dependencies = [
  "prost",
  "prost-types",
  "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
 name = "arrow-ipc"
-version = "55.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ea5967e8b2af39aff5d9de2197df16e305f47f404781d3230b2dc672da5d92"
+checksum = "31f88b0fbb33af28089ccd3e4dcd0ff09de46842168d00220b920f7231feddf5"
 dependencies = [
- "arrow-array 55.2.0",
- "arrow-buffer 55.2.0",
- "arrow-data 55.2.0",
- "arrow-schema 55.2.0",
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
+ "arrow-select 56.2.1",
  "flatbuffers",
-]
-
-[[package]]
-name = "arrow-ipc"
-version = "56.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3594dcddccc7f20fd069bc8e9828ce37220372680ff638c5e00dea427d88f5"
-dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
- "flatbuffers",
- "lz4_flex 0.11.5",
- "zstd",
 ]
 
 [[package]]
@@ -649,22 +566,24 @@ dependencies = [
  "arrow-schema 58.3.0",
  "arrow-select 58.3.0",
  "flatbuffers",
+ "lz4_flex 0.13.1",
+ "zstd",
 ]
 
 [[package]]
 name = "arrow-json"
-version = "56.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88cf36502b64a127dc659e3b305f1d993a544eab0d48cce704424e62074dc04b"
+checksum = "dff14ad7669f0742f3c43c606465ad4aad97cfcee24e6317a30f68eba9d75070"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-cast 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
  "chrono",
  "half",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "lexical-core",
  "memchr",
  "num",
@@ -686,7 +605,7 @@ dependencies = [
  "arrow-schema 57.3.1",
  "chrono",
  "half",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "lexical-core",
  "memchr",
@@ -711,7 +630,7 @@ dependencies = [
  "arrow-select 58.3.0",
  "chrono",
  "half",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "lexical-core",
  "memchr",
@@ -724,15 +643,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "56.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
+checksum = "aed58a38c3db0a2cf75ef70e3cb6bc4bd0da0a3d390de37c36139b31fae826e8"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
+ "arrow-select 56.2.1",
 ]
 
 [[package]]
@@ -763,14 +682,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "56.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
+checksum = "079ced0517daf4f09b070d09ff641cee7cc331aa216bebcb25d1a6474ad53086"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
  "half",
 ]
 
@@ -802,19 +721,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "55.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7686986a3bf2254c9fb130c623cdcb2f8e1f15763e7c71c310f0834da3d292"
-
-[[package]]
-name = "arrow-schema"
-version = "56.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
-dependencies = [
- "serde",
- "serde_json",
-]
+checksum = "5a0d5eb3fe25337ff83e8333a08379bdd1540b0961b1c888f6e505d971c198e1"
 
 [[package]]
 name = "arrow-schema"
@@ -827,32 +736,23 @@ name = "arrow-schema"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
-
-[[package]]
-name = "arrow-select"
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2b45757d6a2373faa3352d02ff5b54b098f5e21dccebc45a21806bc34501e5"
 dependencies = [
- "ahash",
- "arrow-array 55.2.0",
- "arrow-buffer 55.2.0",
- "arrow-data 55.2.0",
- "arrow-schema 55.2.0",
- "num",
+ "serde",
+ "serde_core",
+ "serde_json",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "56.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
+checksum = "2368a78bd32902dba39d52519d70f63799c8b5dc8a9477129a30c2fd3dc70c19"
 dependencies = [
  "ahash",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
  "num",
 ]
 
@@ -886,15 +786,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "56.2.0"
+version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
+checksum = "dece58a130b9187756ded8bc071bd8ee9dd7a146566af244b297c7e632fd1ef7"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 56.2.1",
+ "arrow-buffer 56.2.1",
+ "arrow-data 56.2.1",
+ "arrow-schema 56.2.1",
+ "arrow-select 56.2.1",
  "memchr",
  "num",
  "regex",
@@ -949,20 +849,15 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.19"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
- "bzip2 0.5.2",
- "flate2",
- "futures-core",
+ "compression-codecs",
+ "compression-core",
  "futures-io",
- "memchr",
  "pin-project-lite",
  "tokio",
- "xz2",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -1023,7 +918,7 @@ dependencies = [
  "futures",
  "jpeg-decoder",
  "num_enum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "weezl",
  "zstd",
@@ -1050,29 +945,29 @@ dependencies = [
  "crc32fast",
  "futures-lite",
  "pin-project",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
-name = "atlas"
-version = "0.8.0"
-source = "git+https://github.com/maris-development/atlas.git#859bd319070ad10cc1d85a6277606b6c8cfdb16a"
+name = "atlas-rust"
+version = "0.9.1"
+source = "git+https://github.com/maris-development/atlas.git#9a9a2c0847d1194814fda6f74347d8c43642915e"
 dependencies = [
  "array-format",
  "chrono",
  "futures",
- "indexmap 2.13.0",
- "lz4_flex 0.11.5",
+ "indexmap 2.14.0",
+ "lz4_flex 0.11.6",
  "ndarray",
  "num_cpus",
- "object_store 0.13.2",
+ "object_store",
  "parking_lot",
  "rmp-serde",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "zstd",
@@ -1126,15 +1021,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "base64",
@@ -1188,11 +1083,11 @@ dependencies = [
 
 [[package]]
 name = "axum-streams"
-version = "0.23.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144504cefd7a118724978cd549651c93e8c993978715634aff6e14c2e41f69c5"
+checksum = "e3e3b97b0eb0c163a3a7ed79c496f9b9e6f121259a8434d893c3245b2d9a42c9"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "axum",
  "bytes",
  "futures",
@@ -1211,7 +1106,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.37.3",
+ "object",
  "rustc-demangle",
  "windows-link 0.2.1",
 ]
@@ -1227,9 +1122,9 @@ name = "beacon-api"
 version = "1.6.1"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "arrow-flight",
- "arrow-ipc 56.2.0",
+ "arrow-ipc 58.3.0",
  "axum",
  "axum-streams",
  "base64",
@@ -1262,9 +1157,9 @@ name = "beacon-arrow-atlas"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "async-trait",
- "atlas",
+ "atlas-rust",
  "beacon-common",
  "beacon-config",
  "beacon-datafusion-ext",
@@ -1274,11 +1169,11 @@ dependencies = [
  "crossbeam",
  "datafusion",
  "futures",
- "indexmap 2.13.0",
- "lz4_flex 0.11.5",
+ "indexmap 2.14.0",
+ "lz4_flex 0.11.6",
  "moka",
  "ndarray",
- "object_store 0.12.4",
+ "object_store",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -1293,8 +1188,8 @@ name = "beacon-arrow-netcdf"
 version = "1.6.0"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow 58.3.0",
+ "arrow-schema 58.3.0",
  "async-trait",
  "beacon-common",
  "beacon-config",
@@ -1306,19 +1201,19 @@ dependencies = [
  "datafusion",
  "futures",
  "hifitime",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "moka",
  "ndarray",
  "netcdf",
  "netcdf-sys",
  "num-traits",
- "object_store 0.12.4",
- "ordered-float 5.1.0",
+ "object_store",
+ "ordered-float 5.3.0",
  "regex",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1328,23 +1223,23 @@ name = "beacon-arrow-odv"
 version = "1.6.0"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
- "arrow-csv 56.2.0",
+ "arrow 58.3.0",
+ "arrow-csv 58.3.0",
  "async-trait",
  "async_zip",
  "bytes",
  "csv",
  "futures",
  "futures-util",
- "indexmap 2.13.0",
- "lz4_flex 0.11.5",
- "object_store 0.12.4",
+ "indexmap 2.14.0",
+ "lz4_flex 0.11.6",
+ "object_store",
  "quick-xml 0.37.5",
  "regex",
  "serde",
  "tar",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "utoipa",
@@ -1358,7 +1253,7 @@ name = "beacon-arrow-tiff"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "async-tiff",
  "async-trait",
  "beacon-common",
@@ -1369,9 +1264,9 @@ dependencies = [
  "bytes",
  "datafusion",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "ndarray",
- "object_store 0.12.4",
+ "object_store",
  "serde",
  "tokio",
  "tracing",
@@ -1382,7 +1277,7 @@ name = "beacon-arrow-zarr"
 version = "1.6.0"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "async-trait",
  "beacon-common",
  "beacon-datafusion-ext",
@@ -1391,9 +1286,9 @@ dependencies = [
  "datafusion",
  "futures",
  "hifitime",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "ndarray",
- "object_store 0.12.4",
+ "object_store",
  "parking_lot",
  "regex",
  "serde_json",
@@ -1410,7 +1305,7 @@ name = "beacon-binary-format"
 version = "2.2.0"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
+ "arrow 56.2.1",
  "arrow 57.3.1",
  "arrow 58.3.0",
  "async-trait",
@@ -1420,21 +1315,21 @@ dependencies = [
  "crossbeam",
  "flume",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
- "lz4_flex 0.11.5",
+ "lz4_flex 0.11.6",
  "lzzzz",
  "moka",
  "munge_macro",
  "nd-arrow-array",
- "object_store 0.12.4",
+ "object_store",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rkyv",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "zstd",
@@ -1445,17 +1340,17 @@ name = "beacon-common"
 version = "1.6.0"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "async-stream",
  "async-trait",
  "datafusion",
  "futures",
  "futures-util",
  "glob",
- "indexmap 2.13.0",
- "object_store 0.12.4",
+ "indexmap 2.14.0",
+ "object_store",
  "regex",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -1466,7 +1361,7 @@ version = "1.6.0"
 dependencies = [
  "envconfig",
  "lazy_static",
- "object_store 0.11.2",
+ "object_store",
 ]
 
 [[package]]
@@ -1474,7 +1369,7 @@ name = "beacon-core"
 version = "1.6.0"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "async-stream",
  "async-trait",
  "beacon-arrow-netcdf",
@@ -1496,9 +1391,9 @@ dependencies = [
  "futures-util",
  "geodatafusion",
  "glob",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "inventory",
- "object_store 0.12.4",
+ "object_store",
  "parking_lot",
  "pathdiff",
  "serde",
@@ -1517,7 +1412,7 @@ name = "beacon-data-lake"
 version = "1.6.0"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "async-trait",
  "beacon-arrow-zarr",
  "beacon-binary-format",
@@ -1535,14 +1430,14 @@ dependencies = [
  "geoarrow-array",
  "geoparquet",
  "glob",
- "indexmap 2.13.0",
- "object_store 0.12.4",
+ "indexmap 2.14.0",
+ "object_store",
  "parking_lot",
- "parquet 55.2.0",
+ "parquet",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "typetag",
@@ -1555,17 +1450,17 @@ name = "beacon-datafusion-ext"
 version = "1.6.0"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow 58.3.0",
+ "arrow-schema 58.3.0",
  "async-trait",
  "beacon-common",
  "beacon-object-storage",
  "datafusion",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "moka",
- "object_store 0.12.4",
- "ordered-float 5.1.0",
+ "object_store",
+ "ordered-float 5.3.0",
  "parking_lot",
  "serde",
  "serde_json",
@@ -1579,7 +1474,7 @@ dependencies = [
 name = "beacon-formats"
 version = "1.6.0"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "arrow-flight",
  "async-trait",
  "async_zip",
@@ -1600,25 +1495,25 @@ dependencies = [
  "geoarrow-array",
  "geoparquet",
  "glob",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "lazy_static",
- "lru 0.16.3",
+ "lru 0.16.4",
  "moka",
  "nd-arrow-array",
  "ndarray",
  "num-traits",
  "num_cpus",
- "object_store 0.12.4",
+ "object_store",
  "once_cell",
- "ordered-float 5.1.0",
+ "ordered-float 5.3.0",
  "parking_lot",
- "parquet 56.2.0",
+ "parquet",
  "prost",
  "rlimit",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tonic",
@@ -1633,7 +1528,7 @@ name = "beacon-functions"
 version = "1.6.0"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "beacon-arrow-atlas",
  "beacon-arrow-netcdf",
  "beacon-arrow-tiff",
@@ -1652,9 +1547,9 @@ dependencies = [
  "inventory",
  "lazy_static",
  "lru 0.14.0",
- "object_store 0.12.4",
+ "object_store",
  "once_cell",
- "ordered-float 5.1.0",
+ "ordered-float 5.3.0",
  "serde",
  "serde_json",
  "strsim",
@@ -1668,24 +1563,24 @@ name = "beacon-nd-array"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-schema 58.3.0",
  "async-trait",
  "bytemuck",
  "chrono",
  "criterion 0.5.1",
  "datafusion",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "ndarray",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1695,9 +1590,9 @@ name = "beacon-nd-arrow"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-schema 58.3.0",
  "async-trait",
  "bytemuck",
  "chrono",
@@ -1705,11 +1600,11 @@ dependencies = [
  "futures",
  "ndarray",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -1724,7 +1619,7 @@ dependencies = [
  "flume",
  "futures",
  "notify",
- "object_store 0.12.4",
+ "object_store",
  "once_cell",
  "parking_lot",
  "radix_trie",
@@ -1732,7 +1627,7 @@ dependencies = [
  "serde_json",
  "smol_str",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-test",
@@ -1796,9 +1691,9 @@ dependencies = [
  "beacon-object-storage",
  "chrono",
  "datafusion",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "moka",
- "object_store 0.12.4",
+ "object_store",
  "serde",
  "serde_json",
  "tracing",
@@ -1809,20 +1704,20 @@ name = "beacon-table"
 version = "1.6.0"
 dependencies = [
  "anyhow",
- "arrow 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow 58.3.0",
+ "arrow-schema 58.3.0",
  "async-trait",
  "beacon-datafusion-ext",
  "bytes",
  "datafusion",
  "futures",
- "object_store 0.12.4",
+ "object_store",
  "parking_lot",
- "parquet 56.2.0",
+ "parquet",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "typetag",
@@ -1850,9 +1745,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "blake2"
@@ -1865,16 +1760,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.4.2",
- "cpufeatures",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1914,18 +1809,19 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1934,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1944,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
@@ -1999,18 +1895,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
-
-[[package]]
-name = "bzip2"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
-dependencies = [
- "bzip2-sys",
-]
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
@@ -2022,16 +1909,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,9 +1916,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2062,10 +1939,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.42"
+name = "chacha20"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2113,16 +2001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
 name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,21 +2014,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
- "clap_lex 0.7.7",
+ "clap_lex 1.1.0",
 ]
 
 [[package]]
@@ -2164,9 +2042,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "comfy-table"
@@ -2178,6 +2056,27 @@ dependencies = [
  "strum_macros",
  "unicode-width",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "bzip2",
+ "compression-core",
+ "flate2",
+ "liblzma",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -2207,12 +2106,6 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "constant_time_eq"
@@ -2264,19 +2157,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.4.0"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
- "crc-catalog",
+ "libc",
 ]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32c"
@@ -2333,7 +2220,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.54",
+ "clap 4.6.1",
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
@@ -2495,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -2509,28 +2396,28 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "datafusion"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af15bb3c6ffa33011ef579f6b0bcbe7c26584688bd6c994f548e44df67f011a"
+checksum = "93db0e623840612f7f2cd757f7e8a8922064192363732c88692e0870016e141b"
 dependencies = [
- "arrow 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow 58.3.0",
+ "arrow-schema 58.3.0",
  "async-trait",
  "bytes",
- "bzip2 0.6.1",
+ "bzip2",
  "chrono",
  "datafusion-catalog",
  "datafusion-catalog-listing",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",
+ "datafusion-datasource-arrow",
  "datafusion-datasource-csv",
  "datafusion-datasource-json",
  "datafusion-datasource-parquet",
@@ -2553,28 +2440,28 @@ dependencies = [
  "flate2",
  "futures",
  "itertools 0.14.0",
+ "liblzma",
  "log",
- "object_store 0.12.4",
+ "object_store",
  "parking_lot",
- "parquet 56.2.0",
- "rand 0.9.2",
+ "parquet",
+ "rand 0.9.4",
  "regex",
  "sqlparser",
  "tempfile",
  "tokio",
  "url",
  "uuid",
- "xz2",
  "zstd",
 ]
 
 [[package]]
 name = "datafusion-catalog"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187622262ad8f7d16d3be9202b4c1e0116f1c9aa387e5074245538b755261621"
+checksum = "37cefde60b26a7f4ff61e9d2ff2833322f91df2b568d7238afe67bde5bdffb66"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "async-trait",
  "dashmap",
  "datafusion-common",
@@ -2585,22 +2472,21 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-plan",
  "datafusion-session",
- "datafusion-sql",
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store 0.12.4",
+ "object_store",
  "parking_lot",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9657314f0a32efd0382b9a46fdeb2d233273ece64baa68a7c45f5a192daf0f83"
+checksum = "17e112307715d6a7a331111a4c2330ff54bc237183511c319e3708a4cff431fb"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
@@ -2608,33 +2494,33 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "datafusion-session",
  "futures",
+ "itertools 0.14.0",
  "log",
- "object_store 0.12.4",
- "tokio",
+ "object_store",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a83760d9a13122d025fbdb1d5d5aaf93dd9ada5e90ea229add92aa30898b2d1"
+checksum = "d72a11ca44a95e1081870d3abb80c717496e8a7acb467a1d3e932bb636af5cc2"
 dependencies = [
  "ahash",
- "arrow 56.2.0",
- "arrow-ipc 56.2.0",
- "base64",
+ "arrow 58.3.0",
+ "arrow-ipc 58.3.0",
  "chrono",
  "half",
- "hashbrown 0.14.5",
- "indexmap 2.13.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
  "libc",
  "log",
- "object_store 0.12.4",
- "parquet 56.2.0",
+ "object_store",
+ "parquet",
  "paste",
  "recursive",
  "sqlparser",
@@ -2644,9 +2530,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6234a6c7173fe5db1c6c35c01a12b2aa0f803a3007feee53483218817f8b1e"
+checksum = "89f4afaed29670ec4fd6053643adc749fe3f4bc9d1ce1b8c5679b22c67d12def"
 dependencies = [
  "futures",
  "log",
@@ -2655,15 +2541,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7256c9cb27a78709dd42d0c80f0178494637209cac6e29d5c93edd09b6721b86"
+checksum = "e9fb386e1691355355a96419978a0022b7947b44d4a24a6ea99f00b6b485cbb6"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "async-compression",
  "async-trait",
  "bytes",
- "bzip2 0.6.1",
+ "bzip2",
  "chrono",
  "datafusion-common",
  "datafusion-common-runtime",
@@ -2678,134 +2564,153 @@ dependencies = [
  "futures",
  "glob",
  "itertools 0.14.0",
+ "liblzma",
  "log",
- "object_store 0.12.4",
- "parquet 56.2.0",
- "rand 0.9.2",
- "tempfile",
+ "object_store",
+ "rand 0.9.4",
  "tokio",
  "tokio-util",
  "url",
- "xz2",
  "zstd",
 ]
 
 [[package]]
-name = "datafusion-datasource-csv"
-version = "50.3.0"
+name = "datafusion-datasource-arrow"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64533a90f78e1684bfb113d200b540f18f268134622d7c96bbebc91354d04825"
+checksum = "ffa6c52cfed0734c5f93754d1c0175f558175248bf686c944fb05c373e5fc096"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
+ "arrow-ipc 58.3.0",
  "async-trait",
  "bytes",
- "datafusion-catalog",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "object_store 0.12.4",
+ "itertools 0.14.0",
+ "object_store",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-csv"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503f29e0582c1fc189578d665ff57d9300da1f80c282777d7eb67bb79fb8cdca"
+dependencies = [
+ "arrow 58.3.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store",
  "regex",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7ebeb12c77df0aacad26f21b0d033aeede423a64b2b352f53048a75bf1d6e6"
+checksum = "e33804749abc8d0c8cb7473228483cb8070e524c6f6086ee1b85a64debe2b3d2"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "async-trait",
  "bytes",
- "datafusion-catalog",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "object_store 0.12.4",
+ "object_store",
  "serde_json",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e783c4c7d7faa1199af2df4761c68530634521b176a8d1331ddbc5a5c75133"
+checksum = "32a8e0365e0e08e8ff94d912f0ababcf9065a1a304018ba90b1fc83c855b4997"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "async-trait",
  "bytes",
- "datafusion-catalog",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-adapter",
  "datafusion-physical-expr-common",
- "datafusion-physical-optimizer",
  "datafusion-physical-plan",
  "datafusion-pruning",
  "datafusion-session",
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store 0.12.4",
+ "object_store",
  "parking_lot",
- "parquet 56.2.0",
- "rand 0.9.2",
+ "parquet",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-doc"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ee6b1d9a80d13f9deb2291f45c07044b8e62fb540dbde2453a18be17a36429"
+checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
 
 [[package]]
 name = "datafusion-execution"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4cec0a57653bec7b933fb248d3ffa3fa3ab3bd33bd140dc917f714ac036f531"
+checksum = "c03c7fbdaefcca4ef6ffe425a5fc2325763bfb426599bb0bf4536466efabe709"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
+ "arrow-buffer 58.3.0",
  "async-trait",
+ "chrono",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-physical-expr-common",
  "futures",
  "log",
- "object_store 0.12.4",
+ "object_store",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tempfile",
  "url",
 ]
 
 [[package]]
 name = "datafusion-expr"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef76910bdca909722586389156d0aa4da4020e1631994d50fadd8ad4b1aa05fe"
+checksum = "574b9b6977fedbd2a611cbff12e5caf90f31640ad9dc5870f152836d94bad0dd"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -2814,7 +2719,8 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
  "paste",
  "recursive",
  "serde_json",
@@ -2823,29 +2729,30 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d155ccbda29591ca71a1344dd6bed26c65a4438072b400df9db59447f590bb6"
+checksum = "7d7c3adf3db8bf61e92eb90cb659c8e8b734593a8f7c8e12a843c7ddba24b87e"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "datafusion-common",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de2782136bd6014670fd84fe3b0ca3b3e4106c96403c3ae05c0598577139977"
+checksum = "f28aa4e10384e782774b10e72aca4d93ef7b31aa653095d9d4536b0a3dbc51b6"
 dependencies = [
- "arrow 56.2.0",
- "arrow-buffer 56.2.0",
+ "arrow 58.3.0",
+ "arrow-buffer 58.3.0",
  "base64",
  "blake2",
  "blake3",
  "chrono",
+ "chrono-tz",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -2856,7 +2763,9 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "md-5",
- "rand 0.9.2",
+ "memchr",
+ "num-traits",
+ "rand 0.9.4",
  "regex",
  "sha2",
  "unicode-segmentation",
@@ -2865,12 +2774,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07331fc13603a9da97b74fd8a273f4238222943dffdbbed1c4c6f862a30105bf"
+checksum = "00aa6217e56098ba84e0a338176fe52f0a84cca398021512c6c8c5eff806d0ad"
 dependencies = [
  "ahash",
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -2881,17 +2790,18 @@ dependencies = [
  "datafusion-physical-expr-common",
  "half",
  "log",
+ "num-traits",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5951e572a8610b89968a09b5420515a121fbc305c0258651f318dc07c97ab17"
+checksum = "b511250349407db7c43832ab2de63f5557b19a20dfd236b39ca2c04468b50d47"
 dependencies = [
  "ahash",
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "datafusion-common",
  "datafusion-expr-common",
  "datafusion-physical-expr-common",
@@ -2899,33 +2809,36 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdacca9302c3d8fc03f3e94f338767e786a88a33f5ebad6ffc0e7b50364b9ea3"
+checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
 dependencies = [
- "arrow 56.2.0",
- "arrow-ord 56.2.0",
+ "arrow 58.3.0",
+ "arrow-ord 58.3.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-expr-common",
  "datafusion-functions",
  "datafusion-functions-aggregate",
  "datafusion-functions-aggregate-common",
  "datafusion-macros",
  "datafusion-physical-expr-common",
+ "hashbrown 0.16.1",
  "itertools 0.14.0",
+ "itoa",
  "log",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-table"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37ff8a99434fbbad604a7e0669717c58c7c4f14c472d45067c4b016621d981"
+checksum = "72b40d3f5bbb3905f9ccb1ce9485a9595c77b69758a7c24d3ba79e334ff51e7e"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
@@ -2937,11 +2850,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e2aea7c79c926cffabb13dc27309d4eaeb130f4a21c8ba91cdd241c813652b"
+checksum = "d4e88ec9d57c9b685d02f58bfee7be62d72610430ddcedb82a08e5d9925dbfb6"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-expr",
@@ -2955,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fead257ab5fd2ffc3b40fda64da307e20de0040fe43d49197241d9de82a487f"
+checksum = "8307bb93519b1a91913723a1130cfafeee3f72200d870d88e91a6fc5470ede5c"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2965,28 +2878,28 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6f637bce95efac05cdfb9b6c19579ed4aa5f6b94d951cfa5bb054b7bb4f730"
+checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
 dependencies = [
- "datafusion-expr",
+ "datafusion-doc",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6583ef666ae000a613a837e69e456681a9faa96347bf3877661e9e89e141d8a"
+checksum = "e929015451a67f77d9d8b727b2bf3a40c4445fdef6cdc53281d7d97c76888ace"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-physical-expr",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
  "recursive",
@@ -2996,34 +2909,35 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8668103361a272cbbe3a61f72eca60c9b7c706e87cc3565bcf21e2b277b84f6"
+checksum = "4b1e68aba7a4b350401cfdf25a3d6f989ad898a7410164afe9ca52080244cb59"
 dependencies = [
  "ahash",
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
- "hashbrown 0.14.5",
- "indexmap 2.13.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
- "log",
  "parking_lot",
  "paste",
  "petgraph",
+ "recursive",
+ "tokio",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815acced725d30601b397e39958e0e55630e0a10d66ef7769c14ae6597298bb0"
+checksum = "ea22315f33cf2e0adc104e8ec42e285f6ed93998d565c65e82fec6a9ee9f9db4"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-functions",
@@ -3034,25 +2948,28 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6652fe7b5bf87e85ed175f571745305565da2c0b599d98e697bcbedc7baa47c3"
+checksum = "b04b45ea8ad3ac2d78f2ea2a76053e06591c9629c7a603eda16c10649ecf4362"
 dependencies = [
  "ahash",
- "arrow 56.2.0",
+ "arrow 58.3.0",
+ "chrono",
  "datafusion-common",
  "datafusion-expr-common",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
+ "parking_lot",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b7d623eb6162a3332b564a0907ba00895c505d101b99af78345f1acf929b5c"
+checksum = "7cb13397809a425918f608dfe8653f332015a3e330004ab191b4404187238b95"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -3062,36 +2979,36 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-pruning",
  "itertools 0.14.0",
- "log",
  "recursive",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f7f778a1a838dec124efb96eae6144237d546945587557c9e6936b3414558c"
+checksum = "5edc023675791af9d5fb4cc4c24abf5f7bd3bd4dcf9e5bd90ea1eff6976dcc79"
 dependencies = [
  "ahash",
- "arrow 56.2.0",
- "arrow-ord 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
  "async-trait",
- "chrono",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-functions",
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "futures",
  "half",
- "hashbrown 0.14.5",
- "indexmap 2.13.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
+ "num-traits",
  "parking_lot",
  "pin-project-lite",
  "tokio",
@@ -3099,12 +3016,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1e59e2ca14fe3c30f141600b10ad8815e2856caa59ebbd0e3e07cd3d127a65"
+checksum = "ac8c76860e355616555081cab5968cec1af7a80701ff374510860bcd567e365a"
 dependencies = [
- "arrow 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow 58.3.0",
  "datafusion-common",
  "datafusion-datasource",
  "datafusion-expr-common",
@@ -3117,39 +3033,31 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ef8e2745583619bd7a49474e8f45fbe98ebb31a133f27802217125a7b3d58d"
+checksum = "5412111aa48e2424ba926112e192f7a6b7e4ccb450145d25ce5ede9f19dc491e"
 dependencies = [
- "arrow 56.2.0",
  "async-trait",
- "dashmap",
  "datafusion-common",
- "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-physical-expr",
  "datafusion-physical-plan",
- "datafusion-sql",
- "futures",
- "itertools 0.14.0",
- "log",
- "object_store 0.12.4",
  "parking_lot",
- "tokio",
 ]
 
 [[package]]
 name = "datafusion-sql"
-version = "50.3.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89abd9868770386fede29e5a4b14f49c0bf48d652c3b9d7a8a0332329b87d50b"
+checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.3.0",
  "bigdecimal",
+ "chrono",
  "datafusion-common",
  "datafusion-expr",
- "indexmap 2.13.0",
+ "datafusion-functions-nested",
+ "indexmap 2.14.0",
  "log",
  "recursive",
  "regex",
@@ -3166,16 +3074,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "deflate64"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
-
-[[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -3228,9 +3130,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3249,9 +3151,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -3267,12 +3169,6 @@ name = "endian-type"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
-
-[[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "envconfig"
@@ -3322,9 +3218,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
 dependencies = [
  "serde",
  "serde_core",
@@ -3364,27 +3260,25 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "findshlibs"
@@ -3410,15 +3304,15 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "rustc_version",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -3481,9 +3375,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3496,9 +3390,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3506,15 +3400,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3523,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -3542,9 +3436,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3553,21 +3447,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3577,7 +3471,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -3647,9 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
  "approx",
  "num-traits",
@@ -3664,9 +3557,9 @@ dependencies = [
 
 [[package]]
 name = "geoarrow"
-version = "0.6.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b70b2f4d8f6f2730525296edfd9dac36c961be5c272671d46f23b7e5b0d33b9"
+checksum = "ec42ac7fb4fdcd6982dab92d24faf436f18c36e47c3f813a33619a2728718a30"
 dependencies = [
  "geoarrow-array",
  "geoarrow-schema",
@@ -3674,13 +3567,13 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-array"
-version = "0.6.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1884b17253d8572e88833c282fcbb442365e4ae5f9052ced2831608253436c"
+checksum = "dafe7b7de3fab1a8b7099fd6a6434ca955fa65065f9c19f0f8a133693f3c2b0e"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-schema 58.3.0",
  "geo-traits 0.3.0",
  "geoarrow-schema",
  "num-traits",
@@ -3690,12 +3583,12 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-expr-geo"
-version = "0.6.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67d3b543bc3ebeffdc204b67d69b8f9fcd33d76269ddd4a4618df99f053a934"
+checksum = "8e4a62ac19c86827c6ec81ea584594b3ee96db5a8119b9774d3466c6b373c434"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
  "geo",
  "geo-traits 0.3.0",
  "geoarrow-array",
@@ -3704,11 +3597,11 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-schema"
-version = "0.6.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f1b18b1c9a44ecd72be02e53d6e63bbccfdc8d1765206226af227327e2be6e"
+checksum = "4d4a7edb2a1d87024a93805332a9c8184a0354836271d42c0d18cf628a5e3cd0"
 dependencies = [
- "arrow-schema 56.2.0",
+ "arrow-schema 58.3.0",
  "geo-traits 0.3.0",
  "serde",
  "serde_json",
@@ -3717,13 +3610,13 @@ dependencies = [
 
 [[package]]
 name = "geodatafusion"
-version = "0.1.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d676b8d8b5f391ab4270ba31e9b599ee2c3d780405a38e272a0a7565ea189c"
+checksum = "af7cd430f1a1f59bc97053d824ad410ea6fd123c8977b3c1a75335e289233b8b"
 dependencies = [
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-schema 58.3.0",
  "datafusion",
  "geo",
  "geo-traits 0.3.0",
@@ -3737,18 +3630,18 @@ dependencies = [
 
 [[package]]
 name = "geographiclib-rs"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f611040a2bb37eaa29a78a128d1e92a378a03e0b6e66ae27398d42b1ba9a7841"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "geohash"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb94b1a65401d6cbf22958a9040aa364812c26674f841bee538b12c135db1e6"
+checksum = "7f58890382f70caccc5fa388981f7ac80c913795042afce9f3e065695d8f7464"
 dependencies = [
  "geo-types",
  "libm",
@@ -3764,26 +3657,26 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "geoparquet"
-version = "0.6.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd91ef3510cd6e8968927436ff5406ac6e5f610a200f0774de943bb7679e3ad"
+checksum = "a64b758b2b1fc749c5eb212215afa6bc14e1fca93884dac339ab7097ffc20ce1"
 dependencies = [
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-ord 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
  "geo-traits 0.3.0",
  "geo-types",
  "geoarrow-array",
  "geoarrow-schema",
- "indexmap 2.13.0",
- "parquet 56.2.0",
+ "indexmap 2.14.0",
+ "parquet",
  "serde",
  "serde_json",
  "serde_with",
@@ -3826,6 +3719,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3854,9 +3748,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3864,7 +3758,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3922,10 +3816,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -4035,9 +3925,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hifitime"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae664976c51b75b30deb25aa778bff665169ca129104fb5f427e7154fc611ad5"
+checksum = "a978b79fb40cea4c6592890ffe0021dfea5c51a107fbac565abae82fd24a15af"
 dependencies = [
  "js-sys",
  "lexical-core",
@@ -4051,19 +3941,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -4112,9 +3993,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4127,7 +4008,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -4135,16 +4015,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -4165,14 +4044,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -4181,7 +4059,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -4204,9 +4082,9 @@ checksum = "9190f86706ca38ac8add223b2aed8b1330002b5cdbbce28fb58b10914d38fc27"
 
 [[package]]
 name = "i_overlay"
-version = "4.0.6"
+version = "4.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcccbd4e4274e0f80697f5fbc6540fdac533cce02f2081b328e68629cce24f9"
+checksum = "413183068e6e0289e18d7d0a1f661b81546e6918d5453a44570b9ab30cbed1b3"
 dependencies = [
  "i_float",
  "i_key_sort",
@@ -4232,9 +4110,9 @@ checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -4242,7 +4120,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4256,12 +4134,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -4269,9 +4148,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -4282,9 +4161,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -4296,15 +4175,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -4316,15 +4195,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -4360,9 +4239,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -4381,12 +4260,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -4398,7 +4277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "is-terminal",
  "itoa",
  "log",
@@ -4411,11 +4290,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "inotify-sys",
  "libc",
 ]
@@ -4430,15 +4309,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array 0.14.7",
-]
-
-[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4446,28 +4316,18 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "inventory"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is-terminal"
@@ -4500,15 +4360,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -4518,9 +4369,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -4540,19 +4391,21 @@ checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -4560,11 +4413,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.12.1",
  "libc",
 ]
 
@@ -4639,15 +4492,15 @@ dependencies = [
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -4660,27 +4513,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.15"
+name = "liblzma"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
-name = "libredox"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899"
 dependencies = [
- "bitflags 2.10.0",
- "libc",
- "redox_syscall 0.7.0",
+ "liblzma-sys",
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.23"
+name = "liblzma-sys"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+checksum = "1a60851d15cd8c5346eca4ab8babff585be2ae4bc8097c067291d3ffe2add3b6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -4699,15 +4561,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -4721,9 +4583,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "lru"
@@ -4736,9 +4598,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -4761,9 +4623,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 dependencies = [
  "twox-hash",
 ]
@@ -4778,24 +4640,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "lzma-rs"
-version = "0.3.0"
+name = "lz4_flex"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
- "byteorder",
- "crc",
-]
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
+ "twox-hash",
 ]
 
 [[package]]
@@ -4844,15 +4694,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -4885,9 +4735,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -4897,9 +4747,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dec6bd31b08944e08b58fd99373893a6c17054d6f3ea5006cc894f4f4eee2a"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -4988,10 +4838,10 @@ name = "nd-arrow-array"
 version = "2.0.0"
 source = "git+https://github.com/maris-development/nd-arrow-array.git?branch=main#6693aa470b499f1baa22f324610780dae6196a9e"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 56.2.1",
  "arrow 57.3.1",
  "arrow 58.3.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5014,7 +4864,7 @@ name = "netcdf"
 version = "0.11.1"
 source = "git+https://github.com/robinskil/netcdf.git#35cc74866e5f337f883fe8b70cb509eac17aeda1"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "libc",
  "ndarray",
  "netcdf-sys",
@@ -5058,7 +4908,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "flume",
  "fsevent-sys",
  "inotify",
@@ -5073,15 +4923,18 @@ dependencies = [
 
 [[package]]
 name = "notify-types"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.12.1",
+]
 
 [[package]]
 name = "ntapi"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
 ]
@@ -5131,9 +4984,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-format"
@@ -5198,9 +5051,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -5208,9 +5061,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5224,7 +5077,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -5239,15 +5092,6 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
@@ -5257,37 +5101,18 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.11.2"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures",
- "humantime",
- "itertools 0.13.0",
- "parking_lot",
- "percent-encoding",
- "snafu",
- "tokio",
- "tracing",
- "url",
- "walkdir",
-]
-
-[[package]]
-name = "object_store"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1be0c6c22ec0817cdc77d3842f721a17fd30ab6965001415b5402a74e6b740"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "base64",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http",
  "http-body-util",
  "humantime",
@@ -5296,40 +5121,14 @@ dependencies = [
  "md-5",
  "parking_lot",
  "percent-encoding",
- "quick-xml 0.38.4",
- "rand 0.9.2",
+ "quick-xml 0.39.4",
+ "rand 0.10.1",
  "reqwest",
  "ring",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.17",
- "tokio",
- "tracing",
- "url",
- "walkdir",
- "wasm-bindgen-futures",
- "web-time",
-]
-
-[[package]]
-name = "object_store"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "humantime",
- "itertools 0.14.0",
- "parking_lot",
- "percent-encoding",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -5340,9 +5139,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
@@ -5352,9 +5151,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
@@ -5367,12 +5166,12 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.1.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -5416,58 +5215,24 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "parquet"
-version = "55.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17da4150748086bd43352bc77372efa9b6e3dbd06a04831d2a98c041c225cfa"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
 dependencies = [
  "ahash",
- "arrow-array 55.2.0",
- "arrow-buffer 55.2.0",
- "arrow-cast 55.2.0",
- "arrow-data 55.2.0",
- "arrow-ipc 55.2.0",
- "arrow-schema 55.2.0",
- "arrow-select 55.2.0",
- "base64",
- "brotli",
- "bytes",
- "chrono",
- "flate2",
- "half",
- "hashbrown 0.15.5",
- "lz4_flex 0.11.5",
- "num",
- "num-bigint",
- "paste",
- "seq-macro",
- "simdutf8",
- "snap",
- "thrift",
- "twox-hash",
- "zstd",
-]
-
-[[package]]
-name = "parquet"
-version = "56.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dbd48ad52d7dccf8ea1b90a3ddbfaea4f69878dd7683e51c507d4bc52b5b27"
-dependencies = [
- "ahash",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
  "base64",
  "brotli",
  "bytes",
@@ -5475,13 +5240,13 @@ dependencies = [
  "flate2",
  "futures",
  "half",
- "hashbrown 0.16.1",
- "lz4_flex 0.11.5",
- "num",
+ "hashbrown 0.17.1",
+ "lz4_flex 0.13.1",
  "num-bigint",
- "object_store 0.12.4",
+ "num-integer",
+ "num-traits",
+ "object_store",
  "paste",
- "ring",
  "seq-macro",
  "simdutf8",
  "snap",
@@ -5504,16 +5269,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
-]
-
-[[package]]
 name = "pdqselect"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5533,7 +5288,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -5557,18 +5312,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5577,21 +5332,15 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -5623,15 +5372,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -5649,9 +5398,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -5681,7 +5430,7 @@ dependencies = [
  "spin 0.10.0",
  "symbolic-demangle",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5705,27 +5454,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -5733,9 +5482,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -5746,18 +5495,18 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11f2fedc3b7dafdc2851bc52f277377c5473d378859be234bc7ebb593144d01"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -5803,9 +5552,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -5813,9 +5562,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.18"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ada44a88ef953a3294f6eb55d2007ba44646015e18613d2f213016379203ef3"
+checksum = "d1c821816e9b928e20e92ed59bb3ac4aab321d16ca2316871c9fe7ca739cd477"
 dependencies = [
  "ahash",
  "equivalent",
@@ -5836,8 +5585,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
- "thiserror 2.0.17",
+ "socket2",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -5845,20 +5594,20 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5873,16 +5622,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -5920,9 +5669,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -5932,12 +5681,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5980,6 +5740,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5987,9 +5753,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -6040,23 +5806,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
-dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6066,9 +5823,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6077,9 +5834,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rend"
@@ -6134,9 +5891,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
 ]
@@ -6164,7 +5921,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "munge",
  "ptr_meta",
  "rancor",
@@ -6283,9 +6040,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.9.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -6294,9 +6051,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.9.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6307,9 +6064,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.9.0"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2",
  "walkdir",
@@ -6317,15 +6074,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -6338,11 +6095,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -6351,9 +6108,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "ring",
@@ -6365,9 +6122,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -6377,9 +6134,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -6387,9 +6144,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -6404,9 +6161,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -6419,9 +6176,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -6434,11 +6191,11 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -6447,9 +6204,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6457,9 +6214,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -6503,7 +6260,7 @@ version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -6553,7 +6310,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6580,7 +6337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -6591,7 +6348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -6606,9 +6363,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -6622,9 +6379,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simdutf8"
@@ -6634,15 +6391,15 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -6652,9 +6409,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol_str"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f7a918bd2a9951d18ee6e48f076843e8e73a9a5d22cf05bcd4b7a81bdd04e17"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 dependencies = [
  "borsh",
  "serde_core",
@@ -6662,19 +6419,18 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
 dependencies = [
- "backtrace",
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6700,31 +6456,21 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "spade"
-version = "2.15.0"
+version = "2.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb313e1c8afee5b5647e00ee0fe6855e3d529eb863a0fdae1d60006c4d1e9990"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "num-traits",
  "robust",
  "smallvec",
@@ -6750,9 +6496,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.58.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4b661c54b1e4b603b37873a18c59920e4c51ea8ea2cf527d925424dbd4437c"
+checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
 dependencies = [
  "log",
  "recursive",
@@ -6761,9 +6507,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6778,22 +6524,22 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "str_stack"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
 
 [[package]]
 name = "strsim"
@@ -6828,9 +6574,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.17.1"
+version = "12.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520cf51c674f8b93d533f80832babe413214bb766b6d7cb74ee99ad2971f8467"
+checksum = "332615d90111d8eeaf86a84dc9bbe9f65d0d8c5cf11b4caccedc37754eb0dcfd"
 dependencies = [
  "debugid",
  "memmap2",
@@ -6840,9 +6586,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.17.1"
+version = "12.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0de2ee0ffa2641e17ba715ad51d48b9259778176517979cb38b6aa86fa7425"
+checksum = "912017718eb4d21930546245af9a3475c9dccf15675a5c215664e76621afc471"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -6850,10 +6596,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.114"
+name = "symlink"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6903,9 +6655,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -6914,12 +6666,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6942,11 +6694,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -6962,9 +6714,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7013,9 +6765,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -7028,15 +6780,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7053,9 +6805,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -7073,9 +6825,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -7088,9 +6840,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -7098,16 +6850,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7133,13 +6885,14 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -7163,20 +6916,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -7184,18 +6937,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -7210,14 +6963,25 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
- "socket2 0.5.10",
+ "socket2",
+ "sync_wrapper",
  "tokio",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -7228,7 +6992,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -7241,21 +7005,21 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -7284,12 +7048,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.17",
+ "symlink",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -7328,9 +7093,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -7346,9 +7111,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
 dependencies = [
  "tracing-core",
  "tracing-subscriber",
@@ -7357,9 +7122,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
  "syn",
@@ -7373,19 +7138,18 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
- "thiserror 2.0.17",
- "utf-8",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7402,15 +7166,15 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
 dependencies = [
  "erased-serde",
  "inventory",
@@ -7421,9 +7185,9 @@ dependencies = [
 
 [[package]]
 name = "typetag-impl"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7438,15 +7202,15 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -7485,12 +7249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7502,7 +7260,7 @@ version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -7523,9 +7281,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7565,9 +7323,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -7620,11 +7378,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.46.0",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -7638,9 +7396,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7651,22 +7409,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7674,9 +7429,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7687,9 +7442,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -7711,7 +7466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -7735,17 +7490,17 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7769,13 +7524,11 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "which"
-version = "8.0.0"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
- "env_home",
- "rustix",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
@@ -7816,7 +7569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -7828,7 +7581,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7840,8 +7593,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -7850,7 +7616,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -7895,7 +7661,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
 ]
 
@@ -7909,12 +7675,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7931,15 +7715,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -8159,9 +7934,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -8178,18 +7953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8197,6 +7960,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -8217,7 +7986,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -8247,8 +8016,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
- "indexmap 2.13.0",
+ "bitflags 2.12.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -8267,7 +8036,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -8317,9 +8086,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
@@ -8332,19 +8101,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
-
-[[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -8353,9 +8113,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8365,9 +8125,9 @@ dependencies = [
 
 [[package]]
 name = "zarrs"
-version = "0.23.12"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251f4ec1a9e60ca9c693ade9b29a0b981a61e68ea3e2ae85fa9da31bcdca5dbe"
+checksum = "8132307b8fc041fd21f68c7987103fb6e038b11f9838c16ec43b798f5480ccf5"
 dependencies = [
  "async-generic",
  "async-lock",
@@ -8388,7 +8148,7 @@ dependencies = [
  "itoa",
  "libz-sys",
  "log",
- "lru 0.16.3",
+ "lru 0.16.4",
  "moka",
  "ndarray",
  "num",
@@ -8399,7 +8159,7 @@ dependencies = [
  "rayon_iter_concurrent_limit",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thread_local",
  "unsafe_cell_slice",
  "uuid",
@@ -8425,7 +8185,7 @@ dependencies = [
  "inventory",
  "itertools 0.14.0",
  "rayon",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "zarrs_metadata",
  "zarrs_plugin",
@@ -8457,7 +8217,7 @@ dependencies = [
  "inventory",
  "itertools 0.14.0",
  "rayon",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unsafe_cell_slice",
  "zarrs_chunk_grid",
  "zarrs_data_type",
@@ -8479,7 +8239,7 @@ dependencies = [
  "paste",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zarrs_metadata",
  "zarrs_plugin",
 ]
@@ -8497,7 +8257,7 @@ dependencies = [
  "page_size",
  "pathdiff",
  "positioned-io",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "walkdir",
  "zarrs_storage",
 ]
@@ -8513,7 +8273,7 @@ dependencies = [
  "monostate",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8528,19 +8288,19 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zarrs_metadata",
 ]
 
 [[package]]
 name = "zarrs_object_store"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d9d0d3db426dd50dfb0b5d7cc1660bda368caeb5cd8645c60c46bc4f261a19"
+checksum = "ba1662bcdc585be1923a8b98ee5d6314d19af8c5775d6516a69ca33fd88b46af"
 dependencies = [
  "async-trait",
  "futures",
- "object_store 0.12.4",
+ "object_store",
  "zarrs_storage",
 ]
 
@@ -8553,7 +8313,7 @@ dependencies = [
  "paste",
  "regex",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8568,24 +8328,24 @@ dependencies = [
  "derive_more",
  "futures",
  "itertools 0.14.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unsafe_cell_slice",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8594,18 +8354,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8618,26 +8378,12 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -8646,9 +8392,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -8657,9 +8403,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8672,28 +8418,15 @@ version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
- "aes",
  "arbitrary",
- "bzip2 0.5.2",
- "constant_time_eq 0.3.1",
  "crc32fast",
  "crossbeam-utils",
- "deflate64",
  "displaydoc",
  "flate2",
- "getrandom 0.3.4",
- "hmac",
- "indexmap 2.13.0",
- "lzma-rs",
+ "indexmap 2.14.0",
  "memchr",
- "pbkdf2",
- "sha1",
- "thiserror 2.0.17",
- "time",
- "xz2",
- "zeroize",
+ "thiserror 2.0.18",
  "zopfli",
- "zstd",
 ]
 
 [[package]]
@@ -8705,16 +8438,16 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
  "zopfli",
 ]
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,17 +41,18 @@ lazy_static = "1.5.0"
 bloomfilter = { version = "1", features = ["serde"] }
 bincode = "1"
 
-datafusion = "^50.0.0"
-geodatafusion = "0.1.1"
-object_store = { version = "0.12.4", features = ["aws"] }
+datafusion = "^53"
+geodatafusion = "0.4.0"
+object_store = { version = "0.13.1", features = ["aws"] }
 
-arrow = { version = "^56.0.0", features = ["prettyprint"]}
-arrow-schema = { version = "^56.0.0", features = ["serde"] }
-arrow-ipc = { version = "^56.0.0", features = ["zstd"] }
-arrow-flight = { version = "^56.0.0" }
-parquet = { version = "^56.0.0", features = ["async"] }
-geoarrow = { version = "^0.6.0" }
-geoarrow-array = "^0.6.0"
-geoparquet = "^0.6.0"
+arrow = { version = "^58", features = ["prettyprint"]}
+arrow-schema = { version = "^58", features = ["serde"] }
+arrow-ipc = { version = "^58", features = ["zstd"] }
+arrow-flight = { version = "^58" }
+parquet = { version = "^58", features = ["async"] }
+geoarrow = "^0.8"
+geoarrow-array = "^0.8"
+geoarrow-schema = "^0.8"
+geoparquet = "^0.8"
 
 beacon-nd-arrow = { path = "beacon-nd-arrow" }

--- a/beacon-api/Cargo.toml
+++ b/beacon-api/Cargo.toml
@@ -9,7 +9,7 @@ pprof = { version = "0.15", features = ["flamegraph"] }
 
 [dependencies]
 axum = { version = "0.8.1", features = ["tracing", "multipart", "ws"] }
-axum-streams = { version = "0.23.1", features = ["arrow"]}
+axum-streams = { version = "0.25.0", features = ["arrow"]}
 tower-http = { version = "0.6.1", features = ["trace", "cors"] }
 base64 = "0.22.1"
 
@@ -33,8 +33,8 @@ uuid = { version = "1.16.0" }
 tracing = { workspace = true}
 tracing-subscriber = { workspace = true}
 tracing-appender = { workspace = true}
-tonic = "0.13.1"
-prost = "0.13.1"
+tonic = "0.14.1"
+prost = "0.14.1"
 
 # Local dependencies
 beacon-config = { path = "../beacon-config" }

--- a/beacon-arrow-atlas/Cargo.toml
+++ b/beacon-arrow-atlas/Cargo.toml
@@ -20,7 +20,7 @@ rmp-serde = "1"
 zstd = "0.13"
 lz4_flex = "0.11"
 ndarray = "0.17"
-atlas = { git = "https://github.com/maris-development/atlas.git", version = "0.8.0" }
+atlas = { package = "atlas-rust", git = "https://github.com/maris-development/atlas.git", version = "0.9.1" }
 crossbeam = { workspace = true }
 moka = { workspace = true }
 

--- a/beacon-arrow-atlas/src/datafusion/mod.rs
+++ b/beacon-arrow-atlas/src/datafusion/mod.rs
@@ -386,9 +386,14 @@ impl FileFormat for AtlasFormat {
         _state: &dyn Session,
         conf: FileScanConfig,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        let table_schema = datafusion::datasource::table_schema::TableSchema::new(
+            conf.file_schema().clone(),
+            conf.table_partition_cols().clone(),
+        );
         let source = AtlasSource::new(
             self.datasets_object_store.clone(),
             self.options.read_dimensions.clone(),
+            table_schema,
         );
         let conf = FileScanConfigBuilder::from(conf)
             .with_source(Arc::new(source))
@@ -408,10 +413,14 @@ impl FileFormat for AtlasFormat {
         ))
     }
 
-    fn file_source(&self) -> Arc<dyn FileSource> {
+    fn file_source(
+        &self,
+        table_schema: datafusion::datasource::table_schema::TableSchema,
+    ) -> Arc<dyn FileSource> {
         Arc::new(AtlasSource::new(
             self.datasets_object_store.clone(),
             self.options.read_dimensions.clone(),
+            table_schema,
         ))
     }
 }
@@ -625,7 +634,16 @@ mod tests {
         let store = test_store().await;
         ensure_fixture().await;
         let format = AtlasFormat::new(store, AtlasOptions::default());
-        assert_eq!(format.file_source().file_type(), "atlas");
+        assert_eq!(
+            format
+                .file_source(
+                    datafusion::datasource::table_schema::TableSchema::from_file_schema(Arc::new(
+                        arrow::datatypes::Schema::empty()
+                    ))
+                )
+                .file_type(),
+            "atlas"
+        );
     }
 
     #[tokio::test]
@@ -648,6 +666,8 @@ mod tests {
             insert_op: datafusion::logical_expr::dml::InsertOp::Append,
             keep_partition_by_columns: false,
             file_extension: "atlas.json".to_string(),
+            file_output_mode:
+                datafusion::datasource::physical_plan::FileOutputMode::SingleFile,
         };
         let err = format
             .create_writer_physical_plan(input, &ctx.state(), conf, None)

--- a/beacon-arrow-atlas/src/datafusion/source.rs
+++ b/beacon-arrow-atlas/src/datafusion/source.rs
@@ -11,8 +11,10 @@ use datafusion::{
     common::Statistics,
     config::ConfigOptions,
     datasource::{
-        physical_plan::{FileMeta, FileOpenFuture, FileOpener, FileSource},
+        listing::PartitionedFile,
+        physical_plan::{FileOpenFuture, FileOpener, FileScanConfig, FileSource},
         schema_adapter::{DefaultSchemaAdapterFactory, SchemaAdapter, SchemaAdapterFactory},
+        table_schema::TableSchema,
     },
     physical_expr::{PhysicalExpr, conjunction},
     physical_plan::{
@@ -52,9 +54,8 @@ impl AtlasStreamDatasets {
 pub struct AtlasSource {
     datasets_object_store: Arc<DatasetsStore>,
     schema_adapter_factory: Option<Arc<dyn SchemaAdapterFactory>>,
-    override_schema: Option<SchemaRef>,
+    table_schema: TableSchema,
     execution_plan_metrics: ExecutionPlanMetricsSet,
-    projected_statistics: Option<Statistics>,
     batch_size: usize,
     predicate: Option<Arc<dyn PhysicalExpr>>,
     read_dimensions: Option<Vec<String>>,
@@ -66,13 +67,13 @@ impl AtlasSource {
     pub fn new(
         datasets_object_store: Arc<DatasetsStore>,
         read_dimensions: Option<Vec<String>>,
+        table_schema: TableSchema,
     ) -> Self {
         Self {
             datasets_object_store,
             schema_adapter_factory: None,
-            override_schema: None,
+            table_schema,
             execution_plan_metrics: ExecutionPlanMetricsSet::new(),
-            projected_statistics: None,
             batch_size: usize::MAX,
             predicate: None,
             read_dimensions,
@@ -85,22 +86,19 @@ impl FileSource for AtlasSource {
     fn create_file_opener(
         &self,
         _object_store: Arc<dyn object_store::ObjectStore>,
-        base_config: &datafusion::datasource::physical_plan::FileScanConfig,
+        base_config: &FileScanConfig,
         partition: usize,
-    ) -> Arc<dyn FileOpener> {
-        let table_schema = self
-            .override_schema
-            .clone()
-            .unwrap_or_else(|| base_config.file_schema.clone());
-        let projected_schema = base_config.projected_schema();
+    ) -> datafusion::error::Result<Arc<dyn FileOpener>> {
+        let file_schema = self.table_schema.file_schema().clone();
+        let projected_schema = base_config.projected_schema()?;
         let schema_adapter_factory = self
             .schema_adapter_factory
             .clone()
             .unwrap_or_else(|| Arc::new(DefaultSchemaAdapterFactory));
 
-        let schema_adapter = schema_adapter_factory.create(projected_schema, table_schema.clone());
+        let schema_adapter = schema_adapter_factory.create(projected_schema, file_schema);
 
-        Arc::new(AtlasOpener {
+        Ok(Arc::new(AtlasOpener {
             datasets_object_store: self.datasets_object_store.clone(),
             schema_adapter: Arc::from(schema_adapter),
             batch_size: self.batch_size,
@@ -109,11 +107,15 @@ impl FileSource for AtlasSource {
             read_dimensions: self.read_dimensions.clone(),
             predicate: self.predicate.clone(),
             stream_cache: self.stream_cache.clone(),
-        })
+        }))
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn table_schema(&self) -> &TableSchema {
+        &self.table_schema
     }
 
     fn with_batch_size(&self, batch_size: usize) -> Arc<dyn FileSource> {
@@ -123,41 +125,8 @@ impl FileSource for AtlasSource {
         })
     }
 
-    fn with_schema(&self, schema: SchemaRef) -> Arc<dyn FileSource> {
-        Arc::new(Self {
-            override_schema: Some(schema),
-            ..self.clone()
-        })
-    }
-
-    fn with_projection(
-        &self,
-        _config: &datafusion::datasource::physical_plan::FileScanConfig,
-    ) -> Arc<dyn FileSource> {
-        Arc::new(self.clone())
-    }
-
-    fn with_statistics(&self, statistics: Statistics) -> Arc<dyn FileSource> {
-        Arc::new(Self {
-            projected_statistics: Some(statistics),
-            ..self.clone()
-        })
-    }
-
     fn metrics(&self) -> &ExecutionPlanMetricsSet {
         &self.execution_plan_metrics
-    }
-
-    fn statistics(&self) -> datafusion::error::Result<Statistics> {
-        if let Some(statistics) = &self.projected_statistics {
-            Ok(statistics.clone())
-        } else if let Some(schema) = self.override_schema.as_ref() {
-            Ok(Statistics::new_unknown(schema))
-        } else {
-            Err(datafusion::error::DataFusionError::Execution(
-                "Schema must be set to compute statistics".to_string(),
-            ))
-        }
     }
 
     fn file_type(&self) -> &str {
@@ -328,15 +297,11 @@ impl AtlasOpener {
 }
 
 impl FileOpener for AtlasOpener {
-    fn open(
-        &self,
-        file_meta: FileMeta,
-        _file: datafusion::datasource::listing::PartitionedFile,
-    ) -> datafusion::error::Result<FileOpenFuture> {
+    fn open(&self, file: PartitionedFile) -> datafusion::error::Result<FileOpenFuture> {
         let metrics = Some(DatasetReadMetrics::new(&self.metrics, self.partition));
         let fut = Self::read_task(
             self.datasets_object_store.clone(),
-            file_meta.object_meta,
+            file.object_meta,
             self.stream_cache.clone(),
             self.schema_adapter.clone(),
             self.batch_size,
@@ -357,7 +322,8 @@ mod tests {
     use arrow::array::Array;
     use datafusion::datasource::file_format::FileFormat;
     use datafusion::datasource::listing::PartitionedFile;
-    use datafusion::datasource::physical_plan::{FileMeta, FileScanConfigBuilder, FileSource};
+    use datafusion::datasource::physical_plan::{FileScanConfigBuilder, FileSource};
+    use datafusion::datasource::table_schema::TableSchema;
     use datafusion::execution::object_store::ObjectStoreUrl;
     use datafusion::prelude::SessionContext;
     use futures::StreamExt;
@@ -382,15 +348,17 @@ mod tests {
             .await
             .expect("infer schema");
 
-        let source = AtlasSource::new(store, None);
+        let source =
+            AtlasSource::new(store, None, TableSchema::from_file_schema(table_schema.clone()));
         let conf = FileScanConfigBuilder::new(
             ObjectStoreUrl::local_filesystem(),
-            table_schema.clone(),
             Arc::new(source.clone()) as Arc<dyn FileSource>,
         )
         .build();
 
-        let opener = source.create_file_opener(dummy_store, &conf, 0);
+        let opener = source
+            .create_file_opener(dummy_store, &conf, 0)
+            .expect("file opener");
         (opener, table_schema, object)
     }
 
@@ -402,15 +370,7 @@ mod tests {
             statistics: None,
             extensions: None,
             metadata_size_hint: None,
-        }
-    }
-
-    fn file_meta_for(object: object_store::ObjectMeta) -> FileMeta {
-        FileMeta {
-            object_meta: object,
-            range: None,
-            extensions: None,
-            metadata_size_hint: None,
+            ordering: None,
         }
     }
 
@@ -440,10 +400,9 @@ mod tests {
         // batches from every dataset in the atlas (winter + summer).
         let (opener, schema, object) = build_opener_with_schema().await;
         let pf = pf_for(object.clone());
-        let file_meta = file_meta_for(object);
 
         let stream = opener
-            .open(file_meta, pf)
+            .open(pf)
             .expect("open")
             .await
             .expect("stream");
@@ -472,10 +431,9 @@ mod tests {
         // batches must have real values there.
         let (opener, schema, object) = build_opener_with_schema().await;
         let pf = pf_for(object.clone());
-        let file_meta = file_meta_for(object);
 
         let stream = opener
-            .open(file_meta, pf)
+            .open(pf)
             .expect("open")
             .await
             .expect("stream");
@@ -526,21 +484,23 @@ mod tests {
             .expect("infer schema");
         let cycle_idx = table_schema.index_of("cycle").expect("cycle column");
 
-        let source = AtlasSource::new(store, None);
+        let source =
+            AtlasSource::new(store, None, TableSchema::from_file_schema(table_schema.clone()));
         let conf = FileScanConfigBuilder::new(
             ObjectStoreUrl::local_filesystem(),
-            table_schema.clone(),
             Arc::new(source.clone()) as Arc<dyn FileSource>,
         )
-        .with_projection(Some(vec![cycle_idx]))
+        .with_projection_indices(Some(vec![cycle_idx]))
+        .unwrap()
         .build();
 
-        let opener = source.create_file_opener(dummy_store, &conf, 0);
+        let opener = source
+            .create_file_opener(dummy_store, &conf, 0)
+            .expect("file opener");
         let pf = pf_for(object.clone());
-        let file_meta = file_meta_for(object);
 
         let stream = opener
-            .open(file_meta, pf)
+            .open(pf)
             .expect("open")
             .await
             .expect("stream");
@@ -566,7 +526,7 @@ mod tests {
 
         // First open drains the queue.
         let stream = opener
-            .open(file_meta_for(object.clone()), pf_for(object.clone()))
+            .open(pf_for(object.clone()))
             .expect("open")
             .await
             .expect("stream");
@@ -576,7 +536,7 @@ mod tests {
         // Second open sees an empty queue (same stream_cache entry) and
         // therefore produces no batches.
         let stream = opener
-            .open(file_meta_for(object.clone()), pf_for(object))
+            .open(pf_for(object))
             .expect("open")
             .await
             .expect("stream");

--- a/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -201,9 +201,14 @@ impl FileFormat for NetcdfFormat {
         _state: &dyn Session,
         conf: FileScanConfig,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        let table_schema = datafusion::datasource::table_schema::TableSchema::new(
+            conf.file_schema().clone(),
+            conf.table_partition_cols().clone(),
+        );
         let source = NetCDFSource::new(
             self.datasets_object_store.clone(),
             self.options.read_dimensions.clone(),
+            table_schema,
         );
         let conf = FileScanConfigBuilder::from(conf)
             .with_source(Arc::new(source))
@@ -264,10 +269,14 @@ impl FileFormat for NetcdfFormat {
         }
     }
 
-    fn file_source(&self) -> Arc<dyn FileSource> {
+    fn file_source(
+        &self,
+        table_schema: datafusion::datasource::table_schema::TableSchema,
+    ) -> Arc<dyn FileSource> {
         Arc::new(NetCDFSource::new(
             self.datasets_object_store.clone(),
             self.options.read_dimensions.clone(),
+            table_schema,
         ))
     }
 }
@@ -277,7 +286,6 @@ mod tests {
     use super::*;
     use beacon_object_storage::get_datasets_object_store;
     use datafusion::datasource::listing::PartitionedFile;
-    use datafusion::datasource::physical_plan::FileMeta;
     use datafusion::execution::object_store::ObjectStoreUrl;
     use futures::StreamExt;
     use object_store::path::Path;
@@ -439,7 +447,11 @@ mod tests {
     async fn file_source_returns_netcdf_type() {
         let store = test_store().await;
         let format = test_format(store);
-        let source = format.file_source();
+        let source = format.file_source(
+            datafusion::datasource::table_schema::TableSchema::from_file_schema(Arc::new(
+                arrow::datatypes::Schema::empty(),
+            )),
+        );
         assert_eq!(source.file_type(), "netcdf");
     }
 
@@ -452,30 +464,27 @@ mod tests {
             .await
             .expect("schema");
 
-        let opener = source::NetCDFSource::new(store, None);
+        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(
+            table_schema.clone(),
+        );
+        let opener = source::NetCDFSource::new(store, None, ts);
         let file_opener = {
             let conf = FileScanConfigBuilder::new(
                 ObjectStoreUrl::local_filesystem(),
-                table_schema.clone(),
                 Arc::new(opener.clone()) as Arc<dyn FileSource>,
             )
             .build();
-            opener.create_file_opener(
-                Arc::new(object_store::local::LocalFileSystem::new()),
-                &conf,
-                0,
-            )
-        };
-
-        let file_meta = FileMeta {
-            object_meta: wod_object_meta(),
-            range: None,
-            extensions: None,
-            metadata_size_hint: None,
+            opener
+                .create_file_opener(
+                    Arc::new(object_store::local::LocalFileSystem::new()),
+                    &conf,
+                    0,
+                )
+                .expect("file opener")
         };
 
         let stream = file_opener
-            .open(file_meta, PartitionedFile::new("ignored", 0))
+            .open(PartitionedFile::from(wod_object_meta()))
             .expect("open")
             .await
             .expect("stream future");
@@ -495,30 +504,27 @@ mod tests {
             .await
             .expect("schema");
 
-        let opener = source::NetCDFSource::new(store, None);
+        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(
+            table_schema.clone(),
+        );
+        let opener = source::NetCDFSource::new(store, None, ts);
         let file_opener = {
             let conf = FileScanConfigBuilder::new(
                 ObjectStoreUrl::local_filesystem(),
-                table_schema.clone(),
                 Arc::new(opener.clone()) as Arc<dyn FileSource>,
             )
             .build();
-            opener.create_file_opener(
-                Arc::new(object_store::local::LocalFileSystem::new()),
-                &conf,
-                0,
-            )
-        };
-
-        let file_meta = FileMeta {
-            object_meta: gridded_object_meta(),
-            range: None,
-            extensions: None,
-            metadata_size_hint: None,
+            opener
+                .create_file_opener(
+                    Arc::new(object_store::local::LocalFileSystem::new()),
+                    &conf,
+                    0,
+                )
+                .expect("file opener")
         };
 
         let stream = file_opener
-            .open(file_meta, PartitionedFile::new("ignored", 0))
+            .open(PartitionedFile::from(gridded_object_meta()))
             .expect("open")
             .await
             .expect("stream future");
@@ -541,31 +547,29 @@ mod tests {
         // Project to only the first column.
         let projected_schema: SchemaRef = Arc::new(table_schema.project(&[0]).expect("project"));
 
-        let opener = source::NetCDFSource::new(store, None);
+        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(
+            table_schema.clone(),
+        );
+        let opener = source::NetCDFSource::new(store, None, ts);
         let file_opener = {
             let conf = FileScanConfigBuilder::new(
                 ObjectStoreUrl::local_filesystem(),
-                table_schema.clone(),
                 Arc::new(opener.clone()) as Arc<dyn FileSource>,
             )
-            .with_projection(Some(vec![0]))
+            .with_projection_indices(Some(vec![0]))
+            .unwrap()
             .build();
-            opener.create_file_opener(
-                Arc::new(object_store::local::LocalFileSystem::new()),
-                &conf,
-                0,
-            )
-        };
-
-        let file_meta = FileMeta {
-            object_meta: gridded_object_meta(),
-            range: None,
-            extensions: None,
-            metadata_size_hint: None,
+            opener
+                .create_file_opener(
+                    Arc::new(object_store::local::LocalFileSystem::new()),
+                    &conf,
+                    0,
+                )
+                .expect("file opener")
         };
 
         let stream = file_opener
-            .open(file_meta, PartitionedFile::new("ignored", 0))
+            .open(PartitionedFile::from(gridded_object_meta()))
             .expect("open")
             .await
             .expect("stream future");
@@ -598,30 +602,27 @@ mod tests {
         .await
         .expect("dim schema");
 
-        let opener = source::NetCDFSource::new(store, Some(vec!["time".to_string()]));
+        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(
+            dim_schema.clone(),
+        );
+        let opener = source::NetCDFSource::new(store, Some(vec!["time".to_string()]), ts);
         let file_opener = {
             let conf = FileScanConfigBuilder::new(
                 ObjectStoreUrl::local_filesystem(),
-                dim_schema.clone(),
                 Arc::new(opener.clone()) as Arc<dyn FileSource>,
             )
             .build();
-            opener.create_file_opener(
-                Arc::new(object_store::local::LocalFileSystem::new()),
-                &conf,
-                0,
-            )
-        };
-
-        let file_meta = FileMeta {
-            object_meta: gridded_object_meta(),
-            range: None,
-            extensions: None,
-            metadata_size_hint: None,
+            opener
+                .create_file_opener(
+                    Arc::new(object_store::local::LocalFileSystem::new()),
+                    &conf,
+                    0,
+                )
+                .expect("file opener")
         };
 
         let stream = file_opener
-            .open(file_meta, PartitionedFile::new("ignored", 0))
+            .open(PartitionedFile::from(gridded_object_meta()))
             .expect("open")
             .await
             .expect("stream future");

--- a/beacon-arrow-netcdf/src/datafusion/sink.rs
+++ b/beacon-arrow-netcdf/src/datafusion/sink.rs
@@ -1080,6 +1080,8 @@ mod tests {
             insert_op: InsertOp::Append,
             keep_partition_by_columns: false,
             file_extension: "nc".to_string(),
+            file_output_mode:
+                datafusion::datasource::physical_plan::FileOutputMode::SingleFile,
         }
     }
 

--- a/beacon-arrow-netcdf/src/datafusion/source.rs
+++ b/beacon-arrow-netcdf/src/datafusion/source.rs
@@ -14,8 +14,10 @@ use datafusion::{
     common::{pruning::PrunableStatistics, Statistics},
     config::ConfigOptions,
     datasource::{
-        physical_plan::{FileMeta, FileOpenFuture, FileOpener, FileSource},
+        listing::PartitionedFile,
+        physical_plan::{FileOpenFuture, FileOpener, FileScanConfig, FileSource},
         schema_adapter::{DefaultSchemaAdapterFactory, SchemaAdapter, SchemaAdapterFactory},
+        table_schema::TableSchema,
     },
     physical_expr::{conjunction, PhysicalExpr},
     physical_optimizer::pruning::PruningPredicate,
@@ -38,9 +40,8 @@ use super::reader;
 pub struct NetCDFSource {
     datasets_object_store: Arc<DatasetsStore>,
     schema_adapter_factory: Option<Arc<dyn SchemaAdapterFactory>>,
-    override_schema: Option<SchemaRef>,
+    table_schema: TableSchema,
     execution_plan_metrics: ExecutionPlanMetricsSet,
-    projected_statistics: Option<Statistics>,
     read_dimensions: Option<Vec<String>>,
     batch_size: usize,
     predicate: Option<Arc<dyn PhysicalExpr>>,
@@ -50,13 +51,13 @@ impl NetCDFSource {
     pub fn new(
         datasets_object_store: Arc<DatasetsStore>,
         read_dimensions: Option<Vec<String>>,
+        table_schema: TableSchema,
     ) -> Self {
         Self {
             datasets_object_store,
             schema_adapter_factory: None,
-            override_schema: None,
+            table_schema,
             execution_plan_metrics: ExecutionPlanMetricsSet::new(),
-            projected_statistics: None,
             read_dimensions,
             batch_size: usize::MAX,
             predicate: None,
@@ -68,35 +69,36 @@ impl FileSource for NetCDFSource {
     fn create_file_opener(
         &self,
         _object_store: Arc<dyn object_store::ObjectStore>,
-        base_config: &datafusion::datasource::physical_plan::FileScanConfig,
+        base_config: &FileScanConfig,
         partition: usize,
-    ) -> Arc<dyn FileOpener> {
-        let table_schema = self
-            .override_schema
-            .clone()
-            .unwrap_or_else(|| base_config.file_schema.clone());
-        let projected_schema = base_config.projected_schema();
+    ) -> datafusion::error::Result<Arc<dyn FileOpener>> {
+        let file_schema = self.table_schema.file_schema().clone();
+        let projected_schema = base_config.projected_schema()?;
         let schema_adapter_factory = self
             .schema_adapter_factory
             .clone()
             .unwrap_or_else(|| Arc::new(DefaultSchemaAdapterFactory));
 
-        let schema_adapter = schema_adapter_factory.create(projected_schema, table_schema.clone());
+        let schema_adapter = schema_adapter_factory.create(projected_schema, file_schema.clone());
 
-        Arc::new(NetCDFOpener::new(
+        Ok(Arc::new(NetCDFOpener::new(
             self.datasets_object_store.clone(),
             Arc::from(schema_adapter),
             self.read_dimensions.clone(),
             self.batch_size,
             self.predicate.clone(),
-            table_schema,
+            file_schema,
             self.execution_plan_metrics.clone(),
             partition,
-        ))
+        )))
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn table_schema(&self) -> &TableSchema {
+        &self.table_schema
     }
 
     fn with_batch_size(&self, batch_size: usize) -> Arc<dyn FileSource> {
@@ -106,52 +108,18 @@ impl FileSource for NetCDFSource {
         })
     }
 
-    fn with_schema(&self, schema: SchemaRef) -> Arc<dyn FileSource> {
-        Arc::new(Self {
-            override_schema: Some(schema),
-            ..self.clone()
-        })
-    }
-
-    fn with_projection(
-        &self,
-        _config: &datafusion::datasource::physical_plan::FileScanConfig,
-    ) -> Arc<dyn FileSource> {
-        Arc::new(self.clone())
-    }
-
-    fn with_statistics(&self, statistics: Statistics) -> Arc<dyn FileSource> {
-        Arc::new(Self {
-            projected_statistics: Some(statistics),
-            ..self.clone()
-        })
-    }
-
     fn repartitioned(
         &self,
         _target_partitions: usize,
         _repartition_file_min_size: usize,
         _output_ordering: Option<datafusion::physical_expr::LexOrdering>,
-        _config: &datafusion::datasource::physical_plan::FileScanConfig,
-    ) -> datafusion::error::Result<Option<datafusion::datasource::physical_plan::FileScanConfig>>
-    {
+        _config: &FileScanConfig,
+    ) -> datafusion::error::Result<Option<FileScanConfig>> {
         Ok(None)
     }
 
     fn metrics(&self) -> &ExecutionPlanMetricsSet {
         &self.execution_plan_metrics
-    }
-
-    fn statistics(&self) -> datafusion::error::Result<Statistics> {
-        if let Some(statistics) = &self.projected_statistics {
-            Ok(statistics.clone())
-        } else if let Some(schema) = self.override_schema.as_ref() {
-            Ok(Statistics::new_unknown(schema))
-        } else {
-            Err(datafusion::error::DataFusionError::Execution(
-                "Schema must be set to compute statistics".to_string(),
-            ))
-        }
     }
 
     fn file_type(&self) -> &str {
@@ -313,20 +281,16 @@ impl NetCDFOpener {
 }
 
 impl FileOpener for NetCDFOpener {
-    fn open(
-        &self,
-        file_meta: FileMeta,
-        file: datafusion::datasource::listing::PartitionedFile,
-    ) -> datafusion::error::Result<FileOpenFuture> {
+    fn open(&self, file: PartitionedFile) -> datafusion::error::Result<FileOpenFuture> {
         if let (Some(stats), Some(prune)) = (&file.statistics, &self.pruning_predicate) {
             let result = prune.prune(&PrunableStatistics::new(
-                vec![stats.clone()],
+                vec![Arc::clone(stats)],
                 self.table_schema.clone(),
             ))?[0];
             if !result {
                 tracing::debug!(
                     "Pruning NetCDF file {} based on statistics.",
-                    file_meta.object_meta.location
+                    file.object_meta.location
                 );
                 // File is pruned, return empty stream.
                 let stream = EmptyRecordBatchStream::new(self.table_schema.clone()).boxed();
@@ -337,7 +301,7 @@ impl FileOpener for NetCDFOpener {
 
         let metrics = Some(DatasetReadMetrics::new(&self.metrics, self.partition));
         let fut = Self::read_task(
-            file_meta.object_meta,
+            file.object_meta,
             self.datasets_object_store.clone(),
             self.schema_adapter.clone(),
             self.read_dimensions.clone(),

--- a/beacon-arrow-odv/Cargo.toml
+++ b/beacon-arrow-odv/Cargo.toml
@@ -8,7 +8,7 @@ serde = { workspace=true}
 tokio = { workspace = true }
 indexmap = { workspace = true }
 arrow = { workspace=true}
-arrow-csv = "^56.0.0"
+arrow-csv = "^58"
 anyhow = { workspace=true}
 async-trait = { workspace=true}
 futures = { workspace=true}
@@ -19,7 +19,9 @@ csv = "1.3.1"
 tar = "0.4.44"
 zstd = "0.13.3"
 lz4_flex = "0.11.3"
-zip = "2.2.3"
+# default-features disabled to drop xz/lzma support (xz2 -> lzma-sys conflicts with
+# datafusion 53's liblzma on the native `lzma` links). Only deflate is used.
+zip = { version = "2.2.3", default-features = false, features = ["deflate"] }
 async_zip = { version = "0.0.18", features = ["tokio", "zstd", "deflate"] }
 tokio-util = "0.7.16"
 walkdir = "2.5.0"

--- a/beacon-arrow-odv/src/reader.rs
+++ b/beacon-arrow-odv/src/reader.rs
@@ -9,7 +9,7 @@ use bytes::{Buf, Bytes};
 use csv::StringRecord;
 use futures::{Stream, StreamExt, TryStreamExt};
 use indexmap::IndexMap;
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use regex::Regex;
 use tokio_util::codec::FramedRead;
 

--- a/beacon-arrow-tiff/src/datafusion/mod.rs
+++ b/beacon-arrow-tiff/src/datafusion/mod.rs
@@ -155,7 +155,11 @@ impl FileFormat for TiffFormat {
         _state: &dyn Session,
         conf: FileScanConfig,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        let source = TiffSource::new();
+        let table_schema = datafusion::datasource::table_schema::TableSchema::new(
+            conf.file_schema().clone(),
+            conf.table_partition_cols().clone(),
+        );
+        let source = TiffSource::new(table_schema);
 
         let conf = FileScanConfigBuilder::from(conf)
             .with_source(Arc::new(source))
@@ -164,8 +168,11 @@ impl FileFormat for TiffFormat {
         Ok(DataSourceExec::from_data_source(conf))
     }
 
-    fn file_source(&self) -> Arc<dyn FileSource> {
-        Arc::new(TiffSource::new())
+    fn file_source(
+        &self,
+        table_schema: datafusion::datasource::table_schema::TableSchema,
+    ) -> Arc<dyn FileSource> {
+        Arc::new(TiffSource::new(table_schema))
     }
 }
 
@@ -177,6 +184,7 @@ mod tests {
     use futures::StreamExt;
     use object_store::memory::InMemory;
     use object_store::path::Path;
+    use object_store::ObjectStoreExt;
 
     const TEST_TIF_BYTES: &[u8] = include_bytes!("../../test-files/test.tif");
 
@@ -233,27 +241,21 @@ mod tests {
             .await
             .expect("schema");
 
-        let source = source::TiffSource::new();
+        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(table_schema);
+        let source = source::TiffSource::new(ts);
         let file_opener = {
             let conf = FileScanConfigBuilder::new(
                 ObjectStoreUrl::parse("memory://").expect("url"),
-                table_schema,
                 Arc::new(source.clone()) as Arc<dyn FileSource>,
             )
             .build();
-            source.create_file_opener(object_store, &conf, 0)
+            source
+                .create_file_opener(object_store, &conf, 0)
+                .expect("file opener")
         };
 
         let stream = file_opener
-            .open(
-                datafusion::datasource::physical_plan::FileMeta {
-                    object_meta: object,
-                    range: None,
-                    extensions: None,
-                    metadata_size_hint: None,
-                },
-                datafusion::datasource::listing::PartitionedFile::new("ignored", 0),
-            )
+            .open(datafusion::datasource::listing::PartitionedFile::from(object))
             .expect("open")
             .await
             .expect("stream");
@@ -342,7 +344,10 @@ mod tests {
 
         // Push the predicate into a TiffSource via try_pushdown_filters.
         let source_with_predicate: Arc<dyn FileSource> = {
-            let base_source = source::TiffSource::new();
+            let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(
+                table_schema.clone(),
+            );
+            let base_source = source::TiffSource::new(ts);
             let pushdown = base_source
                 .try_pushdown_filters(vec![predicate], &ConfigOptions::default())
                 .expect("try_pushdown_filters");
@@ -352,23 +357,16 @@ mod tests {
         let file_opener = {
             let conf = FileScanConfigBuilder::new(
                 ObjectStoreUrl::parse("memory://").expect("url"),
-                table_schema.clone(),
                 source_with_predicate.clone(),
             )
             .build();
-            source_with_predicate.create_file_opener(object_store, &conf, 0)
+            source_with_predicate
+                .create_file_opener(object_store, &conf, 0)
+                .expect("file opener")
         };
 
         let stream = file_opener
-            .open(
-                datafusion::datasource::physical_plan::FileMeta {
-                    object_meta: object,
-                    range: None,
-                    extensions: None,
-                    metadata_size_hint: None,
-                },
-                datafusion::datasource::listing::PartitionedFile::new("ignored", 0),
-            )
+            .open(datafusion::datasource::listing::PartitionedFile::from(object))
             .expect("open")
             .await
             .expect("stream");

--- a/beacon-arrow-tiff/src/datafusion/source.rs
+++ b/beacon-arrow-tiff/src/datafusion/source.rs
@@ -13,8 +13,10 @@ use datafusion::{
     common::Statistics,
     config::ConfigOptions,
     datasource::{
-        physical_plan::{FileMeta, FileOpenFuture, FileOpener, FileSource},
+        listing::PartitionedFile,
+        physical_plan::{FileOpenFuture, FileOpener, FileScanConfig, FileSource},
         schema_adapter::{DefaultSchemaAdapterFactory, SchemaAdapter, SchemaAdapterFactory},
+        table_schema::TableSchema,
     },
     execution::SendableRecordBatchStream,
     physical_expr::{PhysicalExpr, conjunction},
@@ -32,20 +34,18 @@ use super::reader;
 #[derive(Debug, Clone)]
 pub struct TiffSource {
     schema_adapter_factory: Option<Arc<dyn SchemaAdapterFactory>>,
-    override_schema: Option<SchemaRef>,
+    table_schema: TableSchema,
     execution_plan_metrics: ExecutionPlanMetricsSet,
-    projected_statistics: Option<Statistics>,
     batch_size: usize,
     predicate: Option<Arc<dyn PhysicalExpr>>,
 }
 
 impl TiffSource {
-    pub fn new() -> Self {
+    pub fn new(table_schema: TableSchema) -> Self {
         Self {
             schema_adapter_factory: None,
-            override_schema: None,
+            table_schema,
             execution_plan_metrics: ExecutionPlanMetricsSet::new(),
-            projected_statistics: None,
             batch_size: 128 * 1024,
             predicate: None,
         }
@@ -56,34 +56,35 @@ impl FileSource for TiffSource {
     fn create_file_opener(
         &self,
         object_store: Arc<dyn object_store::ObjectStore>,
-        base_config: &datafusion::datasource::physical_plan::FileScanConfig,
+        base_config: &FileScanConfig,
         partition: usize,
-    ) -> Arc<dyn FileOpener> {
-        let table_schema = self
-            .override_schema
-            .clone()
-            .unwrap_or_else(|| base_config.file_schema.clone());
-        let projected_schema = base_config.projected_schema();
+    ) -> datafusion::error::Result<Arc<dyn FileOpener>> {
+        let file_schema = self.table_schema.file_schema().clone();
+        let projected_schema = base_config.projected_schema()?;
         let schema_adapter_factory = self
             .schema_adapter_factory
             .clone()
             .unwrap_or_else(|| Arc::new(DefaultSchemaAdapterFactory));
 
-        let schema_adapter = schema_adapter_factory.create(projected_schema, table_schema.clone());
+        let schema_adapter = schema_adapter_factory.create(projected_schema, file_schema.clone());
 
-        Arc::new(TiffOpener::new(
-            table_schema,
+        Ok(Arc::new(TiffOpener::new(
+            file_schema,
             object_store,
             Arc::from(schema_adapter),
             self.batch_size,
             self.predicate.clone(),
             self.execution_plan_metrics.clone(),
             partition,
-        ))
+        )))
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn table_schema(&self) -> &TableSchema {
+        &self.table_schema
     }
 
     fn with_batch_size(&self, batch_size: usize) -> Arc<dyn FileSource> {
@@ -93,52 +94,18 @@ impl FileSource for TiffSource {
         })
     }
 
-    fn with_schema(&self, schema: SchemaRef) -> Arc<dyn FileSource> {
-        Arc::new(Self {
-            override_schema: Some(schema),
-            ..self.clone()
-        })
-    }
-
-    fn with_projection(
-        &self,
-        _config: &datafusion::datasource::physical_plan::FileScanConfig,
-    ) -> Arc<dyn FileSource> {
-        Arc::new(self.clone())
-    }
-
-    fn with_statistics(&self, statistics: Statistics) -> Arc<dyn FileSource> {
-        Arc::new(Self {
-            projected_statistics: Some(statistics),
-            ..self.clone()
-        })
-    }
-
     fn repartitioned(
         &self,
         _target_partitions: usize,
         _repartition_file_min_size: usize,
         _output_ordering: Option<datafusion::physical_expr::LexOrdering>,
-        _config: &datafusion::datasource::physical_plan::FileScanConfig,
-    ) -> datafusion::error::Result<Option<datafusion::datasource::physical_plan::FileScanConfig>>
-    {
+        _config: &FileScanConfig,
+    ) -> datafusion::error::Result<Option<FileScanConfig>> {
         Ok(None)
     }
 
     fn metrics(&self) -> &ExecutionPlanMetricsSet {
         &self.execution_plan_metrics
-    }
-
-    fn statistics(&self) -> datafusion::error::Result<Statistics> {
-        if let Some(statistics) = &self.projected_statistics {
-            Ok(statistics.clone())
-        } else if let Some(schema) = self.override_schema.as_ref() {
-            Ok(Statistics::new_unknown(schema))
-        } else {
-            Err(datafusion::error::DataFusionError::Execution(
-                "Schema must be set to compute statistics".to_string(),
-            ))
-        }
     }
 
     fn file_type(&self) -> &str {
@@ -282,14 +249,10 @@ impl TiffOpener {
 }
 
 impl FileOpener for TiffOpener {
-    fn open(
-        &self,
-        file_meta: FileMeta,
-        _file: datafusion::datasource::listing::PartitionedFile,
-    ) -> datafusion::error::Result<FileOpenFuture> {
+    fn open(&self, file: PartitionedFile) -> datafusion::error::Result<FileOpenFuture> {
         let metrics = Some(DatasetReadMetrics::new(&self.metrics, self.partition));
         let fut = Self::read_task(
-            file_meta.object_meta,
+            file.object_meta,
             self.object_store.clone(),
             self.schema_adapter.clone(),
             self.batch_size,

--- a/beacon-arrow-tiff/src/reader.rs
+++ b/beacon-arrow-tiff/src/reader.rs
@@ -12,7 +12,7 @@ use beacon_nd_array::{
 
 use crate::backend::{BandConfig, TiffTileBackend};
 use indexmap::IndexMap;
-use object_store::{ObjectStore, path::Path};
+use object_store::{ObjectStore, ObjectStoreExt, path::Path};
 
 #[derive(Clone)]
 pub(crate) struct ObjectStoreAsyncReader {

--- a/beacon-arrow-zarr/Cargo.toml
+++ b/beacon-arrow-zarr/Cargo.toml
@@ -5,10 +5,7 @@ edition = "2024"
 
 [dependencies]
 zarrs = {"version" = "0.23.12", features = ["async"]}
-# zarrs_object_store stays on 0.5.x: 0.6.x requires object_store ^0.13 but
-# the workspace pins object_store 0.12.x. Both 0.5.x and 0.6.x share
-# zarrs_storage 0.4.x so the trait composition with zarrs 0.23 still works.
-zarrs_object_store = "0.5.0"
+zarrs_object_store = "0.6.0"
 zarrs_storage = "0.4.2"
 object_store = { workspace = true }
 tokio = { workspace = true }

--- a/beacon-arrow-zarr/src/datafusion/mod.rs
+++ b/beacon-arrow-zarr/src/datafusion/mod.rs
@@ -237,7 +237,11 @@ impl FileFormat for ZarrFormat {
             file_groups.push(file);
         }
 
-        let source = ZarrSource::default();
+        let table_schema = datafusion::datasource::table_schema::TableSchema::new(
+            conf.file_schema().clone(),
+            conf.table_partition_cols().clone(),
+        );
+        let source = ZarrSource::new(table_schema);
         let conf = FileScanConfigBuilder::from(conf)
             .with_file_groups(file_groups)
             .with_source(Arc::new(source))
@@ -245,8 +249,11 @@ impl FileFormat for ZarrFormat {
         Ok(DataSourceExec::from_data_source(conf))
     }
 
-    fn file_source(&self) -> Arc<dyn FileSource> {
-        Arc::new(ZarrSource::default())
+    fn file_source(
+        &self,
+        table_schema: datafusion::datasource::table_schema::TableSchema,
+    ) -> Arc<dyn FileSource> {
+        Arc::new(ZarrSource::new(table_schema))
     }
 }
 

--- a/beacon-arrow-zarr/src/datafusion/source.rs
+++ b/beacon-arrow-zarr/src/datafusion/source.rs
@@ -20,8 +20,9 @@ use datafusion::{
     config::ConfigOptions,
     datasource::{
         listing::PartitionedFile,
-        physical_plan::{FileMeta, FileOpenFuture, FileOpener, FileScanConfig, FileSource},
+        physical_plan::{FileOpenFuture, FileOpener, FileScanConfig, FileSource},
         schema_adapter::{DefaultSchemaAdapterFactory, SchemaAdapter, SchemaAdapterFactory},
+        table_schema::TableSchema,
     },
     error::DataFusionError,
     physical_expr::conjunction,
@@ -43,29 +44,21 @@ use crate::{reader::dataset_from_group, util::ZarrPath};
 #[derive(Clone)]
 pub struct ZarrSource {
     schema_adapter_factory: Option<Arc<dyn SchemaAdapterFactory>>,
-    override_schema: Option<SchemaRef>,
+    table_schema: TableSchema,
     execution_plan_metrics: ExecutionPlanMetricsSet,
-    projected_statistics: Option<Statistics>,
     batch_size: usize,
     predicate: Option<Arc<dyn PhysicalExpr>>,
 }
 
-impl Default for ZarrSource {
-    fn default() -> Self {
+impl ZarrSource {
+    pub fn new(table_schema: TableSchema) -> Self {
         Self {
             schema_adapter_factory: None,
-            override_schema: None,
+            table_schema,
             execution_plan_metrics: ExecutionPlanMetricsSet::new(),
-            projected_statistics: None,
             batch_size: usize::MAX,
             predicate: None,
         }
-    }
-}
-
-impl ZarrSource {
-    pub fn new() -> Self {
-        Self::default()
     }
 }
 
@@ -75,30 +68,31 @@ impl FileSource for ZarrSource {
         object_store: Arc<dyn ObjectStore>,
         base_config: &FileScanConfig,
         partition: usize,
-    ) -> Arc<dyn FileOpener> {
-        let table_schema = self
-            .override_schema
-            .clone()
-            .unwrap_or_else(|| base_config.file_schema.clone());
-        let projected_schema = base_config.projected_schema();
+    ) -> datafusion::error::Result<Arc<dyn FileOpener>> {
+        let file_schema = self.table_schema.file_schema().clone();
+        let projected_schema = base_config.projected_schema()?;
         let schema_adapter_factory = self
             .schema_adapter_factory
             .clone()
             .unwrap_or_else(|| Arc::new(DefaultSchemaAdapterFactory));
-        let schema_adapter = schema_adapter_factory.create(projected_schema, table_schema);
+        let schema_adapter = schema_adapter_factory.create(projected_schema, file_schema);
 
-        Arc::new(ZarrOpener {
+        Ok(Arc::new(ZarrOpener {
             object_store,
             schema_adapter: Arc::from(schema_adapter),
             predicate: self.predicate.clone(),
             batch_size: self.batch_size,
             metrics: self.execution_plan_metrics.clone(),
             partition,
-        })
+        }))
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn table_schema(&self) -> &TableSchema {
+        &self.table_schema
     }
 
     fn with_batch_size(&self, batch_size: usize) -> Arc<dyn FileSource> {
@@ -108,38 +102,8 @@ impl FileSource for ZarrSource {
         })
     }
 
-    fn with_schema(&self, schema: SchemaRef) -> Arc<dyn FileSource> {
-        Arc::new(Self {
-            override_schema: Some(schema),
-            ..self.clone()
-        })
-    }
-
-    fn with_projection(&self, _config: &FileScanConfig) -> Arc<dyn FileSource> {
-        Arc::new(self.clone())
-    }
-
-    fn with_statistics(&self, statistics: Statistics) -> Arc<dyn FileSource> {
-        Arc::new(Self {
-            projected_statistics: Some(statistics),
-            ..self.clone()
-        })
-    }
-
     fn metrics(&self) -> &ExecutionPlanMetricsSet {
         &self.execution_plan_metrics
-    }
-
-    fn statistics(&self) -> datafusion::error::Result<Statistics> {
-        if let Some(statistics) = &self.projected_statistics {
-            Ok(statistics.clone())
-        } else if let Some(schema) = self.override_schema.as_ref() {
-            Ok(Statistics::new_unknown(schema))
-        } else {
-            Err(DataFusionError::Execution(
-                "Schema must be set to compute statistics".to_string(),
-            ))
-        }
     }
 
     fn file_type(&self) -> &str {
@@ -197,11 +161,7 @@ struct ZarrOpener {
 }
 
 impl FileOpener for ZarrOpener {
-    fn open(
-        &self,
-        _file_meta: FileMeta,
-        file: PartitionedFile,
-    ) -> datafusion::error::Result<FileOpenFuture> {
+    fn open(&self, file: PartitionedFile) -> datafusion::error::Result<FileOpenFuture> {
         let zarr_path = ZarrPath::new_from_object_meta(file.object_meta.clone()).map_err(|e| {
             DataFusionError::Execution(format!("Failed to create ZarrPath from object metadata: {e}"))
         })?;

--- a/beacon-arrow-zarr/src/util.rs
+++ b/beacon-arrow-zarr/src/util.rs
@@ -6,7 +6,7 @@ use std::{
     sync::Arc,
 };
 
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use zarrs::group::Group;
 use zarrs_storage::AsyncReadableListableStorageTraits;
 

--- a/beacon-common/Cargo.toml
+++ b/beacon-common/Cargo.toml
@@ -14,7 +14,7 @@ async-stream = "0.3.6"
 regex = "1.11.1"
 glob = "0.3.3"
 url = "2.5.4"
-object_store = { version = "0.12.3", features = ["aws"] }
+object_store = { workspace = true }
 
 futures = { workspace=true}
 futures-util = { workspace=true}

--- a/beacon-config/Cargo.toml
+++ b/beacon-config/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 lazy_static = "1.4.0"
 envconfig = "0.11.0"
-object_store = "0.11.2"
+object_store = { workspace = true }

--- a/beacon-core/src/statement_handlers/handlers/materialized_view.rs
+++ b/beacon-core/src/statement_handlers/handlers/materialized_view.rs
@@ -12,7 +12,7 @@ use datafusion::{
     datasource::{
         file_format::parquet::ParquetSink,
         listing::ListingTableUrl,
-        physical_plan::{FileGroup, FileSinkConfig},
+        physical_plan::{FileGroup, FileOutputMode, FileSinkConfig},
         sink::DataSinkExec,
     },
     logical_expr::dml::InsertOp,
@@ -21,6 +21,7 @@ use datafusion::{
     sql::{TableReference, sqlparser::ast::ObjectName},
 };
 use futures::StreamExt;
+use object_store::ObjectStoreExt;
 
 /// Current time as Unix epoch milliseconds (0 if the clock is before the epoch).
 pub(crate) fn now_millis() -> i64 {
@@ -58,6 +59,7 @@ pub(crate) async fn write_query_to_datasets_parquet(
         insert_op: InsertOp::Append,
         keep_partition_by_columns: false,
         file_extension: "parquet".to_string(),
+        file_output_mode: FileOutputMode::SingleFile,
     };
 
     let sink = Arc::new(ParquetSink::new(sink_config, TableParquetOptions::default()));

--- a/beacon-data-lake/Cargo.toml
+++ b/beacon-data-lake/Cargo.toml
@@ -10,9 +10,9 @@ geoarrow = { workspace = true }
 geoarrow-array = { workspace = true }
 geoparquet = { workspace = true }
 anyhow = { workspace = true }
-parquet = { version = "^55"}
+parquet = { workspace = true }
 
-object_store = { version = "0.12.3", features = ["aws"] }
+object_store = { workspace = true }
 url = "2.5.4"
 glob = "0.3.3"
 chrono = { version = "0.4.41"}
@@ -40,6 +40,6 @@ beacon-object-storage = { path = "../beacon-object-storage" }
 beacon-config = { path = "../beacon-config" }
 beacon-formats = { path = "../beacon-formats" }
 beacon-arrow-zarr = { path = "../beacon-arrow-zarr" }
-beacon-binary-format = { path = "../beacon-binary-format", default-features = false, features = ["arrow-56"] }
+beacon-binary-format = { path = "../beacon-binary-format", default-features = false, features = ["arrow-58"] }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }
 beacon-table = { path = "../beacon-table" }

--- a/beacon-data-lake/Cargo.toml
+++ b/beacon-data-lake/Cargo.toml
@@ -40,6 +40,6 @@ beacon-object-storage = { path = "../beacon-object-storage" }
 beacon-config = { path = "../beacon-config" }
 beacon-formats = { path = "../beacon-formats" }
 beacon-arrow-zarr = { path = "../beacon-arrow-zarr" }
-beacon-binary-format = { path = "../beacon-binary-format", default-features = false, features = ["arrow-58"] }
+beacon-binary-format = { path = "../beacon-binary-format", default-features = false, features = ["arrow-58", "object-store-13"] }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }
 beacon-table = { path = "../beacon-table" }

--- a/beacon-data-lake/src/files/manager.rs
+++ b/beacon-data-lake/src/files/manager.rs
@@ -4,6 +4,7 @@ use arrow::datatypes::SchemaRef;
 use beacon_common::listing_url::parse_listing_table_url;
 use beacon_datafusion_ext::format_ext::{DatasetMetadata, FileFormatFactoryExt};
 use bytes::Bytes;
+use object_store::ObjectStoreExt;
 use datafusion::{
     catalog::TableProvider, datasource::listing::ListingTableUrl, error::DataFusionError,
     execution::object_store::ObjectStoreUrl, prelude::SessionContext,

--- a/beacon-data-lake/src/table/mod.rs
+++ b/beacon-data-lake/src/table/mod.rs
@@ -5,7 +5,7 @@ use datafusion::{
     catalog::TableProvider, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
 };
 use futures::StreamExt;
-use object_store::{ObjectStore, PutPayload, path::Path};
+use object_store::{ObjectStore, ObjectStoreExt, PutPayload, path::Path};
 
 use crate::table::{_type::TableType, error::TableError};
 

--- a/beacon-data-lake/src/table_runtime/loading.rs
+++ b/beacon-data-lake/src/table_runtime/loading.rs
@@ -44,7 +44,7 @@ pub async fn load_tables_from_object_store(
 mod tests {
     use super::load_tables_from_object_store;
     use crate::table::{_type::TableType, Table, TableFormat, empty::EmptyTable};
-    use object_store::{ObjectStore, memory::InMemory, path::Path};
+    use object_store::{ObjectStore, ObjectStoreExt, memory::InMemory, path::Path};
 
     fn legacy_table_format(name: &str) -> TableFormat {
         TableFormat::Legacy(Table {

--- a/beacon-data-lake/src/table_runtime/schema_persistence.rs
+++ b/beacon-data-lake/src/table_runtime/schema_persistence.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use object_store::ObjectStoreExt;
 
 use beacon_datafusion_ext::table_ext::{
     ExternalTable, MaterializedView, TableDefinition, ViewTableDefinition,
@@ -155,7 +156,7 @@ mod tests {
         datasource::ViewTable, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
     };
     use futures::StreamExt;
-    use object_store::{ObjectStore, memory::InMemory, path::Path};
+    use object_store::{ObjectStore, ObjectStoreExt, memory::InMemory, path::Path};
     use std::sync::Arc;
     use url::Url;
 

--- a/beacon-datafusion-ext/src/listing_table_factory_ext.rs
+++ b/beacon-datafusion-ext/src/listing_table_factory_ext.rs
@@ -157,7 +157,7 @@ fn resolve_schema_and_partition_cols(
         return Ok((None, partition_cols));
     }
 
-    let schema: SchemaRef = Arc::new(cmd.schema.as_ref().to_owned().into());
+    let schema: SchemaRef = Arc::clone(cmd.schema.inner());
     let partition_cols = partition_cols_from_schema(&schema, &cmd.table_partition_cols)?;
     let projected_schema = project_out_partition_columns(&schema, &cmd.table_partition_cols)?;
 

--- a/beacon-datafusion-ext/src/stats_cache.rs
+++ b/beacon-datafusion-ext/src/stats_cache.rs
@@ -14,9 +14,16 @@
 //!
 //! [`DefaultFileStatisticsCache`]: datafusion::execution::cache::cache_unit::DefaultFileStatisticsCache
 
+use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
-use datafusion::{common::Statistics, execution::cache::CacheAccessor};
+use datafusion::{
+    common::Statistics,
+    execution::cache::{
+        CacheAccessor,
+        cache_manager::{CachedFileMetadata, FileStatisticsCache, FileStatisticsCacheEntry},
+    },
+};
 use moka::sync::Cache;
 use object_store::{ObjectMeta, path::Path};
 
@@ -45,7 +52,7 @@ const DEFAULT_MAX_CAPACITY: u64 = 10_000;
 /// Cache entries are invalidated on size or last-modified mismatch, matching
 /// the behaviour of DataFusion's built-in `DefaultFileStatisticsCache`.
 pub struct BeaconFileStatisticsCache {
-    inner: Cache<Path, (ObjectMeta, Arc<Statistics>)>,
+    inner: Cache<Path, CachedFileMetadata>,
 }
 
 impl BeaconFileStatisticsCache {
@@ -67,51 +74,51 @@ impl BeaconFileStatisticsCache {
     pub fn list_entries(&self) -> Vec<(Path, ObjectMeta, Arc<Statistics>)> {
         self.inner
             .iter()
-            .map(|(path, (meta, stats))| ((*path).clone(), meta.clone(), Arc::clone(&stats)))
+            .map(|(path, cached)| {
+                ((*path).clone(), cached.meta.clone(), Arc::clone(&cached.statistics))
+            })
             .collect()
-    }
-}
-
-// ─── CacheAccessor impl ──────────────────────────────────────────────────────
-
-impl CacheAccessor<Path, Arc<Statistics>> for BeaconFileStatisticsCache {
-    type Extra = ObjectMeta;
-
-    fn get(&self, k: &Path) -> Option<Arc<Statistics>> {
-        self.inner.get(k).map(|(_, stats)| stats)
     }
 
     /// Returns `None` if the entry does not exist or the file has changed
     /// (size or last-modified mismatch).
-    fn get_with_extra(&self, k: &Path, e: &ObjectMeta) -> Option<Arc<Statistics>> {
-        self.inner.get(k).and_then(|(saved_meta, stats)| {
-            if saved_meta.size == e.size && saved_meta.last_modified == e.last_modified {
-                Some(stats)
-            } else {
-                None
-            }
-        })
+    pub fn get_with_extra(&self, k: &Path, e: &ObjectMeta) -> Option<Arc<Statistics>> {
+        self.inner
+            .get(k)
+            .filter(|cached| cached.is_valid_for(e))
+            .map(|cached| Arc::clone(&cached.statistics))
     }
 
-    fn put(&self, _key: &Path, _value: Arc<Statistics>) -> Option<Arc<Statistics>> {
-        panic!(
-            "put() without ObjectMeta is not supported by BeaconFileStatisticsCache; use put_with_extra()"
-        )
-    }
-
-    fn put_with_extra(
+    /// Insert `value` keyed by `key`, validating against the file metadata `e`.
+    /// Returns the previously cached statistics, if any.
+    pub fn put_with_extra(
         &self,
         key: &Path,
         value: Arc<Statistics>,
         e: &ObjectMeta,
     ) -> Option<Arc<Statistics>> {
-        let old = self.inner.get(key).map(|(_, stats)| stats);
-        self.inner.insert(key.clone(), (e.clone(), value));
+        let old = self.inner.get(key).map(|cached| Arc::clone(&cached.statistics));
+        self.inner
+            .insert(key.clone(), CachedFileMetadata::new(e.clone(), value, None));
+        old
+    }
+}
+
+// ─── DataFusion CacheAccessor / FileStatisticsCache impls ────────────────────
+
+impl CacheAccessor<Path, CachedFileMetadata> for BeaconFileStatisticsCache {
+    fn get(&self, k: &Path) -> Option<CachedFileMetadata> {
+        self.inner.get(k)
+    }
+
+    fn put(&self, key: &Path, value: CachedFileMetadata) -> Option<CachedFileMetadata> {
+        let old = self.inner.get(key);
+        self.inner.insert(key.clone(), value);
         old
     }
 
-    fn remove(&mut self, k: &Path) -> Option<Arc<Statistics>> {
-        let old = self.inner.get(k).map(|(_, stats)| stats);
+    fn remove(&self, k: &Path) -> Option<CachedFileMetadata> {
+        let old = self.inner.get(k);
         self.inner.invalidate(k);
         old
     }
@@ -130,5 +137,26 @@ impl CacheAccessor<Path, Arc<Statistics>> for BeaconFileStatisticsCache {
 
     fn name(&self) -> String {
         "BeaconFileStatisticsCache".to_string()
+    }
+}
+
+impl FileStatisticsCache for BeaconFileStatisticsCache {
+    fn list_entries(&self) -> HashMap<Path, FileStatisticsCacheEntry> {
+        self.inner
+            .iter()
+            .map(|(path, cached)| {
+                (
+                    (*path).clone(),
+                    FileStatisticsCacheEntry {
+                        object_meta: cached.meta.clone(),
+                        num_rows: cached.statistics.num_rows,
+                        num_columns: cached.statistics.column_statistics.len(),
+                        table_size_bytes: cached.statistics.total_byte_size,
+                        statistics_size_bytes: 0,
+                        has_ordering: cached.ordering.is_some(),
+                    },
+                )
+            })
+            .collect()
     }
 }

--- a/beacon-datafusion-ext/src/unique_values.rs
+++ b/beacon-datafusion-ext/src/unique_values.rs
@@ -52,7 +52,7 @@ pub struct UniqueValuesExec {
     schema: Arc<Schema>,
     columns_to_track: Vec<usize>,
     handle_collection: UniqueValuesHandleCollection,
-    cache: PlanProperties,
+    cache: Arc<PlanProperties>,
 }
 
 impl UniqueValuesExec {
@@ -82,7 +82,7 @@ impl UniqueValuesExec {
                 schema: schema.clone(),
                 columns_to_track: columns_to_track_indices,
                 handle_collection: handle_collection.clone(),
-                cache: Self::create_plan_properties(input.clone()),
+                cache: Arc::new(Self::create_plan_properties(input.clone())),
                 input,
             },
             handle_collection,
@@ -119,16 +119,12 @@ impl ExecutionPlan for UniqueValuesExec {
         self
     }
 
-    fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
+    fn properties(&self) -> &Arc<datafusion::physical_plan::PlanProperties> {
         &self.cache
     }
 
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
-    }
-
-    fn statistics(&self) -> Result<Statistics> {
-        Ok(Statistics::default())
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
@@ -150,7 +146,7 @@ impl ExecutionPlan for UniqueValuesExec {
             schema: self.schema.clone(),
             columns_to_track: self.columns_to_track.clone(),
             handle_collection: self.handle_collection.clone(),
-            cache: Self::create_plan_properties(children[0].clone()),
+            cache: Arc::new(Self::create_plan_properties(children[0].clone())),
         }))
     }
 

--- a/beacon-formats/Cargo.toml
+++ b/beacon-formats/Cargo.toml
@@ -53,7 +53,7 @@ beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }
 nd-arrow-array = { git = "https://github.com/maris-development/nd-arrow-array.git", branch = "main", version = "2.0.0", default-features = false, features = ["arrow-58"] }
 
 # Add beacon binary format
-beacon-binary-format = { path = "../beacon-binary-format", default-features = false, features = ["arrow-58"] }
+beacon-binary-format = { path = "../beacon-binary-format", default-features = false, features = ["arrow-58", "object-store-13"] }
 arrow-flight = { workspace = true }
 tonic = "0.14"
 prost = "0.14"

--- a/beacon-formats/Cargo.toml
+++ b/beacon-formats/Cargo.toml
@@ -50,12 +50,12 @@ beacon-arrow-zarr = { path = "../beacon-arrow-zarr" }
 beacon-config = { path = "../beacon-config" }
 beacon-object-storage = { path = "../beacon-object-storage" }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }
-nd-arrow-array = { git = "https://github.com/maris-development/nd-arrow-array.git", branch = "main", version = "2.0.0", default-features = false, features = ["arrow-56"] }
+nd-arrow-array = { git = "https://github.com/maris-development/nd-arrow-array.git", branch = "main", version = "2.0.0", default-features = false, features = ["arrow-58"] }
 
 # Add beacon binary format
-beacon-binary-format = { path = "../beacon-binary-format", default-features = false, features = ["arrow-56"] }
+beacon-binary-format = { path = "../beacon-binary-format", default-features = false, features = ["arrow-58"] }
 arrow-flight = { workspace = true }
-tonic = "0.13"
-prost = "0.13"
+tonic = "0.14"
+prost = "0.14"
 [dev-dependencies]
 tempfile = "3.10"

--- a/beacon-formats/src/arrow.rs
+++ b/beacon-formats/src/arrow.rs
@@ -169,7 +169,7 @@ impl FileFormat for ArrowFormat {
             .await
     }
 
-    fn file_source(&self) -> Arc<dyn FileSource> {
-        self.inner_format.file_source()
+    fn file_source(&self, table_schema: datafusion::datasource::table_schema::TableSchema) -> Arc<dyn FileSource> {
+        self.inner_format.file_source(table_schema)
     }
 }

--- a/beacon-formats/src/bbf/mod.rs
+++ b/beacon-formats/src/bbf/mod.rs
@@ -159,14 +159,21 @@ impl FileFormat for BBFFormat {
         _state: &dyn Session,
         conf: FileScanConfig,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        let source = BBFSource::default();
+        let table_schema = datafusion::datasource::table_schema::TableSchema::new(
+            conf.file_schema().clone(),
+            conf.table_partition_cols().clone(),
+        );
+        let source = BBFSource::new(table_schema);
         let conf = FileScanConfigBuilder::from(conf)
             .with_source(Arc::new(source))
             .build();
         Ok(DataSourceExec::from_data_source(conf))
     }
 
-    fn file_source(&self) -> Arc<dyn FileSource> {
-        Arc::new(BBFSource::default())
+    fn file_source(
+        &self,
+        table_schema: datafusion::datasource::table_schema::TableSchema,
+    ) -> Arc<dyn FileSource> {
+        Arc::new(BBFSource::new(table_schema))
     }
 }

--- a/beacon-formats/src/bbf/opener.rs
+++ b/beacon-formats/src/bbf/opener.rs
@@ -18,7 +18,7 @@ use datafusion::{
     common::pruning::PruningStatistics,
     datasource::{
         listing::PartitionedFile,
-        physical_plan::{FileMeta, FileOpenFuture, FileOpener},
+        physical_plan::{FileOpenFuture, FileOpener},
         schema_adapter::SchemaAdapter,
     },
     physical_optimizer::pruning::PruningPredicate,
@@ -42,13 +42,9 @@ pub struct BBFOpener {
 }
 
 impl FileOpener for BBFOpener {
-    fn open(
-        &self,
-        file_meta: FileMeta,
-        _file: PartitionedFile,
-    ) -> datafusion::error::Result<FileOpenFuture> {
+    fn open(&self, file: PartitionedFile) -> datafusion::error::Result<FileOpenFuture> {
         let async_reader = ArrowBBFObjectReader::new(
-            file_meta.object_meta.location.clone(),
+            file.object_meta.location.clone(),
             self.object_store.clone(),
         );
         let adapter = self.schema_adapter.clone();
@@ -58,7 +54,7 @@ impl FileOpener for BBFOpener {
         let stream_partition_shares = self.stream_partition_shares.clone();
         let stream_partition_share = {
             let mut stream_partition_share_map = stream_partition_shares.lock();
-            let object_path = file_meta.object_meta.location.clone();
+            let object_path = file.object_meta.location.clone();
             stream_partition_share_map
                 .entry(object_path)
                 .or_insert_with(|| Arc::new(StreamShare::new()))
@@ -69,7 +65,7 @@ impl FileOpener for BBFOpener {
         let fut = async move {
             let (stream, schema_mapper, file_schema) = stream_partition_share
                 .get_or_try_init(|| async move {
-                    tracing::debug!("Opening file: {:?}", file_meta.object_meta.location);
+                    tracing::debug!("Opening file: {:?}", file.object_meta.location);
 
                     let reader = AsyncBBFReader::new(Arc::new(async_reader), 128)
                         .await

--- a/beacon-formats/src/bbf/source.rs
+++ b/beacon-formats/src/bbf/source.rs
@@ -7,6 +7,7 @@ use datafusion::{
     datasource::{
         physical_plan::{FileOpener, FileScanConfig, FileSource},
         schema_adapter::{DefaultSchemaAdapterFactory, SchemaAdapter, SchemaAdapterFactory},
+        table_schema::TableSchema,
     },
     physical_expr::conjunction,
     physical_optimizer::pruning::PruningPredicate,
@@ -25,14 +26,10 @@ use crate::bbf::{metrics::BBFGlobalMetrics, opener::BBFOpener, stream_share::Str
 pub struct BBFSource {
     /// Optional schema adapter factory.
     schema_adapter_factory: Option<Arc<dyn SchemaAdapterFactory>>,
-    /// Optional schema override.
-    override_schema: Option<SchemaRef>,
-    /// Optional column projection.
-    projection: Option<Vec<usize>>,
+    /// The table schema (file schema + partition columns).
+    table_schema: TableSchema,
     /// Execution plan metrics.
     execution_plan_metrics: ExecutionPlanMetricsSet,
-    /// Projected statistics.
-    projected_statistics: Option<Statistics>,
     /// Batch Size.
     batch_size: usize,
     /// Pruning Predicate
@@ -46,29 +43,24 @@ pub struct BBFSource {
 }
 
 impl BBFSource {
-    pub fn set_file_tracer(&self, tracer: Arc<Mutex<Vec<String>>>) {
-        let mut file_tracer = self.file_tracer.lock();
-        *file_tracer = tracer;
-    }
-}
-
-impl Default for BBFSource {
-    fn default() -> Self {
-        // println!("Creating default BBFSource");
+    pub fn new(table_schema: TableSchema) -> Self {
         let base_metrics = ExecutionPlanMetricsSet::new();
         let global_metrics = BBFGlobalMetrics::new(base_metrics.clone());
         Self {
             schema_adapter_factory: None,
-            override_schema: None,
-            projection: None,
+            table_schema,
             execution_plan_metrics: base_metrics,
-            projected_statistics: None,
             batch_size: 32 * 1024,
             predicate: None,
             file_tracer: Arc::new(Mutex::new(Arc::new(Mutex::new(vec![])))),
             stream_partition_shares: Arc::new(Mutex::new(HashMap::new())),
             global_metrics,
         }
+    }
+
+    pub fn set_file_tracer(&self, tracer: Arc<Mutex<Vec<String>>>) {
+        let mut file_tracer = self.file_tracer.lock();
+        *file_tracer = tracer;
     }
 }
 
@@ -79,20 +71,17 @@ impl FileSource for BBFSource {
         object_store: Arc<dyn ObjectStore>,
         base_config: &FileScanConfig,
         _partition: usize,
-    ) -> Arc<dyn FileOpener> {
-        let table_schema = self
-            .override_schema
-            .clone()
-            .unwrap_or_else(|| base_config.file_schema.clone());
-        let projected_schema = base_config.projected_schema();
+    ) -> datafusion::error::Result<Arc<dyn FileOpener>> {
+        let table_schema = self.table_schema.file_schema().clone();
+        let projected_schema = base_config.projected_schema()?;
         let schema_adapter_factory = self
             .schema_adapter_factory
             .clone()
             .unwrap_or_else(|| Arc::new(DefaultSchemaAdapterFactory));
         let schema_adapter =
-            schema_adapter_factory.create(projected_schema.clone(), table_schema.clone());
+            schema_adapter_factory.create(projected_schema, table_schema.clone());
         let arc_schema_adapter: Arc<dyn SchemaAdapter> = Arc::from(schema_adapter);
-        Arc::new(BBFOpener::new(
+        Ok(Arc::new(BBFOpener::new(
             arc_schema_adapter,
             self.predicate
                 .clone()
@@ -102,14 +91,18 @@ impl FileSource for BBFSource {
             self.file_tracer.lock().clone(),
             self.stream_partition_shares.clone(),
             self.global_metrics.clone(),
-        ))
-        // ParquetFormat
+        )))
     }
 
     /// Any
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn table_schema(&self) -> &TableSchema {
+        &self.table_schema
+    }
+
     /// Initialize new type with batch size configuration
     fn with_batch_size(&self, batch_size: usize) -> Arc<dyn FileSource> {
         Arc::new(BBFSource {
@@ -117,42 +110,9 @@ impl FileSource for BBFSource {
             ..self.clone()
         })
     }
-    /// Initialize new instance with a new schema
-    fn with_schema(&self, schema: SchemaRef) -> Arc<dyn FileSource> {
-        Arc::new(BBFSource {
-            override_schema: Some(schema),
-            ..self.clone()
-        })
-    }
-    /// Initialize new instance with projection information
-    fn with_projection(&self, config: &FileScanConfig) -> Arc<dyn FileSource> {
-        Arc::new(BBFSource {
-            projection: config.projection.clone(),
-            ..self.clone()
-        })
-    }
-    /// Initialize new instance with projected statistics
-    fn with_statistics(&self, statistics: Statistics) -> Arc<dyn FileSource> {
-        Arc::new(BBFSource {
-            projected_statistics: Some(statistics),
-            ..self.clone()
-        })
-    }
     /// Return execution plan metrics
     fn metrics(&self) -> &ExecutionPlanMetricsSet {
         &self.execution_plan_metrics
-    }
-    /// Return projected statistics
-    fn statistics(&self) -> datafusion::error::Result<Statistics> {
-        if let Some(statistics) = &self.projected_statistics {
-            Ok(statistics.clone())
-        } else if let Some(schema) = self.override_schema.as_ref() {
-            Ok(Statistics::new_unknown(schema))
-        } else {
-            Err(datafusion::error::DataFusionError::Execution(
-                "Schema must be set to compute statistics".to_string(),
-            ))
-        }
     }
 
     fn schema_adapter_factory(&self) -> Option<Arc<dyn SchemaAdapterFactory>> {
@@ -174,12 +134,6 @@ impl FileSource for BBFSource {
         filters: Vec<Arc<dyn PhysicalExpr>>,
         _config: &ConfigOptions,
     ) -> datafusion::error::Result<FilterPushdownPropagation<Arc<dyn FileSource>>> {
-        let Some(file_schema) = self.override_schema.clone() else {
-            return Ok(FilterPushdownPropagation::with_parent_pushdown_result(
-                vec![PushedDown::No; filters.len()],
-            ));
-        };
-
         let predicate = match self.predicate.clone() {
             Some(predicate) => conjunction(std::iter::once(predicate).chain(filters.clone())),
             None => conjunction(filters.clone()),

--- a/beacon-formats/src/csv.rs
+++ b/beacon-formats/src/csv.rs
@@ -165,7 +165,7 @@ impl FileFormat for CsvFormat {
             .await
     }
 
-    fn file_source(&self) -> Arc<dyn FileSource> {
-        self.inner_format.file_source()
+    fn file_source(&self, table_schema: datafusion::datasource::table_schema::TableSchema) -> Arc<dyn FileSource> {
+        self.inner_format.file_source(table_schema)
     }
 }

--- a/beacon-formats/src/geo_parquet/mod.rs
+++ b/beacon-formats/src/geo_parquet/mod.rs
@@ -203,7 +203,7 @@ impl FileFormat for GeoParquetFormat {
         Ok(Arc::new(DataSinkExec::new(input, sink, order_requirements)))
     }
 
-    fn file_source(&self) -> Arc<dyn FileSource> {
+    fn file_source(&self, table_schema: datafusion::datasource::table_schema::TableSchema) -> Arc<dyn FileSource> {
         panic!("GeoParquetFormat does not support file source");
     }
 }

--- a/beacon-formats/src/odv_ascii/mod.rs
+++ b/beacon-formats/src/odv_ascii/mod.rs
@@ -42,7 +42,7 @@ use datafusion::{
 };
 use futures::TryStreamExt;
 use futures::{AsyncWrite, AsyncWriteExt, StreamExt, future::try_join_all};
-use object_store::{ObjectMeta, ObjectStore};
+use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt};
 use parquet::arrow::async_writer::AsyncFileWriter;
 use tokio::io::AsyncWriteExt as _;
 use tokio_util::compat::{FuturesAsyncWriteCompatExt, TokioAsyncWriteCompatExt};
@@ -226,7 +226,11 @@ impl FileFormat for OdvFormat {
         _state: &dyn Session,
         conf: FileScanConfig,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        let source = OdvSource::new();
+        let table_schema = datafusion::datasource::table_schema::TableSchema::new(
+            conf.file_schema().clone(),
+            conf.table_partition_cols().clone(),
+        );
+        let source = OdvSource::new(table_schema);
         let conf = FileScanConfigBuilder::from(conf)
             .with_source(Arc::new(source))
             .build();
@@ -274,14 +278,17 @@ impl FileFormat for OdvFormat {
         )))
     }
 
-    fn file_source(&self) -> Arc<dyn FileSource> {
-        Arc::new(OdvSource::new())
+    fn file_source(
+        &self,
+        table_schema: datafusion::datasource::table_schema::TableSchema,
+    ) -> Arc<dyn FileSource> {
+        Arc::new(OdvSource::new(table_schema))
     }
 }
 
 #[derive(Debug)]
 pub struct OdvExec {
-    plan_properties: PlanProperties,
+    plan_properties: Arc<PlanProperties>,
     file_scan_config: FileScanConfig,
     projection: Option<Arc<[usize]>>,
     table_schema: SchemaRef,
@@ -290,20 +297,20 @@ pub struct OdvExec {
 
 impl OdvExec {
     pub fn new(file_scan_conf: FileScanConfig) -> Self {
-        let projected_schema = file_scan_conf
-            .projection
+        let projection_indices = file_scan_conf.file_column_projection_indices();
+        let projected_schema = projection_indices
             .as_ref()
-            .map(|p| Arc::new(file_scan_conf.file_schema.project(p).unwrap()))
-            .unwrap_or(file_scan_conf.file_schema.clone());
+            .map(|p| Arc::new(file_scan_conf.file_schema().project(p).unwrap()))
+            .unwrap_or_else(|| file_scan_conf.file_schema().clone());
 
         Self {
-            plan_properties: Self::plan_properties(
+            plan_properties: Arc::new(Self::plan_properties(
                 file_scan_conf.file_groups.len(),
                 projected_schema,
-            ),
-            projection: file_scan_conf.projection.clone().map(Arc::from),
+            )),
+            projection: projection_indices.map(Arc::from),
             schema_adapter_factory: Arc::new(DefaultSchemaAdapterFactory),
-            table_schema: file_scan_conf.file_schema.clone(),
+            table_schema: file_scan_conf.file_schema().clone(),
             file_scan_config: file_scan_conf,
         }
     }
@@ -387,7 +394,7 @@ impl ExecutionPlan for OdvExec {
         self
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.plan_properties
     }
 

--- a/beacon-formats/src/odv_ascii/source.rs
+++ b/beacon-formats/src/odv_ascii/source.rs
@@ -12,14 +12,15 @@ use datafusion::{
     datasource::{
         file_format::file_compression_type::FileCompressionType,
         listing::PartitionedFile,
-        physical_plan::{FileMeta, FileOpenFuture, FileOpener, FileScanConfig, FileSource},
+        physical_plan::{FileOpenFuture, FileOpener, FileScanConfig, FileSource},
         schema_adapter::{DefaultSchemaAdapterFactory, SchemaAdapter, SchemaAdapterFactory},
+        table_schema::TableSchema,
     },
     physical_expr::LexOrdering,
     physical_plan::metrics::ExecutionPlanMetricsSet,
 };
 use futures::{StreamExt, TryFutureExt, TryStreamExt};
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 
 use crate::odv_ascii::OdvFormat;
 
@@ -30,32 +31,20 @@ use crate::odv_ascii::OdvFormat;
 pub struct OdvSource {
     /// Optional factory for schema adapters.
     schema_adapter_factory: Option<Arc<dyn SchemaAdapterFactory>>,
-    /// Optional schema override.
-    override_schema: Option<SchemaRef>,
-    /// Optional column projection.
-    projection: Option<Vec<usize>>,
+    /// The table schema (file schema + partition columns).
+    table_schema: TableSchema,
     /// Execution plan metrics.
     execution_plan_metrics: ExecutionPlanMetricsSet,
-    /// Optional projected statistics.
-    projected_statistics: Option<Statistics>,
 }
 
 impl OdvSource {
-    /// Creates a new [`OdvSource`] with default settings.
-    pub fn new() -> Self {
+    /// Creates a new [`OdvSource`] with the given table schema.
+    pub fn new(table_schema: TableSchema) -> Self {
         Self {
             schema_adapter_factory: None,
-            override_schema: None,
-            projection: None,
+            table_schema,
             execution_plan_metrics: ExecutionPlanMetricsSet::new(),
-            projected_statistics: None,
         }
-    }
-}
-
-impl Default for OdvSource {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -67,25 +56,25 @@ impl FileSource for OdvSource {
         object_store: Arc<dyn ObjectStore>,
         base_config: &FileScanConfig,
         _partition: usize,
-    ) -> Arc<dyn FileOpener> {
-        // Determine the schema to use (override or from config)
-        let table_schema = self
-            .override_schema
-            .clone()
-            .unwrap_or_else(|| base_config.file_schema.clone());
-        let projected_schema = base_config.projected_schema();
+    ) -> datafusion::error::Result<Arc<dyn FileOpener>> {
+        let file_schema = self.table_schema.file_schema().clone();
+        let projected_schema = base_config.projected_schema()?;
 
         // Use provided schema adapter factory or default
         let schema_adapter_factory = self
             .schema_adapter_factory
             .clone()
             .unwrap_or_else(|| Arc::new(DefaultSchemaAdapterFactory));
-        let schema_adapter = schema_adapter_factory.create(projected_schema, table_schema);
+        let schema_adapter = schema_adapter_factory.create(projected_schema, file_schema);
 
-        Arc::new(OdvOpener {
+        Ok(Arc::new(OdvOpener {
             schema_adapter: Arc::from(schema_adapter),
             object_store,
-        })
+        }))
+    }
+
+    fn table_schema(&self) -> &TableSchema {
+        &self.table_schema
     }
 
     fn repartitioned(
@@ -108,46 +97,9 @@ impl FileSource for OdvSource {
         Arc::new(self.clone())
     }
 
-    /// Returns a new [`FileSource`] with the given schema.
-    fn with_schema(&self, schema: SchemaRef) -> Arc<dyn FileSource> {
-        Arc::new(OdvSource {
-            override_schema: Some(schema),
-            ..self.clone()
-        })
-    }
-
-    /// Returns a new [`FileSource`] with the given projection.
-    fn with_projection(&self, config: &FileScanConfig) -> Arc<dyn FileSource> {
-        Arc::new(OdvSource {
-            projection: config.projection.clone(),
-            ..self.clone()
-        })
-    }
-
-    /// Returns a new [`FileSource`] with the given statistics.
-    fn with_statistics(&self, statistics: Statistics) -> Arc<dyn FileSource> {
-        Arc::new(OdvSource {
-            projected_statistics: Some(statistics),
-            ..self.clone()
-        })
-    }
-
     /// Returns the execution plan metrics.
     fn metrics(&self) -> &ExecutionPlanMetricsSet {
         &self.execution_plan_metrics
-    }
-
-    /// Returns the projected statistics, or computes unknown statistics if possible.
-    fn statistics(&self) -> datafusion::error::Result<Statistics> {
-        if let Some(statistics) = &self.projected_statistics {
-            Ok(statistics.clone())
-        } else if let Some(schema) = self.override_schema.as_ref() {
-            Ok(Statistics::new_unknown(schema))
-        } else {
-            Err(datafusion::error::DataFusionError::Execution(
-                "Schema must be set to compute statistics".to_string(),
-            ))
-        }
     }
 
     /// Returns the file type string ("txt").
@@ -161,10 +113,8 @@ impl FileSource for OdvSource {
         factory: Arc<dyn SchemaAdapterFactory>,
     ) -> datafusion::error::Result<Arc<dyn FileSource>> {
         Ok(Arc::new(Self {
-            override_schema: self.override_schema.clone(),
-            projection: self.projection.clone(),
+            table_schema: self.table_schema.clone(),
             execution_plan_metrics: self.execution_plan_metrics.clone(),
-            projected_statistics: self.projected_statistics.clone(),
             schema_adapter_factory: Some(factory),
         }))
     }
@@ -187,18 +137,17 @@ struct OdvOpener {
 
 impl FileOpener for OdvOpener {
     /// Opens an ODV file and returns a stream of record batches.
-    fn open(
-        &self,
-        file_meta: FileMeta,
-        _file: PartitionedFile,
-    ) -> datafusion::error::Result<FileOpenFuture> {
+    fn open(&self, file: PartitionedFile) -> datafusion::error::Result<FileOpenFuture> {
         let schema_adapter = self.schema_adapter.clone();
         let object_store = self.object_store.clone();
-        let compression = OdvFormat::infer_compression(&file_meta.object_meta);
+        let compression = OdvFormat::infer_compression(&file.object_meta);
 
         Ok(Box::pin(async move {
             // Open and decode the schema from the file
-            let input_stream = object_store.get(file_meta.location()).await?.into_stream();
+            let input_stream = object_store
+                .get(&file.object_meta.location)
+                .await?
+                .into_stream();
             let uncompressed_stream =
                 compression.convert_stream(Box::pin(input_stream.map_err(Into::into)))?;
             let odv_schema_mapper =
@@ -212,7 +161,10 @@ impl FileOpener for OdvOpener {
             let (schema_mapper, projection) = schema_adapter.map_schema(&file_schema)?;
 
             // Open and decode the file body
-            let body_stream = object_store.get(file_meta.location()).await?.into_stream();
+            let body_stream = object_store
+                .get(&file.object_meta.location)
+                .await?
+                .into_stream();
             let uncompressed_body_stream =
                 compression.convert_stream(Box::pin(body_stream.map_err(Into::into)))?;
 

--- a/beacon-formats/src/parquet.rs
+++ b/beacon-formats/src/parquet.rs
@@ -176,8 +176,8 @@ impl FileFormat for ParquetFormat {
             .await
     }
 
-    fn file_source(&self) -> Arc<dyn FileSource> {
-        self.inner.file_source()
+    fn file_source(&self, table_schema: datafusion::datasource::table_schema::TableSchema) -> Arc<dyn FileSource> {
+        self.inner.file_source(table_schema)
     }
 }
 

--- a/beacon-functions/Cargo.toml
+++ b/beacon-functions/Cargo.toml
@@ -15,7 +15,7 @@ inventory = "0.3.18"
 serde = { workspace = true}
 serde_json = { workspace = true}
 csv = "1.3.1"
-object_store = { version = "0.12.3", features = ["aws"] }
+object_store = { workspace = true }
 once_cell = { workspace = true }
 
 lazy_static = "1.5.0"

--- a/beacon-functions/src/metadata/view_dataset_statistics.rs
+++ b/beacon-functions/src/metadata/view_dataset_statistics.rs
@@ -42,7 +42,7 @@ use datafusion::{
     prelude::{Expr, SessionContext},
     scalar::ScalarValue,
 };
-use object_store::{ObjectMeta, ObjectStore};
+use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt};
 
 use crate::file_formats::BeaconTableFunctionImpl;
 use super::helpers::{ColumnStatRow, column_stat_rows};
@@ -136,10 +136,13 @@ impl TableFunctionImpl for ViewDatasetStatisticsFunc {
                 .await?;
 
                 if let Some(ref cache) = cache {
-                    if let Some(cached) = cache.get_with_extra(&meta.location, &meta) {
+                    if let Some(cached) = cache
+                        .get(&meta.location)
+                        .filter(|cached| cached.is_valid_for(&meta))
+                    {
                         return Ok::<_, datafusion::error::DataFusionError>((
                             schema.clone(),
-                            cached.clone(),
+                            Arc::clone(&cached.statistics),
                         ));
                     }
                 }
@@ -149,7 +152,14 @@ impl TableFunctionImpl for ViewDatasetStatisticsFunc {
                 );
 
                 if let Some(cache) = cache {
-                    cache.put_with_extra(&meta.location, stats.clone(), &meta);
+                    cache.put(
+                        &meta.location,
+                        datafusion::execution::cache::cache_manager::CachedFileMetadata::new(
+                            meta.clone(),
+                            Arc::clone(&stats),
+                            None,
+                        ),
+                    );
                 }
 
                 Ok((schema, stats))

--- a/beacon-functions/src/metadata/view_statistics_cache.rs
+++ b/beacon-functions/src/metadata/view_statistics_cache.rs
@@ -35,7 +35,7 @@ use datafusion::{
     logical_expr::{Signature, Volatility},
     prelude::{Expr, SessionContext},
 };
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use tokio::runtime::Handle;
 
 use crate::file_formats::BeaconTableFunctionImpl;

--- a/beacon-functions/src/util/try_arrow_cast.rs
+++ b/beacon-functions/src/util/try_arrow_cast.rs
@@ -5,7 +5,7 @@ use datafusion::common::{
     exec_datafusion_err, exec_err, internal_err, DataFusionError, ExprSchema,
 };
 use datafusion::functions::core::arrow_cast::ArrowCastFunc;
-use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
+use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyContext};
 use datafusion::logical_expr::{
     ColumnarValue, ExprSchemable, ReturnFieldArgs, ScalarUDF, Signature, Volatility,
 };
@@ -79,7 +79,7 @@ impl ScalarUDFImpl for TryArrowCastFunc {
     fn simplify(
         &self,
         mut args: Vec<Expr>,
-        info: &dyn SimplifyInfo,
+        info: &SimplifyContext,
     ) -> datafusion::error::Result<ExprSimplifyResult> {
         // convert this into a real cast
         let target_type = data_type_from_args(&args)?;

--- a/beacon-object-storage/src/lib.rs
+++ b/beacon-object-storage/src/lib.rs
@@ -39,7 +39,7 @@ use std::{env::temp_dir, fmt::Display, ops::Deref, path::PathBuf, sync::Arc};
 use ::notify::{RecommendedWatcher, Watcher, recommended_watcher};
 use futures::stream::BoxStream;
 use object_store::{
-    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
     PutMultipartOptions, PutOptions, PutPayload, PutResult, aws::AmazonS3Builder,
     local::LocalFileSystem, path::Path,
 };
@@ -626,8 +626,11 @@ impl ObjectStore for DatasetsStore {
         self.deref().get_opts(location, options).await
     }
 
-    async fn delete(&self, location: &Path) -> object_store::Result<()> {
-        self.deref().delete(location).await
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<Path>>,
+    ) -> BoxStream<'static, object_store::Result<Path>> {
+        self.deref().delete_stream(locations)
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
@@ -638,12 +641,13 @@ impl ObjectStore for DatasetsStore {
         self.deref().list_with_delimiter(prefix).await
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.deref().copy(from, to).await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.deref().copy_if_not_exists(from, to).await
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
+        self.deref().copy_opts(from, to, options).await
     }
 }
 

--- a/beacon-object-storage/src/notified_store.rs
+++ b/beacon-object-storage/src/notified_store.rs
@@ -2,8 +2,8 @@ use std::{fmt::Display, sync::Arc};
 
 use futures::{StreamExt, stream::BoxStream};
 use object_store::{
-    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, path::Path,
 };
 
 use crate::{
@@ -113,8 +113,11 @@ impl<O: ObjectStore> ObjectStore for NotifiedStore<O> {
         self.inner.get_opts(location, options).await
     }
 
-    async fn delete(&self, location: &object_store::path::Path) -> object_store::Result<()> {
-        self.inner.delete(location).await
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<Path>>,
+    ) -> BoxStream<'static, object_store::Result<Path>> {
+        self.inner.delete_stream(locations)
     }
 
     fn list(
@@ -138,20 +141,13 @@ impl<O: ObjectStore> ObjectStore for NotifiedStore<O> {
         self.inner.list_with_delimiter(prefix).await
     }
 
-    async fn copy(
+    async fn copy_opts(
         &self,
-        from: &object_store::path::Path,
-        to: &object_store::path::Path,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
     ) -> object_store::Result<()> {
-        self.inner.copy(from, to).await
-    }
-
-    async fn copy_if_not_exists(
-        &self,
-        from: &object_store::path::Path,
-        to: &object_store::path::Path,
-    ) -> object_store::Result<()> {
-        self.inner.copy_if_not_exists(from, to).await
+        self.inner.copy_opts(from, to, options).await
     }
 }
 

--- a/beacon-table/src/append_exec.rs
+++ b/beacon-table/src/append_exec.rs
@@ -37,7 +37,7 @@ pub struct AppendExec {
     /// The child execution plans to concatenate.
     inputs: Vec<Arc<dyn ExecutionPlan>>,
     /// Cached plan properties (single partition, incremental, bounded).
-    props: PlanProperties,
+    props: Arc<PlanProperties>,
     /// The shared output schema (must be identical across all children).
     schema: SchemaRef,
 }
@@ -74,12 +74,12 @@ impl AppendExec {
         // Exact constructor details vary by DataFusion version.
         let eq = inputs[0].equivalence_properties().clone();
         let partitioning = Partitioning::UnknownPartitioning(1);
-        let props = PlanProperties::new(
+        let props = Arc::new(PlanProperties::new(
             eq,
             partitioning,
             datafusion::physical_plan::execution_plan::EmissionType::Incremental,
             datafusion::physical_plan::execution_plan::Boundedness::Bounded,
-        );
+        ));
 
         Ok(Self {
             inputs,
@@ -111,7 +111,7 @@ impl ExecutionPlan for AppendExec {
         self
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.props
     }
 

--- a/beacon-table/src/deletion_vector_exec.rs
+++ b/beacon-table/src/deletion_vector_exec.rs
@@ -84,7 +84,7 @@ impl ExecutionPlan for DeletionVectorExec {
         "DeletionVectorExec"
     }
 
-    fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
+    fn properties(&self) -> &Arc<datafusion::physical_plan::PlanProperties> {
         self.data.properties()
     }
 
@@ -127,10 +127,6 @@ impl ExecutionPlan for DeletionVectorExec {
         _config: &datafusion::config::ConfigOptions,
     ) -> DataFusionResult<Option<Arc<dyn ExecutionPlan>>> {
         Ok(None)
-    }
-
-    fn statistics(&self) -> DataFusionResult<Statistics> {
-        Ok(Statistics::new_unknown(&self.schema()))
     }
 
     fn execute(

--- a/beacon-table/src/index_exec.rs
+++ b/beacon-table/src/index_exec.rs
@@ -36,7 +36,7 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
 };
 use futures::StreamExt;
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use tokio::sync::Mutex;
 
 use crate::manifest::{self, DataFile};
@@ -339,7 +339,7 @@ pub struct ZOrderSortExec {
     /// Child plan that produces the data to sort.
     child: Arc<dyn ExecutionPlan>,
     /// Cached plan properties.
-    props: PlanProperties,
+    props: Arc<PlanProperties>,
 }
 
 impl ZOrderSortExec {
@@ -347,12 +347,12 @@ impl ZOrderSortExec {
     pub fn new(columns: Vec<String>, child: Arc<dyn ExecutionPlan>) -> Self {
         let schema = child.schema();
         let eq = EquivalenceProperties::new(schema);
-        let props = PlanProperties::new(
+        let props = Arc::new(PlanProperties::new(
             eq,
             Partitioning::UnknownPartitioning(1),
             datafusion::physical_plan::execution_plan::EmissionType::Final,
             datafusion::physical_plan::execution_plan::Boundedness::Bounded,
-        );
+        ));
         Self {
             columns,
             child,
@@ -380,7 +380,7 @@ impl ExecutionPlan for ZOrderSortExec {
         self.child.schema()
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.props
     }
 
@@ -506,7 +506,7 @@ pub struct CreateIndexExec {
     /// The new index configuration to store in the manifest.
     new_index: TableIndex,
     /// Cached plan properties.
-    props: PlanProperties,
+    props: Arc<PlanProperties>,
 }
 
 impl CreateIndexExec {
@@ -527,12 +527,12 @@ impl CreateIndexExec {
 
         let schema = count_schema();
         let eq = EquivalenceProperties::new(schema);
-        let props = PlanProperties::new(
+        let props = Arc::new(PlanProperties::new(
             eq,
             Partitioning::UnknownPartitioning(1),
             datafusion::physical_plan::execution_plan::EmissionType::Final,
             datafusion::physical_plan::execution_plan::Boundedness::Bounded,
-        );
+        ));
 
         Self {
             store,
@@ -569,7 +569,7 @@ impl ExecutionPlan for CreateIndexExec {
         count_schema()
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.props
     }
 

--- a/beacon-table/src/lib.rs
+++ b/beacon-table/src/lib.rs
@@ -53,7 +53,7 @@ use datafusion::{
             parquet::{ParquetFormat, ParquetSink},
         },
         listing::{ListingTableUrl, PartitionedFile},
-        physical_plan::{FileGroup, FileScanConfigBuilder, FileSinkConfig},
+        physical_plan::{FileGroup, FileOutputMode, FileScanConfigBuilder, FileSinkConfig},
         sink::DataSinkExec,
     },
     execution::{SessionState, object_store::ObjectStoreUrl},
@@ -65,7 +65,7 @@ use datafusion::{
     },
     prelude::{Expr, SessionContext},
 };
-use object_store::{ObjectMeta, ObjectStore};
+use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt};
 use std::{any::Any, sync::Arc};
 use tokio::sync::Mutex;
 
@@ -272,10 +272,11 @@ impl BeaconTable {
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
         let parquet_format = ParquetFormat::default();
         let partitioned_file = PartitionedFile::from(object_meta.clone());
+        let table_schema =
+            datafusion::datasource::table_schema::TableSchema::from_file_schema(file_schema);
         let scan_config = FileScanConfigBuilder::new(
             self.store_url.clone(),
-            file_schema,
-            parquet_format.file_source(),
+            parquet_format.file_source(table_schema),
         )
         .with_file(partitioned_file)
         .with_projection(projection)
@@ -469,6 +470,7 @@ impl BeaconTable {
             insert_op: InsertOp::Append,
             keep_partition_by_columns: false,
             file_extension: "parquet".to_string(),
+            file_output_mode: FileOutputMode::SingleFile,
         };
 
         let sink = Arc::new(ParquetSink::new(
@@ -544,6 +546,7 @@ impl BeaconTable {
             insert_op: InsertOp::Append,
             keep_partition_by_columns: false,
             file_extension: "parquet".to_string(),
+            file_output_mode: FileOutputMode::SingleFile,
         };
 
         let sink = Arc::new(ParquetSink::new(
@@ -678,6 +681,7 @@ impl TableProvider for BeaconTable {
             insert_op,
             keep_partition_by_columns: false,
             file_extension: "parquet".to_string(),
+            file_output_mode: FileOutputMode::SingleFile,
         };
 
         let sink = Arc::new(ParquetSink::new(

--- a/beacon-table/src/manifest.rs
+++ b/beacon-table/src/manifest.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 
 use crate::index_exec::TableIndex;
 

--- a/beacon-table/src/vacuum_exec.rs
+++ b/beacon-table/src/vacuum_exec.rs
@@ -19,7 +19,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
 };
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use tokio::sync::Mutex;
 
 use crate::manifest::{self, DataFile};
@@ -71,7 +71,7 @@ pub struct VacuumExec {
     /// Child execution plan that scans all existing table data.
     child: Arc<dyn ExecutionPlan>,
     /// Cached plan properties (single partition, bounded, final emission).
-    props: PlanProperties,
+    props: Arc<PlanProperties>,
 }
 
 impl VacuumExec {
@@ -106,12 +106,12 @@ impl VacuumExec {
 
         let schema = count_schema();
         let eq = EquivalenceProperties::new(schema);
-        let props = PlanProperties::new(
+        let props = Arc::new(PlanProperties::new(
             eq,
             Partitioning::UnknownPartitioning(1),
             datafusion::physical_plan::execution_plan::EmissionType::Final,
             datafusion::physical_plan::execution_plan::Boundedness::Bounded,
-        );
+        ));
 
         Self {
             store,
@@ -150,7 +150,7 @@ impl ExecutionPlan for VacuumExec {
         count_schema()
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.props
     }
 


### PR DESCRIPTION
This pull request updates dependencies and refactors the DataFusion integration for the custom `AtlasFormat` and `NetcdfFormat` file formats to align with recent upstream changes. The most significant changes include updating crate versions for compatibility, refactoring the `FileSource` and `FileOpener` interfaces, and adjusting tests accordingly.

**Dependency updates:**

* Updated core dependencies (`datafusion`, `geodatafusion`, `object_store`, `arrow`, `parquet`, `geoarrow`, `geoparquet`, etc.) to newer versions for compatibility with recent DataFusion releases. 

**DataFusion API refactoring:**

* Refactored `AtlasSource` and `NetCDFSource` to use the new `TableSchema` API, removing deprecated schema overrides and statistics handling, and updating the construction and usage of file sources and openers.

**Test adjustments:**

* Updated tests to use the new `TableSchema` and `FileSource` interfaces, including changes to how file sources and file openers are constructed and invoked. 

These changes ensure compatibility with the latest DataFusion APIs and improve maintainability by adopting the new schema and file source abstractions.