### PR TITLE
Improve error handling & logging in beacon-object-storage

### DIFF
--- a/beacon-object-storage/src/datasets_store.rs
+++ b/beacon-object-storage/src/datasets_store.rs
@@ -28,7 +28,7 @@ use crate::{
 ///   virtual-hosted-style the bucket is encoded in the endpoint host.
 /// - Otherwise a local filesystem store rooted at [`beacon_config::DATASETS_DIR_PATH`]
 ///   is used.
-pub(crate) async fn create_datasets_store() -> Result<DatasetsStore, String> {
+pub(crate) async fn create_datasets_store() -> StorageResult<DatasetsStore> {
     let storage = &beacon_config::CONFIG.storage;
 
     let (inner, event_listener): (
@@ -44,15 +44,14 @@ pub(crate) async fn create_datasets_store() -> Result<DatasetsStore, String> {
 
         if !s3.enable_virtual_hosting {
             // Path-style requests need an explicit bucket name.
-            let bucket = s3.bucket.as_ref().ok_or_else(|| {
-                "S3 bucket name not configured (set BEACON_S3_BUCKET)".to_string()
+            let bucket = s3.bucket.as_ref().ok_or(error::StorageError::MissingConfig {
+                key: "BEACON_S3_BUCKET",
             })?;
             builder = builder.with_bucket_name(bucket);
         }
 
-        let store = builder
-            .build()
-            .map_err(|e| format!("Failed to build S3 object store: {e}"))?;
+        // `object_store::Error` converts into `StorageError::ObjectStore` via `?`.
+        let store = builder.build()?;
 
         // TODO: wire S3 change notifications into an `EventListener` so the
         // cache-backed fast path can be enabled for the S3 backend too.
@@ -61,9 +60,7 @@ pub(crate) async fn create_datasets_store() -> Result<DatasetsStore, String> {
         tracing::info!("Using local filesystem object store for datasets");
 
         let root = beacon_config::DATASETS_DIR_PATH.clone();
-        let store = LocalFileSystem::new_with_prefix(&root)
-            .map_err(|e| format!("Failed to build local filesystem object store: {e}"))?
-            .with_automatic_cleanup(true);
+        let store = LocalFileSystem::new_with_prefix(&root)?.with_automatic_cleanup(true);
         let inner = Arc::new(store) as Arc<dyn ObjectStore + Send + Sync>;
 
         // Watch the datasets directory for changes (on by default; see
@@ -231,8 +228,11 @@ impl DatasetsStore {
             }
             let path = location.as_ref();
             for (prefix, tx) in subs.iter() {
-                if path.starts_with(prefix.as_str()) {
-                    let _ = tx.send(event.clone());
+                if path.starts_with(prefix.as_str()) && tx.send(event.clone()).is_err() {
+                    // No live receivers for this prefix; the sender is pruned
+                    // lazily by `subscribe_events`. Logged at TRACE since a
+                    // subscriber dropping is normal.
+                    tracing::trace!(prefix = %prefix, "no live subscribers; event dropped");
                 }
             }
         }

--- a/beacon-object-storage/src/error.rs
+++ b/beacon-object-storage/src/error.rs
@@ -24,6 +24,11 @@ pub enum StorageError {
         #[source]
         source: VarError,
     },
+
+    /// An error returned by the underlying `object_store` backend (S3 or local
+    /// filesystem), e.g. while building a store or canonicalizing its root.
+    #[error("Object store error: {0}")]
+    ObjectStore(#[from] object_store::Error),
 }
 
 /// Result alias for fallible object storage operations.

--- a/beacon-object-storage/src/lib.rs
+++ b/beacon-object-storage/src/lib.rs
@@ -35,21 +35,51 @@ static TABLES_OBJECT_STORE: tokio::sync::OnceCell<Arc<dyn ObjectStore>> =
 static TMP_OBJECT_STORE: tokio::sync::OnceCell<Arc<dyn ObjectStore>> =
     tokio::sync::OnceCell::const_new();
 
+/// Eagerly initializes all three object stores, returning a structured error if
+/// any fails to build.
+///
+/// Call this once early in startup so configuration/I/O problems surface cleanly
+/// here. Once a store's cell is populated, the corresponding `get_*` accessor
+/// returns it without re-running (and therefore without the fallback panic).
 pub async fn init_datastores() -> StorageResult<()> {
-    let _ = get_datasets_object_store().await;
-    let _ = get_tables_object_store().await;
-    let _ = get_tmp_object_store().await;
+    DATASETS_OBJECT_STORE
+        .get_or_try_init(build_datasets_store)
+        .await?;
+    TABLES_OBJECT_STORE
+        .get_or_try_init(|| async { build_tables_store() })
+        .await?;
+    TMP_OBJECT_STORE
+        .get_or_try_init(|| async { build_tmp_store() })
+        .await?;
+    tracing::info!("object stores initialized");
     Ok(())
+}
+
+/// Builds the datasets store from configuration.
+async fn build_datasets_store() -> StorageResult<Arc<DatasetsStore>> {
+    Ok(Arc::new(datasets_store::create_datasets_store().await?))
+}
+
+/// Builds the local filesystem store backing Beacon's tables.
+fn build_tables_store() -> StorageResult<Arc<dyn ObjectStore>> {
+    let store = LocalFileSystem::new_with_prefix(beacon_config::TABLES_DIR.clone())?
+        .with_automatic_cleanup(true);
+    Ok(Arc::new(store) as Arc<dyn ObjectStore>)
+}
+
+/// Builds the local filesystem store backing Beacon's temporary files.
+fn build_tmp_store() -> StorageResult<Arc<dyn ObjectStore>> {
+    let store = LocalFileSystem::new_with_prefix(temp_dir())?;
+    Ok(Arc::new(store) as Arc<dyn ObjectStore>)
 }
 
 pub async fn get_datasets_object_store() -> Arc<DatasetsStore> {
     DATASETS_OBJECT_STORE
         .get_or_init(|| async {
-            Arc::new(
-                datasets_store::create_datasets_store()
-                    .await
-                    .expect("Failed to initialize datasets object store"),
-            )
+            build_datasets_store().await.unwrap_or_else(|e| {
+                tracing::error!(error = %e, "failed to initialize datasets object store");
+                panic!("failed to initialize datasets object store: {e}");
+            })
         })
         .await
         .clone()
@@ -58,12 +88,11 @@ pub async fn get_datasets_object_store() -> Arc<DatasetsStore> {
 pub async fn get_tables_object_store() -> Arc<dyn ObjectStore> {
     TABLES_OBJECT_STORE
         .get_or_init(|| async {
-            // For tables, we always use the local filesystem
-            Arc::new(
-                LocalFileSystem::new_with_prefix(beacon_config::TABLES_DIR.clone())
-                    .expect("Failed to initialize tables object store")
-                    .with_automatic_cleanup(true),
-            ) as Arc<dyn ObjectStore>
+            // For tables, we always use the local filesystem.
+            build_tables_store().unwrap_or_else(|e| {
+                tracing::error!(error = %e, "failed to initialize tables object store");
+                panic!("failed to initialize tables object store: {e}");
+            })
         })
         .await
         .clone()
@@ -72,10 +101,10 @@ pub async fn get_tables_object_store() -> Arc<dyn ObjectStore> {
 pub async fn get_tmp_object_store() -> Arc<dyn ObjectStore> {
     TMP_OBJECT_STORE
         .get_or_init(|| async {
-            Arc::new(
-                LocalFileSystem::new_with_prefix(temp_dir())
-                    .expect("Failed to initialize tmp object store"),
-            ) as Arc<dyn ObjectStore>
+            build_tmp_store().unwrap_or_else(|e| {
+                tracing::error!(error = %e, "failed to initialize tmp object store");
+                panic!("failed to initialize tmp object store: {e}");
+            })
         })
         .await
         .clone()


### PR DESCRIPTION
Third crate in the workspace-wide error-handling & logging cleanup (#251). This one audits and extends the crate's existing `StorageError` rather than adding one from scratch.

## Changes
- **`error.rs`** — added `StorageError::ObjectStore(#[from] object_store::Error)` so S3 / local-filesystem backend failures are typed instead of stringified.
- **`datasets_store.rs`** — converted the internal `create_datasets_store` from `Result<_, String>` to `StorageResult`, using the structured `MissingConfig` / `ObjectStore` variants (`?` now converts `object_store::Error` directly). Dropped events (no live subscribers) are logged at TRACE in `dispatch_events`.
- **`lib.rs`** — reworked `init_datastores` to use `OnceCell::get_or_try_init`, so store-construction failures surface as a clean `StorageResult` at startup instead of panicking; logs once on success. The `get_*_object_store` accessors keep their infallible `Arc<..>` signatures (changing them would ripple across ~13 callers) but now `tracing::error!` before the fallback panic — which only triggers for callers that skip `init_datastores`.

## Notes
- The three `get_*_object_store` accessors still panic as a last resort (their `Arc<..>` return types can't carry a `Result`), but in the normal flow `init_datastores` populates the cells first, so the fallible path is the one that runs. This keeps the public API stable while making startup failures clean.

## Verification
- `cargo build -p beacon-object-storage` — clean.
- `cargo clippy -p beacon-object-storage` — no warnings.
- `cargo test -p beacon-object-storage` — 25 passed, 1 ignored.
- `cargo build` (whole workspace) — succeeds; all downstream consumers compile unchanged.

Refs #251
