### PR TITLE
Improve error handling in beacon-functions

### DIFF
--- a/beacon-functions/src/blue_cloud/argo/map_platform_edmo.rs
+++ b/beacon-functions/src/blue_cloud/argo/map_platform_edmo.rs
@@ -31,10 +31,10 @@ fn map_argo_platform_edmo_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_argo_platform_edmo",
+            )?;
 
             let array = flag_array.iter().map(|flag| {
                 flag.map(|value| ARGO_PLATFORM_EDMO_MAP.get(value).map(|s| s).cloned())

--- a/beacon-functions/src/blue_cloud/cmems/map_bigram_l05.rs
+++ b/beacon-functions/src/blue_cloud/cmems/map_bigram_l05.rs
@@ -28,7 +28,8 @@ fn map_cmems_bigram_l05_impl(
 
     match &parameters[0] {
         ColumnarValue::Array(array) => {
-            let bigram_array = array.as_any().downcast_ref::<StringArray>().unwrap();
+            let bigram_array =
+                crate::util::downcast_arg::<StringArray>(array, "map_cmems_bigram_l05")?;
 
             Ok(ColumnarValue::Array(Arc::new(StringArray::from_iter(
                 bigram_array.iter().map(|bigram| map_bigram_l05(bigram)),

--- a/beacon-functions/src/blue_cloud/cmems/map_bigram_l06.rs
+++ b/beacon-functions/src/blue_cloud/cmems/map_bigram_l06.rs
@@ -32,11 +32,10 @@ fn map_cmems_bigram_l06_impl(
 
     match (&parameters[0], &parameters[1]) {
         (ColumnarValue::Array(array), ColumnarValue::Array(wmo_inst_type)) => {
-            let bigram_array = array.as_any().downcast_ref::<StringArray>().unwrap();
-            let wmo_inst_type_array = wmo_inst_type
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .unwrap();
+            let bigram_array =
+                crate::util::downcast_arg::<StringArray>(array, "map_cmems_bigram_l06")?;
+            let wmo_inst_type_array =
+                crate::util::downcast_arg::<StringArray>(wmo_inst_type, "map_cmems_bigram_l06")?;
 
             Ok(ColumnarValue::Array(Arc::new(StringArray::from_iter(
                 bigram_array
@@ -49,7 +48,8 @@ fn map_cmems_bigram_l06_impl(
             ColumnarValue::Array(bigram_arr),
             ColumnarValue::Scalar(ScalarValue::Utf8(wmo_inst_type)),
         ) => {
-            let bigram_array = bigram_arr.as_any().downcast_ref::<StringArray>().unwrap();
+            let bigram_array =
+                crate::util::downcast_arg::<StringArray>(bigram_arr, "map_cmems_bigram_l06")?;
 
             Ok(ColumnarValue::Array(Arc::new(StringArray::from_iter(
                 bigram_array
@@ -61,10 +61,8 @@ fn map_cmems_bigram_l06_impl(
             ColumnarValue::Scalar(ScalarValue::Utf8(bigram)),
             ColumnarValue::Array(wmo_inst_type_arr),
         ) => {
-            let wmo_inst_type_array = wmo_inst_type_arr
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .unwrap();
+            let wmo_inst_type_array =
+                crate::util::downcast_arg::<StringArray>(wmo_inst_type_arr, "map_cmems_bigram_l06")?;
 
             Ok(ColumnarValue::Array(Arc::new(StringArray::from_iter(
                 wmo_inst_type_array

--- a/beacon-functions/src/blue_cloud/common/map_c17.rs
+++ b/beacon-functions/src/blue_cloud/common/map_c17.rs
@@ -31,10 +31,8 @@ pub fn map_c17() -> ScalarUDF {
 fn map_c17_impl(parameters: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(value) => {
-            let string_array = value
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let string_array =
+                crate::util::downcast_arg::<arrow::array::StringArray>(value, "map_c17")?;
 
             let c17 = string_array
                 .iter()

--- a/beacon-functions/src/blue_cloud/common/map_c17_l06.rs
+++ b/beacon-functions/src/blue_cloud/common/map_c17_l06.rs
@@ -29,10 +29,8 @@ pub fn map_c17_l06() -> ScalarUDF {
 fn map_c17_l06_impl(parameters: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array =
+                crate::util::downcast_arg::<arrow::array::StringArray>(flag, "map_c17_l06")?;
 
             let array = flag_array
                 .iter()

--- a/beacon-functions/src/blue_cloud/common/map_call_sign_c17.rs
+++ b/beacon-functions/src/blue_cloud/common/map_call_sign_c17.rs
@@ -81,15 +81,14 @@ fn map_call_sign_c17_impl(
 
     match (&parameters[0], &parameters[1]) {
         (ColumnarValue::Array(string_array), ColumnarValue::Array(ts_array)) => {
-            let call_sign_array = string_array
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let call_sign_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                string_array,
+                "map_call_sign_c17",
+            )?;
 
-            let timestamp_array = ts_array
-                .as_any()
-                .downcast_ref::<arrow::array::TimestampNanosecondArray>()
-                .unwrap();
+            let timestamp_array = crate::util::downcast_arg::<
+                arrow::array::TimestampNanosecondArray,
+            >(ts_array, "map_call_sign_c17")?;
 
             let c17 =
                 call_sign_array
@@ -97,7 +96,7 @@ fn map_call_sign_c17_impl(
                     .zip(timestamp_array.iter())
                     .map(|(call_sign, timestamp)| match (call_sign, timestamp) {
                         (Some(cs), Some(ts)) => {
-                            let naive_dt = NaiveDateTime::from_timestamp_nanos(ts).unwrap();
+                            let naive_dt = NaiveDateTime::from_timestamp_nanos(ts)?;
                             find_c17(&CALL_SIGN_MAP, cs, naive_dt)
                         }
                         _ => None,
@@ -108,17 +107,16 @@ fn map_call_sign_c17_impl(
             Ok(ColumnarValue::Array(Arc::new(array)))
         }
         (ColumnarValue::Scalar(ScalarValue::Utf8(call_sign)), ColumnarValue::Array(time_array)) => {
-            let timestamp_array = time_array
-                .as_any()
-                .downcast_ref::<arrow::array::TimestampNanosecondArray>()
-                .unwrap();
+            let timestamp_array = crate::util::downcast_arg::<
+                arrow::array::TimestampNanosecondArray,
+            >(time_array, "map_call_sign_c17")?;
 
             let c17 =
                 timestamp_array
                     .iter()
                     .map(|timestamp| match (call_sign.as_ref(), timestamp) {
                         (Some(cs), Some(ts)) => {
-                            let naive_dt = NaiveDateTime::from_timestamp_nanos(ts).unwrap();
+                            let naive_dt = NaiveDateTime::from_timestamp_nanos(ts)?;
                             find_c17(&CALL_SIGN_MAP, cs, naive_dt)
                         }
                         _ => None,
@@ -132,16 +130,16 @@ fn map_call_sign_c17_impl(
             ColumnarValue::Array(call_sign_array),
             ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(timestamp, _)),
         ) => {
-            let call_signs = call_sign_array
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let call_signs = crate::util::downcast_arg::<arrow::array::StringArray>(
+                call_sign_array,
+                "map_call_sign_c17",
+            )?;
 
             let c17 = call_signs
                 .iter()
                 .map(|call_sign| match (call_sign, timestamp) {
                     (Some(cs), Some(ts)) => {
-                        let naive_dt = NaiveDateTime::from_timestamp_nanos(*ts).unwrap();
+                        let naive_dt = NaiveDateTime::from_timestamp_nanos(*ts)?;
                         find_c17(&CALL_SIGN_MAP, cs, naive_dt)
                     }
                     _ => None,

--- a/beacon-functions/src/blue_cloud/common/map_l22_l05.rs
+++ b/beacon-functions/src/blue_cloud/common/map_l22_l05.rs
@@ -29,10 +29,8 @@ pub fn map_l22_l05() -> ScalarUDF {
 fn map_l22_l05_impl(parameters: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array =
+                crate::util::downcast_arg::<arrow::array::StringArray>(flag, "map_l22_l05")?;
 
             let array = flag_array
                 .iter()

--- a/beacon-functions/src/blue_cloud/common/map_measuring_area_type_feature_type.rs
+++ b/beacon-functions/src/blue_cloud/common/map_measuring_area_type_feature_type.rs
@@ -22,10 +22,10 @@ fn map_measuring_area_type_feature_type_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_measuring_area_type_feature_type",
+            )?;
 
             let array = flag_array
                 .iter()

--- a/beacon-functions/src/blue_cloud/common/map_wmo_instrument_type_l05.rs
+++ b/beacon-functions/src/blue_cloud/common/map_wmo_instrument_type_l05.rs
@@ -31,10 +31,10 @@ fn map_wmo_instrument_type_l05_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_wmo_instrument_type_l05",
+            )?;
 
             let array = flag_array.iter().map(|flag| {
                 flag.map(|wmo_code| L05_MAP.get(wmo_code).map(|s| s).cloned())

--- a/beacon-functions/src/blue_cloud/common/map_wmo_instrument_type_l22.rs
+++ b/beacon-functions/src/blue_cloud/common/map_wmo_instrument_type_l22.rs
@@ -31,10 +31,10 @@ fn map_wmo_instrument_type_l22_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_wmo_instrument_type_l22",
+            )?;
 
             let array = flag_array.iter().map(|flag| {
                 flag.map(|wmo_code| L22_MAP.get(wmo_code).map(|s| s).cloned())

--- a/beacon-functions/src/blue_cloud/common/pressure_to_depth_teos_10.rs
+++ b/beacon-functions/src/blue_cloud/common/pressure_to_depth_teos_10.rs
@@ -26,14 +26,14 @@ fn pressure_to_depth_teos_10_impl(
     //Should accept 1 parameter that is a float
     match (&parameters[0], &parameters[1]) {
         (ColumnarValue::Array(pressure), ColumnarValue::Array(latitude)) => {
-            let float_array = pressure
-                .as_any()
-                .downcast_ref::<arrow::array::Float64Array>()
-                .unwrap();
-            let lat = latitude
-                .as_any()
-                .downcast_ref::<arrow::array::Float64Array>()
-                .unwrap();
+            let float_array = crate::util::downcast_arg::<arrow::array::Float64Array>(
+                pressure,
+                "pressure_to_depth_teos_10",
+            )?;
+            let lat = crate::util::downcast_arg::<arrow::array::Float64Array>(
+                latitude,
+                "pressure_to_depth_teos_10",
+            )?;
 
             let array = PrimitiveArray::<Float64Type>::from_iter(
                 float_array
@@ -45,10 +45,10 @@ fn pressure_to_depth_teos_10_impl(
             Ok(ColumnarValue::Array(Arc::new(array)))
         }
         (ColumnarValue::Scalar(ScalarValue::Float64(pressure)), ColumnarValue::Array(latitude)) => {
-            let lat = latitude
-                .as_any()
-                .downcast_ref::<arrow::array::Float64Array>()
-                .unwrap();
+            let lat = crate::util::downcast_arg::<arrow::array::Float64Array>(
+                latitude,
+                "pressure_to_depth_teos_10",
+            )?;
 
             let array = PrimitiveArray::<Float64Type>::from_iter(lat.iter().map(|l| {
                 l.zip(pressure.clone())
@@ -58,10 +58,10 @@ fn pressure_to_depth_teos_10_impl(
             Ok(ColumnarValue::Array(Arc::new(array)))
         }
         (ColumnarValue::Array(pressure), ColumnarValue::Scalar(ScalarValue::Float64(latitude))) => {
-            let float_array = pressure
-                .as_any()
-                .downcast_ref::<arrow::array::Float64Array>()
-                .unwrap();
+            let float_array = crate::util::downcast_arg::<arrow::array::Float64Array>(
+                pressure,
+                "pressure_to_depth_teos_10",
+            )?;
 
             let array = PrimitiveArray::<Float64Type>::from_iter(float_array.iter().map(|p| {
                 p.zip(latitude.clone())

--- a/beacon-functions/src/blue_cloud/cora/map_instrument_l05.rs
+++ b/beacon-functions/src/blue_cloud/cora/map_instrument_l05.rs
@@ -31,10 +31,10 @@ fn map_cora_instrument_l05_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_cora_instrument_l05",
+            )?;
 
             let array = flag_array.iter().map(|flag| {
                 flag.map(|wmo_code| L05_MAP.get(wmo_code).map(|s| s).cloned())

--- a/beacon-functions/src/blue_cloud/cora/map_instrument_l22.rs
+++ b/beacon-functions/src/blue_cloud/cora/map_instrument_l22.rs
@@ -31,10 +31,10 @@ fn map_cora_instrument_l22_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_cora_instrument_l22",
+            )?;
 
             let array = flag_array.iter().map(|flag| {
                 flag.map(|wmo_code| L22_MAP.get(wmo_code).map(|s| s).cloned())

--- a/beacon-functions/src/blue_cloud/cora/map_platform_l06.rs
+++ b/beacon-functions/src/blue_cloud/cora/map_platform_l06.rs
@@ -32,11 +32,10 @@ fn map_cora_platform_l06_impl(
 
     match (&parameters[0], &parameters[1]) {
         (ColumnarValue::Array(array), ColumnarValue::Array(wmo_inst_type)) => {
-            let bigram_array = array.as_any().downcast_ref::<StringArray>().unwrap();
-            let wmo_inst_type_array = wmo_inst_type
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .unwrap();
+            let bigram_array =
+                crate::util::downcast_arg::<StringArray>(array, "map_cora_platform_l06")?;
+            let wmo_inst_type_array =
+                crate::util::downcast_arg::<StringArray>(wmo_inst_type, "map_cora_platform_l06")?;
 
             Ok(ColumnarValue::Array(Arc::new(StringArray::from_iter(
                 bigram_array.iter().zip(wmo_inst_type_array.iter()).map(
@@ -48,7 +47,8 @@ fn map_cora_platform_l06_impl(
             ColumnarValue::Array(bigram_arr),
             ColumnarValue::Scalar(ScalarValue::Utf8(wmo_inst_type)),
         ) => {
-            let bigram_array = bigram_arr.as_any().downcast_ref::<StringArray>().unwrap();
+            let bigram_array =
+                crate::util::downcast_arg::<StringArray>(bigram_arr, "map_cora_platform_l06")?;
 
             Ok(ColumnarValue::Array(Arc::new(StringArray::from_iter(
                 bigram_array
@@ -60,10 +60,8 @@ fn map_cora_platform_l06_impl(
             ColumnarValue::Scalar(ScalarValue::Utf8(bigram)),
             ColumnarValue::Array(wmo_inst_type_arr),
         ) => {
-            let wmo_inst_type_array = wmo_inst_type_arr
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .unwrap();
+            let wmo_inst_type_array =
+                crate::util::downcast_arg::<StringArray>(wmo_inst_type_arr, "map_cora_platform_l06")?;
 
             Ok(ColumnarValue::Array(Arc::new(StringArray::from_iter(
                 wmo_inst_type_array.iter().map(|wmo_inst_type| {

--- a/beacon-functions/src/blue_cloud/emodnet_chemistry/map_instrument_info_l22.rs
+++ b/beacon-functions/src/blue_cloud/emodnet_chemistry/map_instrument_info_l22.rs
@@ -75,14 +75,14 @@ fn map_instrument_info_l22_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match (&parameters[0], &parameters[1]) {
         (ColumnarValue::Array(line_array), ColumnarValue::Array(p01_array)) => {
-            let line_array = line_array
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
-            let p01_array = p01_array
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let line_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                line_array,
+                "map_instrument_info_l22",
+            )?;
+            let p01_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                p01_array,
+                "map_instrument_info_l22",
+            )?;
 
             let array =
                 line_array
@@ -98,10 +98,10 @@ fn map_instrument_info_l22_impl(
             Ok(ColumnarValue::Array(Arc::new(array)))
         }
         (ColumnarValue::Array(line_array), ColumnarValue::Scalar(ScalarValue::Utf8(p01))) => {
-            let line_array = line_array
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let line_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                line_array,
+                "map_instrument_info_l22",
+            )?;
 
             let array = line_array.iter().map(|line| match (line, p01.as_ref()) {
                 (Some(line), Some(p01)) => get_l22_for_p01_token(line, p01),
@@ -113,10 +113,10 @@ fn map_instrument_info_l22_impl(
             Ok(ColumnarValue::Array(Arc::new(array)))
         }
         (ColumnarValue::Scalar(ScalarValue::Utf8(line)), ColumnarValue::Array(p01_array)) => {
-            let p01_array = p01_array
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let p01_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                p01_array,
+                "map_instrument_info_l22",
+            )?;
 
             let array = p01_array.iter().map(|p01| match (line.as_ref(), p01) {
                 (Some(line), Some(p01)) => get_l22_for_p01_token(line, p01),

--- a/beacon-functions/src/blue_cloud/emodnet_chemistry/map_instrument_l05.rs
+++ b/beacon-functions/src/blue_cloud/emodnet_chemistry/map_instrument_l05.rs
@@ -32,10 +32,10 @@ fn map_emodnet_chemistry_instrument_l05_impl(
 
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_emodnet_chemistry_instrument_l05",
+            )?;
 
             let array = flag_array
                 .iter()

--- a/beacon-functions/src/blue_cloud/emodnet_chemistry/map_instrument_l05_multi.rs
+++ b/beacon-functions/src/blue_cloud/emodnet_chemistry/map_instrument_l05_multi.rs
@@ -48,10 +48,10 @@ fn map_emodnet_chemistry_instrument_l05_multi_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_emodnet_chemistry_instrument_l05_multi",
+            )?;
 
             let array = flag_array.iter().map(|flag| {
                 flag.map(|value| {

--- a/beacon-functions/src/blue_cloud/emodnet_chemistry/map_originator_edmo.rs
+++ b/beacon-functions/src/blue_cloud/emodnet_chemistry/map_originator_edmo.rs
@@ -32,10 +32,10 @@ fn map_emodnet_chemistry_originator_edmo_impl(
 
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_emodnet_chemistry_originator_edmo",
+            )?;
 
             let array = flag_array
                 .iter()

--- a/beacon-functions/src/blue_cloud/emodnet_chemistry/map_p35_contributor_codes_p01.rs
+++ b/beacon-functions/src/blue_cloud/emodnet_chemistry/map_p35_contributor_codes_p01.rs
@@ -88,14 +88,14 @@ fn map_p35_contributor_codes_p01_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match (&parameters[0], &parameters[1]) {
         (ColumnarValue::Array(line_array), ColumnarValue::Array(p35_array)) => {
-            let line_array = line_array
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
-            let p35_array = p35_array
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let line_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                line_array,
+                "map_p35_contributor_codes_p01",
+            )?;
+            let p35_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                p35_array,
+                "map_p35_contributor_codes_p01",
+            )?;
 
             let array =
                 line_array
@@ -111,10 +111,10 @@ fn map_p35_contributor_codes_p01_impl(
             Ok(ColumnarValue::Array(Arc::new(array)))
         }
         (ColumnarValue::Array(line_array), ColumnarValue::Scalar(ScalarValue::Utf8(p35))) => {
-            let line_array = line_array
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let line_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                line_array,
+                "map_p35_contributor_codes_p01",
+            )?;
 
             let array = line_array.iter().map(|line| match (line, p35.as_ref()) {
                 (Some(line), Some(p35)) => get_p01_for_p35(line, p35),
@@ -126,10 +126,10 @@ fn map_p35_contributor_codes_p01_impl(
             Ok(ColumnarValue::Array(Arc::new(array)))
         }
         (ColumnarValue::Scalar(ScalarValue::Utf8(line)), ColumnarValue::Array(p35_array)) => {
-            let p35_array = p35_array
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let p35_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                p35_array,
+                "map_p35_contributor_codes_p01",
+            )?;
 
             let array = p35_array.iter().map(|p35| match (line.as_ref(), p35) {
                 (Some(line), Some(p35)) => get_p01_for_p35(line, p35),

--- a/beacon-functions/src/blue_cloud/emodnet_chemistry/map_platform_l06.rs
+++ b/beacon-functions/src/blue_cloud/emodnet_chemistry/map_platform_l06.rs
@@ -32,10 +32,10 @@ fn map_emodnet_chemistry_platform_l06_impl(
 
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_emodnet_chemistry_platform_l06",
+            )?;
 
             let array = flag_array
                 .iter()

--- a/beacon-functions/src/blue_cloud/seadatanet/map_c17_l06.rs
+++ b/beacon-functions/src/blue_cloud/seadatanet/map_c17_l06.rs
@@ -31,10 +31,10 @@ fn map_platform_c17_l06_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_platform_c17_l06",
+            )?;
 
             let array = flag_array.iter().map(|flag| {
                 flag.map(|value| C17_L06_MAP.get(value).map(|s| s).cloned())

--- a/beacon-functions/src/blue_cloud/seadatanet/map_instrument_l05.rs
+++ b/beacon-functions/src/blue_cloud/seadatanet/map_instrument_l05.rs
@@ -32,10 +32,10 @@ fn map_seadatanet_instrument_l05_impl(
 
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_seadatanet_instrument_l05",
+            )?;
 
             let array = flag_array
                 .iter()

--- a/beacon-functions/src/blue_cloud/seadatanet/map_instrument_l05_salinity.rs
+++ b/beacon-functions/src/blue_cloud/seadatanet/map_instrument_l05_salinity.rs
@@ -49,10 +49,10 @@ fn map_seadatanet_instrument_l05_salinity_impl(
 
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_seadatanet_instrument_l05_salinity",
+            )?;
 
             let array = flag_array
                 .iter()

--- a/beacon-functions/src/blue_cloud/seadatanet/map_instrument_l05_temperature.rs
+++ b/beacon-functions/src/blue_cloud/seadatanet/map_instrument_l05_temperature.rs
@@ -51,10 +51,10 @@ fn map_seadatanet_instrument_l05_temperature_impl(
 
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_seadatanet_instrument_l05_temperature",
+            )?;
 
             let array = flag_array
                 .iter()

--- a/beacon-functions/src/blue_cloud/seadatanet/map_originator_edmo.rs
+++ b/beacon-functions/src/blue_cloud/seadatanet/map_originator_edmo.rs
@@ -32,10 +32,10 @@ fn map_originator_edmo_impl(
 
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_originator_edmo",
+            )?;
 
             let array = flag_array
                 .iter()

--- a/beacon-functions/src/blue_cloud/seadatanet/map_platform_l06.rs
+++ b/beacon-functions/src/blue_cloud/seadatanet/map_platform_l06.rs
@@ -32,10 +32,10 @@ fn map_seadatanet_platform_l06_impl(
 
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_seadatanet_platform_l06",
+            )?;
 
             let array = flag_array
                 .iter()

--- a/beacon-functions/src/blue_cloud/seadatanet/map_units.rs
+++ b/beacon-functions/src/blue_cloud/seadatanet/map_units.rs
@@ -109,36 +109,29 @@ impl ScalarUDFImpl for MapUnits {
         let from_unit = match arg0 {
             ColumnarValue::Array(array) => array,
             ColumnarValue::Scalar(scalar_value) => {
-                scalar_value.to_array_of_size(number_rows).unwrap()
+                scalar_value.to_array_of_size(number_rows)?
             }
         };
         let to_unit = match arg1 {
             ColumnarValue::Array(array) => array,
             ColumnarValue::Scalar(scalar_value) => {
-                scalar_value.to_array_of_size(number_rows).unwrap()
+                scalar_value.to_array_of_size(number_rows)?
             }
         };
 
         let values = match arg2 {
             ColumnarValue::Array(array) => array,
             ColumnarValue::Scalar(scalar_value) => {
-                scalar_value.to_array_of_size(number_rows).unwrap()
+                scalar_value.to_array_of_size(number_rows)?
             }
         };
 
-        let from_unit = from_unit
-            .as_any()
-            .downcast_ref::<arrow::array::StringArray>()
-            .unwrap();
-        let to_unit = to_unit
-            .as_any()
-            .downcast_ref::<arrow::array::StringArray>()
-            .unwrap();
-
-        let values = values
-            .as_any()
-            .downcast_ref::<arrow::array::Float64Array>()
-            .unwrap();
+        let from_unit =
+            crate::util::downcast_arg::<arrow::array::StringArray>(&from_unit, "map_units")?;
+        let to_unit =
+            crate::util::downcast_arg::<arrow::array::StringArray>(&to_unit, "map_units")?;
+        let values =
+            crate::util::downcast_arg::<arrow::array::Float64Array>(&values, "map_units")?;
 
         let array = PrimitiveArray::<Float64Type>::from_iter(
             values

--- a/beacon-functions/src/blue_cloud/world_ocean_database/map_instrument_l05.rs
+++ b/beacon-functions/src/blue_cloud/world_ocean_database/map_instrument_l05.rs
@@ -31,10 +31,10 @@ fn map_wod_instrument_l05_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_wod_instrument_l05",
+            )?;
 
             let array = flag_array.iter().map(|flag| {
                 flag.map(|value| L05_MAP.get(value).map(|s| s).cloned())

--- a/beacon-functions/src/blue_cloud/world_ocean_database/map_instrument_l22.rs
+++ b/beacon-functions/src/blue_cloud/world_ocean_database/map_instrument_l22.rs
@@ -30,10 +30,10 @@ fn map_wod_instrument_l22_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_wod_instrument_l22",
+            )?;
 
             let array = flag_array.iter().map(|flag| {
                 flag.map(|value| L22_MAP.get(value).map(|s| s).cloned())

--- a/beacon-functions/src/blue_cloud/world_ocean_database/map_instrument_l33.rs
+++ b/beacon-functions/src/blue_cloud/world_ocean_database/map_instrument_l33.rs
@@ -31,10 +31,10 @@ fn map_wod_instrument_l33_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_wod_instrument_l33",
+            )?;
 
             let array = flag_array.iter().map(|flag| {
                 flag.map(|value| L33_MAP.get(value).map(|s| s).cloned())

--- a/beacon-functions/src/blue_cloud/world_ocean_database/map_platform_c17.rs
+++ b/beacon-functions/src/blue_cloud/world_ocean_database/map_platform_c17.rs
@@ -31,10 +31,10 @@ fn map_wod_platform_c17_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-                .unwrap();
+            let flag_array = crate::util::downcast_arg::<arrow::array::StringArray>(
+                flag,
+                "map_wod_platform_c17",
+            )?;
 
             let array = flag_array.iter().map(|flag| {
                 flag.map(|value| C17_MAP.get(value).map(|s| s).cloned())

--- a/beacon-functions/src/blue_cloud/world_ocean_database/map_quality_flag.rs
+++ b/beacon-functions/src/blue_cloud/world_ocean_database/map_quality_flag.rs
@@ -42,10 +42,8 @@ fn map_wod_quality_flag_impl(
 ) -> datafusion::error::Result<ColumnarValue> {
     match &parameters[0] {
         ColumnarValue::Array(flag) => {
-            let flag_array = flag
-                .as_any()
-                .downcast_ref::<arrow::array::Int64Array>()
-                .unwrap();
+            let flag_array =
+                crate::util::downcast_arg::<arrow::array::Int64Array>(flag, "map_wod_quality_flag")?;
 
             let array = flag_array.iter().map(|flag| {
                 flag.map(|wod_flag| WOD_FLAG_TO_SDN.get(&wod_flag).map(|s| s).cloned())

--- a/beacon-functions/src/geo/st_within_point.rs
+++ b/beacon-functions/src/geo/st_within_point.rs
@@ -53,7 +53,7 @@ impl ScalarUDFImpl for WithinPointUdf {
         &self,
         args: datafusion::logical_expr::ScalarFunctionArgs,
     ) -> datafusion::error::Result<datafusion::logical_expr::ColumnarValue> {
-        let resized_lon_array = args.args[1].to_array(args.number_rows).unwrap();
+        let resized_lon_array = args.args[1].to_array(args.number_rows)?;
         let mut lon_iter = resized_lon_array
             .as_primitive_opt::<Float64Type>()
             .map(|array| array.iter())
@@ -61,7 +61,7 @@ impl ScalarUDFImpl for WithinPointUdf {
                 "st_within_point expects a float64 array as its second argument".to_string(),
             ))?;
 
-        let resized_lat_array = args.args[2].to_array(args.number_rows).unwrap();
+        let resized_lat_array = args.args[2].to_array(args.number_rows)?;
         let mut lat_iter = resized_lat_array
             .as_primitive_opt::<Float64Type>()
             .map(|array| array.iter())
@@ -88,7 +88,11 @@ impl ScalarUDFImpl for WithinPointUdf {
                                 .map_err(|e| {
                                     datafusion::error::DataFusionError::Execution(e.to_string())
                                 })?;
-                        let geometry: Geometry = wkt.try_into().unwrap();
+                        let geometry: Geometry = wkt.try_into().map_err(|e| {
+                            datafusion::error::DataFusionError::Execution(format!(
+                                "st_within_point: invalid WKT geometry: {e:?}"
+                            ))
+                        })?;
                         let result = st_within_point_fast(geometry, &mut lon_iter, &mut lat_iter)
                             .map_err(|e| {
                             datafusion::error::DataFusionError::Execution(e.to_string())
@@ -135,7 +139,8 @@ fn st_within_point_impl(
         (Some(geom), Some(lon), Some(lat)) => {
             // ST_WithinPoint implementation
             let wkt = Wkt::from_str(geom).map_err(|e| anyhow::anyhow!(e))?;
-            let geometry: Geometry = wkt.try_into().unwrap();
+            let geometry: Geometry =
+                wkt.try_into().map_err(|e| anyhow::anyhow!("invalid WKT geometry: {e:?}"))?;
 
             let point = geo::Point::new(lon, lat);
             Ok(geometry.contains(&point))

--- a/beacon-functions/src/util/cast_int8_as_char.rs
+++ b/beacon-functions/src/util/cast_int8_as_char.rs
@@ -17,10 +17,8 @@ fn cast_int8_as_char_impl(
 ) -> datafusion::error::Result<datafusion::logical_expr::ColumnarValue> {
     match &parameters[0] {
         datafusion::logical_expr::ColumnarValue::Array(array) => {
-            let int8_array = array
-                .as_any()
-                .downcast_ref::<arrow::array::Int8Array>()
-                .unwrap();
+            let int8_array =
+                crate::util::downcast_arg::<arrow::array::Int8Array>(array, "cast_int8_as_char")?;
 
             let array = arrow::array::StringArray::from_iter(
                 int8_array

--- a/beacon-functions/src/util/coalesce_label.rs
+++ b/beacon-functions/src/util/coalesce_label.rs
@@ -57,7 +57,7 @@ impl ScalarUDFImpl for CoalesceLabel {
             let label = &args.args[idx * 2 + 1];
 
             // Convert the column to an ArrayRef
-            arrays.push(col.to_array(args.number_rows).unwrap());
+            arrays.push(col.to_array(args.number_rows)?);
 
             // Convert the label to a StringBuilder
             if let PhysicalColumnarValue::Scalar(ScalarValue::Utf8(Some(label_str))) = label {

--- a/beacon-functions/src/util/mod.rs
+++ b/beacon-functions/src/util/mod.rs
@@ -5,6 +5,27 @@ pub mod cast_int8_as_char;
 pub mod coalesce_label;
 pub mod try_arrow_cast;
 
+/// Downcast a UDF argument array to a concrete Arrow array type, returning a
+/// descriptive [`DataFusionError`](datafusion::error::DataFusionError) instead
+/// of panicking when the runtime type does not match.
+///
+/// UDF signatures coerce arguments to their declared types, so a mismatch here
+/// normally indicates an internal/coercion inconsistency rather than bad user
+/// input — but surfacing it as an error keeps a malformed call from crashing the
+/// whole query engine.
+pub(crate) fn downcast_arg<'a, T: std::any::Any>(
+    array: &'a dyn arrow::array::Array,
+    func: &str,
+) -> datafusion::error::Result<&'a T> {
+    array.as_any().downcast_ref::<T>().ok_or_else(|| {
+        datafusion::error::DataFusionError::Execution(format!(
+            "{func}: unexpected argument array type {:?} (expected {})",
+            array.data_type(),
+            std::any::type_name::<T>(),
+        ))
+    })
+}
+
 pub fn util_udfs() -> Vec<ScalarUDF> {
     vec![
         cast_int8_as_char::cast_int8_as_char(),


### PR DESCRIPTION
Thirteenth crate in the workspace-wide error-handling cleanup (#251).

`beacon-functions` implements the SQL UDFs (geographic/oceanographic/mapping) and file-format table functions. The dominant risk was `array.as_any().downcast_ref::<T>().unwrap()` in UDF `invoke_with_args` — a panic-on-type-mismatch that could crash the query engine. The public surface is DataFusion's `ScalarUDFImpl`/`TableFunctionImpl`, so it keeps returning `datafusion::error::Result` (the DataFusion seam).

## Changes
- **New `util::downcast_arg` helper** — downcasts a UDF argument array to a concrete Arrow array type, returning a descriptive `DataFusionError` instead of panicking. Converted **~60 downcast-unwrap sites** across the `blue_cloud` mapping UDFs and `util/cast_int8_as_char` to use it. (UDF signatures coerce arguments to their declared types, so these were effectively guaranteed — but surfacing a mismatch as an error keeps a malformed call from taking down the engine, and is robust if a signature changes.)
- **`geo/st_within_point`** — the WKT→`Geometry` conversion and the `ColumnarValue::to_array` conversions now propagate errors; user-supplied WKT that parses but isn't a valid geometry no longer panics.
- **`blue_cloud/common/map_call_sign_c17`** — an out-of-range `NaiveDateTime::from_timestamp_nanos` now yields no mapping (graceful `?`) instead of panicking on user timestamp values.
- **`blue_cloud/seadatanet/map_units`** & **`util/coalesce_label`** — propagate the `ScalarValue`→array conversions.

## Notes
- Test-only downcasts (inside `#[cfg(test)]`) are intentionally left as-is.
- Static mapping-table initializers (`serde_json::from_slice(...).expect(...)`, `read_mappings_from_reader(...).unwrap()`) are left as-is: they operate on embedded build-time data, not user input.
- No `println!`/`dbg!` in production code (the earlier survey's hits were all in test code).

## Verification
- `cargo build -p beacon-functions` — clean.
- `cargo test -p beacon-functions` — 33 passed.
- `cargo clippy -p beacon-functions` — no new warnings in touched files (pre-existing: a `from_timestamp_nanos` deprecation and `unused arg_types`, both untouched here).
- `cargo build` (whole workspace) — succeeds.

Refs #251
