### PR TITLE
Per-format config + per-table OPTIONS for netcdf/atlas/bbf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,6 +1259,8 @@ dependencies = [
  "datafusion",
  "futures",
  "object_store 0.13.2",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1295,6 +1297,8 @@ dependencies = [
  "datafusion",
  "futures",
  "object_store 0.13.2",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1377,6 +1381,8 @@ dependencies = [
  "datafusion",
  "futures",
  "object_store 0.13.2",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,6 +1570,7 @@ dependencies = [
  "beacon-arrow-tiff",
  "beacon-arrow-zarr",
  "beacon-common",
+ "beacon-config",
  "beacon-datafusion-ext",
  "beacon-iceberg",
  "beacon-object-storage",

--- a/beacon-common/src/lib.rs
+++ b/beacon-common/src/lib.rs
@@ -5,5 +5,6 @@ pub mod listing_url;
 pub mod schema_table_provider;
 pub mod super_table;
 pub mod super_typing;
+pub mod table_function;
 
 pub use error::CommonError;

--- a/beacon-common/src/table_function.rs
+++ b/beacon-common/src/table_function.rs
@@ -1,0 +1,132 @@
+//! Shared support for Beacon's `read_*` file-format table functions.
+//!
+//! The [`BeaconTableFunctionImpl`] trait and the [`parse_glob_paths_arg`] helper
+//! live here (rather than in `beacon-functions`) so each `beacon-arrow-*` format
+//! crate can host its own `read_*` table function without depending on
+//! `beacon-functions` (which depends on the format crates).
+
+use arrow::datatypes::Field;
+use datafusion::{
+    catalog::TableFunctionImpl,
+    common::plan_err,
+    logical_expr::{Documentation, Signature},
+    prelude::Expr,
+    scalar::ScalarValue,
+};
+
+/// Beacon's extension of DataFusion's [`TableFunctionImpl`] that also carries the
+/// metadata Beacon needs to register the function and render its documentation.
+pub trait BeaconTableFunctionImpl: TableFunctionImpl + Send + Sync {
+    fn name(&self) -> String;
+    fn as_any(&self) -> &dyn std::any::Any;
+    fn arguments(&self) -> Option<Vec<Field>> {
+        None
+    }
+    fn description(&self) -> Option<String> {
+        None
+    }
+    fn signature(&self) -> Signature {
+        // Default field that accepts glob paths
+        let mut all_datatypes = vec![];
+        let options = self.arguments().unwrap_or_default();
+        for option in options {
+            all_datatypes.push(option.data_type().clone());
+        }
+        Signature::exact(all_datatypes, datafusion::logical_expr::Volatility::Immutable)
+    }
+    fn documentation(&self) -> Option<Documentation> {
+        None
+    }
+}
+
+/// Parse the first table-function argument into a list of glob/path strings.
+///
+/// Accepts either a single string scalar (`Utf8`/`LargeUtf8`/`Utf8View`) or a
+/// `List<Utf8>` of strings. `fn_name` is used only to build clear error messages.
+pub fn parse_glob_paths_arg(args: &[Expr], fn_name: &str) -> datafusion::error::Result<Vec<String>> {
+    let Some(first) = args.first() else {
+        return plan_err!("{fn_name} requires at least 1 argument: glob_paths : Utf8 | List<Utf8>");
+    };
+
+    match first {
+        // Single string -> one-element list
+        Expr::Literal(ScalarValue::Utf8(Some(s)), _)
+        | Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _)
+        | Expr::Literal(ScalarValue::Utf8View(Some(s)), _) => Ok(vec![s.clone()]),
+
+        // List of strings
+        Expr::Literal(ScalarValue::List(values), _) => {
+            let string_array = values.as_ref().values();
+            match string_array
+                .as_any()
+                .downcast_ref::<arrow::array::StringArray>()
+            {
+                Some(str_arr) => Ok(str_arr.iter().flatten().map(|s| s.to_string()).collect()),
+                None => plan_err!(
+                    "{fn_name} first argument must be a string or a List<Utf8> of glob paths"
+                ),
+            }
+        }
+        _ => plan_err!("{fn_name} first argument must be a string or a List<Utf8> of glob paths"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_glob_paths_arg;
+    use datafusion::prelude::Expr;
+    use datafusion::scalar::ScalarValue;
+
+    fn list_expr(items: &[&str]) -> Expr {
+        let scalars: Vec<ScalarValue> = items
+            .iter()
+            .map(|s| ScalarValue::Utf8(Some(s.to_string())))
+            .collect();
+        Expr::Literal(
+            ScalarValue::List(ScalarValue::new_list_nullable(
+                &scalars,
+                &arrow::datatypes::DataType::Utf8,
+            )),
+            None,
+        )
+    }
+
+    #[test]
+    fn single_utf8_becomes_one_element_list() {
+        let expr = Expr::Literal(ScalarValue::Utf8(Some("data/*.parquet".to_string())), None);
+        let paths = parse_glob_paths_arg(&[expr], "read_parquet").unwrap();
+        assert_eq!(paths, vec!["data/*.parquet".to_string()]);
+    }
+
+    #[test]
+    fn single_large_utf8_is_accepted() {
+        let expr = Expr::Literal(ScalarValue::LargeUtf8(Some("a.csv".to_string())), None);
+        let paths = parse_glob_paths_arg(&[expr], "read_csv").unwrap();
+        assert_eq!(paths, vec!["a.csv".to_string()]);
+    }
+
+    #[test]
+    fn single_utf8_view_is_accepted() {
+        let expr = Expr::Literal(ScalarValue::Utf8View(Some("a.nc".to_string())), None);
+        let paths = parse_glob_paths_arg(&[expr], "read_netcdf").unwrap();
+        assert_eq!(paths, vec!["a.nc".to_string()]);
+    }
+
+    #[test]
+    fn list_of_strings_is_accepted() {
+        let expr = list_expr(&["a.parquet", "b.parquet"]);
+        let paths = parse_glob_paths_arg(&[expr], "read_parquet").unwrap();
+        assert_eq!(paths, vec!["a.parquet".to_string(), "b.parquet".to_string()]);
+    }
+
+    #[test]
+    fn missing_argument_errors() {
+        assert!(parse_glob_paths_arg(&[], "read_parquet").is_err());
+    }
+
+    #[test]
+    fn wrong_type_errors() {
+        let expr = Expr::Literal(ScalarValue::Int64(Some(42)), None);
+        assert!(parse_glob_paths_arg(&[expr], "read_parquet").is_err());
+    }
+}

--- a/beacon-core/src/query/from.rs
+++ b/beacon-core/src/query/from.rs
@@ -160,10 +160,13 @@ impl FromFormat {
             )) as Arc<dyn FileFormat>),
             FromFormat::Parquet { .. } => Ok(Arc::new(ParquetFormat::new()) as Arc<dyn FileFormat>),
             FromFormat::Arrow { .. } => Ok(Arc::new(ArrowFormat::new()) as Arc<dyn FileFormat>),
-            FromFormat::NetCDF { .. } => Ok(Arc::new(NetcdfFormat::new(
-                beacon_object_storage::get_datasets_object_store().await,
-                NetcdfOptions::default(),
-            )) as Arc<dyn FileFormat>),
+            FromFormat::NetCDF { .. } => Ok(Arc::new(
+                NetcdfFormat::new(
+                    beacon_object_storage::get_datasets_object_store().await,
+                    NetcdfOptions::default(),
+                )
+                .with_enable_statistics(beacon_config::CONFIG.netcdf.enable_statistics),
+            ) as Arc<dyn FileFormat>),
             FromFormat::Tiff { .. } => {
                 Ok(Arc::new(TiffFormat::new(Default::default())) as Arc<dyn FileFormat>)
             }
@@ -172,10 +175,9 @@ impl FromFormat {
                 Ok(Arc::new(beacon_arrow_zarr::datafusion::ZarrFormat::default())
                     as Arc<dyn FileFormat>)
             }
-            FromFormat::Bbf { .. } => {
-                Ok(Arc::new(beacon_arrow_bbf::datafusion::BBFFormat::default())
-                    as Arc<dyn FileFormat>)
-            }
+            FromFormat::Bbf { .. } => Ok(Arc::new(beacon_arrow_bbf::datafusion::BBFFormat {
+                split_streams_slice: beacon_config::CONFIG.runtime.bbf_split_streams_slice,
+            }) as Arc<dyn FileFormat>),
         }
     }
 

--- a/beacon-core/src/query/from.rs
+++ b/beacon-core/src/query/from.rs
@@ -214,3 +214,129 @@ fn file_format_from_session(
     })?;
     factory.create(&state, &std::collections::HashMap::new())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::datasource::file_format::FileFormatFactory;
+    use std::any::Any;
+    use std::collections::HashMap;
+
+    /// (variant, the factory it should resolve) for every store/listing format
+    /// that `file_format` builds via a session-registered factory.
+    async fn factory_cases() -> Vec<(FromFormat, Arc<dyn FileFormatFactory>)> {
+        let store = beacon_object_storage::get_datasets_object_store().await;
+        vec![
+            (
+                FromFormat::Parquet { paths: vec![] },
+                Arc::new(beacon_arrow_parquet::datafusion::ParquetFormatFactory),
+            ),
+            (
+                FromFormat::Arrow { paths: vec![] },
+                Arc::new(beacon_arrow_ipc::datafusion::ArrowFormatFactory),
+            ),
+            (
+                FromFormat::NetCDF { paths: vec![] },
+                Arc::new(beacon_arrow_netcdf::datafusion::NetCDFFormatFactory::new(
+                    store.clone(),
+                    Default::default(),
+                    Default::default(),
+                )),
+            ),
+            (
+                FromFormat::Tiff { paths: vec![] },
+                Arc::new(beacon_arrow_tiff::datafusion::TiffFormatFactory::new(
+                    Default::default(),
+                )),
+            ),
+            (
+                FromFormat::Zarr { paths: vec![] },
+                Arc::new(beacon_arrow_zarr::datafusion::ZarrFormatFactory),
+            ),
+            (
+                FromFormat::Bbf { paths: vec![] },
+                Arc::new(beacon_arrow_bbf::datafusion::BBFFormatFactory::new(
+                    Default::default(),
+                )),
+            ),
+        ]
+    }
+
+    fn register(ctx: &SessionContext, factory: Arc<dyn FileFormatFactory>) {
+        let state_ref = ctx.state_ref();
+        let mut state = state_ref.write();
+        state
+            .register_file_format(factory, true)
+            .expect("register file format");
+    }
+
+    /// Each factory-backed `FromFormat` resolves the factory registered on the
+    /// session and builds *that* factory's format (same concrete type), rather
+    /// than constructing a default of its own.
+    #[tokio::test]
+    async fn from_formats_resolve_the_registered_factory() {
+        let ctx = SessionContext::new();
+        let cases = factory_cases().await;
+        for (_, factory) in &cases {
+            register(&ctx, factory.clone());
+        }
+
+        for (variant, factory) in &cases {
+            let expected = factory
+                .create(&ctx.state(), &HashMap::new())
+                .expect("factory create");
+            let actual = variant
+                .file_format(&ctx)
+                .await
+                .expect("file_format should resolve from the session");
+            assert_eq!(
+                actual.as_any().type_id(),
+                expected.as_any().type_id(),
+                "{variant:?} resolved an unexpected file format",
+            );
+        }
+    }
+
+    /// A beacon-specific factory-backed format errors when its factory is not
+    /// registered on the session — proving `file_format` resolves from the
+    /// session rather than constructing a default. (Parquet/Arrow/CSV are
+    /// DataFusion built-ins registered on every `SessionContext`, so they are
+    /// excluded here.)
+    #[tokio::test]
+    async fn factory_backed_format_errors_when_not_registered() {
+        let ctx = SessionContext::new();
+        for variant in [
+            FromFormat::NetCDF { paths: vec![] },
+            FromFormat::Tiff { paths: vec![] },
+            FromFormat::Zarr { paths: vec![] },
+            FromFormat::Bbf { paths: vec![] },
+        ] {
+            assert!(
+                variant.file_format(&ctx).await.is_err(),
+                "{variant:?} should fail without a registered factory",
+            );
+        }
+    }
+
+    /// CSV (per-query delimiter) and ODV (no registered factory) are built
+    /// directly, so they resolve even on a bare session.
+    #[tokio::test]
+    async fn csv_and_odv_build_directly() {
+        let ctx = SessionContext::new();
+        assert!(
+            FromFormat::Csv {
+                delimiter: Some(';'),
+                paths: vec![],
+            }
+            .file_format(&ctx)
+            .await
+            .is_ok()
+        );
+        assert!(
+            FromFormat::Odv { paths: vec![] }
+                .file_format(&ctx)
+                .await
+                .is_ok()
+        );
+    }
+}

--- a/beacon-core/src/query/from.rs
+++ b/beacon-core/src/query/from.rs
@@ -4,17 +4,16 @@
 
 use std::sync::Arc;
 
-use beacon_arrow_netcdf::datafusion::options::NetcdfOptions;
-use beacon_arrow_netcdf::datafusion::NetcdfFormat;
-use beacon_arrow_tiff::datafusion::TiffFormat;
 use beacon_data_lake::{FileManager, TableManager};
 use beacon_datafusion_ext::file_collection::FileCollection;
 use beacon_arrow_odv::datafusion::OdvFormat;
 use beacon_arrow_csv::datafusion::CsvFormat;
-use beacon_arrow_ipc::datafusion::ArrowFormat;
-use beacon_arrow_parquet::datafusion::ParquetFormat;
 use datafusion::{
-    datasource::{file_format::FileFormat, listing::ListingTableUrl, provider_as_source},
+    datasource::{
+        file_format::{FileFormat, FileFormatFactory},
+        listing::ListingTableUrl,
+        provider_as_source,
+    },
     logical_expr::{LogicalPlanBuilder, TableSource},
     prelude::SessionContext,
 };
@@ -149,35 +148,29 @@ impl FromFormat {
     }
 
     /// Returns the corresponding [`FileFormat`] for the variant.
+    ///
+    /// Formats that have a factory registered on the session are built through
+    /// that factory, so the JSON `FROM` path shares the runtime's configured
+    /// format (and, for store-backed formats, its reader cache) instead of
+    /// constructing a default of its own. CSV (carries a per-query delimiter the
+    /// factory does not accept) and ODV (no registered factory) are built
+    /// directly.
     async fn file_format(
         &self,
-        _session_context: &SessionContext,
+        session_context: &SessionContext,
     ) -> datafusion::error::Result<Arc<dyn FileFormat>> {
         match self {
             FromFormat::Csv { delimiter, .. } => Ok(Arc::new(CsvFormat::new(
                 delimiter.unwrap_or(',') as u8,
                 10_000,
             )) as Arc<dyn FileFormat>),
-            FromFormat::Parquet { .. } => Ok(Arc::new(ParquetFormat::new()) as Arc<dyn FileFormat>),
-            FromFormat::Arrow { .. } => Ok(Arc::new(ArrowFormat::new()) as Arc<dyn FileFormat>),
-            FromFormat::NetCDF { .. } => Ok(Arc::new(
-                NetcdfFormat::new(
-                    beacon_object_storage::get_datasets_object_store().await,
-                    NetcdfOptions::default(),
-                )
-                .with_enable_statistics(beacon_config::CONFIG.netcdf.enable_statistics),
-            ) as Arc<dyn FileFormat>),
-            FromFormat::Tiff { .. } => {
-                Ok(Arc::new(TiffFormat::new(Default::default())) as Arc<dyn FileFormat>)
-            }
             FromFormat::Odv { .. } => Ok(Arc::new(OdvFormat::new()) as Arc<dyn FileFormat>),
-            FromFormat::Zarr { .. } => {
-                Ok(Arc::new(beacon_arrow_zarr::datafusion::ZarrFormat::default())
-                    as Arc<dyn FileFormat>)
-            }
-            FromFormat::Bbf { .. } => Ok(Arc::new(beacon_arrow_bbf::datafusion::BBFFormat {
-                split_streams_slice: beacon_config::CONFIG.runtime.bbf_split_streams_slice,
-            }) as Arc<dyn FileFormat>),
+            FromFormat::Parquet { .. } => file_format_from_session(session_context, "parquet"),
+            FromFormat::Arrow { .. } => file_format_from_session(session_context, "arrow"),
+            FromFormat::NetCDF { .. } => file_format_from_session(session_context, "nc"),
+            FromFormat::Tiff { .. } => file_format_from_session(session_context, "tiff"),
+            FromFormat::Zarr { .. } => file_format_from_session(session_context, "zarr"),
+            FromFormat::Bbf { .. } => file_format_from_session(session_context, "bbf"),
         }
     }
 
