### PR TITLE
Accept a single path/glob string in file-format table functions

### DIFF
--- a/beacon-functions/src/file_formats/mod.rs
+++ b/beacon-functions/src/file_formats/mod.rs
@@ -5,10 +5,47 @@ use beacon_datafusion_ext::format_ext::FileFormatFactoryExt;
 use beacon_object_storage::DatasetsStore;
 use datafusion::{
     catalog::TableFunctionImpl,
+    common::plan_err,
     execution::object_store::ObjectStoreUrl,
     logical_expr::{Documentation, Signature},
-    prelude::SessionContext,
+    prelude::{Expr, SessionContext},
+    scalar::ScalarValue,
 };
+
+/// Parse the first table-function argument into a list of glob/path strings.
+///
+/// Accepts either a single string scalar (`Utf8`/`LargeUtf8`/`Utf8View`) or a
+/// `List<Utf8>` of strings. `fn_name` is used only to build clear error messages.
+pub(crate) fn parse_glob_paths_arg(
+    args: &[Expr],
+    fn_name: &str,
+) -> datafusion::error::Result<Vec<String>> {
+    let Some(first) = args.first() else {
+        return plan_err!("{fn_name} requires at least 1 argument: glob_paths : Utf8 | List<Utf8>");
+    };
+
+    match first {
+        // Single string -> one-element list
+        Expr::Literal(ScalarValue::Utf8(Some(s)), _)
+        | Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _)
+        | Expr::Literal(ScalarValue::Utf8View(Some(s)), _) => Ok(vec![s.clone()]),
+
+        // List of strings
+        Expr::Literal(ScalarValue::List(values), _) => {
+            let string_array = values.as_ref().values();
+            match string_array
+                .as_any()
+                .downcast_ref::<arrow::array::StringArray>()
+            {
+                Some(str_arr) => Ok(str_arr.iter().flatten().map(|s| s.to_string()).collect()),
+                None => plan_err!(
+                    "{fn_name} first argument must be a string or a List<Utf8> of glob paths"
+                ),
+            }
+        }
+        _ => plan_err!("{fn_name} first argument must be a string or a List<Utf8> of glob paths"),
+    }
+}
 
 pub mod list_datasets;
 pub mod read_arrow;
@@ -122,5 +159,65 @@ pub trait BeaconTableFunctionImpl: TableFunctionImpl + Send + Sync {
     }
     fn documentation(&self) -> Option<Documentation> {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_glob_paths_arg;
+    use datafusion::prelude::Expr;
+    use datafusion::scalar::ScalarValue;
+
+    fn list_expr(items: &[&str]) -> Expr {
+        let scalars: Vec<ScalarValue> = items
+            .iter()
+            .map(|s| ScalarValue::Utf8(Some(s.to_string())))
+            .collect();
+        Expr::Literal(
+            ScalarValue::List(ScalarValue::new_list_nullable(
+                &scalars,
+                &arrow::datatypes::DataType::Utf8,
+            )),
+            None,
+        )
+    }
+
+    #[test]
+    fn single_utf8_becomes_one_element_list() {
+        let expr = Expr::Literal(ScalarValue::Utf8(Some("data/*.parquet".to_string())), None);
+        let paths = parse_glob_paths_arg(&[expr], "read_parquet").unwrap();
+        assert_eq!(paths, vec!["data/*.parquet".to_string()]);
+    }
+
+    #[test]
+    fn single_large_utf8_is_accepted() {
+        let expr = Expr::Literal(ScalarValue::LargeUtf8(Some("a.csv".to_string())), None);
+        let paths = parse_glob_paths_arg(&[expr], "read_csv").unwrap();
+        assert_eq!(paths, vec!["a.csv".to_string()]);
+    }
+
+    #[test]
+    fn single_utf8_view_is_accepted() {
+        let expr = Expr::Literal(ScalarValue::Utf8View(Some("a.nc".to_string())), None);
+        let paths = parse_glob_paths_arg(&[expr], "read_netcdf").unwrap();
+        assert_eq!(paths, vec!["a.nc".to_string()]);
+    }
+
+    #[test]
+    fn list_of_strings_is_accepted() {
+        let expr = list_expr(&["a.parquet", "b.parquet"]);
+        let paths = parse_glob_paths_arg(&[expr], "read_parquet").unwrap();
+        assert_eq!(paths, vec!["a.parquet".to_string(), "b.parquet".to_string()]);
+    }
+
+    #[test]
+    fn missing_argument_errors() {
+        assert!(parse_glob_paths_arg(&[], "read_parquet").is_err());
+    }
+
+    #[test]
+    fn wrong_type_errors() {
+        let expr = Expr::Literal(ScalarValue::Int64(Some(42)), None);
+        assert!(parse_glob_paths_arg(&[expr], "read_parquet").is_err());
     }
 }

