### PR TITLE
Improve error handling & logging in beacon-arrow-netcdf

### DIFF
--- a/beacon-arrow-netcdf/src/compat.rs
+++ b/beacon-arrow-netcdf/src/compat.rs
@@ -363,7 +363,10 @@ pub fn variable_to_nd_array(
                         None
                     };
 
-                let fixed_string_size = last_dim.unwrap().len();
+                // Safe: `is_fixed_string_array` is only true when `last_dim` is `Some`.
+                let fixed_string_size = last_dim
+                    .expect("is_fixed_string_array implies a trailing dimension exists")
+                    .len();
 
                 // The trailing dimension stores fixed string length and is consumed
                 // by StringVariableDecoder; exclude it from the ND logical shape.

--- a/beacon-arrow-netcdf/src/encoders/default.rs
+++ b/beacon-arrow-netcdf/src/encoders/default.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use arrow::{
-    array::{self, ArrayRef},
+    array::{self, Array, ArrayRef},
     datatypes::{DataType, Field, SchemaRef},
 };
 use ndarray::ArrayView;
@@ -148,21 +148,36 @@ impl DefaultEncoder {
         let mut extents = vec![offset..offset + array.len()];
 
         let nc_file = &mut self.nc_file;
-        let mut variable = nc_file.variable_mut(var_name).expect("Variable not found");
+        let mut variable = nc_file
+            .variable_mut(var_name)
+            .ok_or_else(|| anyhow::anyhow!("NetCDF variable not found: {var_name}"))?;
 
         match array.data_type() {
             DataType::FixedSizeBinary(size) => {
                 let array = array
                     .as_any()
                     .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
-                    .expect("Failed to downcast to FixedSizeBinaryArray");
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("failed to downcast column {var_name} to FixedSizeBinaryArray")
+                    })?;
                 extents.push(0..*size as usize);
 
                 let byte_slice = array.value_data();
 
-                let view = ArrayView::from_shape((1_000_000, 5), byte_slice).unwrap();
+                // Shape is (rows, fixed-size width); previously this was a hardcoded
+                // (1_000_000, 5), which panicked for any other array dimensions.
+                let view = ArrayView::from_shape((array.len(), *size as usize), byte_slice)
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "failed to view FixedSizeBinary column {var_name} as ({}, {}): {e}",
+                            array.len(),
+                            size
+                        )
+                    })?;
 
