### PR TITLE
Improve error handling in beacon-datafusion-ext

### DIFF
--- a/beacon-arrow-netcdf/src/datafusion/sink.rs
+++ b/beacon-arrow-netcdf/src/datafusion/sink.rs
@@ -225,7 +225,7 @@ impl DataSink for NetCDFNdSink {
 
         let unique_values_collection: Arc<ColumnValueMap> = self
             .unique_values
-            .unique_values()
+            .unique_values()?
             .ok_or_else(|| {
                 DataFusionError::Execution(
                     "No dimensions values collected for NetCDFNdSink".to_string(),

--- a/beacon-datafusion-ext/src/file_collection.rs
+++ b/beacon-datafusion-ext/src/file_collection.rs
@@ -46,7 +46,10 @@ impl FileCollection {
             schemas.push(schema.clone());
         }
 
-        let super_schema = super_type_schema(&schemas).unwrap();
+        let super_schema = super_type_schema(&schemas).map_err(|e| {
+            tracing::error!(error = %e, "failed to compute union schema for file collection");
+            DataFusionError::Plan(format!("failed to compute union schema: {e}"))
+        })?;
 
         let config = ListingTableConfig::new_with_multi_paths(table_urls)
             .with_listing_options(listing_options)

--- a/beacon-datafusion-ext/src/unique_values.rs
+++ b/beacon-datafusion-ext/src/unique_values.rs
@@ -207,10 +207,10 @@ impl UniqueValuesHandleCollection {
 
     /// Merges the unique values collected across all registered handles into a
     /// single map grouped by column (field).
-    pub fn unique_values(&self) -> Option<ColumnValueMap> {
+    pub fn unique_values(&self) -> Result<Option<ColumnValueMap>> {
         let handles = self.handles();
         if handles.is_empty() {
-            return None;
+            return Ok(None);
         }
 
         let mut merged: ColumnValueMap = ColumnValueMap::new();
@@ -221,16 +221,15 @@ impl UniqueValuesHandleCollection {
                 let field_ref = field.clone();
                 let target = match merged.entry(field_ref.clone()) {
                     indexmap::map::Entry::Occupied(entry) => entry.into_mut(),
-                    indexmap::map::Entry::Vacant(entry) => entry.insert(
-                        UniqueValuesHandle::init_column_values(field_ref.clone())
-                            .expect("unsupported data type for unique value tracking"),
-                    ),
+                    indexmap::map::Entry::Vacant(entry) => {
+                        entry.insert(UniqueValuesHandle::init_column_values(field_ref.clone())?)
+                    }
                 };
-                merge_column_value_sets(&field_ref, target, source_values);
+                merge_column_value_sets(&field_ref, target, source_values)?;
             }
         }
 
-        Some(merged)
+        Ok(Some(merged))
     }
 }
 
@@ -238,20 +237,31 @@ fn merge_column_value_sets(
     field: &FieldRef,
     target: &mut ErasedColumnValues,
     source: &ErasedColumnValues,
-) {
+) -> Result<()> {
     let field_name = field.name().clone();
 
     macro_rules! merge_values {
         ($ty:ty) => {{
+            // A type mismatch here means the per-column collectors created by
+            // `init_column_values` got out of sync with this merge dispatch —
+            // an internal invariant violation rather than bad user input.
             let target_column = target
                 .as_mut()
                 .as_mut()
                 .downcast_mut::<UniqueColumnValues<$ty>>()
-                .unwrap_or_else(|| panic!("Unexpected unique value type for column {field_name}"));
+                .ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                        "Unexpected unique value type for column {field_name}"
+                    ))
+                })?;
             let source_column = source
                 .as_any()
                 .downcast_ref::<UniqueColumnValues<$ty>>()
-                .unwrap_or_else(|| panic!("Unexpected unique value type for column {field_name}"));
+                .ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                        "Unexpected unique value type for column {field_name}"
+                    ))
+                })?;
             target_column.compare_and_add(source_column.values.iter().cloned());
         }};
     }
@@ -278,8 +288,14 @@ fn merge_column_value_sets(
         DataType::Float32 => merge_values!(OrderedFloat<f32>),
         DataType::Float64 => merge_values!(OrderedFloat<f64>),
         DataType::Decimal128(_, _) => merge_values!(i128),
-        other => panic!("Unsupported data type for unique value merge: {:?}", other),
+        other => {
+            return Err(DataFusionError::NotImplemented(format!(
+                "Unsupported data type for unique value merge: {other:?}"
+            )));
+        }
     }
+
+    Ok(())
 }
 
 pub type ErasedColumnValues = Box<dyn UniqueVec + Send + Sync>;
@@ -937,6 +953,7 @@ mod tests {
 
         let merged_map = collection
             .unique_values()
+            .expect("merge should succeed")
             .expect("expected single merged map");
 
         let station_values = merged_map
@@ -973,6 +990,6 @@ mod tests {
     #[test]
     fn unique_value_handles_return_empty_when_no_handles_registered() {
         let collection = UniqueValuesHandleCollection::new();
-        assert!(collection.unique_values().is_none());
+        assert!(collection.unique_values().unwrap().is_none());
     }
 }


### PR DESCRIPTION
Sixth crate in the workspace-wide error-handling & logging cleanup (#251).

`beacon-datafusion-ext` is a DataFusion extension, so it keeps returning `datafusion::error::Result` (the DataFusion integration seam) rather than introducing a `thiserror` enum — consistent with the seam exceptions agreed for this effort. This pass focuses on converting the genuinely reachable panics into propagated `DataFusionError`s.

## Changes
- **`unique_values.rs`** — `merge_column_value_sets` and `UniqueValuesHandleCollection::unique_values` now return `datafusion::error::Result`:
  - the two type-downcast `panic!`s become `DataFusionError::Internal` (they signal an internal collector/merge invariant violation),
  - the `other => panic!` unsupported-type arm becomes `DataFusionError::NotImplemented`,
  - the `.expect()` on `init_column_values` is propagated with `?`.
- **`file_collection.rs`** — `super_type_schema(..).unwrap()` now propagates a `DataFusionError::Plan` (with a `tracing::error!`) instead of panicking when schema merge fails.
- **`beacon-arrow-netcdf/sink.rs`** — updated the single external caller of `unique_values()` for the new `Result<Option<..>>` return (`?` then `.ok_or_else`). This is the only cross-crate touch and is required by the signature change.

## Notes
- Provably-infallible sites are intentionally left as-is (e.g. `internal_object_store_url()`'s parse of a `const` URL, the `peek().unwrap()` chain guarded by the preceding match). The bulk of the `expect`/`unwrap` calls flagged in the original survey were in test code.
- `UniqueValuesHandle::new()` (a documented convenience that delegates to the fallible `try_new`) is kept as-is.

## Verification
- `cargo build -p beacon-datafusion-ext -p beacon-arrow-netcdf` — clean.
- `cargo clippy -p beacon-datafusion-ext` — no new warnings (remaining ones are pre-existing dead-code/unused-import in untouched files).
- `cargo test -p beacon-datafusion-ext` — 47 passed.
- `cargo build` (whole workspace) — succeeds.

Refs #251