--- a/beacon-functions/src/file_formats/read_arrow.rs
+++ b/beacon-functions/src/file_formats/read_arrow.rs
@@ -4,11 +4,7 @@ use arrow::datatypes::{DataType, Field};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
 use beacon_arrow_ipc::datafusion::ArrowFormat;
 use datafusion::{
-    catalog::TableFunctionImpl,
-    common::plan_err,
-    execution::object_store::ObjectStoreUrl,
-    prelude::{Expr, SessionContext},
-    scalar::ScalarValue,
+    catalog::TableFunctionImpl, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
 };
 
 use crate::file_formats::BeaconTableFunctionImpl;
@@ -67,38 +63,7 @@ impl TableFunctionImpl for ReadArrowFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let mut glob_paths: Vec<String> = vec![];
-        if let Some(glob_path_arg) = args.first() {
-            match glob_path_arg {
-                Expr::Literal(ScalarValue::List(values), _) => {
-                    let string_array = values.as_ref().values();
-                    match string_array
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        Some(str_arr) => {
-                            str_arr.iter().for_each(|opt_str| {
-                                if let Some(s) = opt_str {
-                                    glob_paths.push(s.to_string());
-                                }
-                            });
-                        }
-                        None => {
-                            return plan_err!(
-                                "read_arrow first argument must be a List<Utf8> of glob paths"
-                            );
-                        }
-                    }
-                }
-                _ => {
-                    return plan_err!(
-                        "read_arrow first argument must be a List<Utf8> of glob paths"
-                    );
-                }
-            }
-        } else {
-            return plan_err!("read_arrow requires at least 1 argument: glob_paths : List<Utf8>");
-        }
+        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_arrow")?;
 
         tracing::debug!("read_arrow glob paths: {:?}", glob_paths);
 

--- a/beacon-functions/src/file_formats/read_atlas.rs
+++ b/beacon-functions/src/file_formats/read_atlas.rs
@@ -83,38 +83,7 @@ impl TableFunctionImpl for ReadAtlasFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let mut glob_paths: Vec<String> = vec![];
-        if let Some(glob_path_arg) = args.first() {
-            match glob_path_arg {
-                Expr::Literal(ScalarValue::List(values), _) => {
-                    let string_array = values.as_ref().values();
-                    match string_array
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        Some(str_arr) => {
-                            str_arr.iter().for_each(|opt_str| {
-                                if let Some(s) = opt_str {
-                                    glob_paths.push(s.to_string());
-                                }
-                            });
-                        }
-                        None => {
-                            return plan_err!(
-                                "read_atlas first argument must be a List<Utf8> of glob paths"
-                            );
-                        }
-                    }
-                }
-                _ => {
-                    return plan_err!(
-                        "read_atlas first argument must be a List<Utf8> of glob paths"
-                    );
-                }
-            }
-        } else {
-            return plan_err!("read_atlas requires at least 1 argument: glob_paths : List<Utf8>");
-        }
+        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_atlas")?;
 
         let mut dimensions: Option<Vec<String>> = None;
         if let Some(dimensions_arg) = args.get(1) {

--- a/beacon-functions/src/file_formats/read_bbf.rs
+++ b/beacon-functions/src/file_formats/read_bbf.rs
@@ -4,11 +4,7 @@ use arrow::datatypes::{DataType, Field};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
 use beacon_arrow_bbf::datafusion::BBFFormat;
 use datafusion::{
-    catalog::TableFunctionImpl,
-    common::plan_err,
-    execution::object_store::ObjectStoreUrl,
-    prelude::{Expr, SessionContext},
-    scalar::ScalarValue,
+    catalog::TableFunctionImpl, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
 };
 
 use crate::file_formats::BeaconTableFunctionImpl;
@@ -67,36 +63,7 @@ impl TableFunctionImpl for ReadBBFFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let mut glob_paths: Vec<String> = vec![];
-        if let Some(glob_path_arg) = args.first() {
-            match glob_path_arg {
-                Expr::Literal(ScalarValue::List(values), _) => {
-                    let string_array = values.as_ref().values();
-                    match string_array
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        Some(str_arr) => {
-                            str_arr.iter().for_each(|opt_str| {
-                                if let Some(s) = opt_str {
-                                    glob_paths.push(s.to_string());
-                                }
-                            });
-                        }
-                        None => {
-                            return plan_err!(
-                                "read_bbf first argument must be a List<Utf8> of glob paths"
-                            );
-                        }
-                    }
-                }
-                _ => {
-                    return plan_err!("read_bbf first argument must be a List<Utf8> of glob paths");
-                }
-            }
-        } else {
-            return plan_err!("read_bbf requires at least 1 argument: glob_paths : List<Utf8>");
-        }
+        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_bbf")?;
 
         tracing::debug!("read_bbf glob paths: {:?}", glob_paths);
 

