### PR TITLE
Fix Swagger/Scalar redirects under a non-empty base path

### DIFF
--- a/beacon-api/src/axum/router.rs
+++ b/beacon-api/src/axum/router.rs
@@ -39,6 +39,12 @@ pub(crate) fn setup_router(beacon_runtime: Arc<Runtime>) -> anyhow::Result<Route
     let swagger_url = format!("{base_path}/swagger");
     let openapi_url = format!("{base_path}/openapi.json");
 
+    // Redirect targets must be absolute and include the base path. Relative
+    // targets (e.g. "./swagger") resolve against the incoming request URI, which
+    // breaks once the router is nested under a non-empty base path.
+    let swagger_redirect: &'static str = format!("{base_path}/swagger").leak();
+    let scalar_redirect: &'static str = format!("{base_path}/scalar/").leak();
+
     let docs = if base_path.is_empty() {
         api_docs_client
     } else {
@@ -48,12 +54,18 @@ pub(crate) fn setup_router(beacon_runtime: Arc<Runtime>) -> anyhow::Result<Route
     let router = client_router
         .merge(admin_router)
         .merge(Scalar::with_url("/scalar/", docs.clone()))
-        .route("/scalar", get(|| async { Redirect::to("./scalar/") }))
+        .route(
+            "/scalar",
+            get(move || async move { Redirect::to(scalar_redirect) }),
+        )
         .route(
             "/api/health",
             get(|| async { Response::new("Ok".to_string()) }),
         )
-        .route("/", get(|| async { Redirect::to("./swagger") }))
+        .route(
+            "/",
+            get(move || async move { Redirect::to(swagger_redirect) }),
+        )
         .layer(build_cors_layer()?)
         .with_state::<_>(beacon_runtime);
 


### PR DESCRIPTION
## Problem

The `/` and `/scalar` redirect handlers used **relative** targets (`./swagger`, `./scalar/`). A relative `Location` header is resolved by the browser against the incoming request URI, so once the router is nested under a non-empty `BEACON_BASE_PATH` the prefix was dropped and the redirect landed on a 404 (e.g. `GET /foo` → `Location: /swagger` instead of `/foo/swagger`).

## Fix

Build the redirect targets as absolute, base-path-aware paths (mirroring how `swagger_url`/`openapi_url` are already constructed), so they resolve correctly whether or not a base path is configured.

## Verification

Ran the binary with and without a base path and followed each redirect:

| Request | Base path | `Location` | Followed result |
|---|---|---|---|
| `GET /foo` | `/foo` | `/foo/swagger` | 200 |
| `GET /foo/scalar` | `/foo` | `/foo/scalar/` | 200 |
| `GET /` | (empty) | `/swagger` | 200 |
| `GET /scalar` | (empty) | `/scalar/` | 200 |

## Note

`GET /foo/` (root *with* trailing slash) still 404s — that's a pre-existing axum nested-router quirk (the inner `/` route only matches `/foo`), independent of this redirect fix and out of scope here.