### PR TITLE
Python Docker integration tests + HTTP write support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Keep the Docker build context small. The Dockerfile COPYs individual crate
+# directories plus Cargo.{toml,lock} and rust-toolchain, so none of the entries
+# below are needed inside the image — excluding them avoids shipping multi-GB
+# directories (notably target/ and data/) to the daemon on a clean build.
+.git
+target
+data
+logs
+mappings
+docs
+benchmarks
+test-datasets
+vocab-generation-tooling
+beacon-studio
+beacon-example
+beacon-py
+integration-tests
+**/.venv
+**/node_modules
+**/*.pyc
+__pycache__
+*.ipynb

--- a/beacon-api/src/axum/client/query.rs
+++ b/beacon-api/src/axum/client/query.rs
@@ -17,13 +17,22 @@ use std::sync::Arc;
 
 /// Resolves the HTTP super-user flag from the request's `Authorization` header.
 ///
-/// - No `Authorization` header → anonymous, read-only (`Ok(false)`).
+/// Only HTTP basic auth elevates a request: this transport has no bearer concept
+/// (bearer tokens are Flight-SQL-only), so non-`Basic` schemes are left untouched
+/// rather than rejected.
+///
+/// - No `Authorization` header, or a non-`Basic` scheme (e.g. `Bearer …`) →
+///   anonymous, read-only (`Ok(false)`).
 /// - Valid admin basic credentials → super-user, DDL/DML allowed (`Ok(true)`).
-/// - An `Authorization` header that fails validation → `Err(UNAUTHORIZED)` so
-///   bad credentials surface as an error instead of silently degrading to
-///   read-only.
+/// - A `Basic` header that fails validation → `Err(UNAUTHORIZED)` so bad
+///   credentials surface as an error instead of silently degrading to read-only.
 fn resolve_super_user(headers: &HeaderMap) -> Result<bool, StatusCode> {
-    if headers.contains_key(header::AUTHORIZATION) {
+    let is_basic = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.starts_with("Basic "));
+
+    if is_basic {
         crate::axum::auth::verify_basic_auth_header(headers)?;
         Ok(true)
     } else {
@@ -371,5 +380,15 @@ mod tests {
     fn wrong_credentials_are_rejected() {
         let headers = basic_auth_headers("not-the-admin", "wrong-password");
         assert_eq!(resolve_super_user(&headers), Err(StatusCode::UNAUTHORIZED));
+    }
+
+    /// A non-Basic scheme (e.g. a bearer token, which the endpoint's OpenAPI
+    /// advertises) must not be treated as failed basic auth: it falls through to
+    /// anonymous/read-only rather than being rejected with 401.
+    #[test]
+    fn bearer_token_is_anonymous_not_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Authorization", "Bearer some-token".parse().unwrap());
+        assert_eq!(resolve_super_user(&headers), Ok(false));
     }
 }

--- a/beacon-api/src/axum/client/query.rs
+++ b/beacon-api/src/axum/client/query.rs
@@ -3,7 +3,7 @@
 use ::axum::{
     body::Body,
     extract::{Path, State},
-    http::{header, HeaderName, HeaderValue, StatusCode},
+    http::{header, HeaderMap, HeaderName, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
@@ -15,12 +15,28 @@ use beacon_core::{
 use futures::TryStreamExt;
 use std::sync::Arc;
 
+/// Resolves the HTTP super-user flag from the request's `Authorization` header.
+///
+/// - No `Authorization` header → anonymous, read-only (`Ok(false)`).
+/// - Valid admin basic credentials → super-user, DDL/DML allowed (`Ok(true)`).
+/// - An `Authorization` header that fails validation → `Err(UNAUTHORIZED)` so
+///   bad credentials surface as an error instead of silently degrading to
+///   read-only.
+fn resolve_super_user(headers: &HeaderMap) -> Result<bool, StatusCode> {
+    if headers.contains_key(header::AUTHORIZATION) {
+        crate::axum::auth::verify_basic_auth_header(headers)?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
 /// Executes a query against the runtime and streams the result to the client.
 ///
 /// The response is either an Arrow IPC stream (zstd-compressed) for in-memory
 /// results or a file download when the query produced a materialized output
 /// file (CSV, Parquet, Arrow, JSON, ODV, NetCDF, GeoParquet).
-#[tracing::instrument(level = "info", skip(state))]
+#[tracing::instrument(level = "info", skip(state, headers))]
 #[utoipa::path(
     tag = "query",
     post,
@@ -36,6 +52,7 @@ use std::sync::Arc;
 )]
 pub(crate) async fn query(
     State(state): State<Arc<Runtime>>,
+    headers: HeaderMap,
     Json(query_obj): Json<QueryRequest>,
 ) -> Result<Response<Body>, (StatusCode, Json<String>)> {
     let query = query_obj.into_query().map_err(|err| {
@@ -54,8 +71,15 @@ pub(crate) async fn query(
         ));
     }
 
-    // HTTP client queries are read-only.
-    let query_result = state.run_query(query, false).await.map_err(|err| {
+    // HTTP client queries are read-only by default; supplying valid admin basic
+    // credentials elevates the request to super-user, allowing DDL/DML (e.g.
+    // CREATE EXTERNAL TABLE, CREATE/INSERT on managed tables) over HTTP. This
+    // mirrors the Flight SQL transport, where basic auth resolves to an admin
+    // `AuthContext`.
+    let is_super_user = resolve_super_user(&headers).map_err(|status| {
+        (status, Json("invalid admin credentials".to_string()))
+    })?;
+    let query_result = state.run_query(query, is_super_user).await.map_err(|err| {
         tracing::error!("Error running beacon query: {}", err);
         (StatusCode::BAD_REQUEST, Json(err.to_string()))
     })?;
@@ -303,4 +327,49 @@ pub(crate) async fn available_columns(State(state): State<Arc<Runtime>>) -> Json
             .map(|f| f.name.clone())
             .collect(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use ::axum::http::{HeaderMap, StatusCode};
+    use base64::{engine::general_purpose, Engine as _};
+
+    use super::resolve_super_user;
+
+    /// Builds an `Authorization: Basic ...` header map for the given credentials.
+    fn basic_auth_headers(username: &str, password: &str) -> HeaderMap {
+        let value = format!(
+            "Basic {}",
+            general_purpose::STANDARD.encode(format!("{username}:{password}"))
+        );
+        let mut headers = HeaderMap::new();
+        headers.insert("Authorization", value.parse().unwrap());
+        headers
+    }
+
+    /// Valid admin credentials elevate the HTTP request to super-user so DDL/DML
+    /// is allowed over HTTP.
+    #[test]
+    fn valid_admin_credentials_resolve_to_super_user() {
+        let headers = basic_auth_headers(
+            &beacon_config::CONFIG.admin.username,
+            &beacon_config::CONFIG.admin.password,
+        );
+        assert_eq!(resolve_super_user(&headers), Ok(true));
+    }
+
+    /// No credentials at all stays anonymous (read-only), not an error.
+    #[test]
+    fn missing_authorization_header_is_anonymous() {
+        let headers = HeaderMap::new();
+        assert_eq!(resolve_super_user(&headers), Ok(false));
+    }
+
+    /// Credentials that are present but wrong are rejected rather than silently
+    /// degrading to read-only.
+    #[test]
+    fn wrong_credentials_are_rejected() {
+        let headers = basic_auth_headers("not-the-admin", "wrong-password");
+        assert_eq!(resolve_super_user(&headers), Err(StatusCode::UNAUTHORIZED));
+    }
 }

--- a/integration-tests/.gitignore
+++ b/integration-tests/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+.pytest_cache/
+__pycache__/
+*.pyc

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,76 @@
+# Beacon integration tests
+
+Black-box, end-to-end tests that **build the Beacon Docker image**, run the container,
+and exercise the HTTP API: querying generated Parquet in place, creating external
+tables, and the full managed-table write lifecycle (`CREATE` / `INSERT` / `UPDATE` /
+`DELETE` / `DROP`).
+
+These are intentionally **local / opt-in** — they are not wired into CI, because a full
+image build compiles the Rust workspace in release mode and takes a while.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) (the `docker` CLI must be on `PATH`;
+  the whole suite is skipped if it is not).
+- Python 3.10+.
+
+## Running
+
+```powershell
+# Windows
+./run.ps1
+```
+
+```bash
+# macOS / Linux
+./run.sh
+```
+
+The runner creates a `.venv`, installs `requirements.txt`, and invokes `pytest`. Extra
+arguments pass through to pytest:
+
+```bash
+./run.sh -v -k external      # only the external-table tests, verbose
+```
+
+To run pytest directly in an existing environment:
+
+```bash
+pip install -r requirements.txt
+pytest -v
+```
+
+## Configuration
+
+| Env var | Default | Effect |
+| ------- | ------- | ------ |
+| `BEACON_IMAGE` | _(unset)_ | If set, run this image instead of building the local `Dockerfile`. Use `ghcr.io/maris-development/beacon:latest` for fast reruns. |
+
+> **Note:** The published image will **fail** the external- and managed-table tests
+> until the HTTP write-path change in `beacon-api` (admin basic-auth → super-user on
+> `POST /api/query`) ships in a release. Build the local image to validate the full
+> suite. This mismatch is itself a useful regression signal.
+
+## What runs
+
+| File | Covers |
+| ---- | ------ |
+| `test_health.py` | `/api/health`, `/swagger`, `beacon_version()`, `/api/datasets`, `list_datasets()` |
+| `test_queries_parquet.py` | `read_parquet()` counts/aggregates over a multi-file glob; equivalent JSON DSL; malformed-query 400 |
+| `test_external_tables.py` | `CREATE EXTERNAL TABLE` (admin); `SHOW TABLES` / `/api/tables`; no-auth → 400, bad-auth → 401 |
+| `test_managed_tables.py` | managed-table `CREATE`/`INSERT`/`SELECT`/`UPDATE`/`DELETE`/`DROP`; writes need admin |
+
+## How it works
+
+`conftest.py` provides session-scoped fixtures that:
+
+1. Build (or reuse) the image.
+2. Generate small deterministic Parquet files (plus a CSV) into a temp datasets dir with
+   `pyarrow`, and an empty temp tables dir for managed-table storage.
+3. `docker run` Beacon with those dirs mounted at `/beacon/data/datasets` and
+   `/beacon/data/tables`, admin credentials set, and the HTTP port published to a random
+   host port (resolved via `docker port`).
+4. Poll `/api/health` until ready, then hand tests a `BeaconHTTPClient`.
+
+On teardown the container is removed; if any test failed, its `docker logs` are dumped
+first to aid debugging.

--- a/integration-tests/beacon_client.py
+++ b/integration-tests/beacon_client.py
@@ -1,0 +1,97 @@
+"""Thin HTTP client for the Beacon API used by the integration tests.
+
+Beacon exposes a single query endpoint (``POST /api/query``) that accepts either a
+SQL string or a JSON DSL body. The HTTP transport is read-only unless valid admin
+basic-auth is supplied, which elevates the request to super-user and allows DDL/DML
+(``CREATE EXTERNAL TABLE``, managed-table ``CREATE``/``INSERT``/...). This mirrors the
+pattern in ``benchmarks/harness/clients.py``.
+
+Two response modes matter:
+
+* **Reads** (``SELECT``, JSON DSL queries) request ``output: {format: csv}`` so the
+  result is easy to parse.
+* **Writes** (DDL/DML) must NOT set an ``output`` format: an output format makes the
+  runtime wrap the plan in a ``COPY ... TO`` file, and a DDL node nested inside a COPY
+  cannot be physically planned. Sending no ``output`` runs the statement directly and
+  returns an (empty) Arrow IPC stream, of which we only need the status code.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+
+import requests
+
+
+class QueryError(RuntimeError):
+    """Raised when a query returns a non-2xx status, carrying the status code."""
+
+    def __init__(self, status_code: int, body: str):
+        self.status_code = status_code
+        self.body = body
+        super().__init__(f"beacon query failed [{status_code}]: {body[:300]}")
+
+
+class BeaconHTTPClient:
+    def __init__(self, base_url: str, username: str, password: str, timeout: float = 600.0):
+        self.base_url = base_url.rstrip("/")
+        self._auth = (username, password)
+        self._timeout = timeout
+        self._session = requests.Session()
+
+    # -- low-level --------------------------------------------------------------
+    def _post(self, body: dict, admin: bool) -> requests.Response:
+        return self._session.post(
+            f"{self.base_url}/api/query",
+            json=body,
+            auth=self._auth if admin else None,
+            timeout=self._timeout,
+        )
+
+    # -- writes (DDL/DML): no output format -------------------------------------
+    def execute(self, sql: str, admin: bool = True) -> None:
+        """Run a side-effecting statement (DDL/DML) and raise on failure."""
+        resp = self._post({"sql": sql}, admin)
+        if resp.status_code != 200:
+            raise QueryError(resp.status_code, resp.text)
+
+    # -- reads: CSV output ------------------------------------------------------
+    def sql_rows(self, sql: str, admin: bool = False) -> list[list[str]]:
+        """Run a read query and return all CSV rows (row 0 is the header)."""
+        resp = self._post({"sql": sql, "output": {"format": "csv"}}, admin)
+        if resp.status_code != 200:
+            raise QueryError(resp.status_code, resp.text)
+        return list(csv.reader(io.StringIO(resp.text)))
+
+    def scalar(self, sql: str, admin: bool = False):
+        """Run a read query and return the single first data cell (e.g. a count)."""
+        rows = self.sql_rows(sql, admin)
+        if len(rows) < 2 or not rows[1]:
+            raise QueryError(200, f"expected a scalar result, got: {rows!r}")
+        return rows[1][0]
+
+    def count(self, inner_sql: str, admin: bool = False) -> int:
+        """Wrap a query as ``SELECT count(*)`` and return the integer count."""
+        return int(float(self.scalar(f"SELECT count(*) AS n FROM ({inner_sql}) AS _sub", admin)))
+
+    def query_json_rows(self, body: dict, admin: bool = False) -> list[list[str]]:
+        resp = self._post({**body, "output": {"format": "csv"}}, admin)
+        if resp.status_code != 200:
+            raise QueryError(resp.status_code, resp.text)
+        return list(csv.reader(io.StringIO(resp.text)))
+
+    # -- status-only (negative tests) -------------------------------------------
+    def status(self, sql: str, admin: bool = False) -> int:
+        """Run a statement (no output format) and return only the HTTP status."""
+        return self._post({"sql": sql}, admin).status_code
+
+    # -- discovery / health -----------------------------------------------------
+    def get(self, path: str) -> requests.Response:
+        return self._session.get(f"{self.base_url}{path}", timeout=self._timeout)
+
+    def datasets(self) -> requests.Response:
+        return self.get("/api/datasets")
+
+    def tables(self) -> requests.Response:
+        return self.get("/api/tables")

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -1,0 +1,225 @@
+"""Pytest fixtures that build the Beacon image, generate sample data, run the
+container, and hand tests an HTTP client.
+
+The whole suite is skipped when the ``docker`` CLI is unavailable. Set
+``BEACON_IMAGE`` to reuse a prebuilt image instead of building the local Dockerfile
+(fast reruns); leave it unset to build ``beacon-integration:local`` from the repo root.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from beacon_client import BeaconHTTPClient
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LOCAL_IMAGE_TAG = "beacon-integration:local"
+
+ADMIN_USERNAME = "admin"
+ADMIN_PASSWORD = "securepassword"
+
+# Container internal ports.
+HTTP_PORT = 5001
+FLIGHT_PORT = 32011
+
+CONTAINER_NAME = "beacon-integration-test"
+HEALTH_TIMEOUT_S = 180
+BUILD_TIMEOUT_S = 3600
+
+# Generated dataset: number of rows split across two parquet files so the tests
+# exercise multi-file globs. Kept tiny so the suite stays fast.
+ROWS_FILE_A = 600
+ROWS_FILE_B = 400
+TOTAL_ROWS = ROWS_FILE_A + ROWS_FILE_B
+PLATFORMS = ["SHIP", "BUOY", "GLIDER", "FLOAT"]
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+
+
+pytestmark = pytest.mark.skipif(not _docker_available(), reason="docker CLI not available")
+
+
+@pytest.fixture(scope="session")
+def beacon_image() -> str:
+    """The image to run: an override via ``BEACON_IMAGE`` or a freshly built local one."""
+    override = os.environ.get("BEACON_IMAGE")
+    if override:
+        return override
+
+    print(f"\n[integration] building image {LOCAL_IMAGE_TAG} from {REPO_ROOT} ...")
+    result = _run(
+        ["docker", "build", "-t", LOCAL_IMAGE_TAG, str(REPO_ROOT)],
+        timeout=BUILD_TIMEOUT_S,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"docker build failed:\n{result.stdout}\n{result.stderr}")
+    return LOCAL_IMAGE_TAG
+
+
+@pytest.fixture(scope="session")
+def sample_data():
+    """Generate deterministic oceanographic-style rows shared by all tests.
+
+    Returns a dict with the in-memory column data plus expected aggregates the tests
+    assert against, so the expectations live next to the generator.
+    """
+    n = TOTAL_ROWS
+    rows = []
+    for i in range(n):
+        rows.append(
+            {
+                "time": 1_700_000_000 + i * 3600,
+                "latitude": -60.0 + (i % 120) * 1.0,
+                "longitude": -180.0 + (i % 360) * 1.0,
+                "depth": float(i % 500),
+                "platform": PLATFORMS[i % len(PLATFORMS)],
+                "platform_id": i % 50,
+                # Spans 5.0..34.0 so the > 20 filter splits the data meaningfully.
+                "temperature": 5.0 + float(i % 30),
+                "salinity": 30.0 + (i % 10) * 0.4,
+            }
+        )
+    warm = [r for r in rows if r["temperature"] > 20]
+    return {
+        "rows": rows,
+        "total": n,
+        "warm_count": len(warm),
+        "platforms": PLATFORMS,
+    }
+
+
+def _write_parquet(rows: list[dict], path: Path) -> None:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    if not rows:
+        return
+    cols = {k: [r[k] for r in rows] for k in rows[0].keys()}
+    schema = pa.schema(
+        [
+            ("time", pa.int64()),
+            ("latitude", pa.float64()),
+            ("longitude", pa.float64()),
+            ("depth", pa.float32()),
+            ("platform", pa.string()),
+            ("platform_id", pa.int32()),
+            ("temperature", pa.float32()),
+            ("salinity", pa.float32()),
+        ]
+    )
+    table = pa.table(cols, schema=schema)
+    pq.write_table(table, path)
+
+
+@pytest.fixture(scope="session")
+def datasets_dir(tmp_path_factory, sample_data) -> Path:
+    """A datasets directory mounted into the container at /beacon/data/datasets."""
+    root = tmp_path_factory.mktemp("beacon-datasets")
+    obs = root / "obs"
+    obs.mkdir()
+    rows = sample_data["rows"]
+    _write_parquet(rows[:ROWS_FILE_A], obs / "part-0.parquet")
+    _write_parquet(rows[ROWS_FILE_A:], obs / "part-1.parquet")
+
+    # A small CSV so the CSV reader is exercised too.
+    csv_path = root / "stations.csv"
+    csv_path.write_text(
+        "platform,description\n" + "\n".join(f"{p},{p.lower()} platform" for p in PLATFORMS) + "\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+@pytest.fixture(scope="session")
+def tables_dir(tmp_path_factory) -> Path:
+    """Empty directory for managed (Iceberg) table persistence."""
+    return tmp_path_factory.mktemp("beacon-tables")
+
+
+@pytest.fixture(scope="session")
+def beacon_container(request, beacon_image, datasets_dir, tables_dir):
+    """Run Beacon in a container and yield its base HTTP URL."""
+    # Remove any stale container from a previous interrupted run.
+    _run(["docker", "rm", "-f", CONTAINER_NAME])
+
+    run_cmd = [
+        "docker", "run", "-d",
+        "--name", CONTAINER_NAME,
+        "-p", f"{HTTP_PORT}",          # publish container HTTP port to a random host port
+        "-p", f"{FLIGHT_PORT}",
+        "-v", f"{datasets_dir}:/beacon/data/datasets",
+        "-v", f"{tables_dir}:/beacon/data/tables",
+        "-e", "BEACON_ENABLE_SQL=true",
+        "-e", f"BEACON_ADMIN_USERNAME={ADMIN_USERNAME}",
+        "-e", f"BEACON_ADMIN_PASSWORD={ADMIN_PASSWORD}",
+        "-e", "BEACON_LOG_LEVEL=info",
+        beacon_image,
+    ]
+    started = _run(run_cmd)
+    if started.returncode != 0:
+        pytest.fail(f"docker run failed:\n{started.stdout}\n{started.stderr}")
+
+    def _dump_logs_and_remove():
+        # Dump logs when the session had failures, to aid debugging in CI/local.
+        if request.session.testsfailed:
+            logs = _run(["docker", "logs", CONTAINER_NAME])
+            print("\n===== beacon container logs =====")
+            print(logs.stdout)
+            print(logs.stderr)
+            print("===== end logs =====")
+        _run(["docker", "rm", "-f", CONTAINER_NAME])
+
+    request.addfinalizer(_dump_logs_and_remove)
+
+    host_port = _resolve_host_port(CONTAINER_NAME, HTTP_PORT)
+    base_url = f"http://127.0.0.1:{host_port}"
+    _wait_healthy(base_url, CONTAINER_NAME)
+    return base_url
+
+
+def _resolve_host_port(container: str, container_port: int) -> int:
+    result = _run(["docker", "port", container, f"{container_port}/tcp"])
+    if result.returncode != 0 or not result.stdout.strip():
+        pytest.fail(f"could not resolve host port for {container_port}:\n{result.stderr}")
+    # Output looks like "0.0.0.0:49154" (possibly multiple lines for ipv4/ipv6).
+    first = result.stdout.strip().splitlines()[0]
+    return int(first.rsplit(":", 1)[1])
+
+
+def _wait_healthy(base_url: str, container: str) -> None:
+    import requests
+
+    deadline = time.time() + HEALTH_TIMEOUT_S
+    last_err = None
+    while time.time() < deadline:
+        # Bail early with logs if the container died.
+        state = _run(["docker", "inspect", "-f", "{{.State.Running}}", container])
+        if state.stdout.strip() != "true":
+            logs = _run(["docker", "logs", container])
+            pytest.fail(f"beacon container exited early:\n{logs.stdout}\n{logs.stderr}")
+        try:
+            resp = requests.get(f"{base_url}/api/health", timeout=5)
+            if resp.status_code == 200:
+                return
+            last_err = f"status {resp.status_code}"
+        except Exception as exc:  # noqa: BLE001 - just record and retry
+            last_err = str(exc)
+        time.sleep(2)
+    pytest.fail(f"beacon did not become healthy within {HEALTH_TIMEOUT_S}s (last: {last_err})")
+
+
+@pytest.fixture(scope="session")
+def client(beacon_container) -> BeaconHTTPClient:
+    return BeaconHTTPClient(beacon_container, ADMIN_USERNAME, ADMIN_PASSWORD)

--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest>=8.0
+requests>=2.31
+pyarrow>=15.0

--- a/integration-tests/run.ps1
+++ b/integration-tests/run.ps1
@@ -1,0 +1,20 @@
+#requires -Version 5.1
+# Convenience runner for the Beacon Docker integration tests (Windows / PowerShell).
+#
+# Usage:
+#   ./run.ps1                       # build the local Dockerfile and run the suite
+#   $env:BEACON_IMAGE="ghcr.io/maris-development/beacon:latest"; ./run.ps1   # reuse an image
+#
+# Any extra arguments are passed through to pytest, e.g.:
+#   ./run.ps1 -k external -v
+
+$ErrorActionPreference = "Stop"
+Set-Location -Path $PSScriptRoot
+
+$venv = Join-Path $PSScriptRoot ".venv"
+if (-not (Test-Path $venv)) {
+    python -m venv $venv
+}
+& (Join-Path $venv "Scripts/python.exe") -m pip install --quiet --upgrade pip
+& (Join-Path $venv "Scripts/python.exe") -m pip install --quiet -r requirements.txt
+& (Join-Path $venv "Scripts/python.exe") -m pytest @args

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Convenience runner for the Beacon Docker integration tests (POSIX shells).
+#
+# Usage:
+#   ./run.sh                                  # build the local Dockerfile and run the suite
+#   BEACON_IMAGE=ghcr.io/maris-development/beacon:latest ./run.sh   # reuse an image
+#
+# Any extra arguments are passed through to pytest, e.g.:
+#   ./run.sh -k external -v
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [ ! -d .venv ]; then
+    python3 -m venv .venv
+fi
+# shellcheck disable=SC1091
+. .venv/bin/activate
+pip install --quiet --upgrade pip
+pip install --quiet -r requirements.txt
+pytest "$@"

--- a/integration-tests/test_external_tables.py
+++ b/integration-tests/test_external_tables.py
@@ -1,0 +1,70 @@
+"""External tables: create one over the generated Parquet (admin), then query it.
+
+Also asserts the read-only gate still holds for the HTTP transport:
+- no credentials  -> anonymous, DDL rejected by the query planner (400)
+- bad credentials -> rejected by auth (401)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from beacon_client import QueryError
+
+CREATE_DDL = "CREATE EXTERNAL TABLE obs_ext STORED AS PARQUET LOCATION 'obs/'"
+
+
+@pytest.fixture(scope="module")
+def external_table(client):
+    """Create the external table once for this module (admin-authenticated)."""
+    # Drop first so reruns against a reused image stay idempotent.
+    try:
+        client.execute("DROP TABLE IF EXISTS obs_ext", admin=True)
+    except QueryError:
+        pass
+    client.execute(CREATE_DDL, admin=True)
+    yield "obs_ext"
+    try:
+        client.execute("DROP TABLE IF EXISTS obs_ext", admin=True)
+    except QueryError:
+        pass
+
+
+def test_external_table_count_matches_in_place(client, external_table, sample_data):
+    via_table = client.count(f"SELECT * FROM {external_table}")
+    in_place = client.count("SELECT * FROM read_parquet(['obs/*.parquet'])")
+    assert via_table == in_place == sample_data["total"]
+
+
+def test_external_table_listed_in_tables_endpoint(client, external_table):
+    resp = client.tables()
+    assert resp.status_code == 200
+    assert external_table in resp.json()
+
+
+def test_external_table_listed_in_show_tables(client, external_table):
+    rows = client.sql_rows("SHOW TABLES", admin=True)
+    flat = {cell for row in rows[1:] for cell in row}
+    assert external_table in flat
+
+
+def test_create_ddl_without_credentials_is_rejected(client):
+    """Anonymous (no auth) -> read-only: the planner rejects DDL with a 400."""
+    status = client.status(
+        "CREATE EXTERNAL TABLE should_not_exist STORED AS PARQUET LOCATION 'obs/'",
+        admin=False,
+    )
+    assert status == 400
+
+
+def test_invalid_credentials_are_rejected(beacon_container):
+    """Present-but-wrong credentials must error (401), not silently downgrade."""
+    import requests
+
+    resp = requests.post(
+        f"{beacon_container}/api/query",
+        json={"sql": "SELECT 1", "output": {"format": "csv"}},
+        auth=("admin", "wrong-password"),
+        timeout=30,
+    )
+    assert resp.status_code == 401

--- a/integration-tests/test_health.py
+++ b/integration-tests/test_health.py
@@ -1,0 +1,39 @@
+"""Smoke tests: the container is up, the API answers, and it sees our datasets."""
+
+from __future__ import annotations
+
+
+def test_health_endpoint_ok(client):
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    assert resp.text.strip() == "Ok"
+
+
+def test_swagger_reachable(client):
+    resp = client.get("/swagger")
+    assert resp.status_code == 200
+
+
+def test_beacon_version_non_empty(client):
+    version = client.scalar("SELECT beacon_version() AS v")
+    assert version
+    assert version.strip()
+
+
+def test_datasets_endpoint_lists_generated_files(client):
+    resp = client.datasets()
+    assert resp.status_code == 200
+    files = resp.json()
+    assert any("part-0.parquet" in f for f in files)
+    assert any("part-1.parquet" in f for f in files)
+
+
+def test_list_datasets_table_function(client):
+    """The list_datasets() SQL table function should report both parquet files."""
+    rows = client.sql_rows(
+        "SELECT file_name FROM list_datasets() WHERE file_format = 'parquet' ORDER BY file_name"
+    )
+    # rows[0] is the header.
+    names = [r[0] for r in rows[1:]]
+    assert any("part-0.parquet" in n for n in names)
+    assert any("part-1.parquet" in n for n in names)

--- a/integration-tests/test_managed_tables.py
+++ b/integration-tests/test_managed_tables.py
@@ -1,0 +1,68 @@
+"""Managed (local) tables: the full Iceberg-backed write lifecycle over HTTP.
+
+CREATE -> INSERT -> SELECT -> UPDATE -> DELETE -> DROP, all requiring admin auth.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from beacon_client import QueryError
+
+TABLE = "itest_measurements"
+
+
+@pytest.fixture(scope="module")
+def managed_table(client):
+    try:
+        client.execute(f"DROP TABLE IF EXISTS {TABLE}", admin=True)
+    except QueryError:
+        pass
+    client.execute(
+        f"CREATE TABLE {TABLE} (id BIGINT, name VARCHAR, value DOUBLE)", admin=True
+    )
+    yield TABLE
+    try:
+        client.execute(f"DROP TABLE IF EXISTS {TABLE}", admin=True)
+    except QueryError:
+        pass
+
+
+def test_insert_and_select(client, managed_table):
+    client.execute(
+        f"INSERT INTO {managed_table} VALUES "
+        "(1, 'argo', 12.5), (2, 'glider', 9.0), (3, 'argo', 7.0)",
+        admin=True,
+    )
+    assert client.count(f"SELECT * FROM {managed_table}") == 3
+    # Reads do not need credentials.
+    assert client.count(f"SELECT * FROM {managed_table} WHERE name = 'argo'") == 2
+
+
+def test_update(client, managed_table):
+    client.execute(
+        f"UPDATE {managed_table} SET value = 100.0 WHERE name = 'glider'", admin=True
+    )
+    val = client.scalar(f"SELECT value FROM {managed_table} WHERE name = 'glider'")
+    assert float(val) == 100.0
+
+
+def test_delete(client, managed_table):
+    client.execute(f"DELETE FROM {managed_table} WHERE name = 'argo'", admin=True)
+    assert client.count(f"SELECT * FROM {managed_table}") == 1
+
+
+def test_insert_requires_admin(client, managed_table):
+    """Writes without credentials stay read-only and are rejected (400)."""
+    status = client.status(
+        f"INSERT INTO {managed_table} VALUES (99, 'anon', 0.0)", admin=False
+    )
+    assert status == 400
+
+
+def test_drop_table(client):
+    name = "itest_drop_me"
+    client.execute(f"CREATE TABLE IF NOT EXISTS {name} (id BIGINT)", admin=True)
+    assert name in client.tables().json()
+    client.execute(f"DROP TABLE {name}", admin=True)
+    assert name not in client.tables().json()

--- a/integration-tests/test_queries_parquet.py
+++ b/integration-tests/test_queries_parquet.py
@@ -1,0 +1,46 @@
+"""Query the freshly generated Parquet files in place, over SQL and the JSON DSL."""
+
+from __future__ import annotations
+
+
+def test_sql_count_all_rows(client, sample_data):
+    n = client.count("SELECT * FROM read_parquet(['obs/*.parquet'])")
+    assert n == sample_data["total"]
+
+
+def test_sql_where_filter(client, sample_data):
+    n = client.count(
+        "SELECT * FROM read_parquet(['obs/*.parquet']) WHERE temperature > 20"
+    )
+    assert n == sample_data["warm_count"]
+    assert sample_data["warm_count"] > 0  # guard: the filter must be meaningful
+
+
+def test_sql_group_by_aggregation(client, sample_data):
+    rows = client.sql_rows(
+        "SELECT platform, count(*) AS n, avg(temperature) AS avg_temp "
+        "FROM read_parquet(['obs/*.parquet']) "
+        "GROUP BY platform ORDER BY platform"
+    )
+    platforms = sorted(r[0] for r in rows[1:])
+    assert platforms == sorted(sample_data["platforms"])
+    total = sum(int(r[1]) for r in rows[1:])
+    assert total == sample_data["total"]
+
+
+def test_json_dsl_matches_sql(client, sample_data):
+    """The JSON DSL parquet source + range filter must match the SQL count."""
+    rows = client.query_json_rows(
+        {
+            "from": {"parquet": {"paths": ["obs/*.parquet"]}},
+            "select": ["time", "temperature"],
+            "filters": [{"column": "temperature", "min": 20.0001}],
+            "limit": 1_000_000,
+        }
+    )
+    # Subtract the header row; the JSON DSL returns the matching rows directly.
+    assert len(rows) - 1 == sample_data["warm_count"]
+
+
+def test_malformed_query_returns_400(client):
+    assert client.status("SELECT FROM WHERE not valid sql") == 400


### PR DESCRIPTION
## Summary

Adds a pytest-based **integration test suite** that builds the Beacon Docker image, boots the container, and exercises the HTTP API end-to-end — plus the small `beacon-api` change needed to make table creation work over HTTP.

`POST /api/query` was hard-coded read-only (`run_query(query, false)`), so DDL/DML only worked via Flight SQL. It now resolves super-user from **admin basic-auth**, mirroring the Flight SQL transport:

- **No credentials** → anonymous, read-only.
- **Valid admin credentials** → super-user, DDL/DML allowed (`CREATE EXTERNAL TABLE`, managed-table `CREATE`/`INSERT`/`UPDATE`/`DELETE`/`DROP`).
- **Present-but-invalid credentials** → rejected with `401` (rather than silently degrading).
- `conftest.py` builds the Dockerfile (or reuses `BEACON_IMAGE`), generates deterministic Parquet + CSV fixtures with `pyarrow`, runs the container with datasets/tables volumes mounted, polls `/api/health`, and dumps `docker logs` on failure. Skips cleanly when Docker is unavailable.
- Tests: health/version/swagger/`list_datasets()`; Parquet queries in place (SQL + JSON DSL); external tables (`CREATE EXTERNAL TABLE`, `SHOW TABLES`, `/api/tables`); managed tables (full write lifecycle); negative tests for no-auth (400) and bad-auth (401).
- `run.ps1` / `run.sh` runners and a README. **Local / opt-in** — not wired into CI.
- Adds `.dockerignore` — the repo had none, so a clean `docker build` shipped the multi-GB `target/` and `data/` dirs as build context.
- DDL/DML must be sent **without** an `output` format: an output format wraps the plan in `COPY ... TO`, and a DDL node nested in a COPY fails physical planning. The client handles this.
- The published `ghcr.io` image will fail the table-creation tests until this `beacon-api` change ships; build the local image (the default) to validate the full suite.

## Test plan
- From `integration-tests/`: `./run.sh` (or `./run.ps1`) — builds the image and runs **20 tests, all passing**.