@@ -204,4 +197,20 @@ impl FromFormat {
         }
         Ok(listing_table_urls)
     }
+}
+
+/// Build a [`FileFormat`] from the factory registered on the session under
+/// `format` (its `get_ext` identity), with default options. This shares the
+/// runtime's configured factory rather than constructing a default format.
+fn file_format_from_session(
+    session_context: &SessionContext,
+    format: &str,
+) -> datafusion::error::Result<Arc<dyn FileFormat>> {
+    let state = session_context.state();
+    let factory = state.get_file_format_factory(format).ok_or_else(|| {
+        datafusion::error::DataFusionError::Execution(format!(
+            "file format '{format}' is not registered on the session"
+        ))
+    })?;
+    factory.create(&state, &std::collections::HashMap::new())
 }

--- a/beacon-core/src/query/output.rs
+++ b/beacon-core/src/query/output.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use beacon_arrow_netcdf::datafusion::{options::NetcdfOptions, NetCDFFormatFactory};
+use beacon_arrow_netcdf::datafusion::{options::NetcdfOptions, NetCDFFormatFactory, NetcdfConfig};
 use beacon_arrow_odv::datafusion::OdvFileFormatFactory;
 use beacon_arrow_odv::writer::OdvOptions;
 use beacon_data_lake::FileManager;
