### PR TITLE
Log panics through tracing so they reach the rolling log file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,6 +1188,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-appender",
+ "tracing-panic",
  "tracing-subscriber",
  "utoipa",
  "utoipa-axum",
@@ -7567,6 +7568,16 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-panic"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bf1298a179837099f9309243af3b554e840f7f67f65e9f55294913299bd4cc5"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/beacon-api/Cargo.toml
+++ b/beacon-api/Cargo.toml
@@ -33,6 +33,7 @@ uuid = { version = "1.16.0" }
 tracing = { workspace = true}
 tracing-subscriber = { workspace = true}
 tracing-appender = { workspace = true}
+tracing-panic = "0.1"
 tonic = "0.14.1"
 prost = "0.14.1"
 

--- a/beacon-api/src/main.rs
+++ b/beacon-api/src/main.rs
@@ -39,6 +39,7 @@ fn main() -> anyhow::Result<()> {
 /// Initializes shared services and starts all configured API transports.
 async fn async_main() -> anyhow::Result<()> {
     setup_tracing();
+    install_panic_hook();
 
     tracing::info!("Beacon v{}", BEACON_VERSION);
     let beacon_runtime = Arc::new(beacon_core::runtime::Runtime::new().await?);
@@ -79,6 +80,16 @@ async fn serve_http(router: ::axum::Router, addr: std::net::SocketAddr) -> anyho
         .context("HTTP server failed")?;
 
     Ok(())
+}
+
+/// Routes panics through `tracing` (so they land in the rolling log file) while
+/// preserving the default hook's stderr output.
+fn install_panic_hook() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        tracing_panic::panic_hook(info); // ERROR event -> stdout + rolling log file
+        default_hook(info); // preserve default stderr output
+    }));
 }
 
 /// Configures stdout and rolling-file tracing subscribers for the API process.


### PR DESCRIPTION
Rust's default panic hook writes only to stderr, so panics never reached the rolling file appender (logs/beacon.log.*), making post-mortem debugging from log files impossible.

Install a panic hook in async_main() (right after setup_tracing) that routes panics through `tracing` at ERROR level via the tracing-panic crate, while chaining the default hook to preserve stderr output. Panics now appear in both stdout and the rolling log file with message, location, and (when RUST_BACKTRACE is set) a backtrace.

Closes #239