### PR TITLE
Sync 1.7.3 docs with code; fix stale config reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ It is built on [Apache Arrow](https://arrow.apache.org/) and [Apache DataFusion]
 
 - **Query files where they live.** Read NetCDF, Zarr, Parquet, ODV, CSV and more directly from a local volume or S3-compatible object store — no ingestion step.
 - **One API, many formats in and out.** Send a SQL or JSON query, choose your output format (Parquet, CSV, NetCDF, GeoParquet, Arrow IPC, ODV) and stream the result.
-- **Built for scale.** Columnar execution, predicate/projection pushdown, and schema caching on top of Arrow + DataFusion.
+- **Built for scale.** Columnar execution, predicate/projection pushdown, and statistics-based pruning on top of Arrow + DataFusion.
 - **Self-describing.** A built-in OpenAPI/Swagger UI documents every endpoint, and discovery endpoints expose available datasets, tables, columns, and functions.
 
 ## Features
 
-- **Input formats:** Parquet, NetCDF, Zarr, ODV, CSV, Arrow IPC, GeoTIFF, and the native Beacon Binary Format (BBF).
+- **Input formats:** Parquet, GeoParquet, NetCDF, Zarr, Atlas, ODV, CSV, Arrow IPC, GeoTIFF, Delta Lake, and the native Beacon Binary Format (BBF).
 - **Output formats:** Parquet, GeoParquet, NetCDF, ND-NetCDF, CSV, Arrow IPC, and ODV.
 - **Two query interfaces:** a structured **JSON query** API and read-only raw **SQL** (enabled by default; toggle with `BEACON_ENABLE_SQL`).
 - **Arrow Flight SQL** endpoint for high-throughput clients (enabled by default).
@@ -163,7 +163,7 @@ Beacon is configured entirely through `BEACON_*` environment variables. The most
 | `BEACON_FLIGHT_SQL_ENABLE` | `true` | Enable the Arrow Flight SQL endpoint. |
 | `BEACON_FLIGHT_SQL_PORT` | `32011` | Arrow Flight SQL port. |
 
-S3-compatible storage, CORS, NetCDF caching, and Flight SQL authentication have their own `BEACON_*` settings — see the [configuration reference](https://maris-development.github.io/beacon/) for the complete list.
+S3-compatible storage, CORS, NetCDF caching, the crawler, and Flight SQL authentication have their own `BEACON_*` settings — see the [configuration reference](https://maris-development.github.io/beacon/docs/1.7.3/data-lake/configuration.html) for the complete list.
 
 ## Documentation
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -487,7 +487,7 @@ export default defineConfig({
                 { text: 'Datasets', link: '/docs/1.7.3/api/exploring-data-lake#datasets' },
                 { text: 'Tables', link: '/docs/1.7.3/api/exploring-data-lake#tables' },
                 { text: 'Functions', link: '/docs/1.7.3/api/exploring-data-lake#functions' },
-                { text: 'Admin', link: '/docs/1.7.3/api/exploring-data-lake#admin-file-management' },
+                { text: 'Admin', link: '/docs/1.7.3/api/exploring-data-lake#admin' },
               ]
             },
             {

--- a/docs/docs/1.7.3/api/exploring-data-lake.md
+++ b/docs/docs/1.7.3/api/exploring-data-lake.md
@@ -24,6 +24,11 @@ Returns Beacon version, configuration summary, and registered table count.
 GET /api/list-datasets
 ```
 
+::: info Deprecated alias
+`GET /api/datasets` is a deprecated alias of `/api/list-datasets`. Use
+`/api/list-datasets` in new code.
+:::
+
 Optional query parameters:
 
 | Parameter | Description |
@@ -80,6 +85,15 @@ GET /api/default-table
 GET /api/table-schema?table_name=default
 ```
 
+### Default table schema
+
+The Arrow schema of the default table (the one queried when a request omits
+`from`):
+
+```http
+GET /api/default-table-schema
+```
+
 ### All tables with schemas
 
 Convenient for UI discovery, but can be slow on large installations:
@@ -130,4 +144,28 @@ Content-Type: application/json
 { "sql": "DROP TABLE argo" }
 ```
 
-Browse `/swagger` for the full request and response shapes.
+Write operations require the admin credentials (`BEACON_ADMIN_USERNAME` /
+`BEACON_ADMIN_PASSWORD`) via HTTP basic auth; anonymous requests are read-only.
+
+## Admin
+
+Beacon has no separate file-management API — creating, replacing, and removing
+tables is done through authenticated SQL DDL on `/api/query` (see
+[Table lifecycle](#table-lifecycle) above). The only dedicated admin endpoint is a
+connectivity check that verifies your admin credentials:
+
+```http
+GET /api/admin/check
+Authorization: Basic <base64(username:password)>
+```
+
+Returns `{ "is_admin": true }` when the credentials are valid, or `401` otherwise.
+
+## OpenAPI
+
+This page is a curated subset. The complete, always-current request and response
+shapes are generated from the server itself:
+
+- Swagger UI: `/swagger`
+- Scalar UI: `/scalar/`
+- OpenAPI document: `/openapi.json`

--- a/docs/docs/1.7.3/data-lake/configuration.md
+++ b/docs/docs/1.7.3/data-lake/configuration.md
@@ -121,7 +121,7 @@ environment values.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `AWS_ENDPOINT` | _(none)_ | S3-compatible endpoint URL, e.g. `https://s3.amazonaws.com` or `http://minio:9000`. If the endpoint does not embed the bucket, set `BEACON_S3_BUCKET`. |
+| `AWS_ENDPOINT` | _(none)_ | S3-compatible endpoint URL, e.g. `https://s3.amazonaws.com` or `http://minio:9000`. The bucket is always taken from `BEACON_S3_BUCKET`, never parsed from this URL. |
 | `AWS_REGION` | _(none)_ | S3 region. (Note: `AWS_DEFAULT_REGION` is **not** used — set `AWS_REGION`.) |
 | `AWS_ACCESS_KEY_ID` | _(none)_ | Access key. Only required when the object store needs authentication. |
 | `AWS_SECRET_ACCESS_KEY` | _(none)_ | Secret key. Only required when the object store needs authentication. |

--- a/docs/docs/1.7.3/data-lake/configuration.md
+++ b/docs/docs/1.7.3/data-lake/configuration.md
@@ -1,61 +1,199 @@
+---
+description: Complete reference of Beacon's BEACON_* environment variables — server, query engine, storage, S3, Arrow Flight SQL, crawler, file formats, and API docs metadata — with their defaults.
+---
+
 # Configuration
 
-Beacon's data lake can be configured using environment variables. Below is a list of the available configuration options along with their descriptions and default values.
+Beacon is configured entirely through **environment variables**. There is no
+configuration file: every option below is read from the environment at startup.
+Unset variables fall back to the defaults listed here.
 
 ::: info
-The configuration options can be specified using Environment Variables.
+All settings use `BEACON_*` names, except the S3 credential variables, which use
+the standard `AWS_*` names so they interoperate with existing AWS tooling (see
+[S3 object storage](#s3-object-storage)).
 :::
 
-## Configuration Options in Beacon
+## Server
 
-Beacon provides several configuration options that allow users to customize the behavior of the tool to their needs.
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_HOST` | `0.0.0.0` | IP address the HTTP API listens on. |
+| `BEACON_PORT` | `5001` | Port the HTTP API listens on. |
+| `BEACON_WORKER_THREADS` | `8` | Number of worker threads for the async runtime. |
+| `BEACON_LOG_LEVEL` | `info` | Log level: `trace`, `debug`, `info`, `warn`, `error` (case-insensitive). |
+| `BEACON_BASE_PATH` | _(empty)_ | Optional URL path prefix for the HTTP API, OpenAPI document, and Swagger UI (e.g. `/beacon`). Useful behind a reverse proxy. Normalized to exactly one leading slash and no trailing slash, so `beacon`, `/beacon`, and `/beacon/` are equivalent. Only URL-safe characters are allowed (letters, digits, `-`, `_`, `.`, `~`, and `/` as a separator); any other character causes Beacon to exit at startup with a descriptive error. |
 
-## ENVIRONMENT VARIABLES
+## Admin
 
-Some of the configuration options can be set using environment variables. The following environment variables can be used to set the configuration options:
+The admin credentials gate the authenticated write/management surface (DDL/DML
+over HTTP and the admin endpoints).
 
-- `BEACON_HOST` - IP address to listen on. (Default is `0.0.0.0`)
-- `BEACON_PORT` - Port number to listen on. (Default is `5001`)
-- `BEACON_BASE_PATH` - Optional URL path prefix to serve the HTTP API, OpenAPI document, and Swagger UI under (default is empty, i.e. served at the root). Useful when running Beacon behind a reverse proxy or on a shared subpath, e.g. `/beacon`. The value is normalized to exactly one leading slash and no trailing slash, so `beacon`, `/beacon`, and `/beacon/` are equivalent. Only URL-safe characters are allowed (letters, digits, `-`, `_`, `.`, `~`, and `/` as a separator); any other character (e.g. spaces, `?`, `#`, `%`) causes Beacon to exit at startup with a descriptive error.
-- `BEACON_ADMIN_USERNAME` - The admin username for the beacon admin panel.
-- `BEACON_ADMIN_PASSWORD` - The admin password for the beacon admin panel.
-- `BEACON_VM_MEMORY_SIZE` - The amount of memory to allocate to the Beacon Virtual Machine in MB (default is 8192MB). More is better for performance, especially when working with larger datasets and performing actions such as spatial joins and group by.
-- `BEACON_ENABLE_SQL` - Whether to enable the SQL query engine. Default is `true`.
-- `BEACON_WORKER_THREADS` - Number of worker threads to use (default is 8).
-- `BEACON_ST_WITHIN_POINT_CACHE_SIZE` - Size of the cache for ST_WithinPoint queries (default is 10000).
-- `BEACON_DEFAULT_TABLE` - The default table to use when no table is specified in the `from` clause of a query. Only applicable to the JSON query API, as SQL queries must specify a source. Default is `default`.
-- `BEACON_LOG_LEVEL` - Log level [`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`]. Default is `INFO`.
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_ADMIN_USERNAME` | `beacon-admin` | Admin username for management endpoints. |
+| `BEACON_ADMIN_PASSWORD` | `beacon-password` | Admin password — **change this in production**. |
 
-- `BEACON_S3_DATA_LAKE` - Whether to enable S3 data lake support. Set to `true` to enable. Default is `false` and uses local system file storage. To connect to S3-compatible object storage, the following environment variables should also be set:
-  - `AWS_ACCESS_KEY_ID` -  S3 access_key_id. Only required when the S3-compatible object storage requires authentication.
-  - `AWS_SECRET_ACCESS_KEY` - S3 secret_access_key. Only required when the S3-compatible object storage requires authentication.
-  - `AWS_DEFAULT_REGION` -  S3 optional region
-  - `AWS_ENDPOINT` -  S3 endpoint. This should include the full URL to the S3-compatible object storage service. If the endpoint URL does not contain the bucket name, the bucket name should be specified using the `BEACON_S3_BUCKET` environment variable.
-  - `AWS_SKIP_SIGNATURE` - Set to `true` to skip request signing. Useful for local S3-compatible object storage that does not require signed requests.
-- `BEACON_S3_BUCKET` - The bucket name for the S3-compatible object storage. If the env variable `BEACON_S3_DATA_LAKE` is enabled, and the `AWS_ENDPOINT` doesn't contain the bucket name, the bucket name should be specified here.
+## Query engine
 
-- `BEACON_ENABLE_FS_EVENTS` - Whether to enable file system events monitoring, so new files in watched datasets are picked up automatically. Uses inotify on Linux systems. Default is `true`; set to `false` to disable. This is not supported when using S3 data lake. (Be aware that using mounted volumes with Docker may interfere with filesystem events, so test this setting in your deployment environment.)
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_ENABLE_SQL` | `true` | Enable the raw SQL query interface. Set to `false` to disable it (the JSON query API stays available). |
+| `BEACON_VM_MEMORY_SIZE` | `8192` | Working memory (MB) available to the query engine. More is better for larger datasets and memory-heavy operations such as spatial joins and `GROUP BY`. |
+| `BEACON_DEFAULT_TABLE` | `default` | Table queried when a request omits the source. Only applies to the JSON query API — SQL queries must always specify a source. |
+| `BEACON_ENABLE_PUSHDOWN_PROJECTION` | `true` | Push column projection down into file readers so only requested columns are decoded. |
+| `BEACON_SANITIZE_SCHEMA` | `false` | Sanitize dataset schemas (normalize column names/types) during discovery. |
+| `BEACON_ST_WITHIN_POINT_CACHE_SIZE` | `10000` | Cache size for `st_within_point` geometry lookups. |
+| `BEACON_BATCH_SIZE` | `64000` | Batch size, in rows, for NetCDF reads (local and MPIO). |
 
-- `BEACON_ENABLE_SYS_INFO` - Whether to expose system information. Set to `true` to enable.
+### SQL result-stream coalescing
 
-- `BEACON_CORS_ALLOWED_METHODS` - Comma-separated list of allowed HTTP methods for CORS (default is `GET,POST,PUT,DELETE,OPTIONS`).
-- `BEACON_CORS_ALLOWED_ORIGINS` - Comma-separated list of allowed origins for CORS (default is `*`).
-- `BEACON_CORS_ALLOWED_HEADERS` - Comma-separated list of allowed headers for CORS (default is `Content-Type,Authorization`).
-- `BEACON_CORS_ALLOWED_CREDENTIALS` - Whether to allow credentials for CORS (default is `false`).
-- `BEACON_CORS_MAX_AGE` - The maximum age for CORS preflight requests (default is 3600).
+Small record batches produced by a query are merged into larger ones before being
+streamed to the client, which improves throughput for fine-grained results.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_SQL_STREAM_COALESCE_ENABLED` | `true` | Enable coalescing of the SQL result stream. |
+| `BEACON_SQL_STREAM_COALESCE_TARGET_ROWS` | `65536` | Target rows per coalesced batch. |
+| `BEACON_SQL_STREAM_COALESCE_FLUSH_TIMEOUT_MS` | `25` | Max time (ms) to wait while accumulating rows before flushing a partial batch. |
+| `BEACON_SQL_STREAM_COALESCE_MAX_ROWS` | `262144` | Hard upper bound on rows per coalesced batch. |
+
+## Arrow Flight SQL
+
+Beacon also exposes an [Arrow Flight SQL](https://arrow.apache.org/docs/format/FlightSql.html)
+endpoint on its own port, used by clients such as JetBrains DataGrip and the
+Python ADBC driver (see [Connect](../connect/jetbrains-datagrip.md)). Unlike the
+HTTP API, Flight SQL uses bearer-token authentication.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_FLIGHT_SQL_ENABLE` | `true` | Enable the Arrow Flight SQL server. |
+| `BEACON_FLIGHT_SQL_HOST` | `0.0.0.0` | Address the Flight SQL server binds to. |
+| `BEACON_FLIGHT_SQL_PORT` | `32011` | Port the Flight SQL server listens on. |
+| `BEACON_FLIGHT_SQL_ALLOW_ANONYMOUS` | `false` | Allow unauthenticated Flight SQL sessions. |
+| `BEACON_FLIGHT_SQL_TOKEN_TTL_SECS` | `3600` | Lifetime (seconds) of an issued session token. |
+| `BEACON_FLIGHT_SQL_STATEMENT_TTL_SECS` | `300` | Lifetime (seconds) of a server-side statement handle. |
+| `BEACON_FLIGHT_SQL_PREPARED_STATEMENT_TTL_SECS` | `900` | Lifetime (seconds) of a prepared-statement handle. |
+
+## Storage and data directories
+
+Beacon keeps all local state under a single root directory.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_DATA_DIR` | `./data` | Root directory for all local data. |
+| `BEACON_ENABLE_FS_EVENTS` | `true` | Watch the local datasets directory so new files are picked up automatically (uses inotify on Linux). Set to `false` to disable. Not used with the S3 data lake. Mounted Docker volumes can interfere with filesystem events — test this in your deployment environment. |
+
+The following sub-directories are created under `BEACON_DATA_DIR` and used by
+Beacon:
+
+| Sub-directory | Purpose |
+| --- | --- |
+| `datasets/` | Local datasets store (the files you query in place). |
+| `tables/` | Persisted external tables, views, and managed-table definitions. |
+| `tmp/` | Temporary files (e.g. materialized query output). |
+| `indexes/` | Dataset path/index data. |
+| `cache/` | Internal caches. |
+
+When mounting volumes with Docker, mount the sub-directories you want to persist
+(e.g. `-v ./datasets:/beacon/data/datasets`, `-v ./tables:/beacon/data/tables`).
+
+## S3 object storage
+
+Set `BEACON_S3_DATA_LAKE=true` to back the **datasets** store with S3-compatible
+object storage instead of the local filesystem. The `tables/`, `tmp/`, `indexes/`,
+and `cache/` directories remain on local disk.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_S3_DATA_LAKE` | `false` | Use S3-compatible object storage as the datasets store. When `false`, the local filesystem is used. |
+| `BEACON_S3_BUCKET` | _(none)_ | Bucket name. **Required** when `BEACON_S3_DATA_LAKE=true` — Beacon exits at startup if it is missing. Never inferred from the endpoint. |
+| `BEACON_S3_ENABLE_VIRTUAL_HOSTING` | `false` | Use virtual-hosted-style addressing (bucket in the host) instead of path-style (`{endpoint}/{bucket}/{key}`). |
+| `BEACON_S3_ALLOW_HTTP` | `true` | Allow plain `http://` endpoints (useful for local MinIO; disable for production). |
+| `BEACON_ENABLE_S3_EVENTS` | `false` | Reserved: wire S3 change notifications into the event listener. |
+
+### S3 credentials and endpoint (`AWS_*`)
+
+Credentials and the endpoint are resolved through the standard AWS environment
+chain (object-store's `from_env`), so the usual `AWS_*` variables apply. The
+endpoint and region Beacon captures here always override the corresponding
+environment values.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `AWS_ENDPOINT` | _(none)_ | S3-compatible endpoint URL, e.g. `https://s3.amazonaws.com` or `http://minio:9000`. If the endpoint does not embed the bucket, set `BEACON_S3_BUCKET`. |
+| `AWS_REGION` | _(none)_ | S3 region. (Note: `AWS_DEFAULT_REGION` is **not** used — set `AWS_REGION`.) |
+| `AWS_ACCESS_KEY_ID` | _(none)_ | Access key. Only required when the object store needs authentication. |
+| `AWS_SECRET_ACCESS_KEY` | _(none)_ | Secret key. Only required when the object store needs authentication. |
+| `AWS_SKIP_SIGNATURE` | _(none)_ | Set to `true` to send unsigned requests — useful for public/anonymous buckets. |
+
+## Crawler
+
+The [crawler](./crawlers.md) discovers files under a prefix and registers them as
+external tables.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_CRAWLER_ENABLE` | `true` | Master switch for crawler scheduling and event triggers. When `false`, crawlers can still be defined and run on demand, but no background tasks are spawned. |
+| `BEACON_CRAWLER_DEFAULT_INTERVAL_SECS` | `900` | Fallback poll interval (seconds) for an event-driven crawler on a deployment where storage events are unavailable. |
+
+## CORS
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_CORS_ALLOWED_METHODS` | `GET,POST,PUT,DELETE,OPTIONS` | Allowed HTTP methods. |
+| `BEACON_CORS_ALLOWED_ORIGINS` | `*` | Allowed origins. |
+| `BEACON_CORS_ALLOWED_HEADERS` | `Content-Type,Authorization` | Allowed request headers. |
+| `BEACON_CORS_ALLOWED_CREDENTIALS` | `false` | Allow credentials. |
+| `BEACON_CORS_MAX_AGE` | `3600` | Preflight cache duration (seconds). |
+
+## File formats
+
+Per-format tuning. See [Performance Tuning](./performance-tuning.md) for guidance
+on when to change these.
 
 ### NetCDF
 
-- `BEACON_NETCDF_USE_SCHEMA_CACHE` - Whether to cache discovered NetCDF Arrow schemas in-memory (default is `true`).
-- `BEACON_NETCDF_SCHEMA_CACHE_SIZE` - Max number of schema entries to keep in the in-memory schema cache (default is `1024`).
-- `BEACON_NETCDF_USE_READER_CACHE` - Whether to cache opened NetCDF readers in-memory (default is `true`).
-- `BEACON_NETCDF_READER_CACHE_SIZE` - Max number of reader entries to keep in the in-memory reader cache (default is `128`).
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_NETCDF_ENABLE_STATISTICS` | `true` | Compute and cache per-file statistics used for query pruning. |
+| `BEACON_NETCDF_USE_READER_CACHE` | `true` | Cache opened NetCDF readers in memory. |
+| `BEACON_NETCDF_READER_CACHE_SIZE` | `128` | Max NetCDF reader entries to keep cached. |
 
 ### Atlas
 
-- `BEACON_ATLAS_USE_READER_CACHE` - Whether to cache opened Atlas store readers in-memory (default is `true`). This avoids re-opening the same `atlas.json` store across queries.
-- `BEACON_ATLAS_READER_CACHE_SIZE` - Max number of Atlas reader entries to keep in the in-memory reader cache (default is `32`).
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_ATLAS_USE_READER_CACHE` | `true` | Cache opened Atlas store readers in memory, avoiding re-opening the same `atlas.json` across queries. |
+| `BEACON_ATLAS_READER_CACHE_SIZE` | `32` | Max Atlas reader entries to keep cached. |
 
-### Beacon Binary Format
+### Beacon Binary Format (BBF)
 
-- `BEACON_ENABLE_BBF_SPLIT_STREAMS_SLICE` - Whether to enable splitting large batches into smaller batches to better manage memory and parallelism for queries in the Beacon Binary Format (BBF). Set to `true` to enable. Default is `false`. When enabled, this allows for more efficient handling of large queries by splitting the data into multiple streams.
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_ENABLE_BBF_SPLIT_STREAMS_SLICE` | `false` | Split large batches into smaller slices for better memory use and parallelism on BBF queries. |
+
+## API documentation metadata
+
+These customize the top-level metadata of the generated OpenAPI document and the
+Swagger / Scalar UIs, so a deployment can brand its own API docs without
+recompiling. All are optional except the title and description, which have
+defaults.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_API_TITLE` | `Beacon Rest API` | API document title. |
+| `BEACON_API_DESCRIPTION` | _(built-in summary)_ | API document description. |
+| `BEACON_API_TERMS_OF_SERVICE` | _(none)_ | Terms-of-service URL. |
+| `BEACON_API_CONTACT_NAME` | _(none)_ | Contact name. |
+| `BEACON_API_CONTACT_URL` | _(none)_ | Contact URL. |
+| `BEACON_API_CONTACT_EMAIL` | _(none)_ | Contact email. |
+| `BEACON_API_LICENSE_NAME` | _(none)_ | License name. |
+| `BEACON_API_LICENSE_URL` | _(none)_ | License URL. |
+| `BEACON_API_LICENSE_IDENTIFIER` | _(none)_ | SPDX license identifier. |
+
+## Miscellaneous
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_ENABLE_SYS_INFO` | `false` | Expose host system information (CPU, memory) via the API. |

--- a/docs/docs/1.7.3/data-lake/crawlers.md
+++ b/docs/docs/1.7.3/data-lake/crawlers.md
@@ -149,6 +149,8 @@ Directory/marker-based stores — **Zarr** (`*.zarr/zarr.json`) and **Atlas** (`
 
 GeoParquet files (`*.parquet`) are claimed by the Parquet crawler; create a GeoParquet external table explicitly if you need GeoArrow geometry decoding.
 
+**Delta Lake** tables — directories containing a `_delta_log/` — are also **not** auto-crawled. Register them explicitly with [`CREATE EXTERNAL TABLE ... STORED AS DELTA`](./delta-lake.md).
+
 ## See also
 
 - [External Tables](./external-tables.md) — the tables a crawler produces

--- a/docs/docs/1.7.3/getting-started.md
+++ b/docs/docs/1.7.3/getting-started.md
@@ -51,6 +51,10 @@ services:
 
 If you used Compose, start it with `docker compose up -d`. Beacon is now running. Open `http://localhost:5001/swagger` to verify and explore the API. Any files placed in `./datasets` are immediately available for querying.
 
+::: tip Two ways to connect
+Beacon exposes two endpoints. The **HTTP API** on port `5001` serves SQL/JSON queries and the OpenAPI docs. The **Arrow Flight SQL** server on port `32011` is a high-throughput, columnar protocol used by clients such as [JetBrains DataGrip](./connect/jetbrains-datagrip.md) and the [Python ADBC driver](./connect/python-adbc.md). Flight SQL uses bearer-token authentication and can be tuned or disabled via the `BEACON_FLIGHT_SQL_*` [settings](./data-lake/configuration.md#arrow-flight-sql).
+:::
+
 ## S3-Compatible Object Storage
 
 Add the S3 environment variables and remove the datasets volume:

--- a/docs/docs/1.7.3/introduction.md
+++ b/docs/docs/1.7.3/introduction.md
@@ -79,10 +79,13 @@ SQL is sent over the HTTP API (`POST /api/query`, with `BEACON_ENABLE_SQL=true`)
 | Zarr | v2 and v3 |
 | Atlas | Array store optimized for NetCDF/Zarr query performance |
 | Parquet | Native columnar, Hive partitioning supported |
+| [GeoParquet](/docs/1.7.3/data-lake/geoparquet) | Parquet with geometry columns (WKB) |
 | GeoTIFF / COG | Cloud-Optimized GeoTIFF supported |
 | ODV ASCII | Ocean Data View spreadsheet format |
 | CSV | Header row required, delimiter configurable |
 | Arrow IPC | `.arrow`, `.ipc` stream files |
+| [Delta Lake](/docs/1.7.3/data-lake/delta-lake) | Read & append, with time travel |
+| [Beacon Binary Format](/docs/1.7.3/data-lake/datasets#beacon-binary-format-bbf) | Beacon's native columnar format (BBF) |
 
 ## Key concepts
 


### PR DESCRIPTION
## Summary

Audit of the 1.7.3 documentation against the current code, correcting drift. Most feature pages were already accurate; the work concentrated where the docs had fallen out of sync — chiefly the configuration reference.

## Changes

- **`data-lake/configuration.md`** — full rewrite against `beacon-config` `RawConfig`:
  - Removed the two NetCDF schema-cache vars that no longer exist.
  - Fixed `AWS_DEFAULT_REGION` → `AWS_REGION` (the code reads `AWS_REGION`; `AWS_DEFAULT_REGION` is not recognized) and the `BEACON_LOG_LEVEL` default.
  - Added ~30 missing settings in clear sections: `BEACON_DATA_DIR` + the derived directory layout, query-engine flags, **Arrow Flight SQL**, **SQL stream coalescing**, **crawler**, and **API-docs metadata**.
  - Documented the `AWS_*` credential chain (resolved via `AmazonS3Builder::from_env`).
- **`introduction.md`** — added GeoParquet, Delta Lake, and BBF to the supported-formats table.
- **`api/exploring-data-lake.md`** — documented `GET /api/default-table-schema`, added an **Admin** section (`GET /api/admin/check`) and an OpenAPI pointer, and noted the deprecated `/api/datasets` alias. Fixed the dead `#admin-file-management` sidebar anchor in `config.mts`.
- **`data-lake/crawlers.md`** — noted that Delta tables are not auto-crawled.
- **`getting-started.md`** — explained the Arrow Flight SQL endpoint (port 32011).
- **`README.md`** — aligned the input-formats list, dropped the stale "schema caching" claim, and linked to the configuration reference page.

## Verification

- Cross-checked every `BEACON_*`/`AWS_*` env var in `beacon-config/src/lib.rs` — all appear in the rewritten config doc.
- `npm run docs:build` (VitePress) succeeds; new cross-link anchors resolve.

Authoritative sources: `beacon-config/src/lib.rs`, `beacon-api/src/axum/`, `beacon-functions/src/file_formats/mod.rs`, `beacon-object-storage/src/config.rs`.