### PR TITLE
Improve error handling & logging in beacon-arrow-zarr

### DIFF
--- a/beacon-arrow-zarr/src/backend.rs
+++ b/beacon-arrow-zarr/src/backend.rs
@@ -395,5 +395,16 @@ impl<T: NdArrayType> ArrayBackend<T> for AttributeBackend<T> {
 /// `calendar` is the CF `calendar` attribute (`None` defaults to Gregorian).
 /// Thin wrapper over [`beacon_common::cf_time::parse_cf_time`].
 pub fn parse_cf_time_units(units: &str, calendar: Option<&str>) -> Option<(Epoch, hifitime::Unit)> {
-    beacon_common::cf_time::parse_cf_time(units, calendar).ok()
+    match beacon_common::cf_time::parse_cf_time(units, calendar) {
+        Ok(parsed) => Some(parsed),
+        Err(e) => {
+            tracing::warn!(
+                units,
+                calendar = ?calendar,
+                error = %e,
+                "failed to parse CF time units; treating column as a non-time variable"
+            );
+            None
+        }
+    }
 }

--- a/beacon-arrow-zarr/src/compat.rs
+++ b/beacon-arrow-zarr/src/compat.rs
@@ -46,13 +46,14 @@ fn array_metadata(array: &ZarrArray) -> (Vec<usize>, Vec<String>, Vec<usize>) {
 
     // Chunk 0's shape is the (regular) chunk shape; boundary chunks are handled
     // by the engine's chunk iterator. Fall back to the full shape if unavailable.
-    let chunk_shape: Vec<usize> = array
-        .chunk_grid()
-        .subset(&vec![0u64; ndim])
-        .ok()
-        .flatten()
-        .map(|s| s.shape().iter().map(|&x| x as usize).collect())
-        .unwrap_or_else(|| shape.clone());
+    let chunk_shape: Vec<usize> = match array.chunk_grid().subset(&vec![0u64; ndim]) {
+        Ok(Some(s)) => s.shape().iter().map(|&x| x as usize).collect(),
+        Ok(None) => shape.clone(),
+        Err(e) => {
+            tracing::debug!(error = %e, "failed to query Zarr chunk grid; falling back to full array shape");
+            shape.clone()
+        }
+    };
 
     (shape, dimensions, chunk_shape)
 }

--- a/beacon-arrow-zarr/src/datafusion/mod.rs
+++ b/beacon-arrow-zarr/src/datafusion/mod.rs
@@ -93,7 +93,13 @@ impl FileFormatFactoryExt for ZarrFormatFactory {
         let top_level_datasets = top_level_zarr_meta_v3(&datasets);
         let zarr_paths: Vec<ZarrPath> = top_level_datasets
             .into_iter()
-            .filter_map(|path| ZarrPath::new_from_object_meta(path).ok())
+            .filter_map(|path| match ZarrPath::new_from_object_meta(path) {
+                Ok(zarr_path) => Some(zarr_path),
+                Err(e) => {
+                    tracing::trace!(error = %e, "skipping non-Zarr object during dataset discovery");
+                    None
+                }
+            })
             .collect();
 
         let datasets: Vec<DatasetMetadata> = zarr_paths


### PR DESCRIPTION
Ninth crate in the workspace-wide error-handling & logging cleanup (#251).

`beacon-arrow-zarr` already had **no reachable production panics** and propagates DataFusion errors correctly. The remaining gaps were silent error swallows, so this pass surfaces them via tracing. Keeps the existing `anyhow` / `datafusion::error::Result` / `ArrayBackend` (cross-crate seam) return types.

## Changes
- **`backend.rs`** — `parse_cf_time_units` now logs a `WARN` with the offending units when `parse_cf_time` fails, instead of silently mapping the error to `None` (it still falls back to treating the column as a non-time variable).
- **`compat.rs`** — a failing Zarr chunk-grid query is now logged at `DEBUG` before falling back to the full array shape (previously dropped via `.ok()`).
- **`datafusion/mod.rs`** — objects skipped during dataset discovery because they aren't Zarr metadata are now logged at `TRACE` instead of being silently filtered.

## Verification
- `cargo build -p beacon-arrow-zarr` — clean.
- `cargo test -p beacon-arrow-zarr` — 13 passed.
- `cargo clippy -p beacon-arrow-zarr` — no new warnings in touched files.
- `cargo build` (whole workspace) — succeeds.

Refs #251
