### PR TITLE
Improve error handling & logging in beacon-nd-arrow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,6 +1678,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/beacon-nd-arrow/Cargo.toml
+++ b/beacon-nd-arrow/Cargo.toml
@@ -14,6 +14,7 @@ arrow-schema = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 chrono = { workspace = true, optional = true }
 ndarray = { version = "0.17", optional = true }
 anyhow = { workspace=true }

--- a/beacon-nd-arrow/src/array/backend/mem.rs
+++ b/beacon-nd-arrow/src/array/backend/mem.rs
@@ -1,6 +1,7 @@
 use crate::array::backend::{ArrayBackend, BackendSubsetResult};
 use crate::array::compat_typings::ArrowTypeConversion;
 use crate::array::subset::ArraySubset;
+use crate::error::{NdArrowError, Result};
 
 #[derive(Debug, Clone)]
 pub struct InMemoryArrayBackend<T: ArrowTypeConversion> {
@@ -12,37 +13,56 @@ pub struct InMemoryArrayBackend<T: ArrowTypeConversion> {
 }
 
 impl<T: ArrowTypeConversion> InMemoryArrayBackend<T> {
+    /// Construct a backend without a validity mask. Infallible — there is no
+    /// validity mask whose shape could disagree with the array.
     pub fn new(
         array: ndarray::ArrayD<T>,
         shape: Vec<usize>,
         dimensions: Vec<String>,
         fill_value: Option<T>,
     ) -> Self {
-        Self::new_with_validity(array, shape, dimensions, fill_value, None)
+        Self {
+            array,
+            validity: None,
+            shape,
+            dimensions,
+            fill_value,
+        }
     }
 
+    /// Construct a backend with an optional validity mask.
+    ///
+    /// Returns [`NdArrowError::ValidityShapeMismatch`] if the mask's shape does
+    /// not match the array shape (previously this panicked via `assert_eq!`).
     pub fn new_with_validity(
         array: ndarray::ArrayD<T>,
         shape: Vec<usize>,
         dimensions: Vec<String>,
         fill_value: Option<T>,
         validity: Option<ndarray::ArrayD<bool>>,
-    ) -> Self {
-        if let Some(validity_array) = &validity {
-            assert_eq!(
-                validity_array.shape(),
-                shape.as_slice(),
-                "validity shape must match array shape"
+    ) -> Result<Self> {
+        if let Some(validity_array) = &validity
+            && validity_array.shape() != shape.as_slice()
+        {
+            let validity_shape = validity_array.shape().to_vec();
+            tracing::error!(
+                ?validity_shape,
+                array_shape = ?shape,
+                "validity shape does not match array shape"
             );
+            return Err(NdArrowError::ValidityShapeMismatch {
+                validity_shape,
+                array_shape: shape,
+            });
         }
 
-        Self {
+        Ok(Self {
             array,
             validity,
             shape,
             dimensions,
             fill_value,
-        }
+        })
     }
 }
 

--- a/beacon-nd-arrow/src/array/mod.rs
+++ b/beacon-nd-arrow/src/array/mod.rs
@@ -10,6 +10,7 @@ use crate::array::{
     compat_typings::attach_validity_mask,
     subset::ArraySubset,
 };
+use crate::error::{NdArrowError, Result};
 
 pub mod backend;
 pub mod compat_typings;
@@ -55,7 +56,7 @@ impl<T: ArrowTypeConversion> NdArrowArrayDispatch<T> {
         shape: Vec<usize>,
         dimensions: Vec<String>,
         fill_value: Option<T>,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self> {
         Self::new_in_mem_with_validity(array, shape, dimensions, fill_value, None)
     }
 
@@ -65,18 +66,20 @@ impl<T: ArrowTypeConversion> NdArrowArrayDispatch<T> {
         dimensions: Vec<String>,
         fill_value: Option<T>,
         validity: Option<Vec<bool>>,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self> {
         let validity = validity
             .map(|values| ndarray::ArrayD::from_shape_vec(shape.clone(), values))
-            .transpose()?;
-        let nd_array = ndarray::ArrayD::from_shape_vec(shape.clone(), array)?;
+            .transpose()
+            .map_err(|e| NdArrowError::InvalidShape(e.to_string()))?;
+        let nd_array = ndarray::ArrayD::from_shape_vec(shape.clone(), array)
+            .map_err(|e| NdArrowError::InvalidShape(e.to_string()))?;
         let backend = InMemoryArrayBackend::new_with_validity(
             nd_array,
             shape.clone(),
             dimensions.clone(),
             fill_value,
             validity,
-        );
+        )?;
         Self::new(backend)
     }
 }
@@ -90,25 +93,23 @@ impl<T: ArrowTypeConversion, B: ArrayBackend<T>> NdArrowArrayDispatch<T, B> {
     ///
     /// # Errors
     /// Returns an error if validation fails.
-    pub fn new(backend: B) -> anyhow::Result<Self> {
+    pub fn new(backend: B) -> Result<Self> {
         let shape = backend.shape();
         let dimensions = backend.dimensions();
         if shape.len() != dimensions.len() {
-            return Err(anyhow::anyhow!(
-                "Shape length {} does not match dimensions length {}",
-                shape.len(),
-                dimensions.len()
-            ));
+            return Err(NdArrowError::ShapeDimensionMismatch {
+                shape_len: shape.len(),
+                dims_len: dimensions.len(),
+            });
         }
 
         // Validate that the total size implied by the shape matches the backend length
         let total_size: usize = shape.iter().product();
         if total_size != backend.len() {
-            return Err(anyhow::anyhow!(
-                "Total size implied by shape {} does not match backend length {}",
-                total_size,
-                backend.len()
-            ));
+            return Err(NdArrowError::SizeMismatch {
+                expected: total_size,
+                actual: backend.len(),
+            });
         }
 
         Self::from_parts(Arc::new(backend), shape, dimensions)
@@ -118,13 +119,12 @@ impl<T: ArrowTypeConversion, B: ArrayBackend<T>> NdArrowArrayDispatch<T, B> {
         backend: Arc<B>,
         shape: Vec<usize>,
         dimensions: Vec<String>,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self> {
         if shape.len() != dimensions.len() {
-            return Err(anyhow::anyhow!(
-                "Shape length {} does not match dimensions length {}",
-                shape.len(),
-                dimensions.len()
-            ));
+            return Err(NdArrowError::ShapeDimensionMismatch {
+                shape_len: shape.len(),
+                dims_len: dimensions.len(),
+            });
         }
 
         Ok(Self {
@@ -258,9 +258,11 @@ impl<T: ArrowTypeConversion, B: ArrayBackend<T>> NdArrowArray for NdArrowArrayDi
         }
 
         let broadcasted = aligned.broadcast(target_shape).ok_or_else(|| {
+            let source_shape = self.shape();
+            tracing::warn!(?source_shape, ?target_shape, "cannot broadcast array to target shape");
             anyhow::anyhow!(
                 "Cannot broadcast array of shape {:?} to target shape {:?}",
-                self.shape(),
+                source_shape,
                 target_shape
             )
         })?;

--- a/beacon-nd-arrow/src/error.rs
+++ b/beacon-nd-arrow/src/error.rs
@@ -1,0 +1,42 @@
+//! Error types for the `beacon-nd-arrow` crate.
+//!
+//! [`NdArrowError`] is the crate's typed error for its "front-door" array
+//! construction and validation paths (mirroring `beacon-nd-array`'s
+//! `NdArrayError`).
+//!
+//! The async traits ([`NdArrowArray`](crate::array::NdArrowArray),
+//! [`ArrayBackend`](crate::array::backend::ArrayBackend),
+//! [`ArrowTypeConversion`](crate::array::compat_typings::ArrowTypeConversion))
+//! keep returning [`anyhow::Result`]; the [`NdArrowError::Other`] bridge lets a
+//! typed error convert into `anyhow::Error` (and back, via `?`) so the two
+//! coexist and the trait methods can migrate incrementally.
+
+/// Errors produced by `beacon-nd-arrow`'s array construction and shape logic.
+#[derive(Debug, thiserror::Error)]
+pub enum NdArrowError {
+    /// The provided values could not be arranged into the requested shape.
+    #[error("failed to create ndarray from values and dimensions: {0}")]
+    InvalidShape(String),
+
+    /// The number of shape axes does not match the number of named dimensions.
+    #[error("shape length {shape_len} does not match dimensions length {dims_len}")]
+    ShapeDimensionMismatch { shape_len: usize, dims_len: usize },
+
+    /// The element count implied by the shape disagrees with the backend.
+    #[error("total size implied by shape ({expected}) does not match backend length ({actual})")]
+    SizeMismatch { expected: usize, actual: usize },
+
+    /// A supplied validity mask does not have the same shape as its array.
+    #[error("validity shape {validity_shape:?} must match array shape {array_shape:?}")]
+    ValidityShapeMismatch {
+        validity_shape: Vec<usize>,
+        array_shape: Vec<usize>,
+    },
+
+    /// Any other error, including failures bubbled up from a trait method.
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+/// Result alias for fallible `beacon-nd-arrow` front-door operations.
+pub type Result<T> = std::result::Result<T, NdArrowError>;

--- a/beacon-nd-arrow/src/lib.rs
+++ b/beacon-nd-arrow/src/lib.rs
@@ -11,8 +11,10 @@
 
 pub mod array;
 pub mod batch;
+pub mod error;
 pub mod stream;
 
 pub use array::NdArrowArrayDispatch;
+pub use error::NdArrowError;
 pub use batch::NdRecordBatch;
 pub use stream::{NdToArrowPipeOptions, pipe_nd_record_batch_stream};


### PR DESCRIPTION
Fifth crate in the workspace-wide error-handling & logging cleanup (#251), mirroring the sibling `beacon-nd-array` (#255).

## Changes
- **New `beacon-nd-arrow/src/error.rs`** — `NdArrowError` (`thiserror`) + `Result` alias with typed variants (`InvalidShape`, `ShapeDimensionMismatch`, `SizeMismatch`, `ValidityShapeMismatch`) and an `#[from] anyhow::Error` bridge.
- **`array/mod.rs`** — converted the `NdArrowArrayDispatch` front-door constructors (`new_in_mem`, `new_in_mem_with_validity`, `new`, `from_parts`) to the typed `Result`.
- **Fixed a reachable panic:** `InMemoryArrayBackend::new_with_validity` used `assert_eq!` on a caller-supplied validity/shape mismatch — it now returns `NdArrowError::ValidityShapeMismatch` and logs via `tracing::error!`. `new` stays infallible (it never supplies a validity mask).
- **Added the missing `tracing` dependency** and a `tracing::warn!` on the broadcast failure path.

## Notes
- The async traits (`NdArrowArray`, `ArrayBackend`, `ArrowTypeConversion`) stay on `anyhow`, bridged via `NdArrowError::Other`, matching the approach in `beacon-nd-array`. (This crate is currently self-contained — no external consumers — so the change is low-risk regardless.)

## Verification
- `cargo build -p beacon-nd-arrow` — clean.
- `cargo clippy -p beacon-nd-arrow` — no new warnings (2 remaining are pre-existing, in files not touched here).
- `cargo test -p beacon-nd-arrow` — 17 passed.
- `cargo build` (whole workspace) — succeeds.

Refs #251
