### PR TITLE
Fix EDMO code extraction to use the last parentheses

### DIFF
--- a/beacon-functions/src/blue_cloud/seadatanet/map_originator_edmo.rs
+++ b/beacon-functions/src/blue_cloud/seadatanet/map_originator_edmo.rs
@@ -21,7 +21,7 @@ fn map_originator_edmo_impl(
     parameters: &[ColumnarValue],
 ) -> datafusion::error::Result<ColumnarValue> {
     fn extract_first_value(s: &str) -> Option<String> {
-        if let Some(start) = s.find('(') {
+        if let Some(start) = s.rfind('(') {
             if let Some(end) = s[start..].find(')') {
                 let edmo_code = &s[start + 1..start + end];
                 return Some(edmo_code.to_string());
@@ -60,5 +60,66 @@ fn map_originator_edmo_impl(
                 "Invalid input type".to_string(),
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Array;
+
+    fn scalar_result(input: Option<&str>) -> Option<String> {
+        let value = ColumnarValue::Scalar(ScalarValue::Utf8(input.map(|s| s.to_string())));
+        match map_originator_edmo_impl(&[value]).unwrap() {
+            ColumnarValue::Scalar(ScalarValue::Utf8(v)) => v,
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn scalar_uses_last_parentheses() {
+        // The originator string contains several parenthesized groups; the EDMO
+        // code lives in the last one.
+        assert_eq!(
+            scalar_result(Some("National Oceanography Centre (NOC) (43)")),
+            Some("43".to_string())
+        );
+    }
+
+    #[test]
+    fn scalar_single_parentheses() {
+        assert_eq!(scalar_result(Some("Some Institute (123)")), Some("123".to_string()));
+    }
+
+    #[test]
+    fn scalar_no_parentheses_is_none() {
+        assert_eq!(scalar_result(Some("No code here")), None);
+    }
+
+    #[test]
+    fn scalar_null_is_none() {
+        assert_eq!(scalar_result(None), None);
+    }
+
+    #[test]
+    fn array_uses_last_parentheses() {
+        let input = StringArray::from(vec![
+            Some("Institute A (foo) (1)"),
+            Some("Institute B (2)"),
+            Some("No parens"),
+            None,
+        ]);
+        let result = map_originator_edmo_impl(&[ColumnarValue::Array(Arc::new(input))]).unwrap();
+
+        let array = match result {
+            ColumnarValue::Array(array) => array,
+            other => panic!("unexpected result: {:?}", other),
+        };
+        let array = array.as_any().downcast_ref::<StringArray>().unwrap();
+
+        assert_eq!(array.value(0), "1");
+        assert_eq!(array.value(1), "2");
+        assert!(array.is_null(2));
+        assert!(array.is_null(3));
     }
 }


### PR DESCRIPTION
Fixes #225 

This pull request improves the `map_originator_edmo_impl` function in `map_originator_edmo.rs` by updating how EDMO codes are extracted from strings and by adding comprehensive unit tests to verify the new logic. The main change ensures that the function now extracts the EDMO code from the last set of parentheses in the input string, which matches the intended data format.

**Extraction logic update:**

* Changed the `extract_first_value` helper to use `rfind('(')` instead of `find('(')`, so it now extracts the value from the last set of parentheses in a string, ensuring the correct EDMO code is captured.

**Testing improvements:**

* Added a new test module with unit tests covering scalar and array inputs, including cases with multiple parenthesis groups, single group, no parentheses, and null values, to validate the updated extraction logic.