### PR TITLE
Homepage hero redesign, animated intro diagram, SEO/AEO & OSS polish

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,5 +1,32 @@
 import { defineConfig } from 'vitepress'
 
+const SITE_URL = 'https://maris-development.github.io/beacon/'
+const OG_IMAGE = SITE_URL + 'hero.png'
+const DESCRIPTION =
+  'Beacon is an open-source (AGPL-3.0) data lakehouse query engine for scientific and climate data — query NetCDF, Zarr, Parquet, GeoTIFF, CSV, ODV, Arrow and Atlas files in place over SQL and JSON APIs, on local storage or S3, with no data migration.'
+
+const structuredData = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'Beacon',
+    url: SITE_URL,
+    description: DESCRIPTION
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'Beacon',
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'Linux, macOS, Docker',
+    description: DESCRIPTION,
+    url: SITE_URL,
+    license: 'https://www.gnu.org/licenses/agpl-3.0.html',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+    sameAs: ['https://github.com/maris-development/beacon']
+  }
+]
+
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   markdown: {
@@ -8,12 +35,46 @@ export default defineConfig({
       light: 'light-plus',
     }
   },
-  head: [['link', { rel: 'icon', href: '/beacon/favicon.ico' }]],
+  head: [
+    ['link', { rel: 'icon', href: '/beacon/favicon.ico' }],
+    ['meta', { name: 'author', content: 'MARIS' }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:site_name', content: 'Beacon' }],
+    ['meta', { property: 'og:image', content: OG_IMAGE }],
+    ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+    ['meta', { name: 'twitter:image', content: OG_IMAGE }],
+    ['script', { type: 'application/ld+json' }, JSON.stringify(structuredData[0])],
+    ['script', { type: 'application/ld+json' }, JSON.stringify(structuredData[1])],
+  ],
   base: '/beacon/',
   ignoreDeadLinks: true,
   title: "Beacon",
-  description: "Beacon Documentation",
+  description: DESCRIPTION,
   lastUpdated: true,
+  sitemap: { hostname: SITE_URL },
+  transformHead({ pageData }) {
+    const path = pageData.relativePath
+      .replace(/\.md$/, '.html')
+      .replace(/(^|\/)index\.html$/, '$1')
+    const url = SITE_URL + path
+    const isHome =
+      pageData.frontmatter?.layout === 'home' ||
+      !pageData.title ||
+      pageData.title === 'Beacon'
+    const title = isHome
+      ? 'Beacon — a data lakehouse for scientific data'
+      : `${pageData.title} | Beacon`
+    const description =
+      pageData.description || pageData.frontmatter?.description || DESCRIPTION
+    return [
+      ['link', { rel: 'canonical', href: url }],
+      ['meta', { property: 'og:title', content: title }],
+      ['meta', { property: 'og:description', content: description }],
+      ['meta', { property: 'og:url', content: url }],
+      ['meta', { name: 'twitter:title', content: title }],
+      ['meta', { name: 'twitter:description', content: description }]
+    ]
+  },
   themeConfig: {
     search: {
       provider: 'local'
@@ -817,6 +878,14 @@ export default defineConfig({
     socialLinks: [
       { icon: 'slack', link: 'https://join.slack.com/t/beacontechnic-wwa5548/shared_invite/zt-2dp1vv56r-tj_KFac0sAKNuAgUKPPDRg' },
       { icon: 'github', link: 'https://github.com/maris-development/beacon' },
-    ]
+    ],
+    editLink: {
+      pattern: 'https://github.com/maris-development/beacon/edit/main/docs/:path',
+      text: 'Edit this page on GitHub'
+    },
+    footer: {
+      message: 'Released under the AGPL-3.0 License.',
+      copyright: 'Copyright © MARIS & the Beacon contributors'
+    }
   }
 })

--- a/docs/.vitepress/theme/components/ArchDiagram.vue
+++ b/docs/.vitepress/theme/components/ArchDiagram.vue
@@ -74,7 +74,7 @@ const cards = [
 <style scoped>
 .arch {
   margin: 3.75rem auto 1rem;
-  max-width: 880px;
+  max-width: 1000px;
   padding: 0 1.5rem;
   text-align: center;
 }
@@ -92,15 +92,15 @@ const cards = [
 .depcards {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 0.8rem;
+  gap: 1rem;
 }
 
 .depcard {
   border: 1px solid var(--vp-c-divider);
-  border-top: 3px solid var(--vp-c-divider);
-  border-radius: 12px;
+  border-top: 4px solid var(--vp-c-divider);
+  border-radius: 14px;
   background: var(--vp-c-bg-soft);
-  padding: 16px 14px 14px;
+  padding: 22px 20px 20px;
   text-align: left;
 }
 .accent-cloud  { border-top-color: var(--vp-c-brand-1); }
@@ -110,13 +110,13 @@ const cards = [
 .depcard-head {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 14px;
-  font-size: 14px;
+  gap: 10px;
+  margin-bottom: 18px;
+  font-size: 16px;
   font-weight: 700;
   color: var(--vp-c-text-1);
 }
-.dh-ico { font-size: 16px; }
+.dh-ico { font-size: 18px; }
 
 .depflow {
   display: flex;
@@ -126,38 +126,38 @@ const cards = [
 .dep-node {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
+  gap: 12px;
+  padding: 11px 13px;
   border: 1px solid var(--vp-c-divider);
-  border-radius: 8px;
+  border-radius: 10px;
   background: var(--vp-c-bg);
 }
 .dn-ico {
-  width: 24px;
+  width: 28px;
   text-align: center;
-  font-size: 17px;
+  font-size: 20px;
   flex: none;
 }
 .dn-logo {
-  width: 22px;
-  height: 22px;
+  width: 26px;
+  height: 26px;
   flex: none;
 }
-.dn-text { display: flex; flex-direction: column; line-height: 1.25; min-width: 0; }
-.dn-text b { font-size: 13px; color: var(--vp-c-text-1); }
-.dn-text small { font-size: 11px; color: var(--vp-c-text-3); }
+.dn-text { display: flex; flex-direction: column; line-height: 1.3; min-width: 0; }
+.dn-text b { font-size: 14.5px; color: var(--vp-c-text-1); }
+.dn-text small { font-size: 12px; color: var(--vp-c-text-3); }
 
 /* vertical connector + label, aligned under the node icon column */
 .dep-link {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 2px 0 2px 21px;
+  gap: 10px;
+  padding: 3px 0 3px 26px;
 }
 .dl-line {
   position: relative;
   width: 2px;
-  height: 22px;
+  height: 28px;
   background: var(--vp-c-divider);
   flex: none;
 }
@@ -175,18 +175,18 @@ const cards = [
   0%   { top: -5px; opacity: 0; }
   15%  { opacity: 1; }
   85%  { opacity: 1; }
-  100% { top: 22px; opacity: 0; }
+  100% { top: 28px; opacity: 0; }
 }
 .dep-link em {
   font-style: normal;
-  font-size: 10.5px;
+  font-size: 11.5px;
   color: var(--vp-c-text-3);
 }
 
 .depcard-foot {
-  margin: 14px 0 0;
-  font-size: 11.5px;
-  line-height: 1.45;
+  margin: 18px 0 0;
+  font-size: 12.5px;
+  line-height: 1.5;
   color: var(--vp-c-text-2);
 }
 
@@ -194,7 +194,7 @@ const cards = [
   .dl-dot { display: none; }
 }
 
-@media (max-width: 640px) {
-  .depcards { grid-template-columns: 1fr; max-width: 360px; margin-inline: auto; }
+@media (max-width: 720px) {
+  .depcards { grid-template-columns: 1fr; max-width: 380px; margin-inline: auto; }
 }
 </style>

--- a/docs/.vitepress/theme/components/HeroBackdrop.vue
+++ b/docs/.vitepress/theme/components/HeroBackdrop.vue
@@ -1,0 +1,180 @@
+<script setup>
+// Decorative hero background: a "beacon" light + a drifting data-point network.
+// Points/lines are hand-placed in a 1200×600 viewBox.
+const points = [
+  [80, 90], [210, 180], [150, 320], [60, 470], [300, 90], [330, 260],
+  [420, 410], [250, 500], [470, 150], [560, 300], [620, 470], [510, 540],
+  [690, 110], [760, 260], [840, 420], [720, 540], [900, 170], [970, 330],
+  [1040, 470], [890, 540], [1120, 100], [1150, 300], [1080, 540],
+  [390, 200], [600, 90], [820, 90], [1010, 90], [180, 540],
+]
+const links = [
+  [0, 1], [1, 2], [2, 3], [1, 23], [23, 4], [4, 24], [23, 5], [5, 6],
+  [6, 7], [5, 8], [8, 9], [9, 10], [10, 11], [9, 13], [12, 13], [13, 14],
+  [14, 15], [13, 16], [16, 17], [17, 18], [18, 19], [16, 20], [20, 21],
+  [21, 22], [24, 25], [25, 26], [26, 20], [3, 27],
+]
+
+// Data packets travelling between beacons — a subset of links, alternating
+// direction, staggered so only a few are visible at once.
+const packets = links
+  .filter((_, i) => i % 3 === 0)
+  .map((l, i) => {
+    const fwd = i % 2 === 0
+    const a = points[l[fwd ? 0 : 1]]
+    const b = points[l[fwd ? 1 : 0]]
+    return {
+      x: a[0], y: a[1],
+      dx: b[0] - a[0], dy: b[1] - a[1],
+      delay: +(i * 0.8).toFixed(2),
+      dur: 3.4 + (i % 4) * 0.7,
+    }
+  })
+</script>
+
+<template>
+  <div class="hero-backdrop" aria-hidden="true">
+    <!-- beacon light -->
+    <div class="hb-sweep"></div>
+    <div class="hb-glow"></div>
+
+    <!-- data-point network -->
+    <svg class="hb-net" viewBox="0 0 1200 600" preserveAspectRatio="xMidYMid slice">
+      <g class="hb-drift">
+        <line v-for="(l, i) in links" :key="'l' + i" class="hb-line"
+              :x1="points[l[0]][0]" :y1="points[l[0]][1]"
+              :x2="points[l[1]][0]" :y2="points[l[1]][1]" />
+        <circle v-for="(p, i) in points" :key="'p' + i" class="hb-dot"
+                :cx="p[0]" :cy="p[1]" :r="i % 4 === 0 ? 3.4 : 2.2"
+                :style="{ animationDelay: (i * 0.27) + 's' }" />
+        <circle v-for="(pk, i) in packets" :key="'k' + i" class="hb-packet"
+                :cx="pk.x" :cy="pk.y" r="1.8"
+                :style="{ '--dx': pk.dx + 'px', '--dy': pk.dy + 'px',
+                          animationDelay: pk.delay + 's', animationDuration: pk.dur + 's' }" />
+      </g>
+    </svg>
+  </div>
+</template>
+
+<style scoped>
+.hero-backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 760px;
+  z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+  /* fade out toward the bottom so it blends into the page */
+  -webkit-mask-image: linear-gradient(to bottom, #000 58%, transparent 100%);
+  mask-image: linear-gradient(to bottom, #000 58%, transparent 100%);
+}
+
+/* ---- beacon light ---- */
+.hb-glow {
+  position: absolute;
+  top: -160px;
+  left: 8%;
+  width: 720px;
+  height: 720px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at center,
+    color-mix(in srgb, var(--vp-c-brand-1) 30%, transparent) 0%,
+    color-mix(in srgb, #24c6dc 18%, transparent) 38%,
+    transparent 68%
+  );
+  filter: blur(8px);
+  opacity: 0.6;
+  animation: hb-pulse 7s ease-in-out infinite;
+}
+
+.hb-sweep {
+  position: absolute;
+  top: -360px;
+  left: -120px;
+  width: 900px;
+  height: 900px;
+  background: conic-gradient(
+    from 0deg,
+    transparent 0deg,
+    color-mix(in srgb, var(--vp-c-brand-1) 22%, transparent) 18deg,
+    transparent 42deg,
+    transparent 360deg
+  );
+  opacity: 0.07;
+  animation: hb-rotate 22s linear infinite;
+}
+
+@keyframes hb-pulse {
+  0%, 100% { opacity: 0.5; transform: scale(1); }
+  50%      { opacity: 0.72; transform: scale(1.06); }
+}
+@keyframes hb-rotate {
+  to { transform: rotate(360deg); }
+}
+
+/* ---- data-point network ---- */
+.hb-net {
+  position: absolute;
+  top: -50px;          /* clear the nav / menu bar */
+  left: 0;
+  right: 0;
+  bottom: 0;
+  opacity: 0.5;
+}
+.hb-drift {
+  transform-origin: center;
+  animation: hb-driftmove 32s ease-in-out infinite alternate;
+}
+.hb-line {
+  stroke: color-mix(in srgb, var(--vp-c-brand-1) 45%, transparent);
+  stroke-width: 1;
+  opacity: 0.35;
+}
+.hb-dot {
+  fill: var(--vp-c-brand-1);
+  filter: drop-shadow(0 0 3px color-mix(in srgb, #24c6dc 70%, transparent));
+  animation: hb-twinkle 4.5s ease-in-out infinite;
+}
+.hb-dot:nth-child(3n) { fill: #24c6dc; }
+
+/* data packets travelling between beacons */
+.hb-packet {
+  fill: #24c6dc;
+  filter: drop-shadow(0 0 3px color-mix(in srgb, #24c6dc 80%, transparent));
+  animation-name: hb-travel;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+@keyframes hb-driftmove {
+  0%   { transform: translate(0, 0); }
+  100% { transform: translate(-26px, 18px); }
+}
+@keyframes hb-twinkle {
+  0%, 100% { opacity: 0.55; }
+  50%      { opacity: 1; }
+}
+@keyframes hb-travel {
+  0%   { transform: translate(0, 0); opacity: 0; }
+  12%  { opacity: 0.85; }
+  88%  { opacity: 0.85; }
+  100% { transform: translate(var(--dx), var(--dy)); opacity: 0; }
+}
+
+.dark .hb-glow { opacity: 0.8; }
+.dark .hb-net { opacity: 0.7; }
+.dark .hb-sweep { opacity: 0.1; }
+
+@media (max-width: 760px) {
+  .hero-backdrop { height: 560px; }
+  .hb-glow { width: 480px; height: 480px; left: -40px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hb-glow, .hb-sweep, .hb-drift, .hb-dot { animation: none; }
+  .hb-packet { display: none; }
+}
+</style>

--- a/docs/.vitepress/theme/components/QueryFlow.vue
+++ b/docs/.vitepress/theme/components/QueryFlow.vue
@@ -1,0 +1,207 @@
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { withBase } from 'vitepress'
+
+const logo = withBase('/beacon-logo-small.png')
+
+// Each setup mirrors the homepage deployment cards. The env box wraps Beacon +
+// storage for cloud/on-prem, and the whole thing (incl. the client) for local.
+const setups = [
+  {
+    key: 'cloud', label: '☁ Cloud (AWS)', cls: 'env-cloud',
+    box: { x: 376, w: 596, lx: 392 },
+    client: { ico: '💻', sub: 'remote notebook' },
+    beaconSub: 'on EC2',
+    store: { ico: '🪣', title: 'S3 Bucket', sub: 'object storage' },
+  },
+  {
+    key: 'onprem', label: '🖥 On-premise', cls: 'env-onprem',
+    box: { x: 376, w: 596, lx: 392 },
+    client: { ico: '💻', sub: 'remote notebook' },
+    beaconSub: 'your server',
+    store: { ico: '💾', title: 'Local disk', sub: 'NetCDF · Parquet' },
+  },
+  {
+    key: 'local', label: '💻 Local', cls: 'env-local',
+    box: { x: 8, w: 964, lx: 24 },
+    client: { ico: '📓', sub: 'same machine' },
+    beaconSub: 'localhost:5001',
+    store: { ico: '💾', title: 'Local files', sub: 'on disk' },
+  },
+]
+
+const active = ref(0)
+const cur = computed(() => setups[active.value])
+
+let timer = null
+onMounted(() => {
+  const reduce = window.matchMedia &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  if (reduce) return
+  timer = setInterval(() => {
+    active.value = (active.value + 1) % setups.length
+  }, 3000)
+})
+onBeforeUnmount(() => { if (timer) clearInterval(timer) })
+</script>
+
+<template>
+  <div class="qflow">
+    <svg class="qflow-svg" viewBox="0 0 980 260" role="img"
+         aria-label="A client sends an SQL or JSON query to Beacon along a request lane; Beacon reads from storage and the results (Parquet, NetCDF or Arrow) flow back along a response lane. Beacon can be deployed in the cloud, on-premise, or fully locally.">
+      <!-- ===== resizing deployment-environment box ===== -->
+      <rect class="env-fill" :class="cur.cls" :x="cur.box.x" y="56" :width="cur.box.w" height="176" rx="18" />
+      <rect class="env-border" :x="cur.box.x" y="56" :width="cur.box.w" height="176" rx="18" />
+
+      <!-- ===== request lane (top, flows right) ===== -->
+      <path class="wire" d="M220 118 H392" />
+      <path class="wire" d="M588 118 H760" />
+      <!-- ===== response lane (bottom, flows left) ===== -->
+      <path class="wire" d="M220 156 H392" />
+      <path class="wire" d="M588 156 H760" />
+
+      <!-- ===== animated packets ===== -->
+      <circle class="pkt fwd q"   cx="220" cy="118" r="5" />
+      <circle class="pkt fwd rd"  cx="588" cy="118" r="4.5" />
+      <circle class="pkt ret dt"  cx="760" cy="156" r="4.5" />
+      <circle class="pkt ret res" cx="392" cy="156" r="5" />
+
+      <!-- ===== lane labels ===== -->
+      <text class="elabel" x="306" y="106">SQL / JSON</text>
+      <text class="elabel" x="674" y="106">reads</text>
+      <text class="elabel" x="674" y="176">data</text>
+      <text class="elabel res-label" x="306" y="176">Parquet · NetCDF · Arrow</text>
+
+      <!-- ===== node frames + static text ===== -->
+      <g class="node">
+        <rect x="24" y="84" width="196" height="104" rx="14" />
+        <text class="n-title" x="74" y="130">Clients</text>
+      </g>
+      <g class="node">
+        <rect class="beacon-rect" x="392" y="84" width="196" height="104" rx="14" />
+        <image :href="logo" x="408" y="118" width="36" height="36" />
+        <text class="n-title big" x="454" y="130">Beacon</text>
+      </g>
+      <g class="node">
+        <rect x="760" y="84" width="196" height="104" rx="14" />
+      </g>
+
+      <!-- ===== per-setup content (crossfades on change) ===== -->
+      <Transition name="setup">
+        <g :key="cur.key" class="setup-layer">
+          <text class="env-name" :class="cur.cls" :x="cur.box.lx" y="80">{{ cur.label }}</text>
+
+          <text class="ico" x="52" y="144">{{ cur.client.ico }}</text>
+          <text class="n-sub tight" x="74" y="150">{{ cur.client.sub }}</text>
+
+          <text class="n-sub" x="454" y="150">{{ cur.beaconSub }}</text>
+
+          <text class="ico" x="788" y="144">{{ cur.store.ico }}</text>
+          <text class="n-title" x="810" y="130">{{ cur.store.title }}</text>
+          <text class="n-sub" x="810" y="150">{{ cur.store.sub }}</text>
+        </g>
+      </Transition>
+    </svg>
+  </div>
+</template>
+
+<style scoped>
+.qflow { margin: 1.25rem 0 0.5rem; }
+.qflow-svg { width: 100%; height: auto; overflow: visible; }
+
+/* environment box — morphs size + colour per setup */
+.env-fill {
+  stroke: none;
+  transition: x 0.5s ease, width 0.5s ease, fill 0.5s ease;
+}
+.env-border {
+  fill: none;
+  stroke: var(--vp-c-divider);
+  stroke-width: 1.5;
+  stroke-dasharray: 6 6;
+  transition: x 0.5s ease, width 0.5s ease;
+}
+.env-cloud  { fill: color-mix(in srgb, var(--vp-c-brand-soft) 26%, transparent); }
+.env-onprem { fill: color-mix(in srgb, var(--vp-c-green-soft, var(--vp-c-bg-soft)) 38%, transparent); }
+.env-local  { fill: color-mix(in srgb, var(--vp-c-yellow-soft, var(--vp-c-bg-soft)) 36%, transparent); }
+
+.env-name { font-size: 13.5px; font-weight: 700; letter-spacing: 0.02em; }
+.env-name.env-cloud  { fill: var(--vp-c-brand-1); }
+.env-name.env-onprem { fill: var(--vp-c-green-1); }
+.env-name.env-local  { fill: var(--vp-c-yellow-2, var(--vp-c-text-1)); }
+
+/* per-setup crossfade */
+.setup-enter-active, .setup-leave-active { transition: opacity 0.45s ease; }
+.setup-enter-from, .setup-leave-to { opacity: 0; }
+
+/* connectors */
+.wire { fill: none; stroke: var(--vp-c-divider); stroke-width: 2.5; }
+
+/* nodes */
+.node rect { fill: var(--vp-c-bg); stroke: var(--vp-c-divider); stroke-width: 1.5; }
+.beacon-rect { fill: var(--vp-c-bg-soft); }
+.n-title { fill: var(--vp-c-text-1); font-size: 15px; font-weight: 700; }
+.n-title.big { font-size: 18px; }
+.n-sub { fill: var(--vp-c-text-3); font-size: 11.5px; }
+.n-sub.tight { font-size: 11px; }
+.ico { font-size: 24px; text-anchor: middle; }
+
+.elabel { fill: var(--vp-c-text-3); font-size: 12px; text-anchor: middle; }
+.res-label { opacity: 0.9; }
+
+/* ===== round-trip packet animation (shared 5s loop) ===== */
+.pkt { filter: drop-shadow(0 0 2px currentColor); }
+.pkt.fwd { fill: var(--vp-c-brand-1); color: var(--vp-c-brand-1); }
+.pkt.ret { fill: var(--vp-c-green-1); color: var(--vp-c-green-1); }
+.pkt.q   { animation: qf-q   5s ease-in-out infinite; }
+.pkt.rd  { animation: qf-rd  5s ease-in-out infinite; }
+.pkt.dt  { animation: qf-dt  5s ease-in-out infinite; }
+.pkt.res { animation: qf-res 5s ease-in-out infinite; }
+
+/* forward (right) along the top lane: client->beacon, then beacon->storage */
+@keyframes qf-q {
+  0%   { transform: translateX(0);     opacity: 0; }
+  4%   { opacity: 1; }
+  20%  { transform: translateX(172px); opacity: 1; }
+  23%, 100% { transform: translateX(172px); opacity: 0; }
+}
+@keyframes qf-rd {
+  0%, 30%   { transform: translateX(0);     opacity: 0; }
+  34%       { opacity: 1; }
+  48%       { transform: translateX(172px); opacity: 1; }
+  51%, 100% { transform: translateX(172px); opacity: 0; }
+}
+/* return (left) along the bottom lane: storage->beacon, then beacon->client */
+@keyframes qf-dt {
+  0%, 52%   { transform: translateX(0);      opacity: 0; }
+  56%       { opacity: 1; }
+  68%       { transform: translateX(-172px); opacity: 1; }
+  71%, 100% { transform: translateX(-172px); opacity: 0; }
+}
+@keyframes qf-res {
+  0%, 72%   { transform: translateX(0);      opacity: 0; }
+  76%       { opacity: 1; }
+  92%       { transform: translateX(-172px); opacity: 1; }
+  95%, 100% { transform: translateX(-172px); opacity: 0; }
+}
+
+/* beacon glow while it's working (between receiving query and sending result) */
+.beacon-rect { animation: qf-glow 5s ease-in-out infinite; }
+@keyframes qf-glow {
+  0%, 18% { stroke: var(--vp-c-divider); }
+  24%     { stroke: var(--vp-c-brand-1); }
+  72%     { stroke: var(--vp-c-brand-1); }
+  78%     { stroke: var(--vp-c-divider); }
+  100%    { stroke: var(--vp-c-divider); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pkt { display: none; }
+  .beacon-rect { animation: none; }
+  .env-fill, .env-border { transition: none; }
+}
+
+@media (max-width: 560px) {
+  .qflow-svg .n-sub { display: none; }
+}
+</style>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -22,6 +22,46 @@
   100% { background-position: 0% 50%; }
 }
 
+/* ===== hero backdrop stacking ===== */
+.VPHome { position: relative; }
+.VPHome .VPHero,
+.VPHome .home-hero-badges {
+  position: relative;
+  z-index: 1;
+}
+
+/* ===== scroll-reveal (hidden state added by JS only -> no-JS safe) ===== */
+.reveal {
+  opacity: 0;
+  transform: translateY(26px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+  will-change: opacity, transform;
+}
+.reveal.in-view {
+  opacity: 1;
+  transform: none;
+}
+/* blocks already on screen at landing cascade in (one-shot, JS-added) */
+.land-in {
+  animation: hero-in 0.6s cubic-bezier(0.22, 1, 0.36, 1) backwards;
+}
+@media (prefers-reduced-motion: reduce) {
+  .reveal { opacity: 1; transform: none; transition: none; }
+  .land-in { animation: none; }
+}
+
+/* ===== feature card hover lift / glow ===== */
+.VPFeature {
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+.VPFeature:hover {
+  transform: translateY(-4px);
+  border-color: color-mix(in srgb, var(--vp-c-brand-1) 55%, var(--vp-c-divider));
+  box-shadow:
+    0 14px 32px rgba(0, 0, 0, 0.10),
+    0 0 0 1px color-mix(in srgb, var(--vp-c-brand-1) 20%, transparent);
+}
+
 /* Make the VitePress home hero screenshot larger */
 .VPHero.has-image .container {
   max-width: 1180px;
@@ -84,6 +124,32 @@
     background-size: 300% 300%;
     animation: gradientMove 4s ease infinite;
 }
+
+/* ===== hero entrance on load (one-shot, staggered) =====
+   No-JS safe via `backwards` fill; the name keeps its gradient shimmer because
+   we animate the parent .heading, not the .name itself. */
+.VPHome .VPHero .heading,
+.VPHome .VPHero .tagline,
+.VPHome .VPHero .actions,
+.VPHome .VPHero .image {
+  animation: hero-in 0.65s cubic-bezier(0.22, 1, 0.36, 1) backwards;
+}
+.VPHome .VPHero .heading { animation-delay: 0.05s; }
+.VPHome .VPHero .image   { animation-delay: 0.18s; }
+.VPHome .VPHero .tagline { animation-delay: 0.22s; }
+.VPHome .VPHero .actions { animation-delay: 0.34s; }
+
+@keyframes hero-in {
+  from { opacity: 0; transform: translateY(18px); }
+  to   { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .VPHome .VPHero .heading,
+  .VPHome .VPHero .tagline,
+  .VPHome .VPHero .actions,
+  .VPHome .VPHero .image { animation: none; }
+}
 .format-badges-wrap {
   margin: 1.75rem auto 3rem;
   margin-top: 0;
@@ -124,7 +190,7 @@
 
 .home-hero-badges {
   margin: 1.75rem auto 3.25rem;
-  max-width: 820px;
+  max-width: 1000px;
   padding: 0 1.5rem;
   text-align: center;
 }

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,4 +1,4 @@
-import { h } from 'vue'
+import { h, onMounted } from 'vue'
 import DefaultTheme from 'vitepress/theme'
 import FormatBadges from './components/FormatBadges.vue'
 import IntegrationBadges from './components/IntegrationBadges.vue'
@@ -6,22 +6,51 @@ import HeroQuery from './components/HeroQuery.vue'
 import ArchDiagram from './components/ArchDiagram.vue'
 import FeaturesIntro from './components/FeaturesIntro.vue'
 import GetStartedCta from './components/GetStartedCta.vue'
+import QueryFlow from './components/QueryFlow.vue'
+import HeroBackdrop from './components/HeroBackdrop.vue'
 import './custom.css'
 
-export default {
-    extends: DefaultTheme,
+// Reveal sections as they scroll into view. No-JS safe (the hidden state is only
+// ever added by JS), and below-the-fold-only (so above-the-fold content never
+// flashes). Skipped under reduced-motion.
+function setupScrollReveal() {
+    if (typeof window === 'undefined') return
+    const reduce = window.matchMedia &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    requestAnimationFrame(() => {
+        const targets = document.querySelectorAll(
+            '.home-hero-badges, .arch, .feat-intro, .VPFeature, .cta'
+        )
+        if (!targets.length || reduce || !('IntersectionObserver' in window)) return
+        const io = new IntersectionObserver((entries, obs) => {
+            entries.forEach((e) => {
+                if (e.isIntersecting) {
+                    e.target.classList.add('in-view')
+                    obs.unobserve(e.target)
+                }
+            })
+        }, { rootMargin: '0px 0px -8% 0px', threshold: 0.08 })
+        let landIndex = 0
+        targets.forEach((el) => {
+            if (el.getBoundingClientRect().top > window.innerHeight * 0.88) {
+                // below the fold -> reveal on scroll
+                el.classList.add('reveal')
+                io.observe(el)
+            } else {
+                // already on screen at landing -> entrance, cascading after the hero
+                el.style.animationDelay = (0.45 + landIndex * 0.12) + 's'
+                el.classList.add('land-in')
+                landIndex++
+            }
+        })
+    })
+}
 
-    enhanceApp({ app }) {
-        app.component('FormatBadges', FormatBadges)
-        app.component('IntegrationBadges', IntegrationBadges)
-        app.component('HeroQuery', HeroQuery)
-        app.component('ArchDiagram', ArchDiagram)
-        app.component('FeaturesIntro', FeaturesIntro)
-        app.component('GetStartedCta', GetStartedCta)
-    },
-
-    Layout() {
-        return h(DefaultTheme.Layout, null, {
+const Layout = {
+    setup() {
+        onMounted(setupScrollReveal)
+        return () => h(DefaultTheme.Layout, null, {
+            'home-hero-before': () => h(HeroBackdrop),
             'home-hero-image': () => h(HeroQuery),
             'home-hero-after': () =>
                 h('div', { class: 'home-hero-badges' }, [
@@ -33,4 +62,21 @@ export default {
             'home-features-after': () => h(GetStartedCta)
         })
     }
+}
+
+export default {
+    extends: DefaultTheme,
+
+    enhanceApp({ app }) {
+        app.component('FormatBadges', FormatBadges)
+        app.component('IntegrationBadges', IntegrationBadges)
+        app.component('HeroQuery', HeroQuery)
+        app.component('ArchDiagram', ArchDiagram)
+        app.component('FeaturesIntro', FeaturesIntro)
+        app.component('GetStartedCta', GetStartedCta)
+        app.component('QueryFlow', QueryFlow)
+        app.component('HeroBackdrop', HeroBackdrop)
+    },
+
+    Layout
 }

--- a/docs/docs/1.7.0/getting-started.md
+++ b/docs/docs/1.7.0/getting-started.md
@@ -1,3 +1,7 @@
+---
+description: Run Beacon with Docker in minutes — locally or against S3-compatible object storage — then point it at your files and query them over SQL or JSON.
+---
+
 # Getting Started
 
 This guide gets a Beacon instance running with Docker Compose. For ready-made examples including MinIO and sample datasets, see the [beacon-example repository](https://github.com/maris-development/beacon-example).

--- a/docs/docs/1.7.0/introduction.md
+++ b/docs/docs/1.7.0/introduction.md
@@ -1,3 +1,7 @@
+---
+description: How Beacon fits together — send SQL or JSON to the query engine, read NetCDF, Zarr, Parquet, GeoTIFF and more in place from local files or S3, and stream results back as Parquet, NetCDF or Arrow.
+---
+
 # Introduction
 
 :::info Open Source (AGPL V3)
@@ -6,24 +10,48 @@ Beacon is open source under the AGPL V3 license. Source code and contributions: 
 
 Beacon is a data lakehouse query engine built for scientific datasets. Point it at your existing files — on disk or in S3 — and it exposes a SQL query API instantly, with no data migration or preprocessing required.
 
+<QueryFlow />
+
 Clients query Beacon using **SQL** or **JSON** and receive results as a file (Parquet, NetCDF, Arrow IPC, …) or a streaming Arrow IPC response. Beacon handles filtering, aggregation, and joins across files entirely server-side.
 
 ## Your first query
 
-You can query files directly, with no setup, or register them once and query by name:
+The same query three ways — as raw SQL, over the HTTP API, or from the Python SDK. No setup required: `read_netcdf()` reads the files in place.
 
-```sql
--- Query files directly, no setup required
-SELECT * FROM read_netcdf(['argo/**/*.nc']) LIMIT 100;
+::: code-group
 
--- Or register a table once, then query it by name
-SELECT temperature, latitude, longitude
-FROM ocean_profiles
-WHERE latitude BETWEEN 0 AND 70
-LIMIT 100;
+```sql [SQL]
+SELECT time, latitude, longitude, temperature
+FROM read_netcdf(['argo/**/*.nc'])
+WHERE temperature > 20
+LIMIT 100
 ```
 
-Queries are submitted over the HTTP API (`POST /api/query`) or Arrow Flight SQL.
+```http [HTTP]
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT time, latitude, longitude, temperature FROM read_netcdf(['argo/**/*.nc']) WHERE temperature > 20 LIMIT 100",
+  "output": { "format": "csv" }
+}
+```
+
+```python [Python]
+from beacon_api import Client
+
+client = Client("https://your-beacon-node")
+
+df = client.sql_query(
+    "SELECT time, latitude, longitude, temperature "
+    "FROM read_netcdf(['argo/**/*.nc']) "
+    "WHERE temperature > 20 LIMIT 100"
+).to_pandas_dataframe()
+```
+
+:::
+
+SQL is sent over the HTTP API (`POST /api/query`, with `BEACON_ENABLE_SQL=true`) or Arrow Flight SQL. Prefer querying by name? Register the files as an [external table](/docs/1.7.0/data-lake/external-tables) first.
 
 ## Supported formats
 
@@ -38,33 +66,6 @@ Queries are submitted over the HTTP API (`POST /api/query`) or Arrow Flight SQL.
 | CSV | Header row required, delimiter configurable |
 | Arrow IPC | `.arrow`, `.ipc` stream files |
 | Beacon Binary Format | Beacon's native ingest format |
-
-## How it fits together
-
-```text
-                    Clients
-           (notebooks · apps · scripts)
-                       |
-                  SQL / JSON
-                       |
-                       v
-               +---------------+
-               |    Beacon     |
-               | query engine  |
-               +-------+-------+
-                       |
-           +-----------+-----------+
-           |                       |
-           v                       v
-    Local files               S3 / Object Store
-    (NetCDF, Zarr, …)         (existing bucket)
-           |                       |
-           +-----------+-----------+
-                       |
-                       v
-              Result returned to client
-              (Parquet · NetCDF · Arrow)
-```
 
 ## Key concepts
 

--- a/docs/docs/1.7.0/sql/index.md
+++ b/docs/docs/1.7.0/sql/index.md
@@ -1,3 +1,7 @@
+---
+description: Query Beacon with standard SQL (Apache DataFusion) — SELECT, WHERE, GROUP BY, JOIN, table functions like read_netcdf(), DDL, and a full function reference.
+---
+
 # SQL Guide
 
 Beacon embeds [Apache DataFusion](https://datafusion.apache.org/) as its query engine, giving you a broad standard SQL dialect — `SELECT`, `WHERE`, `GROUP BY`, `JOIN`, `ORDER BY`, window functions, and more.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,22 @@
+# Beacon
+
+> Beacon is a high-performance, open-source (AGPL-3.0) data lakehouse query engine for scientific and climate data. Point it at existing files — NetCDF, Zarr, Parquet, GeoTIFF/COG, CSV, ODV ASCII, Arrow IPC, Atlas and BBF — on local storage or S3, and query them in place over SQL or a JSON API, with no data migration. Built in Rust on Apache Arrow and DataFusion.
+
+## Documentation
+- [Introduction](https://maris-development.github.io/beacon/docs/1.7.0/introduction.html): What Beacon is and how a query flows through it.
+- [Getting started](https://maris-development.github.io/beacon/docs/1.7.0/getting-started.html): Run Beacon with Docker, locally or against S3.
+- [SQL guide](https://maris-development.github.io/beacon/docs/1.7.0/sql/): SELECT/WHERE/GROUP BY/JOIN, table functions, DDL, and the function reference.
+- [Data lakehouse setup](https://maris-development.github.io/beacon/docs/1.7.0/data-lake/): Supported formats, external tables, managed (Iceberg) tables, views, configuration, performance tuning.
+- [REST API](https://maris-development.github.io/beacon/docs/1.7.0/api/): HTTP query API (SQL and JSON DSL) and output formats.
+- [Changelog](https://maris-development.github.io/beacon/docs/changelog): Release history.
+
+## Key facts
+- Query surfaces: HTTP API (`POST /api/query`) and Arrow Flight SQL.
+- Output formats: Parquet, NetCDF, Arrow IPC, CSV, GeoParquet.
+- Managed tables are backed by Apache Iceberg (ACID, snapshots, schema evolution); external tables read existing files in place.
+- Deployable in the cloud, on-premise, or fully locally.
+- License: AGPL-3.0. Source: https://github.com/maris-development/beacon
+
+## Optional
+- [Available public nodes](https://maris-development.github.io/beacon/available-nodes/available-nodes.html): Euro-Argo, World Ocean Database, CORA Profiles & Time Series (personal access token required).
+- [GitHub repository](https://github.com/maris-development/beacon)

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://maris-development.github.io/beacon/sitemap.xml


### PR DESCRIPTION
Builds on the homepage refresh (#245) with an animated hero, an animated
"how it fits together" diagram, and a round of SEO/AEO + open-source polish.
All motion is theme-aware, SSR/no-JS-safe, and respects `prefers-reduced-motion`.

## Hero
- **Animated backdrop** (`HeroBackdrop.vue`): a soft "beacon" light glow + a
  drifting network of data points, with packets travelling between nodes
  (a constellation of Beacons exchanging data). Decorative / `aria-hidden`,
  sits behind the hero content.
- **Entrance animations**: a one-shot staggered fade-up of the hero
  (heading → query card → tagline → buttons) on load; blocks already on screen
  cascade in after it, while below-the-fold sections reveal on scroll. Feature
  cards get a hover lift/glow. The hidden state is only ever added by JS, so
  no-JS users see everything.

## Introduction page
- Replaced the ASCII "How it fits together" block with an animated flow diagram
  (`QueryFlow.vue`): request/response lanes (SQL/JSON → Beacon → storage →
  Parquet/NetCDF/Arrow) that rotate through the Cloud / On-premise / Local
  setups, with the environment box resizing per setup.

## Deployment cards
- Enlarged the "Deploy Beacon anywhere" cards (wider container + scaled internals).

## SEO & AI discoverability
- Sitemap (`sitemap.xml`), `robots.txt`, and an `llms.txt` map for LLMs.
- Per-page canonical URLs and OpenGraph/Twitter meta; site-wide JSON-LD
  (`WebSite` + `SoftwareApplication`).
- Keyword-rich site description + unique `description:` frontmatter on key pages.

## Open-source polish
- Site footer (AGPL-3.0 + copyright), "Edit this page on GitHub" links, and an
  OpenGraph social card.

## Notes
- Canonical/OG/sitemap URLs use the GitHub Pages host
  `https://maris-development.github.io/beacon/`. Because the site is served from
  a subpath, root-level `robots.txt`/`llms.txt` aren't honored by crawlers — a
  custom domain (docs at a root) would unlock full indexing; update `SITE_URL`
  + those two files if/when that happens.
- OG image is the existing square `hero.png`; a 1200×630 card would unfurl better.