--- a/beacon-functions/src/file_formats/read_csv.rs
+++ b/beacon-functions/src/file_formats/read_csv.rs
@@ -71,36 +71,7 @@ impl TableFunctionImpl for ReadCsvFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let mut glob_paths: Vec<String> = vec![];
-        if let Some(glob_path_arg) = args.first() {
-            match glob_path_arg {
-                Expr::Literal(ScalarValue::List(values), _) => {
-                    let string_array = values.as_ref().values();
-                    match string_array
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        Some(str_arr) => {
-                            str_arr.iter().for_each(|opt_str| {
-                                if let Some(s) = opt_str {
-                                    glob_paths.push(s.to_string());
-                                }
-                            });
-                        }
-                        None => {
-                            return plan_err!(
-                                "read_csv first argument must be a List<Utf8> of glob paths"
-                            );
-                        }
-                    }
-                }
-                _ => {
-                    return plan_err!("read_csv first argument must be a List<Utf8> of glob paths");
-                }
-            }
-        } else {
-            return plan_err!("read_csv requires at least 1 argument: glob_paths : List<Utf8>");
-        }
+        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_csv")?;
 
         let delimeter = if let Some(delimiter_arg) = args.get(1) {
             match delimiter_arg {

--- a/beacon-functions/src/file_formats/read_geoparquet.rs
+++ b/beacon-functions/src/file_formats/read_geoparquet.rs
@@ -4,11 +4,7 @@ use arrow::datatypes::{DataType, Field};
 use beacon_arrow_geoparquet::datafusion::{GeoParquetFormat, GeoParquetOptions};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
 use datafusion::{
-    catalog::TableFunctionImpl,
-    common::plan_err,
-    execution::object_store::ObjectStoreUrl,
-    prelude::{Expr, SessionContext},
-    scalar::ScalarValue,
+    catalog::TableFunctionImpl, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
 };
 
 use crate::file_formats::BeaconTableFunctionImpl;
@@ -70,40 +66,7 @@ impl TableFunctionImpl for ReadGeoParquetFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let mut glob_paths: Vec<String> = vec![];
-        if let Some(glob_path_arg) = args.first() {
-            match glob_path_arg {
-                Expr::Literal(ScalarValue::List(values), _) => {
-                    let string_array = values.as_ref().values();
-                    match string_array
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        Some(str_arr) => {
-                            str_arr.iter().for_each(|opt_str| {
-                                if let Some(s) = opt_str {
-                                    glob_paths.push(s.to_string());
-                                }
-                            });
-                        }
-                        None => {
-                            return plan_err!(
-                                "read_geoparquet first argument must be a List<Utf8> of glob paths"
-                            );
-                        }
-                    }
-                }
-                _ => {
-                    return plan_err!(
-                        "read_geoparquet first argument must be a List<Utf8> of glob paths"
-                    );
-                }
-            }
-        } else {
-            return plan_err!(
-                "read_geoparquet requires at least 1 argument: glob_paths : List<Utf8>"
-            );
-        }
+        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_geoparquet")?;
 
         tracing::debug!("read_geoparquet glob paths: {:?}", glob_paths);
 

--- a/beacon-functions/src/file_formats/read_netcdf.rs
+++ b/beacon-functions/src/file_formats/read_netcdf.rs
@@ -71,38 +71,7 @@ impl TableFunctionImpl for ReadNetCDFFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let mut glob_paths: Vec<String> = vec![];
-        if let Some(glob_path_arg) = args.first() {
-            match glob_path_arg {
-                Expr::Literal(ScalarValue::List(values), _) => {
-                    let string_array = values.as_ref().values();
-                    match string_array
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        Some(str_arr) => {
-                            str_arr.iter().for_each(|opt_str| {
-                                if let Some(s) = opt_str {
-                                    glob_paths.push(s.to_string());
-                                }
-                            });
-                        }
-                        None => {
-                            return plan_err!(
-                                "read_netcdf first argument must be a List<Utf8> of glob paths"
-                            );
-                        }
-                    }
-                }
-                _ => {
-                    return plan_err!(
-                        "read_netcdf first argument must be a List<Utf8> of glob paths"
-                    );
-                }
-            }
-        } else {
-            return plan_err!("read_netcdf requires at least 1 argument: glob_paths : List<Utf8>");
-        }
+        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_netcdf")?;
         let mut dimensions: Option<Vec<String>> = None;
         if let Some(dimensions_arg) = args.get(1) {
             if let Expr::Literal(ScalarValue::List(values), _) = dimensions_arg {

--- a/beacon-functions/src/file_formats/read_odv_ascii.rs
+++ b/beacon-functions/src/file_formats/read_odv_ascii.rs
@@ -5,10 +5,8 @@ use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperList
 use beacon_arrow_odv::datafusion::OdvFormat;
 use datafusion::{
     catalog::TableFunctionImpl,
-    common::plan_err,
     execution::object_store::ObjectStoreUrl,
     prelude::{Expr, SessionContext},
-    scalar::ScalarValue,
 };
 
 use crate::file_formats::BeaconTableFunctionImpl;
@@ -66,40 +64,7 @@ impl TableFunctionImpl for ReadOdvAsciiFunc {
         &self,
         args: &[Expr],
     ) -> datafusion::error::Result<Arc<dyn datafusion::catalog::TableProvider>> {
-        let mut glob_paths: Vec<String> = vec![];
-        if let Some(glob_path_arg) = args.first() {
-            match glob_path_arg {
-                Expr::Literal(ScalarValue::List(values), _) => {
-                    let string_array = values.as_ref().values();
-                    match string_array
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        Some(str_arr) => {
-                            str_arr.iter().for_each(|opt_str| {
-                                if let Some(s) = opt_str {
-                                    glob_paths.push(s.to_string());
-                                }
-                            });
-                        }
-                        None => {
-                            return plan_err!(
-                                "read_odv_ascii first argument must be a List<Utf8> of glob paths"
-                            );
-                        }
-                    }
-                }
-                _ => {
-                    return plan_err!(
-                        "read_odv_ascii first argument must be a List<Utf8> of glob paths"
-                    );
-                }
-            }
-        } else {
-            return plan_err!(
-                "read_odv_ascii requires at least 1 argument: glob_paths : List<Utf8>"
-            );
-        }
+        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_odv_ascii")?;
 
         tracing::debug!("read_odv_ascii glob paths: {:?}", glob_paths);
 

--- a/beacon-functions/src/file_formats/read_parquet.rs
+++ b/beacon-functions/src/file_formats/read_parquet.rs
@@ -4,11 +4,7 @@ use arrow::datatypes::{DataType, Field};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
 use beacon_arrow_parquet::datafusion::ParquetFormat;
 use datafusion::{
-    catalog::TableFunctionImpl,
-    common::plan_err,
-    execution::object_store::ObjectStoreUrl,
-    prelude::{Expr, SessionContext},
-    scalar::ScalarValue,
+    catalog::TableFunctionImpl, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
 };
 
 use crate::file_formats::BeaconTableFunctionImpl;
@@ -67,38 +63,7 @@ impl TableFunctionImpl for ReadParquetFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let mut glob_paths: Vec<String> = vec![];
-        if let Some(glob_path_arg) = args.first() {
-            match glob_path_arg {
-                Expr::Literal(ScalarValue::List(values), _) => {
-                    let string_array = values.as_ref().values();
-                    match string_array
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        Some(str_arr) => {
-                            str_arr.iter().for_each(|opt_str| {
-                                if let Some(s) = opt_str {
-                                    glob_paths.push(s.to_string());
-                                }
-                            });
-                        }
-                        None => {
-                            return plan_err!(
-                                "read_parquet first argument must be a List<Utf8> of glob paths"
-                            );
-                        }
-                    }
-                }
-                _ => {
-                    return plan_err!(
-                        "read_parquet first argument must be a List<Utf8> of glob paths"
-                    );
-                }
-            }
-        } else {
-            return plan_err!("read_parquet requires at least 1 argument: glob_paths : List<Utf8>");
-        }
+        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_parquet")?;
 
         tracing::debug!("read_parquet glob paths: {:?}", glob_paths);
 

--- a/beacon-functions/src/file_formats/read_schema.rs
+++ b/beacon-functions/src/file_formats/read_schema.rs
@@ -87,38 +87,7 @@ impl TableFunctionImpl for ReadSchemaFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let mut glob_paths: Vec<String> = vec![];
-        if let Some(glob_path_arg) = args.first() {
-            match glob_path_arg {
-                Expr::Literal(ScalarValue::List(values), _) => {
-                    let string_array = values.as_ref().values();
-                    match string_array
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        Some(str_arr) => {
-                            str_arr.iter().for_each(|opt_str| {
-                                if let Some(s) = opt_str {
-                                    glob_paths.push(s.to_string());
-                                }
-                            });
-                        }
-                        None => {
-                            return plan_err!(
-                                "read_schema first argument must be a List<Utf8> of glob paths"
-                            );
-                        }
-                    }
-                }
-                _ => {
-                    return plan_err!(
-                        "read_schema first argument must be a List<Utf8> of glob paths"
-                    );
-                }
-            }
-        } else {
-            return plan_err!("read_schema requires at least 1 argument: glob_paths : List<Utf8>");
-        }
+        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_schema")?;
 
         tracing::debug!("read_schema glob paths: {:?}", glob_paths);
 

