### PR TITLE
Simplify getting-started docs and quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Beacon is a lightweight, high-performance **data lakehouse query engine** for scientific data. It lets you discover, read, transform, and serve large collections of array and tabular datasets **in place** — no copying into a warehouse, no rigid ETL pipeline. Point Beacon at a directory or object-storage bucket of files and query them directly over HTTP, with results streamed back in the format you ask for.
 
-It is built on [Apache Arrow](https://arrow.apache.org/) and [Apache DataFusion](https://datafusion.apache.org/), so queries run on a columnar, vectorized engine while reading native scientific formats such as NetCDF, Zarr, Parquet, and ODV. Beacon is developed by [MARIS](https://www.maris.nl/) for serving Analysis-Ready, Cloud-Optimized (ARCO) marine and environmental data, but nothing about it is domain-specific.
+It is built on [Apache Arrow](https://arrow.apache.org/) and [Apache DataFusion](https://datafusion.apache.org/), so queries run on a columnar, vectorized engine while reading native scientific formats such as NetCDF, Zarr, Parquet, and ODV.
 
 ## Table of contents
 
@@ -49,6 +49,26 @@ See the [documentation](https://maris-development.github.io/beacon/) for the ful
 
 ## Quick start (Docker)
 
+The fastest way to try Beacon is a single `docker run`. Run it from the directory where you want the `datasets` and `tables` folders to live:
+
+```bash
+docker run -d \
+  --name beacon \
+  -p 5001:5001 \
+  -p 32011:32011 \
+  -e BEACON_ADMIN_USERNAME=admin \
+  -e BEACON_ADMIN_PASSWORD=securepassword \
+  -v ./datasets:/beacon/data/datasets \
+  -v ./tables:/beacon/data/tables \
+  ghcr.io/maris-development/beacon:latest
+```
+
+This maps the HTTP API (`5001`) and Arrow Flight SQL (`32011`) ports, sets the admin credentials, and mounts a local `./datasets` directory of files to query (plus an empty `./tables` directory you can omit if you won't use tables).
+
+### Docker Compose
+
+For a reproducible setup, use Compose instead:
+
 ```yaml
 services:
   beacon:
@@ -56,21 +76,17 @@ services:
     container_name: beacon
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "5001:5001" # HTTP API
+      - "32011:32011" # Arrow Flight SQL
     environment:
-      - BEACON_HOST=0.0.0.0
-      - BEACON_PORT=8080
       - BEACON_ADMIN_USERNAME=admin
       - BEACON_ADMIN_PASSWORD=securepassword
-      - BEACON_VM_MEMORY_SIZE=4096
-      - BEACON_DEFAULT_TABLE=default
-      - BEACON_LOG_LEVEL=INFO
     volumes:
-      - ./datasets:/beacon/data/datasets
-      - ./tables:/beacon/data/tables
+      - ./datasets:/beacon/data/datasets # Mount a local directory of files to query
+      - ./tables:/beacon/data/tables # Mount an empty directory for tables, or omit if you won't use them
 ```
 
-Start it with `docker compose up -d`, then open the interactive API docs at <http://localhost:8080/swagger/>.
+Start it with `docker compose up -d`, then open the interactive API docs at <http://localhost:5001/swagger/>.
 
 Add data by placing files (e.g. `.nc`, `.zarr`, `.parquet`, `.csv`) into `./datasets` — the container discovers them through the mounted volume.
 
@@ -85,7 +101,7 @@ Both examples below post to the same endpoint and stream back a file in the requ
 > SQL is read-only and enabled by default. Set `BEACON_ENABLE_SQL=false` to disable it.
 
 ```http
-POST http://localhost:8080/api/query
+POST http://localhost:5001/api/query
 Content-Type: application/json
 
 {
@@ -99,7 +115,7 @@ Content-Type: application/json
 The JSON query API is always available and needs no extra configuration.
 
 ```http
-POST http://localhost:8080/api/query
+POST http://localhost:5001/api/query
 Content-Type: application/json
 
 {

--- a/docs/docs/1.7.2/data-lake/configuration.md
+++ b/docs/docs/1.7.2/data-lake/configuration.md
@@ -19,11 +19,11 @@ Some of the configuration options can be set using environment variables. The fo
 - `BEACON_BASE_PATH` - Optional URL path prefix to serve the HTTP API, OpenAPI document, and Swagger UI under (default is empty, i.e. served at the root). Useful when running Beacon behind a reverse proxy or on a shared subpath, e.g. `/beacon`. The value is normalized to exactly one leading slash and no trailing slash, so `beacon`, `/beacon`, and `/beacon/` are equivalent. Only URL-safe characters are allowed (letters, digits, `-`, `_`, `.`, `~`, and `/` as a separator); any other character (e.g. spaces, `?`, `#`, `%`) causes Beacon to exit at startup with a descriptive error.
 - `BEACON_ADMIN_USERNAME` - The admin username for the beacon admin panel.
 - `BEACON_ADMIN_PASSWORD` - The admin password for the beacon admin panel.
-- `BEACON_VM_MEMORY_SIZE` - The amount of memory to allocate to the Beacon Virtual Machine in MB (default is 4096MB). More is better for performance, especially when working with larger datasets and performing actions such as spatial joins and group by.
-- `BEACON_ENABLE_SQL` - Whether to enable the SQL query engine. Set to `true` to enable. Default is `false`.
+- `BEACON_VM_MEMORY_SIZE` - The amount of memory to allocate to the Beacon Virtual Machine in MB (default is 8192MB). More is better for performance, especially when working with larger datasets and performing actions such as spatial joins and group by.
+- `BEACON_ENABLE_SQL` - Whether to enable the SQL query engine. Default is `true`.
 - `BEACON_WORKER_THREADS` - Number of worker threads to use (default is 8).
 - `BEACON_ST_WITHIN_POINT_CACHE_SIZE` - Size of the cache for ST_WithinPoint queries (default is 10000).
-- `BEACON_DEFAULT_TABLE` - The default table to use when no table is specified in the `from` clause of a query.
+- `BEACON_DEFAULT_TABLE` - The default table to use when no table is specified in the `from` clause of a query. Only applicable to the JSON query API, as SQL queries must specify a source. Default is `default`.
 - `BEACON_LOG_LEVEL` - Log level [`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`]. Default is `INFO`.
 
 - `BEACON_S3_DATA_LAKE` - Whether to enable S3 data lake support. Set to `true` to enable. Default is `false` and uses local system file storage. To connect to S3-compatible object storage, the following environment variables should also be set:
@@ -34,7 +34,7 @@ Some of the configuration options can be set using environment variables. The fo
   - `AWS_SKIP_SIGNATURE` - Set to `true` to skip request signing. Useful for local S3-compatible object storage that does not require signed requests.
 - `BEACON_S3_BUCKET` - The bucket name for the S3-compatible object storage. If the env variable `BEACON_S3_DATA_LAKE` is enabled, and the `AWS_ENDPOINT` doesn't contain the bucket name, the bucket name should be specified here.
 
-- `BEACON_ENABLE_FS_EVENTS` - Whether to enable file system events monitoring, so new files in watched datasets are picked up automatically. Uses inotify on Linux systems. Default is `true`; set to `false` to disable. This is not supported when using S3 data lake.
+- `BEACON_ENABLE_FS_EVENTS` - Whether to enable file system events monitoring, so new files in watched datasets are picked up automatically. Uses inotify on Linux systems. Default is `true`; set to `false` to disable. This is not supported when using S3 data lake. (Be aware that using mounted volumes with Docker may interfere with filesystem events, so test this setting in your deployment environment.)
 
 - `BEACON_ENABLE_SYS_INFO` - Whether to expose system information. Set to `true` to enable.
 

--- a/docs/docs/1.7.2/getting-started.md
+++ b/docs/docs/1.7.2/getting-started.md
@@ -13,9 +13,24 @@ This guide gets a Beacon instance running with Docker Compose. For ready-made ex
 
 ## Local
 
-Create a `docker-compose.yml` file and adjust the volume path to point at your datasets:
+Start Beacon with a single `docker run`, or define a `docker-compose.yml` for a reproducible setup. Either way, adjust the volume paths to point at your datasets:
 
-```yaml
+::: code-group
+
+```bash [docker run]
+docker run -d \
+    --name beacon \
+    --restart unless-stopped \
+    -p 5001:5001 \
+    -p 32011:32011 \
+    -e BEACON_ADMIN_USERNAME=admin \
+    -e BEACON_ADMIN_PASSWORD=securepassword \
+    -v ./datasets:/beacon/data/datasets \
+    -v ./tables:/beacon/data/tables \
+    ghcr.io/maris-development/beacon:latest
+```
+
+```yaml [docker-compose.yml]
 services:
     beacon:
         image: ghcr.io/maris-development/beacon:latest
@@ -27,27 +42,39 @@ services:
         environment:
             - BEACON_ADMIN_USERNAME=admin
             - BEACON_ADMIN_PASSWORD=securepassword
-            - BEACON_VM_MEMORY_SIZE=4096
-            - BEACON_HOST=0.0.0.0
-            - BEACON_PORT=5001
         volumes:
             - ./datasets:/beacon/data/datasets
             - ./tables:/beacon/data/tables
 ```
 
-Start Beacon:
+:::
 
-```bash
-docker compose up -d
-```
-
-Beacon is now running. Open `http://localhost:5001/swagger` to verify and explore the API. Any files placed in `./datasets` are immediately available for querying.
+If you used Compose, start it with `docker compose up -d`. Beacon is now running. Open `http://localhost:5001/swagger` to verify and explore the API. Any files placed in `./datasets` are immediately available for querying.
 
 ## S3-Compatible Object Storage
 
-Add the S3 environment variables to your compose file and remove the datasets volume:
+Add the S3 environment variables and remove the datasets volume:
 
-```yaml
+::: code-group
+
+```bash [docker run]
+docker run -d \
+    --name beacon \
+    --restart unless-stopped \
+    -p 5001:5001 \
+    -p 32011:32011 \
+    -e BEACON_ADMIN_USERNAME=admin \
+    -e BEACON_ADMIN_PASSWORD=securepassword \
+    -e AWS_ENDPOINT=https://s3.amazonaws.com \
+    -e AWS_ACCESS_KEY_ID=your-access-key \
+    -e AWS_SECRET_ACCESS_KEY=your-secret-key \
+    -e BEACON_S3_BUCKET=your-bucket-name \
+    -e BEACON_S3_DATA_LAKE=true \
+    -v ./tables:/beacon/data/tables \
+    ghcr.io/maris-development/beacon:latest
+```
+
+```yaml [docker-compose.yml]
 services:
     beacon:
         image: ghcr.io/maris-development/beacon:latest
@@ -59,9 +86,6 @@ services:
         environment:
             - BEACON_ADMIN_USERNAME=admin
             - BEACON_ADMIN_PASSWORD=securepassword
-            - BEACON_VM_MEMORY_SIZE=4096
-            - BEACON_HOST=0.0.0.0
-            - BEACON_PORT=5001
             - AWS_ENDPOINT=https://s3.amazonaws.com
             - AWS_ACCESS_KEY_ID=your-access-key
             - AWS_SECRET_ACCESS_KEY=your-secret-key
@@ -71,17 +95,13 @@ services:
             - ./tables:/beacon/data/tables
 ```
 
+:::
+
 :::tip Anonymous / public buckets
 For publicly accessible buckets, omit `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and add `AWS_SKIP_SIGNATURE=true` instead.
 :::
 
-Start Beacon the same way:
-
-```bash
-docker compose up -d
-```
-
-Files already in the S3 bucket are available for querying immediately. The `./tables` volume persists any external tables or views you create.
+If you used Compose, start it with `docker compose up -d`. Files already in the S3 bucket are available for querying immediately. The `./tables` volume persists any external tables or views you create.
 
 ## Next steps
 

--- a/docs/docs/1.7.2/introduction.md
+++ b/docs/docs/1.7.2/introduction.md
@@ -14,37 +14,55 @@ Beacon is a data lakehouse query engine built for scientific datasets. Point it 
 
 Clients query Beacon using **SQL** or **JSON** and receive results as a file (Parquet, NetCDF, Arrow IPC, …) or a streaming Arrow IPC response. Beacon handles filtering, aggregation, and joins across files entirely server-side.
 
+## Quick setup
+
+Start Beacon with Docker, mounting a local `datasets` folder that holds your files:
+
+```bash
+docker run -d \
+  --name beacon \
+  -p 5001:5001 \
+  -v ./datasets:/beacon/data/datasets \
+  ghcr.io/maris-development/beacon:latest
+```
+
+Drop your `.nc` (or Parquet, Zarr, CSV, …) files into `./datasets` and they are queryable immediately at `http://localhost:5001`. For Compose, S3-backed storage, and more, see the [getting started guide](/docs/1.7.2/getting-started).
+
 ## Your first query
 
-The same query three ways — as raw SQL, over the HTTP API, or from the Python SDK. No setup required: `read_netcdf()` reads the files in place.
+The same query several ways — sent over the HTTP API against Parquet or NetCDF files, or from the Python SDK. No table registration required: the `read_*()` functions read the files in place. The paths are always relative to the `datasets` directory you mounted.
 
 ::: code-group
 
-```sql [SQL]
-SELECT time, latitude, longitude, temperature
-FROM read_netcdf(['argo/**/*.nc'])
-WHERE temperature > 20
-LIMIT 100
-```
-
-```http [HTTP]
+```http [HTTP · Parquet]
 POST /api/query
 Content-Type: application/json
 
 {
-  "sql": "SELECT time, latitude, longitude, temperature FROM read_netcdf(['argo/**/*.nc']) WHERE temperature > 20 LIMIT 100",
+  "sql": "SELECT time, latitude, longitude, temperature FROM read_parquet(['example.parquet']) WHERE temperature > 20 LIMIT 100",
+  "output": { "format": "csv" }
+}
+```
+
+```http [HTTP · NetCDF]
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT time, latitude, longitude, temperature FROM read_netcdf(['example.nc']) WHERE temperature > 20 LIMIT 100",
   "output": { "format": "csv" }
 }
 ```
 
 ```python [Python]
+%pip install beacon-api --upgrade
 from beacon_api import Client
 
 client = Client("https://your-beacon-node")
 
 df = client.sql_query(
     "SELECT time, latitude, longitude, temperature "
-    "FROM read_netcdf(['argo/**/*.nc']) "
+    "FROM read_netcdf(['example.nc']) "
     "WHERE temperature > 20 LIMIT 100"
 ).to_pandas_dataframe()
 ```
@@ -65,7 +83,6 @@ SQL is sent over the HTTP API (`POST /api/query`, with `BEACON_ENABLE_SQL=true`)
 | ODV ASCII | Ocean Data View spreadsheet format |
 | CSV | Header row required, delimiter configurable |
 | Arrow IPC | `.arrow`, `.ipc` stream files |
-| Beacon Binary Format | Beacon's native ingest format |
 
 ## Key concepts
 


### PR DESCRIPTION
## Summary

Documentation-only changes that streamline the first-run experience and correct stale details.

- **README quick start** and **getting-started guide**: add a single-command `docker run` example alongside Docker Compose, using VitePress `code-group` tabs in the docs.
- **Correct ports**: `5001` (HTTP API) + `32011` (Arrow Flight SQL), replacing the stale `8080` references.
- **Trim env vars** in the examples down to the essentials (admin credentials + volumes), dropping the verbose `BEACON_HOST`/`BEACON_PORT`/`BEACON_VM_MEMORY_SIZE`/`BEACON_DEFAULT_TABLE`/`BEACON_LOG_LEVEL` lines that just restate defaults.
- **introduction.md**: add a "Quick setup" section, show the first query against both Parquet and NetCDF over HTTP, and use the correct `read_parquet([...])` list syntax.
- **configuration.md**: align the reference with current defaults — `BEACON_VM_MEMORY_SIZE` 8192MB, `BEACON_ENABLE_SQL` enabled by default, a note that `BEACON_DEFAULT_TABLE` applies only to the JSON API, and a caveat about filesystem events with mounted Docker volumes.

## Test plan
Docs only — no code changes. Rendered prose/Markdown reviewed in the diff.