### PR TITLE
Improve error handling & logging in beacon-nd-array

### DIFF
--- a/beacon-nd-array/src/arrow/array.rs
+++ b/beacon-nd-array/src/arrow/array.rs
@@ -23,6 +23,7 @@ macro_rules! convert_ndarray {
             .as_any()
             .downcast_ref::<NdArray<$rust_ty>>()
             .ok_or_else(|| {
+                tracing::error!(target_type = $label, "failed to downcast NdArray for Arrow conversion");
                 anyhow::anyhow!(
                     "Failed to downcast NdArray to NdArray<{}> for Arrow conversion.",
                     $label
@@ -73,6 +74,7 @@ pub async fn ndarray_to_arrow_array(ndarray: &dyn NdArrayD) -> anyhow::Result<Ar
                 .as_any()
                 .downcast_ref::<NdArray<TimestampNanosecond>>()
                 .ok_or_else(|| {
+                    tracing::error!(target_type = "TimestampNanosecond", "failed to downcast NdArray for Arrow conversion");
                     anyhow::anyhow!(
                         "Failed to downcast NdArray to NdArray<TimestampNanosecond> for Arrow conversion."
                     )

--- a/beacon-nd-array/src/dataset/ragged.rs
+++ b/beacon-nd-array/src/dataset/ragged.rs
@@ -93,10 +93,20 @@ impl RaggedDataset {
         }
 
         if row_size_vars.is_empty() {
+            tracing::debug!(
+                dataset = %dataset.name,
+                "no sample_dimension attributes found — not a ragged dataset"
+            );
             anyhow::bail!("no sample_dimension attributes found — not a ragged dataset");
         }
+        tracing::debug!(
+            dataset = %dataset.name,
+            row_size_vars = row_size_vars.len(),
+            "detected CF ragged-array dataset"
+        );
 
         // ── 2. Determine the instance dimension ─────────────────────────
+        // Safe: `row_size_vars` is non-empty (checked above).
         let first_rs_var = row_size_vars.values().next().unwrap();
         let instance_dim = dataset
             .get_array(first_rs_var)
@@ -304,11 +314,9 @@ impl RaggedDataset {
                     arrays.insert(name.clone(), sub);
                 }
                 RaggedArray::ObservationVariable(array) => {
-                    let obs_dim = array
-                        .dimensions()
-                        .first()
-                        .cloned()
-                        .expect("observation variable must have dimensions");
+                    let obs_dim = array.dimensions().first().cloned().ok_or_else(|| {
+                        anyhow::anyhow!("observation variable {name} must have at least one dimension")
+                    })?;
                     let cum = &offsets[&obs_dim];
                     let obs_start = cum[index];
                     let obs_len = cum[index + 1] - obs_start;
@@ -387,11 +395,9 @@ impl RaggedDataset {
                     arrays.insert(name.clone(), sub);
                 }
                 RaggedArray::ObservationVariable(array) => {
-                    let obs_dim = array
-                        .dimensions()
-                        .first()
-                        .cloned()
-                        .expect("observation variable must have dimensions");
+                    let obs_dim = array.dimensions().first().cloned().ok_or_else(|| {
+                        anyhow::anyhow!("observation variable {name} must have at least one dimension")
+                    })?;
                     let cum = &offsets[&obs_dim];
                     let obs_start = cum[start];
                     let obs_len = cum[end] - obs_start;

--- a/beacon-nd-array/src/error.rs
+++ b/beacon-nd-array/src/error.rs
@@ -1,0 +1,44 @@
+//! Error types for the `beacon-nd-array` crate.
+//!
+//! [`NdArrayError`] is the crate's typed error for its "front-door" validation
+//! paths (array construction, shape/dimension checks, broadcasting).
+//!
+//! The [`ArrayBackend`](crate::array::backend::ArrayBackend) trait and the
+//! dataset/Arrow conversion helpers keep returning [`anyhow::Result`]: that trait
+//! is implemented by every reader crate (NetCDF, Atlas, TIFF, Zarr, …), so a
+//! typed error there would cascade across the whole workspace. The
+//! [`NdArrayError::Other`] bridge lets the two coexist — an `anyhow::Error` from
+//! a backend call converts into [`NdArrayError`] via `?`, and an
+//! [`NdArrayError`] converts back into `anyhow::Error` at any caller that still
+//! returns `anyhow::Result`.
+
+/// Errors produced by `beacon-nd-array`'s array construction and shape logic.
+#[derive(Debug, thiserror::Error)]
+pub enum NdArrayError {
+    /// The provided values could not be arranged into the requested shape.
+    #[error("failed to create ndarray from values and dimensions: {0}")]
+    InvalidShape(String),
+
+    /// The number of shape axes does not match the number of named dimensions.
+    #[error("shape length {shape_len} does not match dimensions length {dims_len}")]
+    ShapeDimensionMismatch { shape_len: usize, dims_len: usize },
+
+    /// The element count implied by the shape disagrees with the backend.
+    #[error("total size implied by shape ({expected}) does not match backend length ({actual})")]
+    SizeMismatch { expected: usize, actual: usize },
+
+    /// A set of source dimensions is not a subset of the broadcast target.
+    #[error("source dimensions {source_dims:?} are not a subset of target dimensions {target_dims:?}")]
+    BroadcastDimensions {
+        source_dims: Vec<String>,
+        target_dims: Vec<String>,
+    },
+
+    /// Any other error, including failures bubbled up from an
+    /// [`ArrayBackend`](crate::array::backend::ArrayBackend) call.
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+/// Result alias for fallible `beacon-nd-array` front-door operations.
+pub type Result<T> = std::result::Result<T, NdArrayError>;

--- a/beacon-nd-array/src/lib.rs
+++ b/beacon-nd-array/src/lib.rs
@@ -61,9 +61,14 @@ pub mod array;
 pub mod arrow;
 pub mod dataset;
 pub mod datatypes;
+pub mod error;
 pub mod projection;
 
+pub use error::NdArrayError;
+
 use std::sync::Arc;
+
+use crate::error::Result;
 
 use crate::{
     array::{
@@ -152,38 +157,32 @@ impl<T: NdArrayType> NdArray<T> {
         dim_sizes: Vec<usize>,
         dim_names: Vec<String>,
         fill_value: Option<T>,
-    ) -> anyhow::Result<Self> {
-        let array = ArrayD::from_shape_vec(dim_sizes.clone(), values.clone()).map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to create ArrayD from provided values and dimensions: {}",
-                e
-            )
-        })?;
+    ) -> Result<Self> {
+        let array = ArrayD::from_shape_vec(dim_sizes.clone(), values.clone())
+            .map_err(|e| NdArrayError::InvalidShape(e.to_string()))?;
         let backend = InMemoryArrayBackend::new(array, dim_sizes, dim_names, fill_value);
         Ok(Self(Arc::new(backend)))
     }
 }
 
 impl<T: NdArrayType> NdArray<T> {
-    pub fn new_with_backend<B: ArrayBackend<T>>(backend: B) -> anyhow::Result<Self> {
+    pub fn new_with_backend<B: ArrayBackend<T>>(backend: B) -> Result<Self> {
         let shape = backend.shape();
         let dimensions = backend.dimensions();
 
         if shape.len() != dimensions.len() {
-            return Err(anyhow::anyhow!(
-                "Shape length {} does not match dimensions length {}",
-                shape.len(),
-                dimensions.len()
-            ));
+            return Err(NdArrayError::ShapeDimensionMismatch {
+                shape_len: shape.len(),
+                dims_len: dimensions.len(),
+            });
         }
 
         let total_size: usize = shape.iter().product();
         if total_size != backend.len() {
-            return Err(anyhow::anyhow!(
-                "Total size implied by shape {} does not match backend length {}",
-                total_size,
-                backend.len()
-            ));
+            return Err(NdArrayError::SizeMismatch {
+                expected: total_size,
+                actual: backend.len(),
+            });
         }
 
         Ok(Self(Arc::new(backend)))
@@ -206,32 +205,40 @@ impl<T: NdArrayType> NdArray<T> {
     }
 
     pub async fn into_raw_vec(self) -> Vec<T> {
+        let shape = self.shape();
         let array = self
             .0
             .read_subset(ArraySubset {
-                start: vec![0; self.shape().len()],
-                shape: self.shape(),
+                start: vec![0; shape.len()],
+                shape: shape.clone(),
             })
             .await
-            .unwrap();
+            .unwrap_or_else(|e| {
+                tracing::error!(error = %e, ?shape, "failed to read full array into raw vec");
+                panic!("failed to read full array into raw vec: {e}");
+            });
 
         array.into_raw_vec_and_offset().0
     }
 
     pub async fn clone_into_raw_vec(&self) -> Vec<T> {
+        let shape = self.shape();
         let array = self
             .0
             .read_subset(ArraySubset {
-                start: vec![0; self.shape().len()],
-                shape: self.shape(),
+                start: vec![0; shape.len()],
+                shape: shape.clone(),
             })
             .await
-            .unwrap();
+            .unwrap_or_else(|e| {
+                tracing::error!(error = %e, ?shape, "failed to read full array into raw vec");
+                panic!("failed to read full array into raw vec: {e}");
+            });
 
         array.into_raw_vec_and_offset().0
     }
 
-    pub async fn subset(&self, subset: ArraySubset) -> anyhow::Result<NdArray<T>> {
+    pub async fn subset(&self, subset: ArraySubset) -> Result<NdArray<T>> {
         let nd_array = self.0.read_subset(subset.clone()).await?;
         let backend = InMemoryArrayBackend::new(
             nd_array,
@@ -246,7 +253,7 @@ impl<T: NdArrayType> NdArray<T> {
         &self,
         target_shape: &[usize],
         dimensions: &[String],
-    ) -> anyhow::Result<NdArray<T>> {
+    ) -> Result<NdArray<T>> {
         // This will always materialize the array. In the future, we may want to return a lazy broadcast view instead.
         let nd_array = self
             .0
@@ -265,11 +272,10 @@ impl<T: NdArrayType> NdArray<T> {
             .collect();
 
         if source_axis_order.len() != source_dims.len() {
-            return Err(anyhow::anyhow!(
-                "Source dimensions {:?} are not a subset of target dimensions {:?}",
+            return Err(NdArrayError::BroadcastDimensions {
                 source_dims,
-                dimensions
-            ));
+                target_dims: dimensions.to_vec(),
+            });
         }
 
         let mut aligned = nd_array


### PR DESCRIPTION
Fourth crate in the workspace-wide error-handling & logging cleanup (#251).

## Changes
- **New `beacon-nd-array/src/error.rs`** — `NdArrayError` (`thiserror`) + `Result` alias with typed variants (`InvalidShape`, `ShapeDimensionMismatch`, `SizeMismatch`, `BroadcastDimensions`) and an `#[from] anyhow::Error` bridge.
- **`lib.rs`** — converted the `NdArray` front-door methods (`try_new_from_vec_in_mem`, `new_with_backend`, `subset`, `broadcast`) to the typed `Result`. Downstream callers are unaffected: an `NdArrayError` converts into their `anyhow::Result` via `?`.
- **Fixed reachable panics:** the bare `.unwrap()` in `into_raw_vec`/`clone_into_raw_vec` now logs via `tracing::error!` and panics with shape context (their `Vec<T>` signature is shared across ~15 call sites in 4 reader crates, so it can't carry a `Result`); the two `.expect("observation variable must have dimensions")` in `RaggedDataset` now propagate as errors.
- **Tracing:** added to ragged-dataset detection and to Arrow-conversion downcast failures.

## Notes (intentional scope)
The `ArrayBackend` trait (`read_subset`/`validate_subset`) and the dataset/Arrow free functions stay on `anyhow`. That trait is implemented by ~10 backends across NetCDF, Atlas, TIFF, Zarr, and nd-arrow, so typing it would cascade across the whole workspace. `NdArrayError` bridges to `anyhow` via `#[from]`, so the typed front-door and the anyhow trait seam coexist and the rest can migrate incrementally — the same approach used for the DataFusion / object_store seams in the earlier crates.

## Verification
- `cargo build -p beacon-nd-array` — clean (no new warnings).
- `cargo clippy -p beacon-nd-array` — no warnings in touched files.
- `cargo test -p beacon-nd-array` — 121 passed.
- `cargo build` (whole workspace) — succeeds; all downstream reader crates compile unchanged.

Refs #251