--- a/beacon-functions/src/file_formats/read_tiff.rs
+++ b/beacon-functions/src/file_formats/read_tiff.rs
@@ -5,11 +5,7 @@ use beacon_arrow_tiff::datafusion::TiffFormat;
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
 use beacon_object_storage::DatasetsStore;
 use datafusion::{
-    catalog::TableFunctionImpl,
-    common::plan_err,
-    execution::object_store::ObjectStoreUrl,
-    prelude::{Expr, SessionContext},
-    scalar::ScalarValue,
+    catalog::TableFunctionImpl, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
 };
 
 use crate::file_formats::BeaconTableFunctionImpl;
@@ -68,38 +64,7 @@ impl TableFunctionImpl for ReadTiffFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let mut glob_paths: Vec<String> = vec![];
-        if let Some(glob_path_arg) = args.first() {
-            match glob_path_arg {
-                Expr::Literal(ScalarValue::List(values), _) => {
-                    let string_array = values.as_ref().values();
-                    match string_array
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        Some(str_arr) => {
-                            str_arr.iter().for_each(|opt_str| {
-                                if let Some(s) = opt_str {
-                                    glob_paths.push(s.to_string());
-                                }
-                            });
-                        }
-                        None => {
-                            return plan_err!(
-                                "read_tiff first argument must be a List<Utf8> of glob paths"
-                            );
-                        }
-                    }
-                }
-                _ => {
-                    return plan_err!(
-                        "read_tiff first argument must be a List<Utf8> of glob paths"
-                    );
-                }
-            }
-        } else {
-            return plan_err!("read_tiff requires at least 1 argument: glob_paths : List<Utf8>");
-        }
+        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_tiff")?;
 
         let mut listing_urls = vec![];
         for path in &glob_paths {

--- a/beacon-functions/src/file_formats/read_zarr.rs
+++ b/beacon-functions/src/file_formats/read_zarr.rs
@@ -1,17 +1,10 @@
 use std::{fmt::Debug, sync::Arc};
 
-use arrow::{
-    array::Array,
-    datatypes::{DataType, Field},
-};
+use arrow::datatypes::{DataType, Field};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
 use beacon_arrow_zarr::datafusion::ZarrFormat;
 use datafusion::{
-    catalog::TableFunctionImpl,
-    common::plan_err,
-    execution::object_store::ObjectStoreUrl,
-    prelude::{Expr, SessionContext},
-    scalar::ScalarValue,
+    catalog::TableFunctionImpl, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
 };
 
 use crate::file_formats::BeaconTableFunctionImpl;
@@ -70,38 +63,7 @@ impl TableFunctionImpl for ReadZarrFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let mut glob_paths: Vec<String> = vec![];
-        if let Some(glob_path_arg) = args.first() {
-            match glob_path_arg {
-                Expr::Literal(ScalarValue::List(values), _) => {
-                    let string_array = values.as_ref().values();
-                    match string_array
-                        .as_any()
-                        .downcast_ref::<arrow::array::StringArray>()
-                    {
-                        Some(str_arr) => {
-                            str_arr.iter().for_each(|opt_str| {
-                                if let Some(s) = opt_str {
-                                    glob_paths.push(s.to_string());
-                                }
-                            });
-                        }
-                        None => {
-                            return plan_err!(
-                                "read_zarr first argument must be a List<Utf8> of glob paths"
-                            );
-                        }
-                    }
-                }
-                _ => {
-                    return plan_err!(
-                        "read_zarr first argument must be a List<Utf8> of glob paths"
-                    );
-                }
-            }
-        } else {
-            return plan_err!("read_zarr requires at least 1 argument: glob_paths : List<Utf8>");
-        }
+        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_zarr")?;
 
         tracing::debug!("read_zarr glob paths: {:?}", glob_paths);
 

--- a/docs/docs/1.7.3/sql/table-functions-utility.md
+++ b/docs/docs/1.7.3/sql/table-functions-utility.md
@@ -10,12 +10,16 @@ read_schema(glob_paths, file_format)
 
 Returns the inferred schema (column names and types) for a set of files without reading any data.
 
-`file_format` must be one of: `netcdf`, `zarr`, `parquet`, `arrow`, `csv`, `odv_ascii`, `bbf`, `tiff`.
+`glob_paths` accepts either a single glob/path string or a list of strings. `file_format` must be one of: `parquet`, `netcdf` (or `nc`), `zarr`, `arrow`, `csv`, `bbf`, `tiff` (or `tif`).
 
 ```sql
-SELECT * FROM read_schema(['argo/**/*.nc'], 'netcdf')
+-- Single path or glob
+SELECT * FROM read_schema('argo/**/*.nc', 'netcdf')
 
-SELECT * FROM read_schema(['obs/*.parquet'], 'parquet')
+SELECT * FROM read_schema('obs/*.parquet', 'parquet')
+
+-- A list, to inspect the combined schema across multiple sources
+SELECT * FROM read_schema(['obs/2023/*.parquet', 'obs/2024/*.parquet'], 'parquet')
 ```
 
 ## `list_datasets`

--- a/docs/docs/1.7.3/sql/table-functions.md
+++ b/docs/docs/1.7.3/sql/table-functions.md
@@ -2,18 +2,20 @@
 
 Table functions let you query files directly in a `FROM` clause without creating a persistent [External Table](../data-lake/external-tables.md) first. They are useful for ad-hoc exploration or when you want to embed the file path logic inside a [View](../data-lake/view.md).
 
-All functions accept one or more glob paths as a list. Globs are resolved relative to Beacon's configured dataset storage root.
+All functions take the file path(s) to read as their first argument. This can be **either a single glob/path string** or **a list of strings**. Globs are resolved relative to Beacon's configured dataset storage root.
 
 ```sql
 -- Single path
-SELECT * FROM read_parquet(['profiles/2024.parquet'])
+SELECT * FROM read_parquet('profiles/2024.parquet')
 
--- Folder glob
-SELECT * FROM read_netcdf(['argo/**/*.nc'])
+-- Single folder glob
+SELECT * FROM read_netcdf('argo/**/*.nc')
 
--- Multiple globs in one call
+-- A list, to combine multiple paths or globs in one call
 SELECT * FROM read_netcdf(['argo/**/*.nc', 'wod/**/*.nc'])
 ```
+
+In every signature below, the `glob_paths` argument accepts either form — a single string or a list of strings.
 
 ## `read_netcdf`
 
@@ -28,7 +30,7 @@ The optional `dimensions` argument filters which variables are returned: a varia
 
 ```sql
 SELECT time, latitude, longitude, temperature
-FROM read_netcdf(['argo/**/*.nc'])
+FROM read_netcdf('argo/**/*.nc')
 
 -- With explicit dimension columns
 SELECT *
@@ -42,12 +44,12 @@ NetCDF variable attributes (e.g. `units`, `long_name`) are exposed as additional
 ```sql
 -- Variable attribute
 SELECT temperature, "temperature.units", "temperature.long_name"
-FROM read_netcdf(['argo/**/*.nc'])
+FROM read_netcdf('argo/**/*.nc')
 LIMIT 1
 
 -- Global attribute
 SELECT ".source", temperature
-FROM read_netcdf(['argo/**/*.nc'])
+FROM read_netcdf('argo/**/*.nc')
 LIMIT 1
 ```
 
@@ -62,11 +64,11 @@ Reads Zarr stores matching one or more glob patterns. Each path should point at 
 Predicate pushdown is automatic: Beacon prunes chunks and slices coordinate dimensions (e.g. `time`, `latitude`, `longitude`) based on the query's `WHERE` clause — no statistics columns need to be declared.
 
 ```sql
-SELECT * FROM read_zarr(['sst/*/zarr.json'])
+SELECT * FROM read_zarr('sst/*/zarr.json')
 
 -- Range queries are pruned automatically
 SELECT time, sst
-FROM read_zarr(['sst/*/zarr.json'])
+FROM read_zarr('sst/*/zarr.json')
 WHERE time >= '2024-01-01'
 ```
 
@@ -77,12 +79,12 @@ Per-array attributes are exposed as additional columns using the pattern `<array
 ```sql
 -- Array attribute
 SELECT sst, "sst.units", "sst.long_name"
-FROM read_zarr(['sst/*/zarr.json'])
+FROM read_zarr('sst/*/zarr.json')
 LIMIT 1
 
 -- Root-level global attribute
 SELECT ".Conventions", sst
-FROM read_zarr(['sst/*/zarr.json'])
+FROM read_zarr('sst/*/zarr.json')
 LIMIT 1
 ```
 
@@ -98,7 +100,7 @@ Reads [Atlas](../data-lake/datasets.md#atlas) array stores matching one or more 
 The optional `dimensions` argument filters the arrays to those matching the listed dimension names. Atlas prunes whole datasets using per-column statistics, so range queries over large collections only read the datasets that can match the predicate.
 
 ```sql
-SELECT * FROM read_atlas(['collections/sensor/atlas.json'])
+SELECT * FROM read_atlas('collections/sensor/atlas.json')
 
 -- Combine every Atlas store under a prefix, keeping a subset of dimensions
 SELECT time, temperature
@@ -113,7 +115,7 @@ read_parquet(glob_paths)
 ```
 
 ```sql
-SELECT * FROM read_parquet(['obs/**/*.parquet']) LIMIT 100
+SELECT * FROM read_parquet('obs/**/*.parquet') LIMIT 100
 ```
 
 ## `read_geoparquet`
@@ -125,7 +127,7 @@ read_geoparquet(glob_paths)
 Reads [GeoParquet](https://geoparquet.org/) files. Geometry columns described in the file's `geo` metadata are decoded to their native [GeoArrow](https://geoarrow.org/) representation; files without geometry are read like ordinary Parquet.
 
 ```sql
-SELECT * FROM read_geoparquet(['spatial/**/*.geoparquet']) LIMIT 100
+SELECT * FROM read_geoparquet('spatial/**/*.geoparquet') LIMIT 100
 ```
 
 ## `read_arrow`
@@ -137,7 +139,7 @@ read_arrow(glob_paths)
 Reads Arrow IPC stream files (`.arrow`, `.ipc`).
 
 ```sql
-SELECT * FROM read_arrow(['streams/*.arrow'])
+SELECT * FROM read_arrow('streams/*.arrow')
 ```
 
 ## `read_csv`
@@ -154,7 +156,7 @@ Schema is inferred from the file contents. The first row must be a header row.
 - `infer_records` — number of rows to sample when inferring column types (default: `100`)
 
 ```sql
-SELECT * FROM read_csv(['metadata/*.csv'])
+SELECT * FROM read_csv('metadata/*.csv')
 
 -- Tab-separated, sample 500 rows for type inference
 SELECT * FROM read_csv(['data/*.tsv'], '\t', 500)
@@ -167,7 +169,7 @@ read_odv_ascii(glob_paths)
 ```
 
 ```sql
-SELECT * FROM read_odv_ascii(['odv/**/*.txt'])
+SELECT * FROM read_odv_ascii('odv/**/*.txt')
 ```
 
 ## `read_bbf`
@@ -179,7 +181,7 @@ read_bbf(glob_paths)
 Reads Beacon Binary Format files.
 
 ```sql
-SELECT * FROM read_bbf(['bbf/**/*.bbf'])
+SELECT * FROM read_bbf('bbf/**/*.bbf')
 ```
 
 ## `read_tiff`
@@ -191,7 +193,7 @@ read_tiff(glob_paths)
 Reads GeoTIFF and Cloud-Optimized GeoTIFF files.
 
 ```sql
-SELECT * FROM read_tiff(['rasters/elevation.tif'])
+SELECT * FROM read_tiff('rasters/elevation.tif')
 ```
 
 ### Tag attributes
@@ -201,11 +203,11 @@ Per-band TIFF tags are exposed as additional columns using the pattern `<band>.<
 ```sql
 -- Band attribute
 SELECT band_1, "band_1.nodata", "band_1.scale"
-FROM read_tiff(['rasters/elevation.tif'])
+FROM read_tiff('rasters/elevation.tif')
 LIMIT 1
 
 -- File-level global tag
 SELECT ".crs", band_1
-FROM read_tiff(['rasters/elevation.tif'])
+FROM read_tiff('rasters/elevation.tif')
 LIMIT 1
 ```


### PR DESCRIPTION
## Summary

The `read_*` file-format table functions (`read_parquet`, `read_csv`, `read_netcdf`, `read_zarr`, `read_atlas`, `read_arrow`, `read_geoparquet`, `read_bbf`, `read_tiff`, `read_odv_ascii`, `read_schema`) previously required their first argument to be a **list** of strings. They now also accept a **single string** (a path or a glob), so the ergonomic form works:

```sql
SELECT * FROM read_parquet('data/sample.parquet');   -- single path
SELECT * FROM read_parquet('data/*.parquet');         -- single glob
SELECT * FROM read_parquet(['data/*.parquet']);       -- list (still works)
SELECT * FROM read_csv('data/file.csv', ';');          -- single path + extra args
```

## What changed

- Added a shared `parse_glob_paths_arg(args, fn_name)` helper in `beacon-functions/src/file_formats/mod.rs` that accepts either a single `Utf8`/`LargeUtf8`/`Utf8View` scalar **or** a `List<Utf8>`. Glob expansion is already handled downstream by `parse_listing_table_url`, so a single string just becomes a one-element list.
- Replaced the ~30-line duplicated argument-parsing block in all 11 `read_*` functions with a one-line call to the helper, pruning now-unused imports.
- Added 6 unit tests for the helper (single `Utf8`/`LargeUtf8`/`Utf8View`, list form, missing arg, wrong type).
- Updated the VitePress docs (`docs/docs/1.7.3/sql/table-functions.md`) to document and demonstrate both forms.

## Testing

- `cargo build -p beacon-functions` — no errors, no new warnings
- `cargo test -p beacon-functions` — 39 passed (incl. 6 new helper tests)
- `cargo test -p beacon-common` — `listing_url` glob tests pass