### PR TITLE
Make S3Config the single source of truth for object storage

### DIFF
--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -182,6 +182,15 @@ struct RawConfig {
     s3_enable_virtual_hosting: bool,
     #[envconfig(from = "BEACON_S3_DATA_LAKE", default = "false")]
     s3_data_lake: bool,
+    // S3-compatible endpoint and region. Read from the standard AWS env vars so
+    // they can be captured into `S3Config` (the single source of truth) instead
+    // of being re-read from the environment at use time.
+    #[envconfig(from = "AWS_ENDPOINT")]
+    aws_endpoint: Option<String>,
+    #[envconfig(from = "AWS_REGION")]
+    aws_region: Option<String>,
+    #[envconfig(from = "BEACON_S3_ALLOW_HTTP", default = "true")]
+    s3_allow_http: bool,
     // Filesystem change events are on by default for the local datasets store;
     // set BEACON_ENABLE_FS_EVENTS=false to disable the watcher.
     #[envconfig(from = "BEACON_ENABLE_FS_EVENTS", default = "true")]
@@ -309,6 +318,9 @@ impl From<RawConfig> for Config {
                     bucket: raw.s3_bucket,
                     enable_virtual_hosting: raw.s3_enable_virtual_hosting,
                     data_lake: raw.s3_data_lake,
+                    endpoint: raw.aws_endpoint,
+                    region: raw.aws_region,
+                    allow_http: raw.s3_allow_http,
                 },
             },
             cors: CorsConfig {

--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -58,6 +58,7 @@ impl Runtime {
             &config.storage,
             config.data.datasets.clone(),
             config.data.tables.clone(),
+            config.data.tmp.clone(),
         )
         .await?;
 

--- a/beacon-data-lake/src/files/manager.rs
+++ b/beacon-data-lake/src/files/manager.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, path::Path, sync::Arc};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use arrow::datatypes::SchemaRef;
 use beacon_common::listing_url::parse_listing_table_url;
