### PR TITLE
Fix Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,6 @@ COPY beacon-iceberg/ /beacon-iceberg/
 COPY beacon-nd-array/ /beacon-nd-array/
 COPY beacon-nd-arrow/ /beacon-nd-arrow/
 COPY beacon-object-storage/ /beacon-object-storage/
-COPY beacon-planner/ /beacon-planner/
-COPY beacon-query/ /beacon-query/
 COPY Cargo.toml /
 COPY Cargo.lock /
 COPY rust-toolchain /


### PR DESCRIPTION
## Problem

The `Dockerfile` failed to build. It copied `beacon-planner/` and `beacon-query/`, which no longer exist in the repo and are not workspace members in `Cargo.toml`. Docker fails a `COPY` step when the source path is missing, so the build broke before compilation even started.

## Fix

Removed the two `COPY` lines for the nonexistent crates. The remaining `COPY` lines now map exactly to the `Cargo.toml` workspace members (`beacon-binary-format-toolbox` is in the workspace `exclude` list, so it's correctly omitted).

## Verification

Ran `docker build --target builder` — it passed the COPY stage, compiled the full workspace including `beacon-api v1.7.1`, and exported the image successfully (only pre-existing warnings, no errors).