@@ -124,6 +124,7 @@ impl OutputFormat {
                 format_as_file_type(Arc::new(NetCDFFormatFactory::new(
                     beacon_object_storage::get_datasets_object_store().await,
                     options,
+                    NetcdfConfig::default(),
                 )))
             }
             OutputFormat::NdNetCDF { dimension_columns } => {
@@ -134,6 +135,7 @@ impl OutputFormat {
                 format_as_file_type(Arc::new(NetCDFFormatFactory::new(
                     beacon_object_storage::get_datasets_object_store().await,
                     options,
+                    NetcdfConfig::default(),
                 )))
             }
             OutputFormat::Odv(options) => {

--- a/beacon-data-lake/Cargo.toml
+++ b/beacon-data-lake/Cargo.toml
@@ -23,6 +23,7 @@ futures = { workspace = true }
 tokio = { workspace = true }
 
 beacon-common = { path = "../beacon-common" }
+beacon-config = { path = "../beacon-config" }
 beacon-object-storage = { path = "../beacon-object-storage" }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }
 beacon-iceberg = { path = "../beacon-iceberg" }

--- a/beacon-data-lake/src/file_formats.rs
+++ b/beacon-data-lake/src/file_formats.rs
@@ -5,12 +5,12 @@
 
 use std::sync::Arc;
 
-use beacon_arrow_atlas::datafusion::{AtlasFormatFactory, options::AtlasOptions};
-use beacon_arrow_bbf::datafusion::BBFFormatFactory;
+use beacon_arrow_atlas::datafusion::{AtlasConfig, AtlasFormatFactory, options::AtlasOptions};
+use beacon_arrow_bbf::datafusion::{BBFFormatFactory, BbfConfig};
 use beacon_arrow_csv::datafusion::CsvFormatFactory;
 use beacon_arrow_geoparquet::datafusion::GeoParquetFormatFactory;
 use beacon_arrow_ipc::datafusion::ArrowFormatFactory;
-use beacon_arrow_netcdf::datafusion::{NetCDFFormatFactory, options::NetcdfOptions};
+use beacon_arrow_netcdf::datafusion::{NetCDFFormatFactory, NetcdfConfig, options::NetcdfOptions};
 use beacon_arrow_parquet::datafusion::ParquetFormatFactory;
 use beacon_arrow_tiff::datafusion::TiffFormatFactory;
 use beacon_arrow_zarr::datafusion::ZarrFormatFactory;
@@ -26,6 +26,21 @@ pub fn file_formats(
     let state_ref = session_context.state_ref();
     let mut state = state_ref.write();
 
+    // Bridge: build the per-format config (owned by each format crate) from the
+    // process-global config. A later change threads an owned config in instead.
+    let netcdf_config = NetcdfConfig {
+        use_reader_cache: beacon_config::CONFIG.netcdf.use_reader_cache,
+        reader_cache_size: beacon_config::CONFIG.netcdf.reader_cache_size,
+        enable_statistics: beacon_config::CONFIG.netcdf.enable_statistics,
+    };
+    let atlas_config = AtlasConfig {
+        use_reader_cache: beacon_config::CONFIG.atlas.use_reader_cache,
+        reader_cache_size: beacon_config::CONFIG.atlas.reader_cache_size,
+    };
+    let bbf_config = BbfConfig {
+        split_streams_slice: beacon_config::CONFIG.runtime.bbf_split_streams_slice,
+    };
+
     let formats: Vec<Arc<dyn FileFormatFactoryExt>> = vec![
         Arc::new(ParquetFormatFactory),
         Arc::new(CsvFormatFactory),
@@ -33,14 +48,16 @@ pub fn file_formats(
         Arc::new(NetCDFFormatFactory::new(
             datasets_object_store.clone(),
             NetcdfOptions::default(),
+            netcdf_config,
         )),
         Arc::new(AtlasFormatFactory::new(
             datasets_object_store.clone(),
             AtlasOptions::default(),
+            atlas_config,
         )),
         Arc::new(TiffFormatFactory::new(Default::default())),
         Arc::new(ZarrFormatFactory),
-        Arc::new(BBFFormatFactory),
+        Arc::new(BBFFormatFactory::new(bbf_config)),
         Arc::new(GeoParquetFormatFactory::default()),
     ];
 

--- a/beacon-file-formats/beacon-arrow-atlas/src/datafusion/cache.rs
+++ b/beacon-file-formats/beacon-arrow-atlas/src/datafusion/cache.rs
@@ -1,10 +1,12 @@
-//! Centralized cache of opened atlas stores keyed by marker path
-//! plus freshness (`last_modified` + `size`). Every caller that wants
-//! an `Arc<Atlas>` should go through [`get_or_open_atlas`] so a single
-//! `atlas.json` is opened exactly once across the process for as long
-//! as its on-disk metadata is unchanged.
+//! Cache of opened atlas stores keyed by marker path plus freshness
+//! (`last_modified` + `size`). Callers that want an `Arc<Atlas>` go through
+//! [`get_or_open_atlas`] so a single `atlas.json` is opened once for as long as
+//! its on-disk metadata is unchanged.
+//!
+//! The cache is owned per-runtime ([`AtlasReaderCache`]) rather than being a
+//! process-global static; passing `None` opens directly with no caching.
 
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use atlas::Atlas;
 use beacon_object_storage::DatasetsStore;
@@ -21,27 +23,50 @@ struct CacheKey {
     size: u64,
 }
 
-static ATLAS_CACHE: LazyLock<Cache<CacheKey, Arc<Atlas>>> = LazyLock::new(|| {
-    Cache::builder()
-        .max_capacity(beacon_config::CONFIG.atlas.reader_cache_size)
-        .build()
-});
-
-/// Return a cached [`Arc<Atlas>`] for `marker`, opening from disk on
-/// miss. Freshness is encoded in the cache key — a marker whose
-/// `last_modified` or `size` differs from the cached entry produces a
-/// new key, forcing a re-open. The previous entry lingers until evicted
-/// by the LRU bound.
+/// A reader cache for opened atlas stores, sized at construction time.
 ///
-/// Concurrent first-readers for the same key coalesce inside
+/// Cloning shares the underlying [`moka`] cache (reference-counted internally),
+/// so a single instance is shared across the formats, sources and openers a
+/// runtime hands a clone to. This is per-runtime state — there is no
+/// process-global cache.
+#[derive(Clone)]
+pub struct AtlasReaderCache {
+    cache: Cache<CacheKey, Arc<Atlas>>,
+}
+
+impl AtlasReaderCache {
+    /// Build a cache holding up to `capacity` opened atlas stores.
+    pub fn new(capacity: u64) -> Self {
+        Self {
+            cache: Cache::builder().max_capacity(capacity).build(),
+        }
+    }
+}
+
+// `Atlas` is not `Debug`, so the cache contents can't be derived. The cache is
+// embedded in `Debug` structs (formats/sources), so provide an opaque impl.
+impl std::fmt::Debug for AtlasReaderCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AtlasReaderCache").finish_non_exhaustive()
+    }
+}
+
+/// Return a cached [`Arc<Atlas>`] for `marker`, opening from disk on miss.
+///
+/// When `cache` is `None`, the store is opened directly with no caching.
+/// Otherwise freshness is encoded in the cache key — a marker whose
+/// `last_modified` or `size` differs from the cached entry produces a new key,
+/// forcing a re-open. The previous entry lingers until evicted by the LRU
+/// bound. Concurrent first-readers for the same key coalesce inside
 /// [`moka::future::Cache::try_get_with`].
 pub async fn get_or_open_atlas(
+    cache: Option<&AtlasReaderCache>,
     store: Arc<DatasetsStore>,
     marker: &ObjectMeta,
 ) -> datafusion::error::Result<Arc<Atlas>> {
-    if !beacon_config::CONFIG.atlas.use_reader_cache {
+    let Some(cache) = cache else {
         return reader::open_atlas_store(store, &marker.location).await;
-    }
+    };
 
     let key = CacheKey {
         path: marker.location.clone(),
@@ -50,7 +75,8 @@ pub async fn get_or_open_atlas(
     };
     let path = marker.location.clone();
 
-    ATLAS_CACHE
+    cache
+        .cache
         .try_get_with(key, async move { reader::open_atlas_store(store, &path).await })
         .await
         .map_err(|e: Arc<datafusion::error::DataFusionError>| {
@@ -81,11 +107,12 @@ mod tests {
         ensure_fixture().await;
         let store = test_store().await;
         let marker = fixture_marker_object_meta();
+        let cache = AtlasReaderCache::new(32);
 
-        let first = get_or_open_atlas(store.clone(), &marker)
+        let first = get_or_open_atlas(Some(&cache), store.clone(), &marker)
             .await
             .expect("first open");
-        let second = get_or_open_atlas(store, &marker)
+        let second = get_or_open_atlas(Some(&cache), store, &marker)
             .await
             .expect("second open");
 
@@ -105,11 +132,12 @@ mod tests {
             base.last_modified + chrono::Duration::seconds(1),
             base.size,
         );
+        let cache = AtlasReaderCache::new(32);
 
-        let first = get_or_open_atlas(store.clone(), &base)
+        let first = get_or_open_atlas(Some(&cache), store.clone(), &base)
             .await
             .expect("first open");
-        let second = get_or_open_atlas(store, &bumped)
+        let second = get_or_open_atlas(Some(&cache), store, &bumped)
             .await
             .expect("second open");
 
@@ -125,11 +153,12 @@ mod tests {
         let store = test_store().await;
         let base = fixture_marker_object_meta();
         let bumped = marker_with(base.location.clone(), base.last_modified, base.size + 1);
+        let cache = AtlasReaderCache::new(32);
 
-        let first = get_or_open_atlas(store.clone(), &base)
+        let first = get_or_open_atlas(Some(&cache), store.clone(), &base)
             .await
             .expect("first open");
-        let second = get_or_open_atlas(store, &bumped)
+        let second = get_or_open_atlas(Some(&cache), store, &bumped)
             .await
             .expect("second open");
 

--- a/beacon-file-formats/beacon-arrow-atlas/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-atlas/src/datafusion/mod.rs
@@ -31,6 +31,8 @@ pub mod pushdown;
 pub mod reader;
 pub mod source;
 
+pub use cache::AtlasReaderCache;
+
 /// Canonical marker filename used as the format identifier with
 /// DataFusion. Kept stable across atlas versions so the registered
 /// `FileFormat` lookup key doesn't churn even though the on-disk
@@ -87,18 +89,69 @@ fn atlas_marker_filename(p: &object_store::path::Path) -> Option<&'static str> {
         .find(|name| s == *name || s.ends_with(&format!("/{name}")))
 }
 
+/// Runtime configuration for the atlas format.
+///
+/// Plain data with sensible defaults; the caller populates it (no environment
+/// parsing here). The reader-cache capacity is a shared runtime resource, while
+/// `use_reader_cache` is a default that a table can override via
+/// `CREATE EXTERNAL TABLE ... OPTIONS (...)`.
+#[derive(Debug, Clone)]
+pub struct AtlasConfig {
+    /// Whether reads consult the shared reader cache by default.
+    pub use_reader_cache: bool,
+    /// Capacity (number of opened atlas stores) of the shared reader cache.
+    pub reader_cache_size: u64,
+}
+
+impl Default for AtlasConfig {
+    fn default() -> Self {
+        Self {
+            use_reader_cache: true,
+            reader_cache_size: 32,
+        }
+    }
+}
+
+/// Parse a boolean value supplied through a `CREATE EXTERNAL TABLE` option.
+fn parse_bool_option(key: &str, value: &str) -> datafusion::error::Result<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Ok(true),
+        "false" | "0" | "no" | "off" => Ok(false),
+        other => Err(exec_datafusion_err!(
+            "invalid boolean for atlas option '{key}': '{other}'"
+        )),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct AtlasFormatFactory {
     pub datasets_object_store: Arc<DatasetsStore>,
     pub options: AtlasOptions,
+    pub config: AtlasConfig,
+    /// Shared reader cache for this runtime, sized from `config`.
+    cache: AtlasReaderCache,
 }
 
 impl AtlasFormatFactory {
-    pub fn new(datasets_object_store: Arc<DatasetsStore>, options: AtlasOptions) -> Self {
+    pub fn new(
+        datasets_object_store: Arc<DatasetsStore>,
+        options: AtlasOptions,
+        config: AtlasConfig,
+    ) -> Self {
+        let cache = AtlasReaderCache::new(config.reader_cache_size);
         Self {
             datasets_object_store,
             options,
+            config,
+            cache,
         }
+    }
+
+    /// Build an [`AtlasFormat`] with the given per-table effective settings,
+    /// wiring in the shared reader cache when caching is enabled.
+    fn build_format(&self, options: AtlasOptions, use_reader_cache: bool) -> AtlasFormat {
+        let cache = use_reader_cache.then(|| self.cache.clone());
+        AtlasFormat::new(self.datasets_object_store.clone(), options).with_cache(cache)
     }
 }
 
@@ -106,19 +159,31 @@ impl FileFormatFactory for AtlasFormatFactory {
     fn create(
         &self,
         _state: &dyn Session,
-        _format_options: &std::collections::HashMap<String, String>,
+        format_options: &std::collections::HashMap<String, String>,
     ) -> datafusion::error::Result<Arc<dyn FileFormat>> {
-        Ok(Arc::new(AtlasFormat::new(
-            self.datasets_object_store.clone(),
-            self.options.clone(),
-        )))
+        // Per-table overrides from `CREATE EXTERNAL TABLE ... OPTIONS (...)`,
+        // defaulting to the runtime config.
+        let mut options = self.options.clone();
+        let mut use_reader_cache = self.config.use_reader_cache;
+
+        if let Some(value) = format_options.get("read_dimensions") {
+            options.read_dimensions = Some(
+                value
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect(),
+            );
+        }
+        if let Some(value) = format_options.get("use_reader_cache") {
+            use_reader_cache = parse_bool_option("use_reader_cache", value)?;
+        }
+
+        Ok(Arc::new(self.build_format(options, use_reader_cache)))
     }
 
     fn default(&self) -> Arc<dyn FileFormat> {
-        Arc::new(AtlasFormat::new(
-            self.datasets_object_store.clone(),
-            self.options.clone(),
-        ))
+        Arc::new(self.build_format(self.options.clone(), self.config.use_reader_cache))
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -289,6 +354,8 @@ fn marker_parent(p: &object_store::path::Path) -> Option<String> {
 pub struct AtlasFormat {
     pub datasets_object_store: Arc<DatasetsStore>,
     pub options: AtlasOptions,
+    /// Reader cache to consult, or `None` to bypass caching for this format.
+    cache: Option<AtlasReaderCache>,
 }
 
 impl AtlasFormat {
@@ -296,7 +363,14 @@ impl AtlasFormat {
         Self {
             datasets_object_store,
             options,
+            cache: None,
         }
+    }
+
+    /// Wire in a reader cache (`Some`) or disable caching (`None`).
+    pub fn with_cache(mut self, cache: Option<AtlasReaderCache>) -> Self {
+        self.cache = cache;
+        self
     }
 }
 
@@ -334,8 +408,12 @@ impl FileFormat for AtlasFormat {
 
         let mut schemas = Vec::new();
         for marker in markers {
-            let atlas =
-                cache::get_or_open_atlas(self.datasets_object_store.clone(), &marker).await?;
+            let atlas = cache::get_or_open_atlas(
+                self.cache.as_ref(),
+                self.datasets_object_store.clone(),
+                &marker,
+            )
+            .await?;
             let read_dimensions = self.options.read_dimensions.as_deref();
             for dataset_name in atlas.list_datasets() {
                 let view = atlas.open_dataset(&dataset_name).await.map_err(|e| {
@@ -398,6 +476,7 @@ impl FileFormat for AtlasFormat {
             self.options.read_dimensions.clone(),
             table_schema,
         )
+        .with_cache(self.cache.clone())
         .with_projection(projection);
         let conf = FileScanConfigBuilder::from(conf)
             .with_source(Arc::new(source))
@@ -421,11 +500,14 @@ impl FileFormat for AtlasFormat {
         &self,
         table_schema: datafusion::datasource::table_schema::TableSchema,
     ) -> Arc<dyn FileSource> {
-        Arc::new(AtlasSource::new(
-            self.datasets_object_store.clone(),
-            self.options.read_dimensions.clone(),
-            table_schema,
-        ))
+        Arc::new(
+            AtlasSource::new(
+                self.datasets_object_store.clone(),
+                self.options.read_dimensions.clone(),
+                table_schema,
+            )
+            .with_cache(self.cache.clone()),
+        )
     }
 }
 
@@ -435,7 +517,7 @@ pub(crate) mod test_support {
 
     use super::ATLAS_MARKER;
     use crate::reader::test_support::build_two_dataset_store;
-    use beacon_object_storage::{DatasetsStore, get_datasets_object_store};
+    use beacon_object_storage::DatasetsStore;
     use object_store::{ObjectMeta, path::Path as OsPath};
     use std::sync::Arc;
 
@@ -467,7 +549,7 @@ pub(crate) mod test_support {
 
     pub async fn test_store() -> Arc<DatasetsStore> {
         ensure_fixture().await;
-        get_datasets_object_store().await
+        beacon_object_storage::get_datasets_object_store().await
     }
 
     /// `ObjectMeta` for the fixture's `atlas.json` marker.
@@ -486,7 +568,6 @@ pub(crate) mod test_support {
 mod tests {
     use super::test_support::{ensure_fixture, fixture_marker_object_meta, test_store};
     use super::*;
-    use beacon_object_storage::get_datasets_object_store;
     use datafusion::prelude::SessionContext;
     use object_store::local::LocalFileSystem;
     use object_store::path::Path as OsPath;
@@ -554,7 +635,7 @@ mod tests {
     #[tokio::test]
     async fn factory_get_ext_returns_atlas() {
         let store = test_store().await;
-        let factory = AtlasFormatFactory::new(store, AtlasOptions::default());
+        let factory = AtlasFormatFactory::new(store, AtlasOptions::default(), AtlasConfig::default());
         // `get_ext` is the format identity used to register and resolve
         // external tables (`STORED AS ATLAS`), not the marker filename
         // (`atlas.json`).
@@ -565,7 +646,7 @@ mod tests {
     #[tokio::test]
     async fn discover_datasets_emits_one_entry_per_atlas_dataset() {
         let store = test_store().await;
-        let factory = AtlasFormatFactory::new(store, AtlasOptions::default());
+        let factory = AtlasFormatFactory::new(store, AtlasOptions::default(), AtlasConfig::default());
 
         let objects = vec![fixture_marker_object_meta()];
         let datasets = factory.discover_datasets(&objects).expect("discover");
@@ -584,7 +665,7 @@ mod tests {
     #[tokio::test]
     async fn discover_datasets_ignores_non_marker_objects() {
         let store = test_store().await;
-        let factory = AtlasFormatFactory::new(store, AtlasOptions::default());
+        let factory = AtlasFormatFactory::new(store, AtlasOptions::default(), AtlasConfig::default());
         let objects = vec![ObjectMeta {
             location: object_store::path::Path::from("some/other.nc"),
             last_modified: chrono::Utc::now(),
@@ -912,8 +993,8 @@ mod tests {
     #[tokio::test]
     async fn discover_datasets_finds_msgpack_zst_store() {
         ensure_msgpack_zst_fixture().await;
-        let store = get_datasets_object_store().await;
-        let factory = AtlasFormatFactory::new(store, AtlasOptions::default());
+        let store = test_store().await;
+        let factory = AtlasFormatFactory::new(store, AtlasOptions::default(), AtlasConfig::default());
 
         let marker = ObjectMeta {
             location: OsPath::from(format!("{MSGPACK_ZST_FIXTURE_DIR}/atlas.msgpack.zst")),

--- a/beacon-file-formats/beacon-arrow-atlas/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-atlas/src/datafusion/mod.rs
@@ -1123,3 +1123,6 @@ mod tests {
         assert_eq!(temps, vec![20.0f32, 21.0, 22.0], "only summer's temperatures remain");
     }
 }
+
+pub mod table_function;
+pub use table_function::ReadAtlasFunc;

--- a/beacon-file-formats/beacon-arrow-atlas/src/datafusion/pushdown.rs
+++ b/beacon-file-formats/beacon-arrow-atlas/src/datafusion/pushdown.rs
@@ -244,7 +244,9 @@ mod tests {
     async fn fixture_atlas() -> (Arc<Atlas>, SchemaRef) {
         let store = test_store().await;
         let marker = fixture_marker_object_meta();
-        let atlas = get_or_open_atlas(store, &marker).await.expect("open atlas");
+        let atlas = get_or_open_atlas(None, store, &marker)
+            .await
+            .expect("open atlas");
 
         let names = atlas.list_datasets();
         let mut schemas = Vec::with_capacity(names.len());

--- a/beacon-file-formats/beacon-arrow-atlas/src/datafusion/source.rs
+++ b/beacon-file-formats/beacon-arrow-atlas/src/datafusion/source.rs
@@ -7,6 +7,7 @@ use beacon_nd_array::arrow::{
     pushdown_filter::PushdownFilter,
 };
 use beacon_object_storage::DatasetsStore;
+use crate::datafusion::cache::AtlasReaderCache;
 use datafusion::physical_expr_adapter::BatchAdapterFactory;
 use datafusion::{
     common::Statistics,
@@ -60,6 +61,8 @@ pub struct AtlasSource {
     batch_size: usize,
     predicate: Option<Arc<dyn PhysicalExpr>>,
     read_dimensions: Option<Vec<String>>,
+    /// Reader cache to consult for this scan. `None` disables caching.
+    cache: Option<AtlasReaderCache>,
     /// Projection pushed down by the scan, applied on top of the table schema.
     projection: Option<ProjectionExprs>,
 
@@ -80,9 +83,17 @@ impl AtlasSource {
             batch_size: usize::MAX,
             predicate: None,
             read_dimensions,
+            cache: None,
             projection: None,
             stream_cache: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Returns a copy of this source that consults `cache` (when `Some`) for
+    /// opened atlas stores. The format wires in the runtime's shared cache here.
+    pub fn with_cache(mut self, cache: Option<AtlasReaderCache>) -> Self {
+        self.cache = cache;
+        self
     }
 
     /// Returns a copy of this source carrying the given projection. Used to
@@ -111,6 +122,7 @@ impl FileSource for AtlasSource {
             partition,
             read_dimensions: self.read_dimensions.clone(),
             predicate: self.predicate.clone(),
+            cache: self.cache.clone(),
             stream_cache: self.stream_cache.clone(),
         }))
     }
@@ -200,11 +212,13 @@ struct AtlasOpener {
     partition: usize,
     read_dimensions: Option<Vec<String>>,
     predicate: Option<Arc<dyn PhysicalExpr>>,
+    cache: Option<AtlasReaderCache>,
 
     stream_cache: Arc<Mutex<HashMap<String, AtlasStreamDatasets>>>,
 }
 
 impl AtlasOpener {
+    #[allow(clippy::too_many_arguments)]
     async fn read_task(
         datasets_object_store: Arc<DatasetsStore>,
         object_meta: ObjectMeta,
@@ -214,10 +228,14 @@ impl AtlasOpener {
         metrics: Option<DatasetReadMetrics>,
         read_dimensions: Option<Vec<String>>,
         predicate: Option<Arc<dyn PhysicalExpr>>,
+        cache: Option<AtlasReaderCache>,
     ) -> datafusion::error::Result<BoxStream<'static, datafusion::error::Result<RecordBatch>>> {
-        let atlas =
-            crate::datafusion::cache::get_or_open_atlas(datasets_object_store, &object_meta)
-                .await?;
+        let atlas = crate::datafusion::cache::get_or_open_atlas(
+            cache.as_ref(),
+            datasets_object_store,
+            &object_meta,
+        )
+        .await?;
         let object_path = object_meta.location.clone();
 
         let stream_datasets_handle = {
@@ -355,6 +373,7 @@ impl FileOpener for AtlasOpener {
             metrics,
             self.read_dimensions.clone(),
             self.predicate.clone(),
+            self.cache.clone(),
         );
         Ok(Box::pin(fut))
     }

--- a/beacon-file-formats/beacon-arrow-atlas/src/datafusion/table_function.rs
+++ b/beacon-file-formats/beacon-arrow-atlas/src/datafusion/table_function.rs
@@ -12,7 +12,7 @@ use datafusion::{
     scalar::ScalarValue,
 };
 
-use crate::file_formats::BeaconTableFunctionImpl;
+use beacon_common::table_function::BeaconTableFunctionImpl;
 
 /// Format identity the atlas factory is registered under (its `get_ext`).
 const ATLAS_FORMAT: &str = "atlas";
@@ -83,7 +83,7 @@ impl TableFunctionImpl for ReadAtlasFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_atlas")?;
+        let glob_paths = beacon_common::table_function::parse_glob_paths_arg(args, "read_atlas")?;
 
         let mut dimensions: Vec<String> = vec![];
         if let Some(dimensions_arg) = args.get(1) {

--- a/beacon-file-formats/beacon-arrow-bbf/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-bbf/src/datafusion/mod.rs
@@ -225,3 +225,6 @@ impl FileFormat for BBFFormat {
         Arc::new(BBFSource::new(table_schema).with_split_streams_slice(self.split_streams_slice))
     }
 }
+
+pub mod table_function;
+pub use table_function::ReadBBFFunc;

--- a/beacon-file-formats/beacon-arrow-bbf/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-bbf/src/datafusion/mod.rs
@@ -26,8 +26,39 @@ pub mod opener;
 pub mod source;
 pub mod stream_share;
 
-#[derive(Clone, Debug)]
-pub struct BBFFormatFactory;
+/// Runtime configuration for the BBF format.
+///
+/// Plain data with sensible defaults; the caller populates it (no environment
+/// parsing here). `split_streams_slice` is a default that a table can override
+/// via `CREATE EXTERNAL TABLE ... OPTIONS (...)`.
+#[derive(Clone, Debug, Default)]
+pub struct BbfConfig {
+    /// Whether to split each record batch into `batch_size`-row slices to bound
+    /// peak memory for wide tables.
+    pub split_streams_slice: bool,
+}
+
+/// Parse a boolean value supplied through a `CREATE EXTERNAL TABLE` option.
+fn parse_bool_option(key: &str, value: &str) -> datafusion::error::Result<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Ok(true),
+        "false" | "0" | "no" | "off" => Ok(false),
+        other => Err(datafusion::error::DataFusionError::Execution(format!(
+            "invalid boolean for BBF option '{key}': '{other}'"
+        ))),
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct BBFFormatFactory {
+    pub config: BbfConfig,
+}
+
+impl BBFFormatFactory {
+    pub fn new(config: BbfConfig) -> Self {
+        Self { config }
+    }
+}
 
 impl GetExt for BBFFormatFactory {
     fn get_ext(&self) -> String {
@@ -39,9 +70,15 @@ impl FileFormatFactory for BBFFormatFactory {
     fn create(
         &self,
         _state: &dyn Session,
-        _format_options: &HashMap<String, String>,
+        format_options: &HashMap<String, String>,
     ) -> datafusion::error::Result<Arc<dyn FileFormat>> {
-        Ok(Arc::new(BBFFormat {}))
+        // Per-table override from `CREATE EXTERNAL TABLE ... OPTIONS (...)`,
+        // defaulting to the runtime config.
+        let mut split_streams_slice = self.config.split_streams_slice;
+        if let Some(value) = format_options.get("split_streams_slice") {
+            split_streams_slice = parse_bool_option("split_streams_slice", value)?;
+        }
+        Ok(Arc::new(BBFFormat { split_streams_slice }))
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -49,7 +86,9 @@ impl FileFormatFactory for BBFFormatFactory {
     }
 
     fn default(&self) -> std::sync::Arc<dyn FileFormat> {
-        std::sync::Arc::new(BBFFormat {})
+        std::sync::Arc::new(BBFFormat {
+            split_streams_slice: self.config.split_streams_slice,
+        })
     }
 }
 
@@ -77,7 +116,10 @@ impl FileFormatFactoryExt for BBFFormatFactory {
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct BBFFormat {}
+pub struct BBFFormat {
+    /// Whether to split each record batch into `batch_size`-row slices.
+    pub split_streams_slice: bool,
+}
 
 #[async_trait::async_trait]
 impl FileFormat for BBFFormat {
@@ -167,7 +209,9 @@ impl FileFormat for BBFFormat {
         // Preserve a projection that the scan pushed down into the incoming
         // source — rebuilding the source below would otherwise drop it.
         let projection = conf.file_source().projection().cloned();
-        let source = BBFSource::new(table_schema).with_projection(projection);
+        let source = BBFSource::new(table_schema)
+            .with_split_streams_slice(self.split_streams_slice)
+            .with_projection(projection);
         let conf = FileScanConfigBuilder::from(conf)
             .with_source(Arc::new(source))
             .build();
@@ -178,6 +222,6 @@ impl FileFormat for BBFFormat {
         &self,
         table_schema: datafusion::datasource::table_schema::TableSchema,
     ) -> Arc<dyn FileSource> {
-        Arc::new(BBFSource::new(table_schema))
+        Arc::new(BBFSource::new(table_schema).with_split_streams_slice(self.split_streams_slice))
     }
 }

--- a/beacon-file-formats/beacon-arrow-bbf/src/datafusion/opener.rs
+++ b/beacon-file-formats/beacon-arrow-bbf/src/datafusion/opener.rs
@@ -39,6 +39,11 @@ pub struct BBFOpener {
     metrics: BBFGlobalMetrics,
     /// Stream Partition Share
     stream_partition_shares: Arc<Mutex<HashMap<object_store::path::Path, Arc<StreamShare>>>>,
+    /// Whether to split each record batch into `split_batch_size`-row slices.
+    split_streams_slice: bool,
+    /// Row count per slice when `split_streams_slice` is set (the session batch
+    /// size, propagated from the source).
+    split_batch_size: usize,
 }
 
 impl FileOpener for BBFOpener {
@@ -60,6 +65,8 @@ impl FileOpener for BBFOpener {
         };
         let metrics = self.metrics.clone();
         let fut_projected_schema = projected_schema.clone();
+        let split_streams_slice = self.split_streams_slice;
+        let split_batch_size = self.split_batch_size;
 
         let fut = async move {
             let (stream, schema_mapper, file_schema) = stream_partition_share
@@ -154,13 +161,14 @@ impl FileOpener for BBFOpener {
                 )
                 .boxed();
 
-            // If env variable BBF_SPLIT_STREAMS_SLICE is set, we will split the record batch into 16K rows batches to avoid OOM. This is especially helpful for large tables with wide rows.
-            let stream_proxy = if beacon_config::CONFIG.runtime.bbf_split_streams_slice {
+            // When configured (per-runtime default or per-table option), split
+            // each record batch into `split_batch_size`-row slices to avoid OOM.
+            // This is especially helpful for large tables with wide rows.
+            let stream_proxy = if split_streams_slice {
                 stream_proxy
-                    .flat_map(|batch| {
+                    .flat_map(move |batch| {
                         if let Ok(batch) = batch {
-                            let split_batches =
-                                split_record_batch(batch, beacon_config::CONFIG.runtime.batch_size);
+                            let split_batches = split_record_batch(batch, split_batch_size);
                             let split_batches_res =
                                 split_batches.into_iter().map(Ok).collect::<Vec<_>>();
                             futures::stream::iter(split_batches_res)
@@ -194,6 +202,7 @@ fn split_record_batch(batch: RecordBatch, chunk_size: usize) -> Vec<RecordBatch>
 }
 
 impl BBFOpener {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         projected_schema: SchemaRef,
         pruning_predicate: Option<PruningPredicate>,
@@ -202,6 +211,8 @@ impl BBFOpener {
         file_tracer: Arc<Mutex<Vec<String>>>,
         stream_partition_shares: Arc<Mutex<HashMap<object_store::path::Path, Arc<StreamShare>>>>,
         metrics: BBFGlobalMetrics,
+        split_streams_slice: bool,
+        split_batch_size: usize,
     ) -> Self {
         Self {
             projected_schema,
@@ -211,6 +222,8 @@ impl BBFOpener {
             file_tracer,
             stream_partition_shares,
             metrics,
+            split_streams_slice,
+            split_batch_size,
         }
     }
 

--- a/beacon-file-formats/beacon-arrow-bbf/src/datafusion/source.rs
+++ b/beacon-file-formats/beacon-arrow-bbf/src/datafusion/source.rs
@@ -32,6 +32,8 @@ pub struct BBFSource {
     execution_plan_metrics: ExecutionPlanMetricsSet,
     /// Batch Size.
     batch_size: usize,
+    /// Whether to split each record batch into `batch_size`-row slices.
+    split_streams_slice: bool,
     /// Pruning Predicate
     predicate: Option<Arc<dyn PhysicalExpr>>,
     /// File Tracer
@@ -53,12 +55,20 @@ impl BBFSource {
             table_schema,
             execution_plan_metrics: base_metrics,
             batch_size: 32 * 1024,
+            split_streams_slice: false,
             predicate: None,
             file_tracer: Arc::new(Mutex::new(Arc::new(Mutex::new(vec![])))),
             stream_partition_shares: Arc::new(Mutex::new(HashMap::new())),
             global_metrics,
             projection: None,
         }
+    }
+
+    /// Returns a copy of this source that splits each record batch into
+    /// `batch_size`-row slices when `split` is set.
+    pub fn with_split_streams_slice(mut self, split: bool) -> Self {
+        self.split_streams_slice = split;
+        self
     }
 
     /// Returns a copy of this source carrying the given projection. Used to
@@ -98,6 +108,8 @@ impl FileSource for BBFSource {
             self.file_tracer.lock().clone(),
             self.stream_partition_shares.clone(),
             self.global_metrics.clone(),
+            self.split_streams_slice,
+            self.batch_size,
         )))
     }
 

--- a/beacon-file-formats/beacon-arrow-bbf/src/datafusion/table_function.rs
+++ b/beacon-file-formats/beacon-arrow-bbf/src/datafusion/table_function.rs
@@ -10,7 +10,7 @@ use datafusion::{
     prelude::SessionContext,
 };
 
-use crate::file_formats::BeaconTableFunctionImpl;
+use beacon_common::table_function::BeaconTableFunctionImpl;
 
 /// Format identity the BBF factory is registered under (its `get_ext`).
 const BBF_FORMAT: &str = "bbf";
@@ -69,7 +69,7 @@ impl TableFunctionImpl for ReadBBFFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_bbf")?;
+        let glob_paths = beacon_common::table_function::parse_glob_paths_arg(args, "read_bbf")?;
 
         tracing::debug!("read_bbf glob paths: {:?}", glob_paths);
 

--- a/beacon-file-formats/beacon-arrow-csv/Cargo.toml
+++ b/beacon-file-formats/beacon-arrow-csv/Cargo.toml
@@ -4,6 +4,8 @@ version = "1.7.3"
 edition = "2024"
 
 [dependencies]
+tracing = { workspace = true }
+tokio = { workspace = true }
 arrow = { workspace = true }
 datafusion = { workspace = true }
 object_store = { workspace = true }

--- a/beacon-file-formats/beacon-arrow-csv/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-csv/src/datafusion/mod.rs
@@ -170,3 +170,6 @@ impl FileFormat for CsvFormat {
         self.inner_format.file_source(table_schema)
     }
 }
+
+pub mod table_function;
+pub use table_function::ReadCsvFunc;

--- a/beacon-file-formats/beacon-arrow-csv/src/datafusion/table_function.rs
+++ b/beacon-file-formats/beacon-arrow-csv/src/datafusion/table_function.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
-use beacon_arrow_csv::datafusion::CsvFormat;
+use crate::datafusion::CsvFormat;
 use datafusion::{
     catalog::TableFunctionImpl,
     common::plan_err,
@@ -11,7 +11,7 @@ use datafusion::{
     scalar::ScalarValue,
 };
 
-use crate::file_formats::BeaconTableFunctionImpl;
+use beacon_common::table_function::BeaconTableFunctionImpl;
 
 pub struct ReadCsvFunc {
     // Session Reference
@@ -71,7 +71,7 @@ impl TableFunctionImpl for ReadCsvFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_csv")?;
+        let glob_paths = beacon_common::table_function::parse_glob_paths_arg(args, "read_csv")?;
 
         let delimeter = if let Some(delimiter_arg) = args.get(1) {
             match delimiter_arg {

--- a/beacon-file-formats/beacon-arrow-geoparquet/Cargo.toml
+++ b/beacon-file-formats/beacon-arrow-geoparquet/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.7.3"
 edition = "2024"
 
 [dependencies]
+tokio = { workspace = true }
 arrow = { workspace = true }
 datafusion = { workspace = true }
 object_store = { workspace = true }

--- a/beacon-file-formats/beacon-arrow-geoparquet/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-geoparquet/src/datafusion/mod.rs
@@ -551,3 +551,6 @@ mod tests {
         }
     }
 }
+
+pub mod table_function;
+pub use table_function::ReadGeoParquetFunc;

--- a/beacon-file-formats/beacon-arrow-geoparquet/src/datafusion/table_function.rs
+++ b/beacon-file-formats/beacon-arrow-geoparquet/src/datafusion/table_function.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field};
-use beacon_arrow_geoparquet::datafusion::{GeoParquetFormat, GeoParquetOptions};
+use crate::datafusion::{GeoParquetFormat, GeoParquetOptions};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
 use datafusion::{
     catalog::TableFunctionImpl, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
 };
 
-use crate::file_formats::BeaconTableFunctionImpl;
+use beacon_common::table_function::BeaconTableFunctionImpl;
 
 pub struct ReadGeoParquetFunc {
     // Session Reference
@@ -66,7 +66,7 @@ impl TableFunctionImpl for ReadGeoParquetFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_geoparquet")?;
+        let glob_paths = beacon_common::table_function::parse_glob_paths_arg(args, "read_geoparquet")?;
 
         tracing::debug!("read_geoparquet glob paths: {:?}", glob_paths);
 

--- a/beacon-file-formats/beacon-arrow-ipc/Cargo.toml
+++ b/beacon-file-formats/beacon-arrow-ipc/Cargo.toml
@@ -4,6 +4,8 @@ version = "1.7.3"
 edition = "2024"
 
 [dependencies]
+tracing = { workspace = true }
+tokio = { workspace = true }
 arrow = { workspace = true }
 datafusion = { workspace = true }
 object_store = { workspace = true }

--- a/beacon-file-formats/beacon-arrow-ipc/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-ipc/src/datafusion/mod.rs
@@ -174,3 +174,6 @@ impl FileFormat for ArrowFormat {
         self.inner_format.file_source(table_schema)
     }
 }
+
+pub mod table_function;
+pub use table_function::ReadArrowFunc;

--- a/beacon-file-formats/beacon-arrow-ipc/src/datafusion/table_function.rs
+++ b/beacon-file-formats/beacon-arrow-ipc/src/datafusion/table_function.rs
@@ -2,22 +2,21 @@ use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
-use beacon_arrow_odv::datafusion::OdvFormat;
+use crate::datafusion::ArrowFormat;
 use datafusion::{
-    catalog::TableFunctionImpl,
-    execution::object_store::ObjectStoreUrl,
-    prelude::{Expr, SessionContext},
+    catalog::TableFunctionImpl, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
 };
 
-use crate::file_formats::BeaconTableFunctionImpl;
+use beacon_common::table_function::BeaconTableFunctionImpl;
 
-pub struct ReadOdvAsciiFunc {
+pub struct ReadArrowFunc {
+    // Session Reference
     runtime_handle: tokio::runtime::Handle,
     session_ctx: Arc<SessionContext>,
     data_object_store_url: ObjectStoreUrl,
 }
 
-impl ReadOdvAsciiFunc {
+impl ReadArrowFunc {
     pub fn new(
         runtime_handle: tokio::runtime::Handle,
         session_ctx: Arc<SessionContext>,
@@ -31,26 +30,26 @@ impl ReadOdvAsciiFunc {
     }
 }
 
-impl std::fmt::Debug for ReadOdvAsciiFunc {
+impl std::fmt::Debug for ReadArrowFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ReadOdvAsciiFunc")
+        write!(f, "ReadArrowFunc")
     }
 }
 
-impl BeaconTableFunctionImpl for ReadOdvAsciiFunc {
+impl BeaconTableFunctionImpl for ReadArrowFunc {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
 
     fn name(&self) -> String {
-        "read_odv_ascii".to_string()
+        "read_arrow".to_string()
     }
 
     fn description(&self) -> Option<String> {
-        Some("Reads ODV ASCII files from specified glob paths.".to_string())
+        Some("Reads Arrow files from specified glob paths.".to_string())
     }
 
-    fn arguments(&self) -> Option<Vec<Field>> {
+    fn arguments(&self) -> Option<Vec<arrow::datatypes::Field>> {
         Some(vec![Field::new(
             "glob_paths",
             DataType::List(Arc::new(Field::new("glob_path", DataType::Utf8, false))),
@@ -59,22 +58,22 @@ impl BeaconTableFunctionImpl for ReadOdvAsciiFunc {
     }
 }
 
-impl TableFunctionImpl for ReadOdvAsciiFunc {
+impl TableFunctionImpl for ReadArrowFunc {
     fn call(
         &self,
-        args: &[Expr],
-    ) -> datafusion::error::Result<Arc<dyn datafusion::catalog::TableProvider>> {
-        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_odv_ascii")?;
+        args: &[datafusion::prelude::Expr],
+    ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
+        let glob_paths = beacon_common::table_function::parse_glob_paths_arg(args, "read_arrow")?;
 
-        tracing::debug!("read_odv_ascii glob paths: {:?}", glob_paths);
+        tracing::debug!("read_arrow glob paths: {:?}", glob_paths);
 
         let mut listing_urls = vec![];
         for path in &glob_paths {
-            tracing::debug!("read_odv_ascii processing path: {}", path);
+            tracing::debug!("read_arrow processing path: {}", path);
             listing_urls.push(parse_listing_table_url(&self.data_object_store_url, path)?);
         }
 
-        let file_format = OdvFormat::new();
+        let file_format = ArrowFormat::default();
         let super_listing_table = tokio::task::block_in_place(|| {
             self.runtime_handle.block_on(async move {
                 SuperListingTable::new(

--- a/beacon-file-formats/beacon-arrow-netcdf/Cargo.toml
+++ b/beacon-file-formats/beacon-arrow-netcdf/Cargo.toml
@@ -11,6 +11,7 @@ arrow = { workspace = true }
 arrow-schema = { workspace = true }
 anyhow = { workspace=true }
 tempfile = { workspace=true}
+tokio = { workspace=true }
 futures = { workspace=true }
 indexmap = { workspace=true }
 thiserror = { workspace=true }

--- a/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -36,18 +36,81 @@ pub mod sink;
 pub mod source;
 pub mod statistics;
 
+pub use reader::NetcdfReaderCache;
+
+/// Runtime configuration for the NetCDF format.
+///
+/// Plain data with sensible defaults; the caller populates it (there is no
+/// environment parsing here, so the crate stays reusable and the host decides
+/// where the values come from). These are the *defaults* for a runtime — some
+/// can be overridden per table via `CREATE EXTERNAL TABLE ... OPTIONS (...)`.
+#[derive(Debug, Clone)]
+pub struct NetcdfConfig {
+    /// Whether reads consult the shared reader cache by default.
+    pub use_reader_cache: bool,
+    /// Capacity (number of opened datasets) of the shared reader cache.
+    pub reader_cache_size: usize,
+    /// Whether to generate per-file statistics during planning.
+    pub enable_statistics: bool,
+}
+
+impl Default for NetcdfConfig {
+    fn default() -> Self {
+        Self {
+            use_reader_cache: true,
+            reader_cache_size: 128,
+            enable_statistics: true,
+        }
+    }
+}
+
+/// Parse a boolean value supplied through a `CREATE EXTERNAL TABLE` option.
+fn parse_bool_option(key: &str, value: &str) -> datafusion::error::Result<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Ok(true),
+        "false" | "0" | "no" | "off" => Ok(false),
+        other => Err(exec_datafusion_err!(
+            "invalid boolean for NetCDF option '{key}': '{other}'"
+        )),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct NetCDFFormatFactory {
     pub datasets_object_store: Arc<DatasetsStore>,
     pub options: NetcdfOptions,
+    pub config: NetcdfConfig,
+    /// Shared reader cache for this runtime, sized from `config`.
+    cache: NetcdfReaderCache,
 }
 
 impl NetCDFFormatFactory {
-    pub fn new(datasets_object_store: Arc<DatasetsStore>, options: NetcdfOptions) -> Self {
+    pub fn new(
+        datasets_object_store: Arc<DatasetsStore>,
+        options: NetcdfOptions,
+        config: NetcdfConfig,
+    ) -> Self {
+        let cache = NetcdfReaderCache::new(config.reader_cache_size);
         Self {
             datasets_object_store,
             options,
+            config,
+            cache,
         }
+    }
+
+    /// Build a [`NetcdfFormat`] with the given per-table effective settings,
+    /// wiring in the shared reader cache when caching is enabled.
+    fn build_format(
+        &self,
+        options: NetcdfOptions,
+        use_reader_cache: bool,
+        enable_statistics: bool,
+    ) -> NetcdfFormat {
+        let cache = use_reader_cache.then(|| self.cache.clone());
+        NetcdfFormat::new(self.datasets_object_store.clone(), options)
+            .with_cache(cache)
+            .with_enable_statistics(enable_statistics)
     }
 }
 
@@ -55,18 +118,42 @@ impl FileFormatFactory for NetCDFFormatFactory {
     fn create(
         &self,
         _state: &dyn Session,
-        _format_options: &std::collections::HashMap<String, String>,
+        format_options: &std::collections::HashMap<String, String>,
     ) -> datafusion::error::Result<Arc<dyn FileFormat>> {
-        Ok(Arc::new(NetcdfFormat::new(
-            self.datasets_object_store.clone(),
-            self.options.clone(),
+        // Per-table overrides from `CREATE EXTERNAL TABLE ... OPTIONS (...)`,
+        // defaulting to the runtime config.
+        let mut options = self.options.clone();
+        let mut use_reader_cache = self.config.use_reader_cache;
+        let mut enable_statistics = self.config.enable_statistics;
+
+        if let Some(value) = format_options.get("read_dimensions") {
+            options.read_dimensions = Some(
+                value
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect(),
+            );
+        }
+        if let Some(value) = format_options.get("use_reader_cache") {
+            use_reader_cache = parse_bool_option("use_reader_cache", value)?;
+        }
+        if let Some(value) = format_options.get("enable_statistics") {
+            enable_statistics = parse_bool_option("enable_statistics", value)?;
+        }
+
+        Ok(Arc::new(self.build_format(
+            options,
+            use_reader_cache,
+            enable_statistics,
         )))
     }
 
     fn default(&self) -> Arc<dyn FileFormat> {
-        Arc::new(NetcdfFormat::new(
-            self.datasets_object_store.clone(),
+        Arc::new(self.build_format(
             self.options.clone(),
+            self.config.use_reader_cache,
+            self.config.enable_statistics,
         ))
     }
 
@@ -108,6 +195,10 @@ impl FileFormatFactoryExt for NetCDFFormatFactory {
 pub struct NetcdfFormat {
     pub datasets_object_store: Arc<DatasetsStore>,
     pub options: NetcdfOptions,
+    /// Reader cache to consult, or `None` to bypass caching for this format.
+    cache: Option<NetcdfReaderCache>,
+    /// Whether to generate per-file statistics during planning.
+    enable_statistics: bool,
 }
 
 impl NetcdfFormat {
@@ -115,7 +206,21 @@ impl NetcdfFormat {
         Self {
             datasets_object_store,
             options,
+            cache: None,
+            enable_statistics: false,
         }
+    }
+
+    /// Wire in a reader cache (`Some`) or disable caching (`None`).
+    pub fn with_cache(mut self, cache: Option<NetcdfReaderCache>) -> Self {
+        self.cache = cache;
+        self
+    }
+
+    /// Set whether per-file statistics are generated during planning.
+    pub fn with_enable_statistics(mut self, enable_statistics: bool) -> Self {
+        self.enable_statistics = enable_statistics;
+        self
     }
 }
 
@@ -176,7 +281,7 @@ impl FileFormat for NetcdfFormat {
         table_schema: SchemaRef,
         object: &ObjectMeta,
     ) -> datafusion::error::Result<Statistics> {
-        if beacon_config::CONFIG.netcdf.enable_statistics {
+        if self.enable_statistics {
             Ok(statistics::generate_statistics(
                 self.datasets_object_store.clone(),
                 object,
@@ -213,6 +318,7 @@ impl FileFormat for NetcdfFormat {
             self.options.read_dimensions.clone(),
             table_schema,
         )
+        .with_cache(self.cache.clone())
         .with_projection(projection);
         let conf = FileScanConfigBuilder::from(conf)
             .with_source(Arc::new(source))
@@ -277,18 +383,20 @@ impl FileFormat for NetcdfFormat {
         &self,
         table_schema: datafusion::datasource::table_schema::TableSchema,
     ) -> Arc<dyn FileSource> {
-        Arc::new(NetCDFSource::new(
-            self.datasets_object_store.clone(),
-            self.options.read_dimensions.clone(),
-            table_schema,
-        ))
+        Arc::new(
+            NetCDFSource::new(
+                self.datasets_object_store.clone(),
+                self.options.read_dimensions.clone(),
+                table_schema,
+            )
+            .with_cache(self.cache.clone()),
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use beacon_object_storage::get_datasets_object_store;
     use datafusion::datasource::listing::PartitionedFile;
     use datafusion::execution::object_store::ObjectStoreUrl;
     use futures::StreamExt;
@@ -339,7 +447,7 @@ mod tests {
 
     async fn test_store() -> Arc<DatasetsStore> {
         ensure_test_fixtures();
-        get_datasets_object_store().await
+        beacon_object_storage::get_datasets_object_store().await
     }
 
     fn test_format(store: Arc<DatasetsStore>) -> NetcdfFormat {
@@ -462,6 +570,39 @@ mod tests {
             )),
         );
         assert_eq!(source.file_type(), "netcdf");
+    }
+
+    /// `CREATE EXTERNAL TABLE ... OPTIONS (...)` per-table overrides are parsed by
+    /// the factory: known keys are accepted (defaulting to the runtime config) and
+    /// a malformed boolean is rejected.
+    #[tokio::test]
+    async fn create_parses_per_table_options() {
+        use datafusion::datasource::file_format::FileFormatFactory;
+        use std::collections::HashMap;
+
+        let store = test_store().await;
+        let factory =
+            NetCDFFormatFactory::new(store, NetcdfOptions::default(), NetcdfConfig::default());
+        let ctx = datafusion::prelude::SessionContext::new();
+
+        let mut options = HashMap::new();
+        options.insert("use_reader_cache".to_string(), "false".to_string());
+        options.insert("enable_statistics".to_string(), "false".to_string());
+        options.insert("read_dimensions".to_string(), "time, lat".to_string());
+        let format = factory.create(&ctx.state(), &options).expect("valid options");
+        let netcdf = format
+            .as_any()
+            .downcast_ref::<NetcdfFormat>()
+            .expect("netcdf format");
+        assert_eq!(
+            netcdf.options.read_dimensions.as_deref(),
+            Some(["time".to_string(), "lat".to_string()].as_slice())
+        );
+
+        // A malformed boolean for a known option is a hard error.
+        let mut bad = HashMap::new();
+        bad.insert("use_reader_cache".to_string(), "notabool".to_string());
+        assert!(factory.create(&ctx.state(), &bad).is_err());
     }
 
     // ── FileOpener produces batches ────────────────────────────────────

--- a/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -35,8 +35,10 @@ pub mod reader;
 pub mod sink;
 pub mod source;
 pub mod statistics;
+pub mod table_function;
 
 pub use reader::NetcdfReaderCache;
+pub use table_function::ReadNetCDFFunc;
 
 /// Runtime configuration for the NetCDF format.
 ///

--- a/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/reader.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/reader.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use beacon_nd_array::dataset::AnyDataset;
 use beacon_object_storage::DatasetsStore;
@@ -6,7 +6,27 @@ use object_store::ObjectMeta;
 
 use crate::reader;
 
-static DATASET_CACHE: OnceLock<moka::future::Cache<CacheKey, Arc<AnyDataset>>> = OnceLock::new();
+/// A NetCDF dataset reader cache, sized at construction time.
+///
+/// Cloning shares the underlying [`moka`] cache (the cache is reference-counted
+/// internally), so a single cache instance is shared across the formats,
+/// sources and openers that a runtime hands a clone to. This is per-runtime
+/// state — there is no process-global cache.
+#[derive(Debug, Clone)]
+pub struct NetcdfReaderCache {
+    cache: moka::future::Cache<CacheKey, Arc<AnyDataset>>,
+}
+
+impl NetcdfReaderCache {
+    /// Build a cache holding up to `capacity` opened datasets.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            cache: moka::future::Cache::builder()
+                .max_capacity(capacity as u64)
+                .build(),
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct CacheKey {
@@ -14,24 +34,24 @@ struct CacheKey {
     pub last_modified: chrono::DateTime<chrono::Utc>,
 }
 
+/// Open a NetCDF dataset, optionally consulting `cache`.
+///
+/// When `cache` is `Some`, an entry keyed by object path + last-modified is
+/// checked before opening and populated afterwards. When `None`, the dataset is
+/// opened directly with no caching (e.g. schema inference or a table that opted
+/// out of caching).
 pub async fn open_dataset(
+    cache: Option<&NetcdfReaderCache>,
     object_store: Arc<DatasetsStore>,
     object: ObjectMeta,
 ) -> anyhow::Result<AnyDataset> {
-    if beacon_config::CONFIG.netcdf.use_reader_cache {
-        // Check the cache for an existing dataset before opening a new one.
-        let cache = DATASET_CACHE.get_or_init(|| {
-            moka::future::Cache::builder()
-                .max_capacity(beacon_config::CONFIG.netcdf.reader_cache_size as u64)
-                .build()
-        });
+    let key = CacheKey {
+        object: object.location.clone(),
+        last_modified: object.last_modified,
+    };
 
-        let key = CacheKey {
-            object: object.location.clone(),
-            last_modified: object.last_modified,
-        };
-
-        if let Some(cached_dataset) = cache.get(&key).await {
+    if let Some(cache) = cache {
+        if let Some(cached_dataset) = cache.cache.get(&key).await {
             return Ok((*cached_dataset).clone());
         }
     }
@@ -40,19 +60,8 @@ pub async fn open_dataset(
 
     let dataset = reader::open_dataset(netcdf_path).await?;
 
-    if beacon_config::CONFIG.netcdf.use_reader_cache {
-        let cache = DATASET_CACHE.get_or_init(|| {
-            moka::future::Cache::builder()
-                .max_capacity(beacon_config::CONFIG.netcdf.reader_cache_size as u64)
-                .build()
-        });
-
-        let key = CacheKey {
-            object: object.location.clone(),
-            last_modified: object.last_modified,
-        };
-
-        cache.insert(key, Arc::new(dataset.clone())).await;
+    if let Some(cache) = cache {
+        cache.cache.insert(key, Arc::new(dataset.clone())).await;
     }
 
     Ok(dataset)
@@ -69,11 +78,15 @@ pub async fn fetch_schema(
     object: ObjectMeta,
     read_dimensions: Option<Vec<String>>,
 ) -> datafusion::error::Result<arrow::datatypes::SchemaRef> {
-    let dataset = open_dataset(object_store, object).await.map_err(|e| {
-        datafusion::error::DataFusionError::Execution(format!(
-            "Failed to open NetCDF dataset for schema inference: {e}"
-        ))
-    })?;
+    // Schema inference does not consult the reader cache; the cache benefits
+    // repeated data scans, which flow through `NetCDFSource`.
+    let dataset = open_dataset(None, object_store, object)
+        .await
+        .map_err(|e| {
+            datafusion::error::DataFusionError::Execution(format!(
+                "Failed to open NetCDF dataset for schema inference: {e}"
+            ))
+        })?;
 
     let dataset = if let Some(dims) = read_dimensions {
         let proj = beacon_nd_array::projection::DatasetProjection {

--- a/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/source.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/source.rs
@@ -31,7 +31,7 @@ use datafusion::{
 use futures::{stream::BoxStream, FutureExt, StreamExt, TryStreamExt};
 use object_store::ObjectMeta;
 
-use super::reader;
+use super::reader::{self, NetcdfReaderCache};
 
 /// DataFusion [`FileSource`] for NetCDF (`.nc`) files.
 ///
@@ -46,6 +46,8 @@ pub struct NetCDFSource {
     read_dimensions: Option<Vec<String>>,
     batch_size: usize,
     predicate: Option<Arc<dyn PhysicalExpr>>,
+    /// Reader cache to consult for this scan. `None` disables caching.
+    cache: Option<NetcdfReaderCache>,
     /// Projection pushed down by the scan, applied on top of the table schema.
     projection: Option<ProjectionExprs>,
 }
@@ -64,8 +66,16 @@ impl NetCDFSource {
             read_dimensions,
             batch_size: usize::MAX,
             predicate: None,
+            cache: None,
             projection: None,
         }
+    }
+
+    /// Returns a copy of this source that consults `cache` (when `Some`) for
+    /// opened datasets. The format wires in the runtime's shared cache here.
+    pub fn with_cache(mut self, cache: Option<NetcdfReaderCache>) -> Self {
+        self.cache = cache;
+        self
     }
 
     /// Returns a copy of this source carrying the given projection. Used to
@@ -94,6 +104,7 @@ impl FileSource for NetCDFSource {
             self.batch_size,
             self.predicate.clone(),
             file_schema,
+            self.cache.clone(),
             self.execution_plan_metrics.clone(),
             partition,
         )))
@@ -190,11 +201,13 @@ struct NetCDFOpener {
     predicate: Option<Arc<dyn PhysicalExpr>>,
     pruning_predicate: Option<PruningPredicate>,
     table_schema: SchemaRef,
+    cache: Option<NetcdfReaderCache>,
     metrics: ExecutionPlanMetricsSet,
     partition: usize,
 }
 
 impl NetCDFOpener {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         datasets_object_store: Arc<DatasetsStore>,
         projected_schema: SchemaRef,
@@ -202,6 +215,7 @@ impl NetCDFOpener {
         batch_size: usize,
         predicate: Option<Arc<dyn PhysicalExpr>>,
         table_schema: SchemaRef,
+        cache: Option<NetcdfReaderCache>,
         metrics: ExecutionPlanMetricsSet,
         partition: usize,
     ) -> Self {
@@ -217,11 +231,13 @@ impl NetCDFOpener {
             predicate,
             pruning_predicate,
             table_schema,
+            cache,
             metrics,
             partition,
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn read_task(
         object: ObjectMeta,
         datasets_object_store: Arc<DatasetsStore>,
@@ -229,9 +245,10 @@ impl NetCDFOpener {
         read_dimensions: Option<Vec<String>>,
         batch_size: usize,
         predicate: Option<Arc<dyn PhysicalExpr>>,
+        cache: Option<NetcdfReaderCache>,
         metrics: Option<DatasetReadMetrics>,
     ) -> datafusion::error::Result<BoxStream<'static, datafusion::error::Result<RecordBatch>>> {
-        let dataset = reader::open_dataset(datasets_object_store, object.clone())
+        let dataset = reader::open_dataset(cache.as_ref(), datasets_object_store, object.clone())
             .await
             .map_err(|e| {
                 datafusion::error::DataFusionError::Execution(format!(
@@ -345,6 +362,7 @@ impl FileOpener for NetCDFOpener {
             self.read_dimensions.clone(),
             self.batch_size,
             self.predicate.clone(),
+            self.cache.clone(),
             metrics,
         )
         .boxed();

--- a/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/table_function.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/table_function.rs
@@ -12,7 +12,7 @@ use datafusion::{
     scalar::ScalarValue,
 };
 
-use crate::file_formats::BeaconTableFunctionImpl;
+use beacon_common::table_function::BeaconTableFunctionImpl;
 
 /// Format identity the NetCDF factory is registered under (its `get_ext`).
 const NETCDF_FORMAT: &str = "nc";
@@ -71,7 +71,7 @@ impl TableFunctionImpl for ReadNetCDFFunc {
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_netcdf")?;
+        let glob_paths = beacon_common::table_function::parse_glob_paths_arg(args, "read_netcdf")?;
         let mut dimensions: Vec<String> = vec![];
         if let Some(dimensions_arg) = args.get(1) {
             if let Expr::Literal(ScalarValue::List(values), _) = dimensions_arg {

--- a/beacon-file-formats/beacon-arrow-odv/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-odv/src/datafusion/mod.rs
@@ -262,3 +262,6 @@ impl FileFormat for OdvFormat {
         Arc::new(OdvSource::new(table_schema))
     }
 }
+
+pub mod table_function;
+pub use table_function::ReadOdvAsciiFunc;

--- a/beacon-file-formats/beacon-arrow-odv/src/datafusion/table_function.rs
+++ b/beacon-file-formats/beacon-arrow-odv/src/datafusion/table_function.rs
@@ -1,55 +1,56 @@
-use std::{fmt::Debug, sync::Arc};
+use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
-use beacon_arrow_zarr::datafusion::ZarrFormat;
+use crate::datafusion::OdvFormat;
 use datafusion::{
-    catalog::TableFunctionImpl, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
+    catalog::TableFunctionImpl,
+    execution::object_store::ObjectStoreUrl,
+    prelude::{Expr, SessionContext},
 };
 
-use crate::file_formats::BeaconTableFunctionImpl;
+use beacon_common::table_function::BeaconTableFunctionImpl;
 
-pub struct ReadZarrFunc {
-    // Session Reference
+pub struct ReadOdvAsciiFunc {
     runtime_handle: tokio::runtime::Handle,
     session_ctx: Arc<SessionContext>,
     data_object_store_url: ObjectStoreUrl,
 }
 
-impl ReadZarrFunc {
+impl ReadOdvAsciiFunc {
     pub fn new(
         runtime_handle: tokio::runtime::Handle,
-        session: Arc<SessionContext>,
+        session_ctx: Arc<SessionContext>,
         data_object_store_url: ObjectStoreUrl,
     ) -> Self {
         Self {
             runtime_handle,
-            session_ctx: session,
+            session_ctx,
             data_object_store_url,
         }
     }
 }
 
-impl Debug for ReadZarrFunc {
+impl std::fmt::Debug for ReadOdvAsciiFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ReadZarrFunc")
+        write!(f, "ReadOdvAsciiFunc")
     }
 }
 
-impl BeaconTableFunctionImpl for ReadZarrFunc {
+impl BeaconTableFunctionImpl for ReadOdvAsciiFunc {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
 
-    fn description(&self) -> Option<String> {
-        Some("Reads Zarr files from specified glob paths.".to_string())
-    }
-
     fn name(&self) -> String {
-        "read_zarr".to_string()
+        "read_odv_ascii".to_string()
     }
 
-    fn arguments(&self) -> Option<Vec<arrow::datatypes::Field>> {
+    fn description(&self) -> Option<String> {
+        Some("Reads ODV ASCII files from specified glob paths.".to_string())
+    }
+
+    fn arguments(&self) -> Option<Vec<Field>> {
         Some(vec![Field::new(
             "glob_paths",
             DataType::List(Arc::new(Field::new("glob_path", DataType::Utf8, false))),
@@ -58,24 +59,22 @@ impl BeaconTableFunctionImpl for ReadZarrFunc {
     }
 }
 
-impl TableFunctionImpl for ReadZarrFunc {
+impl TableFunctionImpl for ReadOdvAsciiFunc {
     fn call(
         &self,
-        args: &[datafusion::prelude::Expr],
-    ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_zarr")?;
+        args: &[Expr],
+    ) -> datafusion::error::Result<Arc<dyn datafusion::catalog::TableProvider>> {
+        let glob_paths = beacon_common::table_function::parse_glob_paths_arg(args, "read_odv_ascii")?;
 
-        tracing::debug!("read_zarr glob paths: {:?}", glob_paths);
+        tracing::debug!("read_odv_ascii glob paths: {:?}", glob_paths);
 
         let mut listing_urls = vec![];
         for path in &glob_paths {
-            tracing::debug!("read_zarr processing path: {}", path);
+            tracing::debug!("read_odv_ascii processing path: {}", path);
             listing_urls.push(parse_listing_table_url(&self.data_object_store_url, path)?);
         }
 
-        // Predicate pushdown is handled automatically by the shared engine, so
-        // no manual statistics/column selection is needed.
-        let file_format = ZarrFormat::default();
+        let file_format = OdvFormat::new();
         let super_listing_table = tokio::task::block_in_place(|| {
             self.runtime_handle.block_on(async move {
                 SuperListingTable::new(

--- a/beacon-file-formats/beacon-arrow-parquet/Cargo.toml
+++ b/beacon-file-formats/beacon-arrow-parquet/Cargo.toml
@@ -4,6 +4,8 @@ version = "1.7.3"
 edition = "2024"
 
 [dependencies]
+tracing = { workspace = true }
+tokio = { workspace = true }
 arrow = { workspace = true }
 datafusion = { workspace = true }
 object_store = { workspace = true }

--- a/beacon-file-formats/beacon-arrow-parquet/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-parquet/src/datafusion/mod.rs
@@ -213,3 +213,6 @@ fn cast_ts_seconds_to_ms(
     let projected = Arc::new(ProjectionExec::try_new(exprs, input)?);
     Ok(projected)
 }
+
+pub mod table_function;
+pub use table_function::ReadParquetFunc;

--- a/beacon-file-formats/beacon-arrow-parquet/src/datafusion/table_function.rs
+++ b/beacon-file-formats/beacon-arrow-parquet/src/datafusion/table_function.rs
@@ -2,21 +2,21 @@ use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
-use beacon_arrow_ipc::datafusion::ArrowFormat;
+use crate::datafusion::ParquetFormat;
 use datafusion::{
     catalog::TableFunctionImpl, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
 };
 
-use crate::file_formats::BeaconTableFunctionImpl;
+use beacon_common::table_function::BeaconTableFunctionImpl;
 
-pub struct ReadArrowFunc {
+pub struct ReadParquetFunc {
     // Session Reference
     runtime_handle: tokio::runtime::Handle,
     session_ctx: Arc<SessionContext>,
     data_object_store_url: ObjectStoreUrl,
 }
 
-impl ReadArrowFunc {
+impl ReadParquetFunc {
     pub fn new(
         runtime_handle: tokio::runtime::Handle,
         session_ctx: Arc<SessionContext>,
@@ -30,23 +30,23 @@ impl ReadArrowFunc {
     }
 }
 
-impl std::fmt::Debug for ReadArrowFunc {
+impl std::fmt::Debug for ReadParquetFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ReadArrowFunc")
+        write!(f, "ReadParquetFunc")
     }
 }
 
-impl BeaconTableFunctionImpl for ReadArrowFunc {
+impl BeaconTableFunctionImpl for ReadParquetFunc {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
 
-    fn name(&self) -> String {
-        "read_arrow".to_string()
+    fn description(&self) -> Option<String> {
+        Some("Reads Parquet files from specified glob paths.".to_string())
     }
 
-    fn description(&self) -> Option<String> {
-        Some("Reads Arrow files from specified glob paths.".to_string())
+    fn name(&self) -> String {
+        "read_parquet".to_string()
     }
 
     fn arguments(&self) -> Option<Vec<arrow::datatypes::Field>> {
@@ -58,22 +58,22 @@ impl BeaconTableFunctionImpl for ReadArrowFunc {
     }
 }
 
-impl TableFunctionImpl for ReadArrowFunc {
+impl TableFunctionImpl for ReadParquetFunc {
     fn call(
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_arrow")?;
+        let glob_paths = beacon_common::table_function::parse_glob_paths_arg(args, "read_parquet")?;
 
-        tracing::debug!("read_arrow glob paths: {:?}", glob_paths);
+        tracing::debug!("read_parquet glob paths: {:?}", glob_paths);
 
         let mut listing_urls = vec![];
         for path in &glob_paths {
-            tracing::debug!("read_arrow processing path: {}", path);
+            tracing::debug!("read_parquet processing path: {}", path);
             listing_urls.push(parse_listing_table_url(&self.data_object_store_url, path)?);
         }
 
-        let file_format = ArrowFormat::default();
+        let file_format = ParquetFormat::default();
         let super_listing_table = tokio::task::block_in_place(|| {
             self.runtime_handle.block_on(async move {
                 SuperListingTable::new(

--- a/beacon-file-formats/beacon-arrow-tiff/Cargo.toml
+++ b/beacon-file-formats/beacon-arrow-tiff/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+tokio = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }

--- a/beacon-file-formats/beacon-arrow-tiff/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-tiff/src/datafusion/mod.rs
@@ -494,3 +494,6 @@ mod tests {
         assert!(total < 380 * 1287, "predicate should drop some rows");
     }
 }
+
+pub mod table_function;
+pub use table_function::ReadTiffFunc;

--- a/beacon-file-formats/beacon-arrow-tiff/src/datafusion/table_function.rs
+++ b/beacon-file-formats/beacon-arrow-tiff/src/datafusion/table_function.rs
@@ -1,26 +1,27 @@
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field};
+use crate::datafusion::TiffFormat;
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
-use beacon_arrow_parquet::datafusion::ParquetFormat;
+use beacon_object_storage::DatasetsStore;
 use datafusion::{
     catalog::TableFunctionImpl, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
 };
 
-use crate::file_formats::BeaconTableFunctionImpl;
+use beacon_common::table_function::BeaconTableFunctionImpl;
 
-pub struct ReadParquetFunc {
-    // Session Reference
+pub struct ReadTiffFunc {
     runtime_handle: tokio::runtime::Handle,
     session_ctx: Arc<SessionContext>,
     data_object_store_url: ObjectStoreUrl,
 }
 
-impl ReadParquetFunc {
+impl ReadTiffFunc {
     pub fn new(
         runtime_handle: tokio::runtime::Handle,
         session_ctx: Arc<SessionContext>,
         data_object_store_url: ObjectStoreUrl,
+        _datasets_object_store: Arc<DatasetsStore>,
     ) -> Self {
         Self {
             runtime_handle,
@@ -30,23 +31,23 @@ impl ReadParquetFunc {
     }
 }
 
-impl std::fmt::Debug for ReadParquetFunc {
+impl std::fmt::Debug for ReadTiffFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ReadParquetFunc")
+        write!(f, "ReadTiffFunc")
     }
 }
 
-impl BeaconTableFunctionImpl for ReadParquetFunc {
+impl BeaconTableFunctionImpl for ReadTiffFunc {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
 
     fn description(&self) -> Option<String> {
-        Some("Reads Parquet files from specified glob paths.".to_string())
+        Some("Reads TIFF files from specified glob paths.".to_string())
     }
 
     fn name(&self) -> String {
-        "read_parquet".to_string()
+        "read_tiff".to_string()
     }
 
     fn arguments(&self) -> Option<Vec<arrow::datatypes::Field>> {
@@ -58,22 +59,19 @@ impl BeaconTableFunctionImpl for ReadParquetFunc {
     }
 }
 
-impl TableFunctionImpl for ReadParquetFunc {
+impl TableFunctionImpl for ReadTiffFunc {
     fn call(
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_parquet")?;
-
-        tracing::debug!("read_parquet glob paths: {:?}", glob_paths);
+        let glob_paths = beacon_common::table_function::parse_glob_paths_arg(args, "read_tiff")?;
 
         let mut listing_urls = vec![];
         for path in &glob_paths {
-            tracing::debug!("read_parquet processing path: {}", path);
             listing_urls.push(parse_listing_table_url(&self.data_object_store_url, path)?);
         }
 
-        let file_format = ParquetFormat::default();
+        let file_format = TiffFormat::new(Default::default());
         let super_listing_table = tokio::task::block_in_place(|| {
             self.runtime_handle.block_on(async move {
                 SuperListingTable::new(

--- a/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
@@ -518,3 +518,6 @@ mod tests {
         assert!(kept < total, "midpoint predicate should drop some rows");
     }
 }
+
+pub mod table_function;
+pub use table_function::ReadZarrFunc;

--- a/beacon-file-formats/beacon-arrow-zarr/src/datafusion/table_function.rs
+++ b/beacon-file-formats/beacon-arrow-zarr/src/datafusion/table_function.rs
@@ -1,53 +1,52 @@
-use std::sync::Arc;
+use std::{fmt::Debug, sync::Arc};
 
 use arrow::datatypes::{DataType, Field};
-use beacon_arrow_tiff::datafusion::TiffFormat;
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
-use beacon_object_storage::DatasetsStore;
+use crate::datafusion::ZarrFormat;
 use datafusion::{
     catalog::TableFunctionImpl, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
 };
 
-use crate::file_formats::BeaconTableFunctionImpl;
+use beacon_common::table_function::BeaconTableFunctionImpl;
 
-pub struct ReadTiffFunc {
+pub struct ReadZarrFunc {
+    // Session Reference
     runtime_handle: tokio::runtime::Handle,
     session_ctx: Arc<SessionContext>,
     data_object_store_url: ObjectStoreUrl,
 }
 
-impl ReadTiffFunc {
+impl ReadZarrFunc {
     pub fn new(
         runtime_handle: tokio::runtime::Handle,
-        session_ctx: Arc<SessionContext>,
+        session: Arc<SessionContext>,
         data_object_store_url: ObjectStoreUrl,
-        _datasets_object_store: Arc<DatasetsStore>,
     ) -> Self {
         Self {
             runtime_handle,
-            session_ctx,
+            session_ctx: session,
             data_object_store_url,
         }
     }
 }
 
-impl std::fmt::Debug for ReadTiffFunc {
+impl Debug for ReadZarrFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ReadTiffFunc")
+        write!(f, "ReadZarrFunc")
     }
 }
 
-impl BeaconTableFunctionImpl for ReadTiffFunc {
+impl BeaconTableFunctionImpl for ReadZarrFunc {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
 
     fn description(&self) -> Option<String> {
-        Some("Reads TIFF files from specified glob paths.".to_string())
+        Some("Reads Zarr files from specified glob paths.".to_string())
     }
 
     fn name(&self) -> String {
-        "read_tiff".to_string()
+        "read_zarr".to_string()
     }
 
     fn arguments(&self) -> Option<Vec<arrow::datatypes::Field>> {
@@ -59,19 +58,24 @@ impl BeaconTableFunctionImpl for ReadTiffFunc {
     }
 }
 
-impl TableFunctionImpl for ReadTiffFunc {
+impl TableFunctionImpl for ReadZarrFunc {
     fn call(
         &self,
         args: &[datafusion::prelude::Expr],
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
-        let glob_paths = crate::file_formats::parse_glob_paths_arg(args, "read_tiff")?;
+        let glob_paths = beacon_common::table_function::parse_glob_paths_arg(args, "read_zarr")?;
+
+        tracing::debug!("read_zarr glob paths: {:?}", glob_paths);
 
         let mut listing_urls = vec![];
         for path in &glob_paths {
+            tracing::debug!("read_zarr processing path: {}", path);
             listing_urls.push(parse_listing_table_url(&self.data_object_store_url, path)?);
         }
 
-        let file_format = TiffFormat::new(Default::default());
+        // Predicate pushdown is handled automatically by the shared engine, so
+        // no manual statistics/column selection is needed.
+        let file_format = ZarrFormat::default();
         let super_listing_table = tokio::task::block_in_place(|| {
             self.runtime_handle.block_on(async move {
                 SuperListingTable::new(

--- a/beacon-functions/src/file_formats/mod.rs
+++ b/beacon-functions/src/file_formats/mod.rs
@@ -1,65 +1,22 @@
 use std::sync::Arc;
 
-use arrow::datatypes::Field;
 use beacon_datafusion_ext::format_ext::FileFormatFactoryExt;
 use beacon_object_storage::DatasetsStore;
-use datafusion::{
-    catalog::TableFunctionImpl,
-    common::plan_err,
-    execution::object_store::ObjectStoreUrl,
-    logical_expr::{Documentation, Signature},
-    prelude::{Expr, SessionContext},
-    scalar::ScalarValue,
-};
+use datafusion::{execution::object_store::ObjectStoreUrl, prelude::SessionContext};
 
-/// Parse the first table-function argument into a list of glob/path strings.
-///
-/// Accepts either a single string scalar (`Utf8`/`LargeUtf8`/`Utf8View`) or a
-/// `List<Utf8>` of strings. `fn_name` is used only to build clear error messages.
-pub(crate) fn parse_glob_paths_arg(
-    args: &[Expr],
-    fn_name: &str,
-) -> datafusion::error::Result<Vec<String>> {
-    let Some(first) = args.first() else {
-        return plan_err!("{fn_name} requires at least 1 argument: glob_paths : Utf8 | List<Utf8>");
-    };
+// The shared table-function trait and the glob-arg parser now live in
+// `beacon-common` so each `beacon-arrow-*` format crate can host its own
+// `read_*` table function. Re-exported here for the cross-format functions
+// (`read_schema`, `list_datasets`) and existing consumers.
+pub use beacon_common::table_function::{parse_glob_paths_arg, BeaconTableFunctionImpl};
 
-    match first {
-        // Single string -> one-element list
-        Expr::Literal(ScalarValue::Utf8(Some(s)), _)
-        | Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _)
-        | Expr::Literal(ScalarValue::Utf8View(Some(s)), _) => Ok(vec![s.clone()]),
-
-        // List of strings
-        Expr::Literal(ScalarValue::List(values), _) => {
-            let string_array = values.as_ref().values();
-            match string_array
-                .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
-            {
-                Some(str_arr) => Ok(str_arr.iter().flatten().map(|s| s.to_string()).collect()),
-                None => plan_err!(
-                    "{fn_name} first argument must be a string or a List<Utf8> of glob paths"
-                ),
-            }
-        }
-        _ => plan_err!("{fn_name} first argument must be a string or a List<Utf8> of glob paths"),
-    }
-}
-
+// Cross-format table functions that don't belong to a single format crate.
 pub mod list_datasets;
-pub mod read_arrow;
-pub mod read_atlas;
-pub mod read_bbf;
-pub mod read_csv;
-pub mod read_geoparquet;
-pub mod read_netcdf;
-pub mod read_odv_ascii;
-pub mod read_parquet;
 pub mod read_schema;
-pub mod read_tiff;
-pub mod read_zarr;
 
+/// Build the `read_*` table functions. The per-format functions are constructed
+/// from their respective `beacon-arrow-*` crate; the cross-format ones
+/// (`read_schema`, `list_datasets`) live here.
 pub fn register_table_functions(
     runtime_handle: tokio::runtime::Handle,
     session_ctx: Arc<SessionContext>,
@@ -67,48 +24,44 @@ pub fn register_table_functions(
     datasets_object_store: Arc<DatasetsStore>,
     file_formats: Vec<Arc<dyn FileFormatFactoryExt>>,
 ) -> Vec<Arc<dyn BeaconTableFunctionImpl>> {
-    // The `read_*` table functions for store-backed formats (netcdf, atlas, bbf)
-    // build their `FileFormat` from the factory registered on the session, so
-    // they share the runtime's configured format and reader cache rather than
-    // constructing one of their own.
     vec![
-        Arc::new(read_parquet::ReadParquetFunc::new(
+        Arc::new(beacon_arrow_parquet::datafusion::ReadParquetFunc::new(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
         )),
-        Arc::new(read_geoparquet::ReadGeoParquetFunc::new(
+        Arc::new(beacon_arrow_geoparquet::datafusion::ReadGeoParquetFunc::new(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
         )),
-        Arc::new(read_arrow::ReadArrowFunc::new(
+        Arc::new(beacon_arrow_ipc::datafusion::ReadArrowFunc::new(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
         )),
-        Arc::new(read_csv::ReadCsvFunc::new(
+        Arc::new(beacon_arrow_csv::datafusion::ReadCsvFunc::new(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
         )),
-        Arc::new(read_zarr::ReadZarrFunc::new(
+        Arc::new(beacon_arrow_zarr::datafusion::ReadZarrFunc::new(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
         )),
-        Arc::new(read_netcdf::ReadNetCDFFunc::new(
+        Arc::new(beacon_arrow_netcdf::datafusion::ReadNetCDFFunc::new(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
         )),
-        Arc::new(read_tiff::ReadTiffFunc::new(
+        Arc::new(beacon_arrow_tiff::datafusion::ReadTiffFunc::new(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
             datasets_object_store.clone(),
         )),
-        Arc::new(read_bbf::ReadBBFFunc::new(
+        Arc::new(beacon_arrow_bbf::datafusion::ReadBBFFunc::new(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
@@ -119,12 +72,12 @@ pub fn register_table_functions(
             data_object_store_url.clone(),
             datasets_object_store.clone(),
         )),
-        Arc::new(read_odv_ascii::ReadOdvAsciiFunc::new(
+        Arc::new(beacon_arrow_odv::datafusion::ReadOdvAsciiFunc::new(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
         )),
-        Arc::new(read_atlas::ReadAtlasFunc::new(
+        Arc::new(beacon_arrow_atlas::datafusion::ReadAtlasFunc::new(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
@@ -136,90 +89,4 @@ pub fn register_table_functions(
             file_formats,
         )),
     ]
-}
-
-pub trait BeaconTableFunctionImpl: TableFunctionImpl + Send + Sync {
-    fn name(&self) -> String;
-    fn as_any(&self) -> &dyn std::any::Any;
-    fn arguments(&self) -> Option<Vec<Field>> {
-        None
-    }
-    fn description(&self) -> Option<String> {
-        None
-    }
-    fn signature(&self) -> Signature {
-        // Default field that accepts glob paths
-        let mut all_datatypes = vec![];
-        let options = self.arguments().unwrap_or_default();
-        for option in options {
-            all_datatypes.push(option.data_type().clone());
-        }
-        Signature::exact(
-            all_datatypes,
-            datafusion::logical_expr::Volatility::Immutable,
-        )
-    }
-    fn documentation(&self) -> Option<Documentation> {
-        None
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::parse_glob_paths_arg;
-    use datafusion::prelude::Expr;
-    use datafusion::scalar::ScalarValue;
-
-    fn list_expr(items: &[&str]) -> Expr {
-        let scalars: Vec<ScalarValue> = items
-            .iter()
-            .map(|s| ScalarValue::Utf8(Some(s.to_string())))
-            .collect();
-        Expr::Literal(
-            ScalarValue::List(ScalarValue::new_list_nullable(
-                &scalars,
-                &arrow::datatypes::DataType::Utf8,
-            )),
-            None,
-        )
-    }
-
-    #[test]
-    fn single_utf8_becomes_one_element_list() {
-        let expr = Expr::Literal(ScalarValue::Utf8(Some("data/*.parquet".to_string())), None);
-        let paths = parse_glob_paths_arg(&[expr], "read_parquet").unwrap();
-        assert_eq!(paths, vec!["data/*.parquet".to_string()]);
-    }
-
-    #[test]
-    fn single_large_utf8_is_accepted() {
-        let expr = Expr::Literal(ScalarValue::LargeUtf8(Some("a.csv".to_string())), None);
-        let paths = parse_glob_paths_arg(&[expr], "read_csv").unwrap();
-        assert_eq!(paths, vec!["a.csv".to_string()]);
-    }
-
-    #[test]
-    fn single_utf8_view_is_accepted() {
-        let expr = Expr::Literal(ScalarValue::Utf8View(Some("a.nc".to_string())), None);
-        let paths = parse_glob_paths_arg(&[expr], "read_netcdf").unwrap();
-        assert_eq!(paths, vec!["a.nc".to_string()]);
-    }
-
-    #[test]
-    fn list_of_strings_is_accepted() {
-        let expr = list_expr(&["a.parquet", "b.parquet"]);
-        let paths = parse_glob_paths_arg(&[expr], "read_parquet").unwrap();
-        assert_eq!(paths, vec!["a.parquet".to_string(), "b.parquet".to_string()]);
-    }
-
-    #[test]
-    fn missing_argument_errors() {
-        assert!(parse_glob_paths_arg(&[], "read_parquet").is_err());
-    }
-
-    #[test]
-    fn wrong_type_errors() {
-        let expr = Expr::Literal(ScalarValue::Int64(Some(42)), None);
-        assert!(parse_glob_paths_arg(&[expr], "read_parquet").is_err());
-    }
 }

--- a/beacon-functions/src/file_formats/mod.rs
+++ b/beacon-functions/src/file_formats/mod.rs
@@ -30,21 +30,10 @@ pub fn register_table_functions(
     datasets_object_store: Arc<DatasetsStore>,
     file_formats: Vec<Arc<dyn FileFormatFactoryExt>>,
 ) -> Vec<Arc<dyn BeaconTableFunctionImpl>> {
-    // Bridge: build the per-format config (owned by each format crate) from the
-    // process-global config. A later change threads an owned config in instead.
-    let netcdf_config = beacon_arrow_netcdf::datafusion::NetcdfConfig {
-        use_reader_cache: beacon_config::CONFIG.netcdf.use_reader_cache,
-        reader_cache_size: beacon_config::CONFIG.netcdf.reader_cache_size,
-        enable_statistics: beacon_config::CONFIG.netcdf.enable_statistics,
-    };
-    let atlas_config = beacon_arrow_atlas::datafusion::AtlasConfig {
-        use_reader_cache: beacon_config::CONFIG.atlas.use_reader_cache,
-        reader_cache_size: beacon_config::CONFIG.atlas.reader_cache_size,
-    };
-    let bbf_config = beacon_arrow_bbf::datafusion::BbfConfig {
-        split_streams_slice: beacon_config::CONFIG.runtime.bbf_split_streams_slice,
-    };
-
+    // The `read_*` table functions for store-backed formats (netcdf, atlas, bbf)
+    // build their `FileFormat` from the factory registered on the session, so
+    // they share the runtime's configured format and reader cache rather than
+    // constructing one of their own.
     vec![
         Arc::new(read_parquet::ReadParquetFunc::new(
             runtime_handle.clone(),
@@ -75,8 +64,6 @@ pub fn register_table_functions(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
-            datasets_object_store.clone(),
-            netcdf_config.clone(),
         )),
         Arc::new(read_tiff::ReadTiffFunc::new(
             runtime_handle.clone(),
@@ -88,7 +75,6 @@ pub fn register_table_functions(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
-            bbf_config.clone(),
         )),
         Arc::new(read_schema::ReadSchemaFunc::new(
             runtime_handle.clone(),
@@ -105,8 +91,6 @@ pub fn register_table_functions(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
-            datasets_object_store,
-            atlas_config,
         )),
         Arc::new(list_datasets::ListDatasetsFunc::new(
             runtime_handle,

--- a/beacon-functions/src/file_formats/mod.rs
+++ b/beacon-functions/src/file_formats/mod.rs
@@ -30,6 +30,21 @@ pub fn register_table_functions(
     datasets_object_store: Arc<DatasetsStore>,
     file_formats: Vec<Arc<dyn FileFormatFactoryExt>>,
 ) -> Vec<Arc<dyn BeaconTableFunctionImpl>> {
+    // Bridge: build the per-format config (owned by each format crate) from the
+    // process-global config. A later change threads an owned config in instead.
+    let netcdf_config = beacon_arrow_netcdf::datafusion::NetcdfConfig {
+        use_reader_cache: beacon_config::CONFIG.netcdf.use_reader_cache,
+        reader_cache_size: beacon_config::CONFIG.netcdf.reader_cache_size,
+        enable_statistics: beacon_config::CONFIG.netcdf.enable_statistics,
+    };
+    let atlas_config = beacon_arrow_atlas::datafusion::AtlasConfig {
+        use_reader_cache: beacon_config::CONFIG.atlas.use_reader_cache,
+        reader_cache_size: beacon_config::CONFIG.atlas.reader_cache_size,
+    };
+    let bbf_config = beacon_arrow_bbf::datafusion::BbfConfig {
+        split_streams_slice: beacon_config::CONFIG.runtime.bbf_split_streams_slice,
+    };
+
     vec![
         Arc::new(read_parquet::ReadParquetFunc::new(
             runtime_handle.clone(),
@@ -61,6 +76,7 @@ pub fn register_table_functions(
             session_ctx.clone(),
             data_object_store_url.clone(),
             datasets_object_store.clone(),
+            netcdf_config.clone(),
         )),
         Arc::new(read_tiff::ReadTiffFunc::new(
             runtime_handle.clone(),
@@ -72,6 +88,7 @@ pub fn register_table_functions(
             runtime_handle.clone(),
             session_ctx.clone(),
             data_object_store_url.clone(),
+            bbf_config.clone(),
         )),
         Arc::new(read_schema::ReadSchemaFunc::new(
             runtime_handle.clone(),
@@ -89,6 +106,7 @@ pub fn register_table_functions(
             session_ctx.clone(),
             data_object_store_url.clone(),
             datasets_object_store,
+            atlas_config,
         )),
         Arc::new(list_datasets::ListDatasetsFunc::new(
             runtime_handle,

--- a/beacon-functions/src/file_formats/read_atlas.rs
+++ b/beacon-functions/src/file_formats/read_atlas.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field};
-use beacon_arrow_atlas::datafusion::{options::AtlasOptions, AtlasFormat};
+use beacon_arrow_atlas::datafusion::{
+    options::AtlasOptions, AtlasConfig, AtlasFormat, AtlasReaderCache,
+};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
 use beacon_object_storage::DatasetsStore;
 use datafusion::{
@@ -20,6 +22,9 @@ pub struct ReadAtlasFunc {
     session_ctx: Arc<SessionContext>,
     data_object_store_url: ObjectStoreUrl,
     datasets_object_store: Arc<DatasetsStore>,
+    config: AtlasConfig,
+    /// Reader cache shared across calls of this table function (per runtime).
+    cache: AtlasReaderCache,
 }
 
 impl ReadAtlasFunc {
@@ -28,12 +33,16 @@ impl ReadAtlasFunc {
         session_ctx: Arc<SessionContext>,
         data_object_store_url: ObjectStoreUrl,
         datasets_object_store: Arc<DatasetsStore>,
+        config: AtlasConfig,
     ) -> Self {
+        let cache = AtlasReaderCache::new(config.reader_cache_size);
         Self {
             runtime_handle,
             session_ctx,
             data_object_store_url,
             datasets_object_store,
+            config,
+            cache,
         }
     }
 }
@@ -151,7 +160,9 @@ impl TableFunctionImpl for ReadAtlasFunc {
         let atlas_options = AtlasOptions {
             read_dimensions: dimensions,
         };
-        let file_format = AtlasFormat::new(self.datasets_object_store.clone(), atlas_options);
+        let cache = self.config.use_reader_cache.then(|| self.cache.clone());
+        let file_format = AtlasFormat::new(self.datasets_object_store.clone(), atlas_options)
+            .with_cache(cache);
         let super_listing_table = tokio::task::block_in_place(|| {
             self.runtime_handle.block_on(async move {
                 SuperListingTable::new(

--- a/beacon-functions/src/file_formats/read_atlas.rs
+++ b/beacon-functions/src/file_formats/read_atlas.rs
@@ -1,14 +1,12 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field};
-use beacon_arrow_atlas::datafusion::{
-    options::AtlasOptions, AtlasConfig, AtlasFormat, AtlasReaderCache,
-};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
-use beacon_object_storage::DatasetsStore;
 use datafusion::{
     catalog::TableFunctionImpl,
     common::plan_err,
+    datasource::file_format::FileFormatFactory,
     execution::object_store::ObjectStoreUrl,
     prelude::{Expr, SessionContext},
     scalar::ScalarValue,
@@ -16,15 +14,14 @@ use datafusion::{
 
 use crate::file_formats::BeaconTableFunctionImpl;
 
+/// Format identity the atlas factory is registered under (its `get_ext`).
+const ATLAS_FORMAT: &str = "atlas";
+
 pub struct ReadAtlasFunc {
     // Session Reference
     runtime_handle: tokio::runtime::Handle,
     session_ctx: Arc<SessionContext>,
     data_object_store_url: ObjectStoreUrl,
-    datasets_object_store: Arc<DatasetsStore>,
-    config: AtlasConfig,
-    /// Reader cache shared across calls of this table function (per runtime).
-    cache: AtlasReaderCache,
 }
 
 impl ReadAtlasFunc {
@@ -32,17 +29,11 @@ impl ReadAtlasFunc {
         runtime_handle: tokio::runtime::Handle,
         session_ctx: Arc<SessionContext>,
         data_object_store_url: ObjectStoreUrl,
-        datasets_object_store: Arc<DatasetsStore>,
-        config: AtlasConfig,
     ) -> Self {
-        let cache = AtlasReaderCache::new(config.reader_cache_size);
         Self {
             runtime_handle,
             session_ctx,
             data_object_store_url,
-            datasets_object_store,
-            config,
-            cache,
         }
     }
 }
@@ -125,7 +116,7 @@ impl TableFunctionImpl for ReadAtlasFunc {
             return plan_err!("read_atlas requires at least 1 argument: glob_paths : List<Utf8>");
         }
 
-        let mut dimensions: Option<Vec<String>> = None;
+        let mut dimensions: Vec<String> = vec![];
         if let Some(dimensions_arg) = args.get(1) {
             if let Expr::Literal(ScalarValue::List(values), _) = dimensions_arg {
                 let string_array = values.as_ref().values();
@@ -134,11 +125,10 @@ impl TableFunctionImpl for ReadAtlasFunc {
                     .downcast_ref::<arrow::array::StringArray>()
                 {
                     Some(str_arr) => {
-                        let dims: Vec<String> = str_arr
+                        dimensions = str_arr
                             .iter()
                             .filter_map(|opt_str| opt_str.map(|s| s.to_string()))
                             .collect();
-                        dimensions = Some(dims);
                     }
                     None => {
                         return plan_err!(
@@ -157,20 +147,25 @@ impl TableFunctionImpl for ReadAtlasFunc {
             listing_urls.push(parse_listing_table_url(&self.data_object_store_url, path)?);
         }
 
-        let atlas_options = AtlasOptions {
-            read_dimensions: dimensions,
-        };
-        let cache = self.config.use_reader_cache.then(|| self.cache.clone());
-        let file_format = AtlasFormat::new(self.datasets_object_store.clone(), atlas_options)
-            .with_cache(cache);
+        // Build the file format from the factory registered on the session, so the
+        // table function shares the runtime's configured format + reader cache.
+        // Per-call settings (read dimensions) are passed as table options.
+        let mut format_options: HashMap<String, String> = HashMap::new();
+        if !dimensions.is_empty() {
+            format_options.insert("read_dimensions".to_string(), dimensions.join(","));
+        }
+
+        let state = self.session_ctx.state();
+        let factory = state.get_file_format_factory(ATLAS_FORMAT).ok_or_else(|| {
+            datafusion::error::DataFusionError::Execution(
+                "read_atlas: the atlas file format is not registered on the session".to_string(),
+            )
+        })?;
+        let file_format = factory.create(&state, &format_options)?;
+
         let super_listing_table = tokio::task::block_in_place(|| {
-            self.runtime_handle.block_on(async move {
-                SuperListingTable::new(
-                    &self.session_ctx.state(),
-                    Arc::new(file_format),
-                    listing_urls,
-                )
-                .await
+            self.runtime_handle.block_on(async {
+                SuperListingTable::new(&self.session_ctx.state(), file_format, listing_urls).await
             })
         })?;
 

--- a/beacon-functions/src/file_formats/read_bbf.rs
+++ b/beacon-functions/src/file_formats/read_bbf.rs
@@ -1,11 +1,12 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
-use beacon_arrow_bbf::datafusion::{BbfConfig, BBFFormat};
 use datafusion::{
     catalog::TableFunctionImpl,
     common::plan_err,
+    datasource::file_format::FileFormatFactory,
     execution::object_store::ObjectStoreUrl,
     prelude::{Expr, SessionContext},
     scalar::ScalarValue,
@@ -13,12 +14,14 @@ use datafusion::{
 
 use crate::file_formats::BeaconTableFunctionImpl;
 
+/// Format identity the BBF factory is registered under (its `get_ext`).
+const BBF_FORMAT: &str = "bbf";
+
 pub struct ReadBBFFunc {
     // Session Reference
     runtime_handle: tokio::runtime::Handle,
     session_ctx: Arc<SessionContext>,
     data_object_store_url: ObjectStoreUrl,
-    config: BbfConfig,
 }
 
 impl ReadBBFFunc {
@@ -26,13 +29,11 @@ impl ReadBBFFunc {
         runtime_handle: tokio::runtime::Handle,
         session_ctx: Arc<SessionContext>,
         data_object_store_url: ObjectStoreUrl,
-        config: BbfConfig,
     ) -> Self {
         Self {
             runtime_handle,
             session_ctx,
             data_object_store_url,
-            config,
         }
     }
 }
@@ -109,17 +110,20 @@ impl TableFunctionImpl for ReadBBFFunc {
             listing_urls.push(parse_listing_table_url(&self.data_object_store_url, path)?);
         }
 
-        let file_format = BBFFormat {
-            split_streams_slice: self.config.split_streams_slice,
-        };
+        // Build the file format from the factory registered on the session, so the
+        // table function shares the runtime's configured format.
+        let format_options: HashMap<String, String> = HashMap::new();
+        let state = self.session_ctx.state();
+        let factory = state.get_file_format_factory(BBF_FORMAT).ok_or_else(|| {
+            datafusion::error::DataFusionError::Execution(
+                "read_bbf: the BBF file format is not registered on the session".to_string(),
+            )
+        })?;
+        let file_format = factory.create(&state, &format_options)?;
+
         let super_listing_table = tokio::task::block_in_place(|| {
-            self.runtime_handle.block_on(async move {
-                SuperListingTable::new(
-                    &self.session_ctx.state(),
-                    Arc::new(file_format),
-                    listing_urls,
-                )
-                .await
+            self.runtime_handle.block_on(async {
+                SuperListingTable::new(&self.session_ctx.state(), file_format, listing_urls).await
             })
         })?;
 

--- a/beacon-functions/src/file_formats/read_bbf.rs
+++ b/beacon-functions/src/file_formats/read_bbf.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
-use beacon_arrow_bbf::datafusion::BBFFormat;
+use beacon_arrow_bbf::datafusion::{BbfConfig, BBFFormat};
 use datafusion::{
     catalog::TableFunctionImpl,
     common::plan_err,
@@ -18,6 +18,7 @@ pub struct ReadBBFFunc {
     runtime_handle: tokio::runtime::Handle,
     session_ctx: Arc<SessionContext>,
     data_object_store_url: ObjectStoreUrl,
+    config: BbfConfig,
 }
 
 impl ReadBBFFunc {
@@ -25,11 +26,13 @@ impl ReadBBFFunc {
         runtime_handle: tokio::runtime::Handle,
         session_ctx: Arc<SessionContext>,
         data_object_store_url: ObjectStoreUrl,
+        config: BbfConfig,
     ) -> Self {
         Self {
             runtime_handle,
             session_ctx,
             data_object_store_url,
+            config,
         }
     }
 }
@@ -106,7 +109,9 @@ impl TableFunctionImpl for ReadBBFFunc {
             listing_urls.push(parse_listing_table_url(&self.data_object_store_url, path)?);
         }
 
-        let file_format = BBFFormat::default();
+        let file_format = BBFFormat {
+            split_streams_slice: self.config.split_streams_slice,
+        };
         let super_listing_table = tokio::task::block_in_place(|| {
             self.runtime_handle.block_on(async move {
                 SuperListingTable::new(

--- a/beacon-functions/src/file_formats/read_netcdf.rs
+++ b/beacon-functions/src/file_formats/read_netcdf.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field};
-use beacon_arrow_netcdf::datafusion::{options::NetcdfOptions, NetcdfFormat};
+use beacon_arrow_netcdf::datafusion::{
+    options::NetcdfOptions, NetcdfConfig, NetcdfFormat, NetcdfReaderCache,
+};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
 use beacon_object_storage::DatasetsStore;
 use datafusion::{
@@ -20,6 +22,9 @@ pub struct ReadNetCDFFunc {
     session_ctx: Arc<SessionContext>,
     data_object_store_url: ObjectStoreUrl,
     datasets_object_store: Arc<DatasetsStore>,
+    config: NetcdfConfig,
+    /// Reader cache shared across calls of this table function (per runtime).
+    cache: NetcdfReaderCache,
 }
 
 impl ReadNetCDFFunc {
@@ -28,12 +33,16 @@ impl ReadNetCDFFunc {
         session_ctx: Arc<SessionContext>,
         data_object_store_url: ObjectStoreUrl,
         datasets_object_store: Arc<DatasetsStore>,
+        config: NetcdfConfig,
     ) -> Self {
+        let cache = NetcdfReaderCache::new(config.reader_cache_size);
         Self {
             runtime_handle,
             session_ctx,
             data_object_store_url,
             datasets_object_store,
+            config,
+            cache,
         }
     }
 }
@@ -140,7 +149,10 @@ impl TableFunctionImpl for ReadNetCDFFunc {
         let mut netcdf_options = NetcdfOptions::default();
         netcdf_options.read_dimensions = dimensions;
 
-        let file_format = NetcdfFormat::new(self.datasets_object_store.clone(), netcdf_options);
+        let cache = self.config.use_reader_cache.then(|| self.cache.clone());
+        let file_format = NetcdfFormat::new(self.datasets_object_store.clone(), netcdf_options)
+            .with_cache(cache)
+            .with_enable_statistics(self.config.enable_statistics);
         let super_listing_table = tokio::task::block_in_place(|| {
             self.runtime_handle.block_on(async move {
                 SuperListingTable::new(

--- a/beacon-functions/src/file_formats/read_netcdf.rs
+++ b/beacon-functions/src/file_formats/read_netcdf.rs
@@ -1,14 +1,12 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field};
-use beacon_arrow_netcdf::datafusion::{
-    options::NetcdfOptions, NetcdfConfig, NetcdfFormat, NetcdfReaderCache,
-};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
-use beacon_object_storage::DatasetsStore;
 use datafusion::{
     catalog::TableFunctionImpl,
     common::plan_err,
+    datasource::file_format::FileFormatFactory,
     execution::object_store::ObjectStoreUrl,
     prelude::{Expr, SessionContext},
     scalar::ScalarValue,
@@ -16,15 +14,14 @@ use datafusion::{
 
 use crate::file_formats::BeaconTableFunctionImpl;
 
+/// Format identity the NetCDF factory is registered under (its `get_ext`).
+const NETCDF_FORMAT: &str = "nc";
+
 pub struct ReadNetCDFFunc {
     // Session Reference
     runtime_handle: tokio::runtime::Handle,
     session_ctx: Arc<SessionContext>,
     data_object_store_url: ObjectStoreUrl,
-    datasets_object_store: Arc<DatasetsStore>,
-    config: NetcdfConfig,
-    /// Reader cache shared across calls of this table function (per runtime).
-    cache: NetcdfReaderCache,
 }
 
 impl ReadNetCDFFunc {
@@ -32,17 +29,11 @@ impl ReadNetCDFFunc {
         runtime_handle: tokio::runtime::Handle,
         session_ctx: Arc<SessionContext>,
         data_object_store_url: ObjectStoreUrl,
-        datasets_object_store: Arc<DatasetsStore>,
-        config: NetcdfConfig,
     ) -> Self {
-        let cache = NetcdfReaderCache::new(config.reader_cache_size);
         Self {
             runtime_handle,
             session_ctx,
             data_object_store_url,
-            datasets_object_store,
-            config,
-            cache,
         }
     }
 }
@@ -112,7 +103,7 @@ impl TableFunctionImpl for ReadNetCDFFunc {
         } else {
             return plan_err!("read_netcdf requires at least 1 argument: glob_paths : List<Utf8>");
         }
-        let mut dimensions: Option<Vec<String>> = None;
+        let mut dimensions: Vec<String> = vec![];
         if let Some(dimensions_arg) = args.get(1) {
             if let Expr::Literal(ScalarValue::List(values), _) = dimensions_arg {
                 let string_array = values.as_ref().values();
@@ -121,11 +112,10 @@ impl TableFunctionImpl for ReadNetCDFFunc {
                     .downcast_ref::<arrow::array::StringArray>()
                 {
                     Some(str_arr) => {
-                        let dims: Vec<String> = str_arr
+                        dimensions = str_arr
                             .iter()
                             .filter_map(|opt_str| opt_str.map(|s| s.to_string()))
                             .collect();
-                        dimensions = Some(dims);
                     }
                     None => {
                         return plan_err!(
@@ -146,21 +136,25 @@ impl TableFunctionImpl for ReadNetCDFFunc {
 
         tracing::debug!("read_netcdf listing urls: {:?}", listing_urls);
 
-        let mut netcdf_options = NetcdfOptions::default();
-        netcdf_options.read_dimensions = dimensions;
+        // Build the file format from the factory registered on the session, so the
+        // table function shares the runtime's configured format + reader cache.
+        // Per-call settings (read dimensions) are passed as table options.
+        let mut format_options: HashMap<String, String> = HashMap::new();
+        if !dimensions.is_empty() {
+            format_options.insert("read_dimensions".to_string(), dimensions.join(","));
+        }
 
-        let cache = self.config.use_reader_cache.then(|| self.cache.clone());
-        let file_format = NetcdfFormat::new(self.datasets_object_store.clone(), netcdf_options)
-            .with_cache(cache)
-            .with_enable_statistics(self.config.enable_statistics);
+        let state = self.session_ctx.state();
+        let factory = state.get_file_format_factory(NETCDF_FORMAT).ok_or_else(|| {
+            datafusion::error::DataFusionError::Execution(
+                "read_netcdf: the NetCDF file format is not registered on the session".to_string(),
+            )
+        })?;
+        let file_format = factory.create(&state, &format_options)?;
+
         let super_listing_table = tokio::task::block_in_place(|| {
-            self.runtime_handle.block_on(async move {
-                SuperListingTable::new(
-                    &self.session_ctx.state(),
-                    Arc::new(file_format),
-                    listing_urls,
-                )
-                .await
+            self.runtime_handle.block_on(async {
+                SuperListingTable::new(&self.session_ctx.state(), file_format, listing_urls).await
             })
         })?;
 


### PR DESCRIPTION
Decentralizes file-format configuration: each format crate now owns a plain config struct and a **runtime-owned reader cache**, replacing the process-global statics that lived inside the readers. The previously-ignored `CREATE EXTERNAL TABLE ... OPTIONS (...)` map is now parsed so settings can be overridden **per table**.

### Per crate
- **beacon-arrow-netcdf**: `NetcdfConfig` + `NetcdfReaderCache` (replaces the static `OnceLock` moka cache); `enable_statistics` moved onto the format.
- **beacon-arrow-atlas**: `AtlasConfig` + `AtlasReaderCache` (replaces the `LazyLock` moka cache).
- **beacon-arrow-bbf**: `BbfConfig { split_streams_slice }`; batch-split size now comes from the DataFusion `SessionConfig` instead of the global.

### Per-table options
`FileFormatFactory::create` now parses the `OPTIONS` map (it was ignored before): `enable_statistics`, `use_reader_cache`, `read_dimensions` (netcdf/atlas), `split_streams_slice` (bbf). Values default to the runtime config; precedence is option > config default.

## How it stays compatible
The per-format config is **bridged from the process-global `beacon_config`** at the registration sites (`file_formats`, `register_table_functions`, query output/from). This keeps the change self-contained.

## Follow-up
This is the first of a stack. A follow-up PR makes the configuration **runtime-owned** (`Runtime::new(Arc<Config>)`), eliminates the process-global, and removes these temporary bridges.

## Tests
- `cargo build/clippy --workspace` clean.
- Format-crate + functions + data-lake + core tests pass, incl. a new netcdf test exercising per-table `OPTIONS` parsing.