@@ -16,6 +20,10 @@ pub struct FileManager {
     session_context: Arc<SessionContext>,
     data_directory_store_url: ObjectStoreUrl,
     file_formats: Vec<Arc<dyn FileFormatFactoryExt>>,
+    /// Directory temporary output files are created in. Must match the root of
+    /// the tmp object store (`tmp://`) so COPY-written bytes are visible when the
+    /// file is read back. See [`TempOutputFile::new`].
+    tmp_dir: PathBuf,
 }
 
 impl FileManager {
@@ -23,11 +31,13 @@ impl FileManager {
         session_context: Arc<SessionContext>,
         data_directory_store_url: ObjectStoreUrl,
         file_formats: Vec<Arc<dyn FileFormatFactoryExt>>,
+        tmp_dir: PathBuf,
     ) -> Self {
         Self {
             session_context,
             data_directory_store_url,
             file_formats,
+            tmp_dir,
         }
     }
 
@@ -48,11 +58,7 @@ impl FileManager {
     }
 
     pub fn try_create_temp_output_file(&self, extension: &str) -> TempOutputFile {
-        Self::create_temp_output_file(extension)
-    }
-
-    pub fn create_temp_output_file(extension: &str) -> TempOutputFile {
-        TempOutputFile::new(extension)
+        TempOutputFile::new(&self.tmp_dir, extension)
     }
 
     pub async fn list_datasets(

--- a/beacon-data-lake/src/files/temp_output_file.rs
+++ b/beacon-data-lake/src/files/temp_output_file.rs
@@ -1,4 +1,4 @@
-use std::env::temp_dir;
+use std::path::Path;
 
 pub struct TempOutputFile {
     temp_file: tempfile::NamedTempFile,
@@ -7,11 +7,19 @@ pub struct TempOutputFile {
 }
 
 impl TempOutputFile {
-    pub fn new(extension: &str) -> Self {
+    /// Create a temporary output file inside `dir`.
+    ///
+    /// `dir` MUST be the same directory the tmp object store
+    /// ([`crate::TMP_OBJECT_STORE_URL`]) is rooted at: the COPY plan writes to
+    /// `tmp://<file_name>` (see [`Self::output_url`]) which resolves under the
+    /// tmp store's root, while the returned [`tempfile::NamedTempFile`] is read
+    /// back from this filesystem path. If the two diverge the written bytes are
+    /// invisible to the caller.
+    pub fn new(dir: &Path, extension: &str) -> Self {
         let temp_file = tempfile::Builder::new()
             .prefix("beacon_temp_")
             .suffix(extension)
-            .tempfile_in(temp_dir())
+            .tempfile_in(dir)
             .unwrap();
 
         let file_name = temp_file.path().file_name().unwrap().to_string_lossy();

--- a/beacon-data-lake/src/lib.rs
+++ b/beacon-data-lake/src/lib.rs
@@ -109,10 +109,6 @@ impl DataLake {
         self.file_manager.try_create_temp_output_file(extension)
     }
 
-    pub fn create_temp_output_file(extension: &str) -> TempOutputFile {
-        FileManager::create_temp_output_file(extension)
-    }
-
     pub fn table_manager(&self) -> Arc<TableManager> {
         self.table_manager.clone()
     }
@@ -169,6 +165,7 @@ impl DataLake {
             session_context,
             datasets_object_store_url.clone(),
             file_formats,
+            config.data.tmp.clone(),
         ));
 
         Self {

--- a/beacon-iceberg/src/catalog.rs
+++ b/beacon-iceberg/src/catalog.rs
@@ -69,14 +69,17 @@ pub async fn init_datasets_warehouse(
         let bucket = storage.s3.bucket.as_deref().ok_or_else(|| {
             anyhow::anyhow!("Iceberg warehouse on S3 requires a bucket name (set BEACON_S3_BUCKET)")
         })?;
-        // `AmazonS3Builder::from_env()` picks up the AWS_* env; mirror the two
-        // settings beacon configures explicitly for the datasets store.
-        let builder = ObjectStoreBuilder::s3()
-            .with_config("aws_allow_http", "true")
+        // Mirror the datasets store's backend by consuming the same `S3Config`
+        // values (credentials still come from the AWS env chain). Setting the
+        // endpoint/region explicitly keeps the Iceberg warehouse on the same
+        // backend as the datasets without re-reading the environment.
+        let s3 = &storage.s3;
+        let mut builder = ObjectStoreBuilder::s3()
+            .with_config("aws_allow_http", if s3.allow_http { "true" } else { "false" })
             .and_then(|builder| {
                 builder.with_config(
                     "aws_virtual_hosted_style_request",
-                    if storage.s3.enable_virtual_hosting {
+                    if s3.enable_virtual_hosting {
                         "true"
                     } else {
                         "false"
@@ -84,6 +87,16 @@ pub async fn init_datasets_warehouse(
                 )
             })
             .map_err(|error| anyhow::anyhow!("Failed to configure Iceberg S3 store: {error}"))?;
+        if let Some(endpoint) = &s3.endpoint {
+            builder = builder
+                .with_config("aws_endpoint", endpoint)
+                .map_err(|error| anyhow::anyhow!("Failed to configure Iceberg S3 store: {error}"))?;
+        }
+        if let Some(region) = &s3.region {
+            builder = builder
+                .with_config("aws_region", region)
+                .map_err(|error| anyhow::anyhow!("Failed to configure Iceberg S3 store: {error}"))?;
+        }
         (builder, format!("s3://{bucket}/{warehouse_prefix}"))
     } else {
         // Local: root the builder at the datasets directory so warehouse paths

--- a/beacon-object-storage/src/config.rs
+++ b/beacon-object-storage/src/config.rs
@@ -5,6 +5,10 @@
 //! no dependency on `beacon-config`; `beacon-config` re-exports them and fills
 //! them from the environment.
 
+use object_store::aws::AmazonS3Builder;
+
+use crate::error::StorageError;
+
 /// How Beacon's object storage is configured.
 #[derive(Debug, Clone, Default)]
 pub struct StorageConfig {
@@ -14,9 +18,65 @@ pub struct StorageConfig {
 }
 
 /// S3-specific storage settings (used when `s3.data_lake` is set).
-#[derive(Debug, Clone, Default)]
+///
+/// This is the single source of truth for the S3 backend: it drives both store
+/// construction ([`Self::amazon_s3_builder`]) and NetCDF URL translation, so the
+/// two can never diverge. Credentials are intentionally *not* held here — they
+/// flow through the standard AWS environment chain (`AmazonS3Builder::from_env`).
+#[derive(Debug, Clone)]
 pub struct S3Config {
     pub bucket: Option<String>,
     pub enable_virtual_hosting: bool,
     pub data_lake: bool,
+    /// S3-compatible endpoint, e.g. `http://minio:9000`. Captured explicitly so
+    /// store-building and NetCDF URL translation use the same value. `None` =>
+    /// rely on the AWS endpoint resolution (real AWS).
+    pub endpoint: Option<String>,
+    /// Optional region; when `None`, `from_env` still reads `AWS_REGION`.
+    pub region: Option<String>,
+    /// Allow plain HTTP (dev/MinIO). Defaults to `true` (current behavior).
+    pub allow_http: bool,
+}
+
+impl Default for S3Config {
+    fn default() -> Self {
+        Self {
+            bucket: None,
+            enable_virtual_hosting: false,
+            data_lake: false,
+            endpoint: None,
+            region: None,
+            allow_http: true,
+        }
+    }
+}
+
+impl S3Config {
+    /// Build an [`AmazonS3Builder`] from this config — the single place the S3
+    /// backend is configured. Credentials are layered in by
+    /// [`AmazonS3Builder::from_env`]; the explicit values here override the
+    /// corresponding environment variables so the configured endpoint/region
+    /// always win.
+    pub(crate) fn amazon_s3_builder(&self) -> Result<AmazonS3Builder, StorageError> {
+        let mut builder = AmazonS3Builder::from_env()
+            .with_allow_http(self.allow_http)
+            .with_virtual_hosted_style_request(self.enable_virtual_hosting);
+
+        if let Some(endpoint) = &self.endpoint {
+            builder = builder.with_endpoint(endpoint);
+        }
+        if let Some(region) = &self.region {
+            builder = builder.with_region(region);
+        }
+
+        if !self.enable_virtual_hosting {
+            // Path-style requests need an explicit bucket name.
+            let bucket = self.bucket.as_ref().ok_or(StorageError::MissingConfig {
+                key: "BEACON_S3_BUCKET",
+            })?;
+            builder = builder.with_bucket_name(bucket);
+        }
+
+        Ok(builder)
+    }
 }

--- a/beacon-object-storage/src/datasets_store.rs
+++ b/beacon-object-storage/src/datasets_store.rs
@@ -9,8 +9,8 @@ use crate::config::StorageConfig;
 use futures::{StreamExt, future::BoxFuture, stream::BoxStream};
 use object_store::{
     CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOptions, PutOptions, PutPayload, PutResult, aws::AmazonS3Builder,
-    local::LocalFileSystem, path::Path, prefix::PrefixStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, local::LocalFileSystem, path::Path,
+    prefix::PrefixStore,
 };
 use parking_lot::RwLock;
 use tokio::{sync::broadcast, task::JoinHandle};
@@ -53,21 +53,8 @@ pub(crate) async fn create_datasets_store(
     ) = if storage.s3.data_lake {
         tracing::info!("Using S3 object store for datasets");
 
-        let s3 = &storage.s3;
-        let mut builder = AmazonS3Builder::from_env()
-            .with_allow_http(true)
-            .with_virtual_hosted_style_request(s3.enable_virtual_hosting);
-
-        if !s3.enable_virtual_hosting {
-            // Path-style requests need an explicit bucket name.
-            let bucket = s3.bucket.as_ref().ok_or(error::StorageError::MissingConfig {
-                key: "BEACON_S3_BUCKET",
-            })?;
-            builder = builder.with_bucket_name(bucket);
-        }
-
         // `object_store::Error` converts into `StorageError::ObjectStore` via `?`.
-        let store = builder.build()?;
+        let store = storage.s3.amazon_s3_builder()?.build()?;
 
         // TODO: wire S3 change notifications into an `EventListener` so the
         // cache-backed fast path can be enabled for the S3 backend too.
@@ -327,17 +314,26 @@ impl DatasetsStore {
     /// - **Local datasets**: a plain filesystem path rooted at the configured
     ///   datasets directory (no `file://` scheme — NetCDF libraries open local
     ///   paths directly).
-    /// - **S3 datasets**: an `http://`/`https://` URL built from `AWS_ENDPOINT`
-    ///   and the configured bucket, with `#mode=bytes` appended (required by some
-    ///   NetCDF libraries for byte-range access).
+    /// - **S3 datasets**: an `http://`/`https://` URL built from the configured
+    ///   S3 endpoint ([`crate::config::S3Config::endpoint`]) and bucket, with
+    ///   `#mode=bytes` appended (required by some NetCDF libraries for byte-range
+    ///   access). This is the same endpoint used to build the store, so the two
+    ///   never diverge.
     ///
     /// This function intentionally never returns an `s3://...` URL.
     pub fn translate_netcdf_url_path(&self, object: &Path) -> StorageResult<String> {
         let storage = &self.storage;
         if storage.s3.data_lake {
-            let endpoint = s3_endpoint()?;
+            let endpoint =
+                storage
+                    .s3
+                    .endpoint
+                    .as_deref()
+                    .ok_or(error::StorageError::MissingConfig {
+                        key: "AWS_ENDPOINT",
+                    })?;
             let url = s3_object_url(
-                &endpoint,
+                endpoint,
                 storage.s3.bucket.as_deref(),
                 storage.s3.enable_virtual_hosting,
                 object,
@@ -347,22 +343,6 @@ impl DatasetsStore {
             local_object_path(&self.datasets_dir, object)
         }
     }
-}
-
-/// Reads and validates the S3 endpoint used to build NetCDF URLs.
-fn s3_endpoint() -> StorageResult<String> {
-    let endpoint =
-        std::env::var("AWS_ENDPOINT").map_err(|source| error::StorageError::MissingEnvVar {
-            var: "AWS_ENDPOINT",
-            source,
-        })?;
-    if endpoint.trim().is_empty() {
-        return Err(error::StorageError::InvalidConfig {
-            key: "AWS_ENDPOINT",
-            message: "must not be empty".to_string(),
-        });
-    }
-    Ok(endpoint)
 }
 
 /// Builds the `http(s)` URL for an object served from an S3-compatible backend.

--- a/beacon-object-storage/src/error.rs
+++ b/beacon-object-storage/src/error.rs
@@ -1,7 +1,5 @@
 //! Error types for the Beacon object storage layer.
 
-use std::env::VarError;
-
 /// Errors produced while building or operating Beacon's object stores.
 #[derive(thiserror::Error, Debug)]
 pub enum StorageError {
@@ -16,14 +14,6 @@ pub enum StorageError {
     /// A configuration value is present but invalid.
     #[error("Invalid configuration for {key}: {message}")]
     InvalidConfig { key: &'static str, message: String },
-
-    /// A required environment variable is missing or unreadable.
-    #[error("Missing environment variable {var}: {source}")]
-    MissingEnvVar {
-        var: &'static str,
-        #[source]
-        source: VarError,
-    },
 
     /// An error returned by the underlying `object_store` backend (S3 or local
     /// filesystem), e.g. while building a store or canonicalizing its root.

--- a/beacon-object-storage/src/lib.rs
+++ b/beacon-object-storage/src/lib.rs
@@ -10,7 +10,7 @@
 //!   prefix-scoped event subscription, and provides NetCDF URL translation.
 //! - **Tables** / **tmp**: local filesystem.
 
-use std::{env::temp_dir, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 use object_store::{ObjectStore, local::LocalFileSystem};
 
@@ -44,12 +44,13 @@ pub struct ObjectStores {
 impl ObjectStores {
     /// Build all three object stores, returning a structured error if any fails.
     ///
-    /// `datasets_dir`/`tables_dir` are the resolved local roots; the temporary
-    /// store is rooted at the OS temp directory.
+    /// `datasets_dir`/`tables_dir`/`tmp_dir` are the resolved local roots (from
+    /// the runtime's configured data directories).
     pub async fn new(
         storage: &StorageConfig,
         datasets_dir: PathBuf,
         tables_dir: PathBuf,
+        tmp_dir: PathBuf,
     ) -> StorageResult<Self> {
         let datasets =
             Arc::new(datasets_store::create_datasets_store(storage, datasets_dir).await?);
@@ -58,7 +59,7 @@ impl ObjectStores {
             LocalFileSystem::new_with_prefix(tables_dir)?.with_automatic_cleanup(true),
         ) as Arc<dyn ObjectStore>;
 
-        let tmp = Arc::new(LocalFileSystem::new_with_prefix(temp_dir())?) as Arc<dyn ObjectStore>;
+        let tmp = Arc::new(LocalFileSystem::new_with_prefix(tmp_dir)?) as Arc<dyn ObjectStore>;
 
         tracing::info!("object stores initialized");
         Ok(Self {


### PR DESCRIPTION
## Context

After PR #289 config is **runtime-owned** (`Runtime::new(Arc<beacon_config::Config>)`, threaded via `SessionConfig` extensions) with no process-global config. `beacon-object-storage` didn't yet follow this model for S3: backend settings were read from **process-global env in three independent places**, each re-branching local-vs-S3 by hand:

1. `create_datasets_store` — `AmazonS3Builder::from_env()` + allow_http/virtual_hosting/bucket.
2. `translate_netcdf_url_path` / `s3_endpoint()` — read `AWS_ENDPOINT` via `std::env::var` **at call time** to build NetCDF URLs.
3. `beacon-iceberg::init_datasets_warehouse` — re-derived the same settings, relying on `AWS_*` env for the endpoint.

`AWS_ENDPOINT` was never captured in `S3Config`, so the endpoint used to **build** the store and the one used for **NetCDF URL translation** could diverge. Separately, `ObjectStores::new` hardcoded the tmp store to `std::env::temp_dir()`, ignoring the configured `config.data.tmp`.

## Changes

- **`S3Config` is now the single source of truth** — gains `endpoint`, `region`, `allow_http`, and an `amazon_s3_builder()` helper that is the one place an `AmazonS3Builder` is built from config. Credentials still flow via the AWS env chain (`from_env`); no secrets in the struct.
- **`translate_netcdf_url_path`** reads `self.storage.s3.endpoint` instead of `std::env::var("AWS_ENDPOINT")` at call time, guaranteeing the build endpoint and NetCDF-URL endpoint are identical. Removed the `s3_endpoint()` helper and the now-dead `StorageError::MissingEnvVar` variant.
- **`beacon-iceberg::init_datasets_warehouse`** sets `aws_endpoint`/`aws_region` explicitly from `S3Config` and honors `allow_http`, instead of relying on env.
- **`ObjectStores::new`** takes an explicit `tmp_dir` and honors `config.data.tmp` (runtime passes `config.data.tmp.clone()`) instead of `std::env::temp_dir()`.
- **`beacon-config`** reads `AWS_ENDPOINT` / `AWS_REGION` / `BEACON_S3_ALLOW_HTTP` into the new `S3Config` fields.

The two-phase `DatasetsStore::new` + `with_storage` init is left unchanged (out of scope).

## Compatibility

Existing S3 deployments are unaffected: when a field is `None`, `from_env` still reads the same env var. `BEACON_S3_ALLOW_HTTP` defaults to `true`, matching the previously-hardcoded value.

## Verification

- `cargo build -p beacon-object-storage -p beacon-config -p beacon-iceberg -p beacon-core` — clean (no new warnings).
- `cargo test -p beacon-object-storage` — 25 passed.
- `cargo test -p beacon-iceberg` — 7 passed (local + S3 warehouse branches build).
