### PR TITLE
Improve error handling & logging in beacon-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,10 +1412,11 @@ dependencies = [
 name = "beacon-config"
 version = "1.7.1"
 dependencies = [
- "anyhow",
  "envconfig",
  "lazy_static",
  "object_store 0.13.2",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/beacon-config/Cargo.toml
+++ b/beacon-config/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 lazy_static = "1.4.0"
 envconfig = "0.11.0"
 object_store = { workspace = true }
-anyhow = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }

--- a/beacon-config/src/error.rs
+++ b/beacon-config/src/error.rs
@@ -1,0 +1,33 @@
+//! Error types for the `beacon-config` crate.
+//!
+//! [`ConfigError`] is the crate's unified error type, covering the failure modes
+//! of loading configuration from the environment and preparing Beacon's data
+//! directories. Binaries surface these cleanly by calling [`init`](crate::init)
+//! early in `main`.
+
+use std::path::PathBuf;
+
+/// Errors produced while loading Beacon's configuration or preparing its data
+/// directories.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    /// Failed to read or parse one or more configuration values from the
+    /// environment (e.g. a non-numeric value for a numeric variable).
+    #[error("failed to load configuration from environment: {0}")]
+    EnvLoad(String),
+
+    /// `BEACON_BASE_PATH` was set to a value that is not a valid URL base path.
+    #[error("invalid BEACON_BASE_PATH: {0}")]
+    InvalidBasePath(String),
+
+    /// A required data directory could not be created.
+    #[error("failed to create directory {}: {source}", .path.display())]
+    CreateDir {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Result alias for fallible `beacon-config` operations.
+pub type Result<T> = std::result::Result<T, ConfigError>;

--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -1,8 +1,13 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use envconfig::Envconfig;
 use lazy_static::lazy_static;
+
+pub mod error;
+
+pub use error::ConfigError;
+use error::Result;
 
 #[derive(Debug)]
 pub struct Config {
@@ -360,7 +365,7 @@ impl From<RawConfig> for Config {
 /// Errors (with a descriptive message) if the path contains characters outside the
 /// URL "unreserved" set or has an empty internal segment, instead of letting an
 /// invalid value reach axum/utoipa, which panic on malformed paths.
-fn normalize_base_path(raw: &str) -> Result<String, String> {
+fn normalize_base_path(raw: &str) -> std::result::Result<String, String> {
     let trimmed = raw.trim().trim_matches('/');
     if trimmed.is_empty() {
         return Ok(String::new());
@@ -386,12 +391,18 @@ impl Config {
     /// Loads the configuration from the environment, normalizing and validating
     /// fields. Returns a descriptive error instead of panicking, so callers can
     /// report the problem cleanly and exit.
-    pub fn load() -> anyhow::Result<Config> {
+    pub fn load() -> Result<Config> {
         let mut config: Config = RawConfig::init_from_env()
-            .map_err(|e| anyhow::anyhow!("failed to load configuration from environment: {e}"))?
+            .map_err(|e| ConfigError::EnvLoad(e.to_string()))?
             .into();
-        config.server.base_path = normalize_base_path(&config.server.base_path)
-            .map_err(|e| anyhow::anyhow!("invalid BEACON_BASE_PATH: {e}"))?;
+        config.server.base_path =
+            normalize_base_path(&config.server.base_path).map_err(ConfigError::InvalidBasePath)?;
+        tracing::debug!(
+            host = %config.server.host,
+            port = config.server.port,
+            base_path = %config.server.base_path,
+            "loaded Beacon configuration from environment"
+        );
         Ok(config)
     }
 }
@@ -404,7 +415,7 @@ static CONFIG_CELL: OnceLock<Config> = OnceLock::new();
 ///
 /// Call this once early in `main`. It is idempotent: subsequent calls return the
 /// already-initialized [`Config`].
-pub fn init() -> anyhow::Result<&'static Config> {
+pub fn init() -> Result<&'static Config> {
     if let Some(config) = CONFIG_CELL.get() {
         return Ok(config);
     }
@@ -435,55 +446,50 @@ impl std::ops::Deref for ConfigHandle {
 /// Process-global configuration handle. Dereferences to [`Config`].
 pub static CONFIG: ConfigHandle = ConfigHandle;
 
+/// Creates `path` (and any missing parents), returning a structured
+/// [`ConfigError::CreateDir`] and logging the failure on error.
+fn create_dir(path: &Path) -> Result<()> {
+    std::fs::create_dir_all(path).map_err(|source| {
+        tracing::error!(path = %path.display(), error = %source, "failed to create data directory");
+        ConfigError::CreateDir {
+            path: path.to_path_buf(),
+            source,
+        }
+    })
+}
+
+/// [`create_dir`] for the `lazy_static` data-directory accessors below, which
+/// cannot return a `Result`. On failure it panics with the structured
+/// [`ConfigError`] message (path + underlying I/O error) after logging it.
+fn ensure_dir(path: PathBuf) -> PathBuf {
+    if let Err(e) = create_dir(&path) {
+        panic!("{e}");
+    }
+    path
+}
+
 lazy_static! {
-    pub static ref DATA_DIR: PathBuf = {
-        std::fs::create_dir_all("./data").expect("Failed to create data dir");
-        PathBuf::from("./data")
-    };
+    pub static ref DATA_DIR: PathBuf = ensure_dir(PathBuf::from("./data"));
     /// The path to the datasets directory
-    pub static ref DATASETS_DIR_PATH: PathBuf = {
-        //Create the dir if it doesn't exist
-        let dir = DATA_DIR.join("datasets");
-        std::fs::create_dir_all(&dir).expect("Failed to create datasets dir");
-        dir
-    };
+    pub static ref DATASETS_DIR_PATH: PathBuf = ensure_dir(DATA_DIR.join("datasets"));
     /// The prefix for the datasets directory for object store paths
     pub static ref DATASETS_DIR_PREFIX: object_store::path::Path =
         object_store::path::Path::from("datasets");
 
     pub static ref TABLES_DIR_PREFIX: object_store::path::Path =
         object_store::path::Path::from("tables");
-    pub static ref TABLES_DIR: PathBuf = {
-        let dir = DATA_DIR.join("tables");
-        std::fs::create_dir_all(&dir).expect("Failed to create tables dir");
-        dir
-    };
+    pub static ref TABLES_DIR: PathBuf = ensure_dir(DATA_DIR.join("tables"));
 
-    pub static ref TMP_DIR: PathBuf = {
-        let dir = DATA_DIR.join("tmp");
-        std::fs::create_dir_all(&dir).expect("Failed to create tmp dir");
-        dir
-    };
-
+    pub static ref TMP_DIR: PathBuf = ensure_dir(DATA_DIR.join("tmp"));
 
     /// The path to the indexes directory
-    pub static ref INDEX_DIR_PATH: PathBuf = {
-        //Create the dir if it doesn't exist
-        let dir = DATA_DIR.join("indexes");
-        std::fs::create_dir_all(&dir).expect("Failed to create indexes dir");
-        dir
-    };
+    pub static ref INDEX_DIR_PATH: PathBuf = ensure_dir(DATA_DIR.join("indexes"));
     /// The prefix for the indexes directory for object store paths
     pub static ref INDEX_DIR_PREFIX: object_store::path::Path =
         object_store::path::Path::from("indexes");
 
     /// The path to the cache directory
-    pub static ref CACHE_DIR_PATH: PathBuf = {
-        //Create the dir if it doesn't exist
-        let dir = DATA_DIR.join("cache");
-        std::fs::create_dir_all(&dir).expect("Failed to create cache dir");
-        dir
-    };
+    pub static ref CACHE_DIR_PATH: PathBuf = ensure_dir(DATA_DIR.join("cache"));
     /// The prefix for the cache directory for object store paths
     pub static ref CACHE_DIR_PREFIX: object_store::path::Path =
         object_store::path::Path::from("cache");


### PR DESCRIPTION
Second crate in the workspace-wide error-handling & logging cleanup (#251), following the same standard established in #252 (`beacon-common`).

## Changes
- **New `beacon-config/src/error.rs`** — `ConfigError` (`thiserror`) enum + `Result<T>` alias, with variants `EnvLoad`, `InvalidBasePath`, and `CreateDir { path, source }`.
- **`Config::load` / `init`** now return `ConfigError` instead of stringly-typed `anyhow` errors. `beacon-api` keeps working unchanged via `anyhow::Context` (since `ConfigError: std::error::Error + Send + Sync`).
- **Data-directory creation** goes through a `create_dir` helper returning a structured `ConfigError::CreateDir { path, source }` and logging via `tracing::error!`. The `lazy_static` accessors now panic via `ensure_dir` with the full path + underlying I/O error — previously the messages included neither.
- Added `tracing::debug!` on successful config load.
- Dropped the now-unused `anyhow` dependency; added `thiserror` + `tracing`.

## Notes
- The `lazy_static` directory accessors and the `ConfigHandle` deref fallback still panic on failure — they sit on infallible-signature paths (`Deref`, `lazy_static`) that cannot return a `Result`. They now panic with the structured `ConfigError` message. Fully propagating those would require reworking the static accessors across ~8 dependent crates and is intentionally out of scope for this isolated pass.

## Verification
- `cargo build -p beacon-config` — clean.
- `cargo clippy -p beacon-config` — no warnings.
- `cargo test -p beacon-config` — 5 passed.
- `cargo build` (whole workspace) — succeeds; `beacon-api`'s `init().context(...)?` compiles against the new error type.

Refs #251
