### PR TITLE
Update global attribute handling to use leading-dot naming convention

### DIFF
--- a/beacon-arrow-netcdf/src/reader.rs
+++ b/beacon-arrow-netcdf/src/reader.rs
@@ -18,7 +18,8 @@
 //! - Each NetCDF variable becomes a named array in the dataset.
 //! - Variable attributes are surfaced as additional arrays using the dotted
 //!   name convention `"variable_name.attribute_name"`.
-//! - Global file attributes use their bare name.
+//! - Global file attributes are surfaced with a leading dot, e.g.
+//!   `".attribute_name"`.
 //!
 //! # Example
 //!
@@ -107,8 +108,9 @@ pub fn read_arrays<P: AsRef<Path>>(path: P) -> anyhow::Result<IndexMap<String, A
 
     // ── Global file attributes ──────────────────────────────────────────
     for (attr_name, attr_value) in global_attribute_values(&file_ref)? {
-        if let Ok(array) = compat::attribute_to_nd_array(&attr_name, attr_value) {
-            arrays.insert(attr_name, array);
+        let key = format!(".{attr_name}");
+        if let Ok(array) = compat::attribute_to_nd_array(&key, attr_value) {
+            arrays.insert(key, array);
         }
     }
 
@@ -117,8 +119,6 @@ pub fn read_arrays<P: AsRef<Path>>(path: P) -> anyhow::Result<IndexMap<String, A
 
     Ok(arrays)
 }
-
-// ─── Private helpers ───────────────────────────────────────────────────────
 
 /// Collect every attribute of a NetCDF *file* into a map.
 fn global_attribute_values(file: &netcdf::File) -> anyhow::Result<HashMap<String, AttributeValue>> {
@@ -357,14 +357,15 @@ mod tests {
     }
 
     #[test]
-    fn global_attribute_surfaced_by_name() {
+    fn global_attribute_surfaced_with_leading_dot() {
         let tmp = Builder::new().suffix(".nc").tempfile().unwrap();
         {
             let mut nc = netcdf::create(tmp.path()).unwrap();
             nc.add_attribute("Conventions", "CF-1.6").unwrap();
         }
         let arrays = read_arrays(tmp.path()).unwrap();
-        assert!(arrays.contains_key("Conventions"));
+        assert!(arrays.contains_key(".Conventions"));
+        assert!(!arrays.contains_key("Conventions"));
     }
 
     // ── Data correctness (via NdArray downcasting) ─────────────────────
@@ -698,7 +699,7 @@ mod tests {
             let schema = batches[0].schema();
             let field_names: Vec<&str> =
                 schema.fields().iter().map(|f| f.name().as_str()).collect();
-            assert!(field_names.contains(&"Conventions"));
+            assert!(field_names.contains(&".Conventions"));
 
             // Verify the global attribute is repeated in each row.
             for batch in &batches {
@@ -706,7 +707,7 @@ mod tests {
                     continue;
                 }
                 let conv = batch
-                    .column_by_name("Conventions")
+                    .column_by_name(".Conventions")
                     .unwrap()
                     .as_any()
                     .downcast_ref::<StringArray>()

--- a/beacon-nd-array/src/dataset/ragged.rs
+++ b/beacon-nd-array/src/dataset/ragged.rs
@@ -129,7 +129,14 @@ impl RaggedDataset {
         let mut variables: IndexMap<String, RaggedArray> = IndexMap::new();
 
         for (name, array) in &dataset.arrays {
-            // Skip row-size variable attributes (e.g. "z_row_size.sample_dimension").
+            // Global attributes use the leading-dot convention (e.g. ".Conventions").
+            if name.starts_with('.') {
+                variables.insert(name.clone(), RaggedArray::Attribute(array.clone()));
+                continue;
+            }
+
+            // Variable attributes are "var.attr". Skip those belonging to a
+            // row-size variable (e.g. "z_row_size.sample_dimension").
             if name.contains('.') {
                 let var_part = name.split('.').next().unwrap_or("");
                 if row_size_var_set.contains(var_part) {
@@ -321,16 +328,18 @@ impl RaggedDataset {
 
         // ── Second pass: attributes ──────────────────────────────────────
         for (name, var) in &self.variables {
-            if let RaggedArray::Attribute(array) = var
-                && let Some(var_part) = name.split('.').next()
-            {
-                if name.contains('.') {
+            if let RaggedArray::Attribute(array) = var {
+                // A variable attribute is "var.attr" (an interior dot, not
+                // leading). Leading-dot globals and dimensionless attributes
+                // are global and always included.
+                if !name.starts_with('.') && name.contains('.') {
+                    let var_part = name.split('.').next().unwrap_or("");
                     // Variable attribute — include only if parent variable is present.
                     if arrays.contains_key(var_part) {
                         arrays.insert(name.clone(), array.clone());
                     }
                 } else {
-                    // Global attribute (dimensionless, no dot).
+                    // Global attribute (leading-dot or dimensionless).
                     arrays.insert(name.clone(), array.clone());
                 }
             }
@@ -402,16 +411,18 @@ impl RaggedDataset {
 
         // ── Second pass: attributes ──────────────────────────────────────
         for (name, var) in &self.variables {
-            if let RaggedArray::Attribute(array) = var
-                && let Some(var_part) = name.split('.').next()
-            {
-                if name.contains('.') {
+            if let RaggedArray::Attribute(array) = var {
+                // A variable attribute is "var.attr" (an interior dot, not
+                // leading). Leading-dot globals and dimensionless attributes
+                // are global and always included.
+                if !name.starts_with('.') && name.contains('.') {
+                    let var_part = name.split('.').next().unwrap_or("");
                     // Variable attribute — include only if parent variable is present.
                     if arrays.contains_key(var_part) {
                         arrays.insert(name.clone(), array.clone());
                     }
                 } else {
-                    // Global attribute (dimensionless, no dot).
+                    // Global attribute (leading-dot or dimensionless).
                     arrays.insert(name.clone(), array.clone());
                 }
             }


### PR DESCRIPTION
This pull request standardizes the handling of global NetCDF file attributes by surfacing them with a leading dot in their names (e.g., `.Conventions`), updates the relevant logic to support this convention, and adjusts tests and data structures accordingly. The changes ensure consistency in how global attributes are distinguished from variable attributes throughout the codebase.

**NetCDF Attribute Naming Convention:**

* Updated documentation and logic in `beacon-arrow-netcdf/src/reader.rs` so that global file attributes are now surfaced with a leading dot (e.g., `.attribute_name`), instead of their bare name. 

**Test Adjustments:**

* Modified tests in `beacon-arrow-netcdf/src/reader.rs` to expect global attributes with a leading dot, ensuring that both the presence of `.Conventions` and the absence of the old `Conventions` key are checked. 
**Ragged Dataset Handling:**

* Updated `RaggedDataset` logic in `beacon-nd-array/src/dataset/ragged.rs` to recognize and properly handle global attributes using the leading-dot convention, both when constructing and exporting datasets. This ensures global attributes are included as `RaggedArray::Attribute` and are always present, while variable attributes are only included if their parent variable exists.