-                variable.put(view, extents).unwrap();
+                variable.put(view, extents).map_err(|e| {
+                    anyhow::anyhow!("failed to write FixedSizeBinary column {var_name} to NetCDF: {e}")
+                })?;
             }
             DataType::Utf8 => {
                 let string_array = array

--- a/beacon-arrow-netcdf/src/lib.rs
+++ b/beacon-arrow-netcdf/src/lib.rs
@@ -66,8 +66,20 @@ unsafe impl NcTypeDescriptor for NcString {
 
 impl NcString {
     /// Create a NetCDF string from a Rust `&str`.
+    ///
+    /// A C string cannot contain an interior NUL byte. If `s` has one (which a C
+    /// consumer would treat as the string terminator anyway), the value is
+    /// truncated at the first NUL and a warning is logged, rather than panicking.
     pub fn new(s: &str) -> Self {
-        let c_str = CString::new(s).unwrap();
+        let c_str = CString::new(s).unwrap_or_else(|e| {
+            let nul = e.nul_position();
+            tracing::warn!(
+                nul_position = nul,
+                "NetCDF string contains an interior NUL byte; truncating at the first NUL"
+            );
+            // The prefix before the first NUL is by definition NUL-free.
+            CString::new(&s.as_bytes()[..nul]).expect("prefix before first NUL has no NUL byte")
+        });
         let ptr = c_str.into_raw();
         Self(ptr.cast())
     }

--- a/beacon-arrow-netcdf/src/writer.rs
+++ b/beacon-arrow-netcdf/src/writer.rs
@@ -117,18 +117,27 @@ impl<E: Encoder> ArrowRecordBatchWriter<E> {
 
         for batch in reader {
             let batch = batch.map_err(|e| anyhow::anyhow!(e))?;
-            let updated_batch = Self::map_record_batch(batch, updated_schema.clone());
+            let updated_batch = Self::map_record_batch(batch, updated_schema.clone())?;
             nc_writer.write_record_batch(updated_batch)?;
         }
 
         Ok(())
     }
 
-    fn map_record_batch(record_batch: RecordBatch, schema: SchemaRef) -> RecordBatch {
+    fn map_record_batch(
+        record_batch: RecordBatch,
+        schema: SchemaRef,
+    ) -> anyhow::Result<RecordBatch> {
         let mut arrays = vec![];
         for (idx, column) in record_batch.columns().iter().enumerate() {
             if let DataType::FixedSizeBinary(size) = schema.field(idx).data_type() {
-                let string_array = column.as_any().downcast_ref::<StringArray>().unwrap();
+                let string_array = column.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "column {} expected Utf8/StringArray for FixedSizeBinary conversion, got {:?}",
+                        schema.field(idx).name(),
+                        column.data_type()
+                    )
+                })?;
                 let casted_array = string_array_to_fixed_binary(string_array, *size as usize);
                 arrays.push(Arc::new(casted_array) as ArrayRef);
             } else {
@@ -136,7 +145,7 @@ impl<E: Encoder> ArrowRecordBatchWriter<E> {
             }
         }
 
-        RecordBatch::try_new(schema, arrays).unwrap()
+        Ok(RecordBatch::try_new(schema, arrays)?)
     }
 }
 
@@ -149,10 +158,21 @@ fn string_array_to_fixed_binary(
     string_array.iter().for_each(|str| {
         if let Some(str) = str {
             let mut fixed_buffer = vec![b'\0'; fixed_size];
-            fixed_buffer[..str.len()].copy_from_slice(str.as_bytes());
+            // Copy at most `fixed_size` bytes; a longer string is truncated to fit
+            // the fixed width rather than panicking on the slice copy.
+            let n = str.len().min(fixed_size);
+            if str.len() > fixed_size {
+                tracing::warn!(
+                    string_len = str.len(),
+                    fixed_size,
+                    "string longer than fixed NetCDF width; truncating"
+                );
+            }
+            fixed_buffer[..n].copy_from_slice(&str.as_bytes()[..n]);
+            // `fixed_buffer` is always exactly `fixed_size` bytes, so this never fails.
             builder
                 .append_value(fixed_buffer)
-                .expect("append_value binary failed");
+                .expect("append_value with fixed-size buffer is infallible");
         } else {
             builder
                 .append_value(vec![b'\0'; fixed_size])


### PR DESCRIPTION
Seventh crate in the workspace-wide error-handling & logging cleanup (#251).

Public APIs keep their existing `anyhow` / `datafusion::error::Result` / `ArrayBackend` (cross-crate seam) return types; this pass converts the genuinely-reachable production `unwrap`/`expect`/`panic!` in the read/write paths into propagated errors and adds tracing. (Most of the `unwrap`/`expect` count from the survey was in test code.)

## Changes
- **`lib.rs`** — `NcString::new` no longer panics on a string with an interior NUL byte; it truncates at the first NUL (which a C consumer treats as the terminator anyway) and logs a `tracing::warn!`.
- **`encoders/default.rs`** — `write_array_chunk` now propagates the variable lookup, the FixedSizeBinary downcast, the `ArrayView::from_shape`, and the NetCDF `put` as `anyhow` errors instead of `expect`/`unwrap`. **Also fixes a latent bug**: the view shape was hardcoded to `(1_000_000, 5)`, which would panic for any other dimensions — it now uses `(rows, width)`.
- **`writer.rs`** — `map_record_batch` returns `anyhow::Result` and propagates the StringArray downcast and `RecordBatch::try_new`; `string_array_to_fixed_binary` truncates over-long strings (with a warning) instead of panicking on the slice copy.
- **`compat.rs`** — the guarded `last_dim.unwrap()` (only reached when the last dim exists) becomes a justified `expect`.

## Notes
- The `ArrayBackend` impls (`VariableBackend`/`AttributeBackend`) and the DataFusion `FileFormat`/`DataSink` impls keep their fixed signatures.
- Provably-infallible sites left as justified `expect` (e.g. the fixed-size buffer `append_value`, the guarded `last_dim`).

## Verification
- `cargo build -p beacon-arrow-netcdf` — clean.
- `cargo test -p beacon-arrow-netcdf` — 93 passed, 1 ignored.
- `cargo clippy -p beacon-arrow-netcdf` — no new warnings in touched files (remaining ones are pre-existing).
- `cargo build` (whole workspace) — succeeds.

Refs #251
