### PR TITLE
Improve logging in beacon-arrow-atlas

### DIFF
--- a/beacon-arrow-atlas/src/datafusion/pushdown.rs
+++ b/beacon-arrow-atlas/src/datafusion/pushdown.rs
@@ -35,6 +35,7 @@ pub async fn pushdown_with_statistics(
     let mut views = Vec::with_capacity(dataset_names.len());
     for name in &dataset_names {
         let view = store.open_dataset(name).await.map_err(|e| {
+            tracing::debug!(dataset = %name, error = %e, "failed to open atlas dataset for predicate pruning");
             datafusion::error::DataFusionError::Execution(format!(
                 "Failed to open atlas dataset '{name}' for pruning: {e}"
             ))

--- a/beacon-arrow-atlas/src/datafusion/source.rs
+++ b/beacon-arrow-atlas/src/datafusion/source.rs
@@ -245,6 +245,7 @@ impl AtlasOpener {
                     let predicate_cloned = predicate.clone();
                     async move {
                         let view = atlas.open_dataset(&dataset_name).await.map_err(|e| {
+                        tracing::warn!(dataset = %dataset_name, path = %object_path, error = %e, "failed to open atlas dataset");
                         datafusion::error::DataFusionError::Execution(format!(
                             "Failed to open atlas dataset '{dataset_name}' at {object_path}: {e}"
                         ))


### PR DESCRIPTION
Tenth crate in the workspace-wide error-handling & logging cleanup (#251), and the last of the format readers.

`beacon-arrow-atlas` was already in very good shape: **no reachable production panics** (the handful of production `unwrap`/`expect` are provably infallible with safe fallbacks or justified messages), and all I/O errors are already propagated as `anyhow`/`DataFusionError`. The gap was server-side observability on those error paths, so this is a focused logging pass.

## Changes
- **`datafusion/source.rs`** — log a `WARN` (dataset + path + error) when opening an atlas dataset fails during a scan, before mapping to `DataFusionError`.
- **`datafusion/pushdown.rs`** — log a `DEBUG` when opening an atlas dataset for predicate pruning fails.

## Notes
- The `ArrayBackend` impls and DataFusion `FileFormat`/`FileSource`/`FileOpener` impls keep their fixed signatures.
- Existing graceful-skip logging in `reader.rs` (skipped arrays/attributes) was already present and is left as-is.
- The provably-infallible `expect`/`unwrap_or` sites (e.g. `atlas_marker_filename` on an already-validated marker, `ScalarValue::try_from(..).unwrap_or(Null)`) are left as-is.

## Verification
- `cargo build -p beacon-arrow-atlas` — clean.
- `cargo test -p beacon-arrow-atlas` — 59 passed.
- `cargo clippy -p beacon-arrow-atlas` — no new warnings in touched files.
- `cargo build` (whole workspace) — succeeds.

Refs #251
