### PR TITLE
Fix panic on invalid BEACON_BASE_PATH; make config loading fallible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,7 @@ dependencies = [
 name = "beacon-config"
 version = "1.7.0"
 dependencies = [
+ "anyhow",
  "envconfig",
  "lazy_static",
  "object_store 0.13.2",

--- a/beacon-api/src/main.rs
+++ b/beacon-api/src/main.rs
@@ -27,8 +27,13 @@ const BEACON_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Builds the Tokio runtime and hands control to the async entrypoint.
 fn main() -> anyhow::Result<()> {
+    // Load and validate configuration up front so problems (e.g. a malformed
+    // `BEACON_BASE_PATH`) surface as a clean error here rather than panicking
+    // later when the global config is first accessed.
+    let config = beacon_config::init().context("failed to load configuration")?;
+
     let rt = Builder::new_multi_thread()
-        .worker_threads(beacon_config::CONFIG.server.worker_threads)
+        .worker_threads(config.server.worker_threads)
         .enable_all()
         .build()
         .context("failed to build Tokio runtime")?;

--- a/beacon-config/Cargo.toml
+++ b/beacon-config/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 lazy_static = "1.4.0"
 envconfig = "0.11.0"
 object_store = { workspace = true }
+anyhow = { workspace = true }

--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 use envconfig::Envconfig;
 use lazy_static::lazy_static;
@@ -354,16 +355,87 @@ impl From<RawConfig> for Config {
     }
 }
 
+/// Normalizes and validates a configured base path. Returns the canonical form:
+/// exactly one leading `/` and no trailing `/`. A blank value yields `""` (root).
+/// Errors (with a descriptive message) if the path contains characters outside the
+/// URL "unreserved" set or has an empty internal segment, instead of letting an
+/// invalid value reach axum/utoipa, which panic on malformed paths.
+fn normalize_base_path(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim().trim_matches('/');
+    if trimmed.is_empty() {
+        return Ok(String::new());
+    }
+    for segment in trimmed.split('/') {
+        if segment.is_empty() {
+            return Err(format!("'{raw}' contains an empty path segment"));
+        }
+        if let Some(bad) = segment
+            .chars()
+            .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '~')))
+        {
+            return Err(format!(
+                "'{raw}' contains invalid character '{bad}'; only letters, digits, \
+                 '-', '_', '.', '~' and '/' are allowed"
+            ));
+        }
+    }
+    Ok(format!("/{trimmed}"))
+}
+
 impl Config {
-    pub fn init() -> Config {
-        RawConfig::init_from_env()
-            .map(Into::into)
-            .expect("Failed to load config")
+    /// Loads the configuration from the environment, normalizing and validating
+    /// fields. Returns a descriptive error instead of panicking, so callers can
+    /// report the problem cleanly and exit.
+    pub fn load() -> anyhow::Result<Config> {
+        let mut config: Config = RawConfig::init_from_env()
+            .map_err(|e| anyhow::anyhow!("failed to load configuration from environment: {e}"))?
+            .into();
+        config.server.base_path = normalize_base_path(&config.server.base_path)
+            .map_err(|e| anyhow::anyhow!("invalid BEACON_BASE_PATH: {e}"))?;
+        Ok(config)
     }
 }
 
+static CONFIG_CELL: OnceLock<Config> = OnceLock::new();
+
+/// Loads, normalizes, and validates the configuration and stores it in the
+/// process-global cell. Returns a descriptive error instead of panicking, so the
+/// binary can surface configuration problems and exit cleanly.
+///
+/// Call this once early in `main`. It is idempotent: subsequent calls return the
+/// already-initialized [`Config`].
+pub fn init() -> anyhow::Result<&'static Config> {
+    if let Some(config) = CONFIG_CELL.get() {
+        return Ok(config);
+    }
+    let config = Config::load()?;
+    // A concurrent caller may have won the race; either value is equally valid.
+    let _ = CONFIG_CELL.set(config);
+    Ok(CONFIG_CELL.get().expect("config cell populated above"))
+}
+
+/// Zero-sized handle that dereferences to the process-global [`Config`].
+///
+/// All `beacon_config::CONFIG.<field>` accesses go through this. Binaries should
+/// call [`init`] in `main` to surface configuration errors cleanly; this handle
+/// falls back to lazy loading for code paths (e.g. unit tests in other crates)
+/// that do not call [`init`] first.
+pub struct ConfigHandle;
+
+impl std::ops::Deref for ConfigHandle {
+    type Target = Config;
+
+    fn deref(&self) -> &Self::Target {
+        CONFIG_CELL.get_or_init(|| {
+            Config::load().expect("failed to load Beacon configuration from environment")
+        })
+    }
+}
+
+/// Process-global configuration handle. Dereferences to [`Config`].
+pub static CONFIG: ConfigHandle = ConfigHandle;
+
 lazy_static! {
-    pub static ref CONFIG: Config = Config::init();
     pub static ref DATA_DIR: PathBuf = {
         std::fs::create_dir_all("./data").expect("Failed to create data dir");
         PathBuf::from("./data")
@@ -415,4 +487,50 @@ lazy_static! {
     /// The prefix for the cache directory for object store paths
     pub static ref CACHE_DIR_PREFIX: object_store::path::Path =
         object_store::path::Path::from("cache");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_base_path;
+
+    #[test]
+    fn empty_and_blank_serve_at_root() {
+        assert_eq!(normalize_base_path(""), Ok(String::new()));
+        assert_eq!(normalize_base_path("   "), Ok(String::new()));
+        assert_eq!(normalize_base_path("/"), Ok(String::new()));
+        assert_eq!(normalize_base_path("///"), Ok(String::new()));
+    }
+
+    #[test]
+    fn normalizes_to_single_leading_slash_no_trailing() {
+        assert_eq!(normalize_base_path("mybeacon"), Ok("/mybeacon".to_string()));
+        assert_eq!(normalize_base_path("foo"), Ok("/foo".to_string()));
+        assert_eq!(normalize_base_path("/foo"), Ok("/foo".to_string()));
+        assert_eq!(normalize_base_path("/foo/"), Ok("/foo".to_string()));
+        assert_eq!(normalize_base_path("///foo///"), Ok("/foo".to_string()));
+        assert_eq!(normalize_base_path("  /foo/  "), Ok("/foo".to_string()));
+    }
+
+    #[test]
+    fn preserves_nested_segments_and_unreserved_chars() {
+        assert_eq!(normalize_base_path("foo/bar"), Ok("/foo/bar".to_string()));
+        assert_eq!(normalize_base_path("/foo/bar/"), Ok("/foo/bar".to_string()));
+        assert_eq!(
+            normalize_base_path("my-app_v2.1~beta"),
+            Ok("/my-app_v2.1~beta".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_characters() {
+        assert!(normalize_base_path("my path").is_err());
+        assert!(normalize_base_path("foo?bar").is_err());
+        assert!(normalize_base_path("foo#bar").is_err());
+        assert!(normalize_base_path("foo%20bar").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_internal_segment() {
+        assert!(normalize_base_path("a//b").is_err());
+    }
 }

--- a/docs/docs/1.7.0/data-lake/configuration.md
+++ b/docs/docs/1.7.0/data-lake/configuration.md
@@ -16,7 +16,7 @@ Some of the configuration options can be set using environment variables. The fo
 
 - `BEACON_HOST` - IP address to listen on. (Default is `0.0.0.0`)
 - `BEACON_PORT` - Port number to listen on. (Default is `5001`)
-- `BEACON_BASE_PATH` - Optional URL path prefix to serve the HTTP API, OpenAPI document, and Swagger UI under (default is empty, i.e. served at the root). Useful when running Beacon behind a reverse proxy or on a shared subpath, e.g. `/beacon`.
+- `BEACON_BASE_PATH` - Optional URL path prefix to serve the HTTP API, OpenAPI document, and Swagger UI under (default is empty, i.e. served at the root). Useful when running Beacon behind a reverse proxy or on a shared subpath, e.g. `/beacon`. The value is normalized to exactly one leading slash and no trailing slash, so `beacon`, `/beacon`, and `/beacon/` are equivalent. Only URL-safe characters are allowed (letters, digits, `-`, `_`, `.`, `~`, and `/` as a separator); any other character (e.g. spaces, `?`, `#`, `%`) causes Beacon to exit at startup with a descriptive error.
 - `BEACON_ADMIN_USERNAME` - The admin username for the beacon admin panel.
 - `BEACON_ADMIN_PASSWORD` - The admin password for the beacon admin panel.
 - `BEACON_VM_MEMORY_SIZE` - The amount of memory to allocate to the Beacon Virtual Machine in MB (default is 4096MB). More is better for performance, especially when working with larger datasets and performing actions such as spatial joins and group by.


### PR DESCRIPTION
## What & why

Fixes #240. Setting `BEACON_BASE_PATH` to a value without a leading slash (e.g.
`mybeacon`) crashed the server at startup — the raw value was passed straight to
axum's `Router::nest()` and utoipa, which assert that paths begin with `/`.

## Changes

- **Normalize** `base_path` to a canonical form: exactly one leading `/`, no trailing
  `/`; empty/blank serves at root. So `foo`, `/foo`, and `/foo/` are equivalent.
- **Validate** path characters (URL "unreserved" set + `/` as separator); reject
  anything else (spaces, `?`, `#`, `%`, …) and empty internal segments with a
  descriptive error.
- **No more panics in config init.** Replaced the panicking `Config::init()` with a
  fallible `Config::load() -> anyhow::Result<Config>` plus a `OnceLock`-backed
  `beacon_config::init()`, called from `main()` so config errors surface as a clean
  `anyhow` error and the process exits non-zero. `CONFIG` is now a `Deref` handle, so
  all existing `beacon_config::CONFIG.<field>` call sites are unchanged.
- Added unit tests for `normalize_base_path` and documented the behavior in the
  configuration docs.

## Verification

- `cargo test -p beacon-config` — 5 tests pass (normalization + validation).
- `cargo check --workspace` — compiles clean.
- Live smoke test with `BEACON_BASE_PATH="bad path"`: