### PR TITLE
Add beacon-cli: a Python terminal client for Beacon

### DIFF
--- a/clients/beacon-cli/.gitignore
+++ b/clients/beacon-cli/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+__pycache__/
+*.pyc
+*.egg-info/
+.pytest_cache/
+.ruff_cache/
+build/
+dist/

--- a/clients/beacon-cli/README.md
+++ b/clients/beacon-cli/README.md
@@ -1,0 +1,283 @@
+# beacon-cli
+
+A terminal client for the [Beacon](../../) data lake. Run SQL against a running
+`beacon-api` server, explore tables / datasets / schemas, render results as
+tables in your terminal, and export to CSV, Parquet, Arrow IPC, or NetCDF — all
+without leaving the shell.
+
+It talks to the server's `/api/*` HTTP endpoints, decoding the zstd-compressed
+Arrow IPC result stream with `pyarrow`, and offers both one-shot subcommands and
+an interactive REPL.
+
+## Install
+
+```bash
+pip install -e clients/beacon-cli
+# or, with uv:
+uv pip install -e clients/beacon-cli
+```
+
+This installs the `beacon-cli` console script.
+
+## Connecting
+
+Defaults match the Beacon server (`http://localhost:5001`). Override per-invocation
+or via environment variables:
+
+| Option | Env var | Default |
+| --- | --- | --- |
+| `--url` | `BEACON_URL` | `http://localhost:5001` |
+| `--username` | `BEACON_ADMIN_USERNAME` | _(none)_ |
+| `--password` | `BEACON_ADMIN_PASSWORD` | _(none)_ |
+
+Credentials are sent as HTTP Basic auth and elevate the session to super-user,
+which is required for DDL/DML (e.g. `CREATE EXTERNAL TABLE`).
+
+## One-shot commands
+
+```bash
+# Run SQL and render a table
+beacon-cli query "SELECT * FROM default LIMIT 10"
+
+# From a file or stdin
+beacon-cli query -f query.sql
+echo "SELECT count(*) FROM default" | beacon-cli query
+
+# Export results to a file (see "Exporting results" below for all formats/options)
+beacon-cli export "SELECT * FROM default" -o out.parquet
+
+# Explore
+beacon-cli tables                 # list table names
+beacon-cli tables --detail        # + kind / format / location / partitions
+beacon-cli tables --schema        # + each table's columns
+beacon-cli schema default         # one table's schema
+beacon-cli datasets               # list datasets
+beacon-cli dataset-schema path/to/file.parquet
+beacon-cli functions              # scalar/aggregate functions
+beacon-cli functions --table      # table functions
+beacon-cli info                   # server info
+beacon-cli metrics <query-id>     # metrics for a prior query
+```
+
+### `query` options
+
+| Flag | Description |
+| --- | --- |
+| `SQL` (positional) | The statement to run. Omit to read from `--file` or stdin. |
+| `-f`, `--file PATH` | Read the SQL from a file instead of the argument. |
+| `--max-rows N` | Max rows to render (default 100; `-1` = all). |
+| `--all`, `-a` | Fetch the entire result instead of stopping at the render limit. |
+| `--expand`, `-x` | Render rows vertically (field/value) — good for wide tables. |
+| `--json` | Emit rows as JSON on stdout (footer goes to stderr). |
+
+### Wide tables
+
+For tables with many columns the grid layout squeezes each column too narrow.
+Render rows **vertically** instead with `--expand`/`-x` (like psql's `\x`): each
+row becomes a `field | value` block, so the column count no longer competes for
+width.
+
+```bash
+beacon-cli query 'SELECT * FROM wod' --max-rows 1 --expand
+```
+```
+record 1
+  Temperature             | 25.62
+  Temperature.coordinates | time lat lon z
+  Salinity                | 36.79
+  ...
+```
+
+In the REPL, toggle it with `\x`. Other ways to tame wide results: select fewer
+columns in the SQL, use `--json` (one object per row), or lower `--max-rows`.
+
+### Column names with dots or mixed case
+
+The CLI sends SQL through unchanged, so column quoting is standard
+Beacon/DataFusion SQL. An unquoted dot means `relation.column`, and unquoted
+identifiers are lower-cased — so to select a column whose real name contains a
+dot (e.g. `Temperature.coordinates`) or uses mixed case, wrap it in **double
+quotes**:
+
+```sql
+SELECT "Temperature.coordinates", "Temperature" FROM wod
+```
+
+On the command line, put the whole statement in **single** quotes so the double
+quotes survive the shell (works in PowerShell and bash):
+
+```bash
+beacon-cli query 'SELECT "Temperature.coordinates" FROM wod'
+```
+
+In the REPL there's no shell in the way — type the double quotes directly. Use
+`beacon-cli schema <table>` (or `\d <table>`) to see the exact column names.
+
+### Incremental fetching
+
+By default `query` streams the result and **stops once it has more rows than the
+render limit** (`--max-rows`, default 100), so previewing a huge table is fast
+and doesn't download the whole result. When it stops early the footer reads
+`first N rows (more available)`. To fetch the entire result instead (e.g. for an
+accurate total or full `--json` output), pass `--all` (or `--max-rows -1`):
+
+```bash
+beacon-cli query "SELECT * FROM big_table"            # fast preview, first 100 rows
+beacon-cli query "SELECT * FROM big_table" --all      # fetch everything
+```
+
+With `--json`, the rows go to stdout as valid JSON and the footer goes to stderr,
+so `beacon-cli query ... --json | jq` works.
+
+### DDL, admin & crawler statements
+
+`query` (and the REPL) send raw SQL straight through, so anything the server
+accepts works — including Beacon's custom statements. Read-only statements need
+no credentials; anything that mutates state requires admin basic auth
+(`--username`/`--password` or the `BEACON_ADMIN_*` env vars).
+
+```bash
+# Read-only (no credentials)
+beacon-cli query "SHOW TABLES"
+beacon-cli query "SHOW COLUMNS FROM default"
+beacon-cli query "SHOW CRAWLERS"
+beacon-cli query "SELECT * FROM information_schema.tables"
+
+# Admin (credentials required) — DDL/DML
+beacon-cli --username beacon-admin --password beacon-password \
+  query "CREATE EXTERNAL TABLE obs STORED AS DELTA LOCATION 'datasets://obs/'"
+
+# Admin — AWS Glue-style crawlers
+beacon-cli -u ... query \
+  "CREATE CRAWLER cr ON 'crawl_src/' WITH ('format' 'parquet', 'schedule' '15m')"
+beacon-cli -u ... query "RUN CRAWLER cr"
+beacon-cli -u ... query "DROP CRAWLER cr"
+
+# Admin — materialized views / refresh
+beacon-cli -u ... query "CREATE MATERIALIZED VIEW mv AS SELECT * FROM obs"
+beacon-cli -u ... query "REFRESH TABLE obs"
+```
+
+Side-effecting statements print `OK`; statements that return rows
+(`SHOW TABLES`, `SHOW CRAWLERS`, …) render as a table. Mutating statements
+deliberately never set an output format (an `output` format would wrap the plan
+in `COPY ... TO`, which cannot execute DDL).
+
+## Interactive shell
+
+Run `beacon-cli` with no subcommand to open the REPL:
+
+```
+beacon> SELECT * FROM default LIMIT 5;
+beacon> \dt                 -- list tables
+beacon> \dt+                -- tables with kind / format / location
+beacon> \d default          -- table schema
+beacon> \datasets           -- list datasets
+beacon> \crawlers           -- SHOW CRAWLERS
+beacon> \run-crawler cr     -- RUN CRAWLER cr      (admin)
+beacon> \refresh obs        -- REFRESH TABLE obs   (admin)
+beacon> \format parquet     -- set export format
+beacon> \export out.parquet -- write the last statement to a file
+beacon> \limit 50           -- change render cap
+beacon> \x                  -- toggle expanded (field/value) display for wide tables
+beacon> \help               -- full command list
+beacon> \q                  -- quit
+```
+
+SQL statements may span multiple lines; finish with `;` or a blank line.
+Command history is saved under your user config directory.
+
+## Exporting results
+
+Instead of rendering in the terminal, `export` asks the server to materialize the
+result in a file format and streams the bytes to disk. Unlike `query`, an export
+always fetches the **complete** result (the server writes the whole file).
+
+```bash
+beacon-cli export "SELECT * FROM obs WHERE temperature > 20" -o out.parquet
+```
+
+### `export` options
+
+| Flag | Description |
+| --- | --- |
+| `SQL` (positional) | The `SELECT` to export. Omit to read from `--file` or stdin. |
+| `-o`, `--output PATH` | **Required.** Destination file. |
+| `--format FMT` | Output format. If omitted, it's inferred from the `-o` extension. |
+| `-f`, `--file PATH` | Read the SQL from a file instead of the argument. |
+| `--dimension-columns C` | Dimension column(s) for `nd_netcdf` (repeat per column). |
+| `--lon C` / `--lat C` | Longitude/latitude columns for `geoparquet`. |
+
+### Formats
+
+The format is inferred from the output extension, or set explicitly with
+`--format`:
+
+| `--format` | Extension | Notes |
+| --- | --- | --- |
+| `csv` | `.csv` | |
+| `parquet` | `.parquet` | |
+| `ipc` (alias `arrow`) | `.arrow`, `.ipc` | Arrow IPC file |
+| `netcdf` (alias `nc`) | `.nc` | |
+| `nd_netcdf` | — | N-dimensional NetCDF; requires `--dimension-columns` |
+| `geoparquet` | `.geoparquet` | optional `--lon`/`--lat` |
+| `odv` | `.odv` | Ocean Data View |
+
+### Examples
+
+```bash
+# Format inferred from the extension
+beacon-cli export "SELECT * FROM obs" -o obs.csv
+beacon-cli export "SELECT * FROM obs" -o obs.parquet
+beacon-cli export "SELECT * FROM obs" -o obs.nc              # NetCDF
+
+# Explicit format (extension doesn't have to match)
+beacon-cli export "SELECT * FROM obs" -o obs.bin --format ipc
+
+# GeoParquet with geometry built from lon/lat columns
+beacon-cli export "SELECT lon, lat, temperature FROM obs" \
+  -o obs.geoparquet --lon lon --lat lat
+
+# N-dimensional NetCDF over time/lat/lon dimensions
+beacon-cli export "SELECT time, lat, lon, temperature FROM obs" \
+  -o obs.nc --format nd_netcdf \
+  --dimension-columns time --dimension-columns lat --dimension-columns lon
+
+# Read the SQL from a file
+beacon-cli export -f query.sql -o out.parquet
+```
+
+In the REPL, `\format <fmt>` sets a session format and `\export <file>` (or
+`\o <file>`) writes the last statement out:
+
+```
+beacon> SELECT * FROM obs WHERE temperature > 20;
+beacon> \export hot.parquet      -- format from extension
+beacon> \format csv              -- override for subsequent exports
+beacon> \export hot.csv
+```
+
+## Project layout
+
+```
+beacon_cli/
+  cli.py            Typer app + global connection callback
+  __main__.py       enables `python -m beacon_cli`
+  config.py         ClientConfig (URL / auth / timeout, env resolution)
+  errors.py         user-facing error types
+  client.py         BeaconClient — HTTP over /api/*
+  arrow_io.py       QueryResult + Arrow IPC stream decoding
+  formats.py        output-format inference / spec building
+  render/           rich rendering: results.py, metadata.py
+  commands/         one module per command group: query.py, catalog.py
+  repl/             interactive shell: reader, runner, meta, state, help
+tests/              one test module per unit (client, config, formats, …)
+```
+
+## Development
+
+```bash
+pip install -e "clients/beacon-cli[dev]"
+ruff check clients/beacon-cli
+pytest clients/beacon-cli
+```

--- a/clients/beacon-cli/beacon_cli/__init__.py
+++ b/clients/beacon-cli/beacon_cli/__init__.py
@@ -1,0 +1,8 @@
+"""beacon-cli — a terminal client for the Beacon data lake.
+
+Run SQL via one-shot subcommands or an interactive REPL, explore
+tables/datasets/schemas, render results as tables, and export to
+CSV / Parquet / Arrow IPC / NetCDF (and the other server formats).
+"""
+
+__version__ = "0.1.0"

--- a/clients/beacon-cli/beacon_cli/__main__.py
+++ b/clients/beacon-cli/beacon_cli/__main__.py
@@ -1,0 +1,6 @@
+"""Enable ``python -m beacon_cli``."""
+
+from .cli import app
+
+if __name__ == "__main__":
+    app()

--- a/clients/beacon-cli/beacon_cli/arrow_io.py
+++ b/clients/beacon-cli/beacon_cli/arrow_io.py
@@ -1,0 +1,113 @@
+"""Arrow IPC decoding for query results.
+
+In-memory query results come back from the server as a zstd-compressed Arrow IPC
+*stream*, which ``pyarrow`` decodes natively. The stream is consumed
+incrementally: :func:`collect_ipc_stream` reads record batches one at a time and
+can stop early once a row budget is reached, so rendering the first N rows of a
+huge result does not download the whole thing. A side-effecting statement
+(DDL/DML) returns no IPC frames at all, which we surface as an empty table.
+"""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Iterable
+
+import pyarrow as pa
+
+
+class QueryResult:
+    """A decoded in-terminal query result.
+
+    ``truncated`` is True when the fetch was stopped early because the row budget
+    was reached — i.e. the server has more rows than were retrieved.
+    """
+
+    def __init__(
+        self,
+        table: pa.Table,
+        query_id: str | None,
+        elapsed: float,
+        truncated: bool = False,
+    ):
+        self.table = table
+        self.query_id = query_id
+        self.elapsed = elapsed
+        self.truncated = truncated
+
+    @property
+    def num_rows(self) -> int:
+        return self.table.num_rows
+
+    @property
+    def is_empty(self) -> bool:
+        """True for a side-effecting statement (no rows and no columns)."""
+        return self.table.num_rows == 0 and self.table.num_columns == 0
+
+
+class _ChunkStream(io.RawIOBase):
+    """Adapt an iterator of byte chunks (e.g. ``httpx`` ``iter_bytes``) into a
+    readable, non-seekable binary stream that pyarrow can pull from on demand."""
+
+    def __init__(self, chunks: Iterable[bytes]):
+        self._it = iter(chunks)
+        self._buf = bytearray()
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, b) -> int:  # noqa: ANN001 - matches RawIOBase signature
+        need = len(b)
+        while len(self._buf) < need:
+            try:
+                self._buf += next(self._it)
+            except StopIteration:
+                break
+        n = min(need, len(self._buf))
+        b[:n] = self._buf[:n]
+        del self._buf[:n]
+        return n
+
+
+def collect_ipc_stream(
+    chunks: Iterable[bytes], row_limit: int | None
+) -> tuple[pa.Table, bool]:
+    """Read an Arrow IPC stream from ``chunks`` into a table.
+
+    Stops after the first batch that pushes the row count past ``row_limit``
+    (returning ``truncated=True``); a ``row_limit`` of ``None`` or negative reads
+    the whole stream. A stream with no schema message (a side-effecting
+    statement) yields an empty 0-column table.
+    """
+    source = io.BufferedReader(_ChunkStream(chunks))
+    try:
+        reader = pa.ipc.open_stream(source)
+    except pa.ArrowInvalid:
+        return pa.table({}), False
+
+    unlimited = row_limit is None or row_limit < 0
+    batches: list[pa.RecordBatch] = []
+    total = 0
+    truncated = False
+    while True:
+        try:
+            batch = reader.read_next_batch()
+        except StopIteration:
+            break
+        batches.append(batch)
+        total += batch.num_rows
+        if not unlimited and total > row_limit:
+            truncated = True
+            break
+
+    if batches:
+        table = pa.Table.from_batches(batches, reader.schema)
+    else:
+        table = reader.schema.empty_table()
+    return table, truncated
+
+
+def decode_ipc_stream(content: bytes) -> pa.Table:
+    """Decode a fully-buffered Arrow IPC stream (zstd-compressed) into a table."""
+    table, _ = collect_ipc_stream([content] if content else [], None)
+    return table

--- a/clients/beacon-cli/beacon_cli/cli.py
+++ b/clients/beacon-cli/beacon_cli/cli.py
@@ -1,0 +1,65 @@
+"""Typer application wiring for beacon-cli.
+
+This module owns only the Typer ``app`` and the global connection callback;
+the individual subcommands live in :mod:`beacon_cli.commands` and the
+interactive shell in :mod:`beacon_cli.repl`.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from . import __version__, commands
+from .commands._shared import console, err_console, get_client
+from .config import ClientConfig
+
+app = typer.Typer(
+    add_completion=True,
+    no_args_is_help=False,
+    invoke_without_command=True,
+    help="Terminal client for the Beacon data lake.",
+    rich_markup_mode="rich",
+)
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    url: str | None = typer.Option(
+        None, "--url", "-u", envvar="BEACON_URL", help="Beacon server URL."
+    ),
+    username: str | None = typer.Option(
+        None, "--username", envvar="BEACON_ADMIN_USERNAME", help="Admin username (enables DDL/DML)."
+    ),
+    password: str | None = typer.Option(
+        None, "--password", envvar="BEACON_ADMIN_PASSWORD", help="Admin password."
+    ),
+    timeout: float | None = typer.Option(None, "--timeout", help="Request timeout (seconds)."),
+    no_color: bool = typer.Option(False, "--no-color", help="Disable coloured output."),
+    version: bool = typer.Option(False, "--version", help="Show version and exit."),
+) -> None:
+    if version:
+        console.print(f"beacon-cli {__version__}")
+        raise typer.Exit()
+
+    if no_color:
+        console.no_color = True
+        err_console.no_color = True
+
+    config = ClientConfig.resolve(url=url, username=username, password=password, timeout=timeout)
+    ctx.obj = config
+
+    # No subcommand -> interactive shell.
+    if ctx.invoked_subcommand is None:
+        from .repl import run_repl
+
+        with get_client(ctx) as client:
+            run_repl(client, console)
+
+
+# Register all subcommands onto the app.
+commands.register(app)
+
+
+if __name__ == "__main__":
+    app()

--- a/clients/beacon-cli/beacon_cli/client.py
+++ b/clients/beacon-cli/beacon_cli/client.py
@@ -1,0 +1,171 @@
+"""Thin HTTP client over the Beacon ``/api/*`` endpoints.
+
+The request contract mirrors ``integration-tests/beacon_client.py``:
+
+* ``POST /api/query`` accepts either ``{"sql": "..."}`` or a JSON DSL body.
+* **Reads** that should land in a file add ``output: {format: ...}``; the server
+  materializes the file and streams it back as an attachment.
+* **Writes** (DDL/DML) must NOT set an ``output`` format — an output format wraps
+  the plan in ``COPY ... TO`` and a DDL node cannot be physically planned inside
+  a COPY. With no output format the statement runs directly and returns an
+  (often empty) Arrow IPC stream.
+* Basic auth is sent only when credentials are configured, which elevates the
+  request to super-user (DDL/DML allowed).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+
+from .arrow_io import QueryResult, collect_ipc_stream
+from .config import ClientConfig
+from .errors import ConnectionFailedError, QueryError
+
+QUERY_ID_HEADER = "x-beacon-query-id"
+
+
+class BeaconClient:
+    """Synchronous client for a single Beacon server."""
+
+    def __init__(self, config: ClientConfig):
+        self.config = config
+        self._http = httpx.Client(base_url=config.url, timeout=config.timeout)
+
+    def close(self) -> None:
+        self._http.close()
+
+    def __enter__(self) -> BeaconClient:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # -- low level --------------------------------------------------------------
+    def _auth(self) -> tuple[str, str] | None:
+        return self.config.auth
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        try:
+            return self._http.request(method, path, **kwargs)
+        except httpx.ConnectError as exc:
+            raise ConnectionFailedError(self.config.url, str(exc)) from exc
+        except httpx.TimeoutException as exc:
+            raise ConnectionFailedError(self.config.url, f"request timed out: {exc}") from exc
+
+    # -- query (in-terminal, no output format) ----------------------------------
+    def query(self, sql_or_body: str | dict, row_limit: int | None = None) -> QueryResult:
+        """Run a query and decode the Arrow IPC stream into a ``pyarrow.Table``.
+
+        Accepts a raw SQL string or a JSON DSL body dict. Works for SELECTs and
+        for DDL/DML (which yield an empty table).
+
+        The result stream is consumed incrementally: when ``row_limit`` is a
+        non-negative int, only enough record batches are read to exceed that many
+        rows (the rest of the response is never downloaded) and the result is
+        flagged ``truncated``. ``row_limit=None`` (or negative) reads everything.
+        """
+        body = self._build_body(sql_or_body, output=None)
+        start = time.perf_counter()
+        try:
+            with self._http.stream("POST", "/api/query", json=body, auth=self._auth()) as resp:
+                if resp.status_code != 200:
+                    raise QueryError(resp.status_code, resp.read().decode("utf-8", "replace"))
+                query_id = resp.headers.get(QUERY_ID_HEADER)
+                table, truncated = collect_ipc_stream(resp.iter_bytes(), row_limit)
+        except httpx.ConnectError as exc:
+            raise ConnectionFailedError(self.config.url, str(exc)) from exc
+        except httpx.TimeoutException as exc:
+            raise ConnectionFailedError(self.config.url, f"request timed out: {exc}") from exc
+        elapsed = time.perf_counter() - start
+        return QueryResult(table, query_id, elapsed, truncated)
+
+    # -- query to file (sets an output format) ----------------------------------
+    def query_to_file(self, sql_or_body: str | dict, output_format: Any, path: str) -> int:
+        """Run a SELECT, asking the server for ``output_format``; stream to ``path``.
+
+        Returns the number of bytes written. ``output_format`` is the JSON value
+        the server expects under ``output.format`` (a string like ``"csv"`` or a
+        structured object like ``{"nd_netcdf": {"dimension_columns": [...]}}``).
+        """
+        body = self._build_body(sql_or_body, output={"format": output_format})
+        written = 0
+        try:
+            with self._http.stream("POST", "/api/query", json=body, auth=self._auth()) as resp:
+                if resp.status_code != 200:
+                    raise QueryError(resp.status_code, resp.read().decode("utf-8", "replace"))
+                with open(path, "wb") as fh:
+                    for chunk in resp.iter_bytes():
+                        fh.write(chunk)
+                        written += len(chunk)
+        except httpx.ConnectError as exc:
+            raise ConnectionFailedError(self.config.url, str(exc)) from exc
+        except httpx.TimeoutException as exc:
+            raise ConnectionFailedError(self.config.url, f"request timed out: {exc}") from exc
+        return written
+
+    # -- metadata (GET, JSON) ---------------------------------------------------
+    def get_json(self, path: str, params: dict | None = None) -> Any:
+        resp = self._request("GET", path, params=params, auth=self._auth())
+        if resp.status_code != 200:
+            raise QueryError(resp.status_code, resp.text)
+        return resp.json()
+
+    def tables(self) -> list[str]:
+        return self.get_json("/api/tables")
+
+    def tables_with_schema(self) -> list[dict]:
+        return self.get_json("/api/tables-with-schema")
+
+    def table_schema(self, table_name: str) -> dict:
+        return self.get_json("/api/table-schema", {"table_name": table_name})
+
+    def table_config(self, table_name: str) -> dict:
+        return self.get_json("/api/table-config", {"table_name": table_name})
+
+    def tables_with_config(self) -> list[tuple[str, dict]]:
+        """Pair every table with its config (kind/format/location/...).
+
+        Tables without a config (e.g. the built-in ``default``) yield an empty
+        dict rather than failing the whole listing.
+        """
+        entries: list[tuple[str, dict]] = []
+        for name in self.tables():
+            try:
+                entries.append((name, self.table_config(name)))
+            except QueryError:
+                entries.append((name, {}))
+        return entries
+
+    def datasets(self, pattern: str | None = None, limit: int | None = None) -> list[dict]:
+        params: dict[str, Any] = {}
+        if pattern is not None:
+            params["pattern"] = pattern
+        if limit is not None:
+            params["limit"] = limit
+        return self.get_json("/api/list-datasets", params or None)
+
+    def dataset_schema(self, file: str) -> dict:
+        return self.get_json("/api/dataset-schema", {"file": file})
+
+    def functions(self, table: bool = False) -> list[dict]:
+        return self.get_json("/api/table-functions" if table else "/api/functions")
+
+    def info(self) -> Any:
+        return self.get_json("/api/info")
+
+    def metrics(self, query_id: str) -> dict:
+        return self.get_json(f"/api/query/metrics/{query_id}")
+
+    # -- helpers ----------------------------------------------------------------
+    @staticmethod
+    def _build_body(sql_or_body: str | dict, output: dict | None) -> dict:
+        if isinstance(sql_or_body, str):
+            body: dict[str, Any] = {"sql": sql_or_body}
+        else:
+            body = dict(sql_or_body)
+        if output is not None:
+            body["output"] = output
+        return body

--- a/clients/beacon-cli/beacon_cli/client.py
+++ b/clients/beacon-cli/beacon_cli/client.py
@@ -22,7 +22,7 @@ import httpx
 
 from .arrow_io import QueryResult, collect_ipc_stream
 from .config import ClientConfig
-from .errors import ConnectionFailedError, QueryError
+from .errors import ConnectionFailedError, QueryError, StreamInterruptedError
 
 QUERY_ID_HEADER = "x-beacon-query-id"
 
@@ -79,6 +79,8 @@ class BeaconClient:
             raise ConnectionFailedError(self.config.url, str(exc)) from exc
         except httpx.TimeoutException as exc:
             raise ConnectionFailedError(self.config.url, f"request timed out: {exc}") from exc
+        except (httpx.RemoteProtocolError, httpx.ReadError) as exc:
+            raise StreamInterruptedError(self.config.url, str(exc)) from exc
         elapsed = time.perf_counter() - start
         return QueryResult(table, query_id, elapsed, truncated)
 
@@ -104,6 +106,8 @@ class BeaconClient:
             raise ConnectionFailedError(self.config.url, str(exc)) from exc
         except httpx.TimeoutException as exc:
             raise ConnectionFailedError(self.config.url, f"request timed out: {exc}") from exc
+        except (httpx.RemoteProtocolError, httpx.ReadError) as exc:
+            raise StreamInterruptedError(self.config.url, str(exc)) from exc
         return written
 
     # -- metadata (GET, JSON) ---------------------------------------------------

--- a/clients/beacon-cli/beacon_cli/commands/__init__.py
+++ b/clients/beacon-cli/beacon_cli/commands/__init__.py
@@ -1,0 +1,13 @@
+"""CLI command modules, grouped by concern and attached via :func:`register`."""
+
+from __future__ import annotations
+
+import typer
+
+from . import catalog, query
+
+
+def register(app: typer.Typer) -> None:
+    """Attach every subcommand to the Typer ``app``."""
+    query.register(app)
+    catalog.register(app)

--- a/clients/beacon-cli/beacon_cli/commands/_shared.py
+++ b/clients/beacon-cli/beacon_cli/commands/_shared.py
@@ -1,0 +1,41 @@
+"""Shared helpers and consoles for the CLI command modules."""
+
+from __future__ import annotations
+
+import sys
+
+import typer
+from rich.console import Console
+
+from ..client import BeaconClient
+from ..config import ClientConfig
+
+# Shared consoles; cli.main toggles ``no_color`` on these.
+console = Console()
+err_console = Console(stderr=True)
+
+
+def get_client(ctx: typer.Context) -> BeaconClient:
+    """Build a client from the connection config stashed on the Typer context."""
+    config: ClientConfig = ctx.obj
+    return BeaconClient(config)
+
+
+def fail(exc: Exception) -> None:
+    """Print a friendly one-line error and exit non-zero (no traceback)."""
+    err_console.print(f"[red]error:[/red] {exc}")
+    raise typer.Exit(code=1)
+
+
+def read_sql(sql: str | None, file: str | None) -> str:
+    """Resolve a SQL statement from an argument, a ``--file``, or stdin."""
+    if file:
+        with open(file, encoding="utf-8") as fh:
+            return fh.read()
+    if sql is not None:
+        return sql
+    if not sys.stdin.isatty():
+        data = sys.stdin.read().strip()
+        if data:
+            return data
+    raise typer.BadParameter("provide SQL as an argument, with --file, or via stdin")

--- a/clients/beacon-cli/beacon_cli/commands/catalog.py
+++ b/clients/beacon-cli/beacon_cli/commands/catalog.py
@@ -1,0 +1,116 @@
+"""Catalog/metadata commands: tables, schema, datasets, functions, info, metrics."""
+
+from __future__ import annotations
+
+import typer
+
+from ..errors import BeaconCliError
+from ..render import (
+    datasets_to_rich,
+    functions_to_rich,
+    schema_to_rich,
+    tables_detail_to_rich,
+    tables_to_rich,
+)
+from ._shared import console, fail, get_client
+
+
+def tables(
+    ctx: typer.Context,
+    schema: bool = typer.Option(False, "--schema", help="Include each table's columns."),
+    detail: bool = typer.Option(
+        False, "--detail", "-l", help="Show each table's kind, format, location and partitions."
+    ),
+) -> None:
+    """List the tables registered in the catalog."""
+    try:
+        with get_client(ctx) as client:
+            if schema:
+                for entry in client.tables_with_schema():
+                    name = entry.get("table_name", "")
+                    console.print(schema_to_rich(entry.get("columns", []), title=name))
+            elif detail:
+                console.print(tables_detail_to_rich(client.tables_with_config()))
+            else:
+                console.print(tables_to_rich(client.tables()))
+    except BeaconCliError as exc:
+        fail(exc)
+
+
+def schema(ctx: typer.Context, table: str = typer.Argument(..., help="Table name.")) -> None:
+    """Show the schema of a table."""
+    try:
+        with get_client(ctx) as client:
+            view = client.table_schema(table)
+    except BeaconCliError as exc:
+        fail(exc)
+    console.print(schema_to_rich(view.get("fields", []), title=table))
+
+
+def datasets(
+    ctx: typer.Context,
+    pattern: str | None = typer.Option(None, "--pattern", help="Glob pattern filter."),
+    limit: int | None = typer.Option(None, "--limit", help="Maximum datasets to list."),
+) -> None:
+    """List available datasets."""
+    try:
+        with get_client(ctx) as client:
+            rows = client.datasets(pattern, limit)
+    except BeaconCliError as exc:
+        fail(exc)
+    console.print(datasets_to_rich(rows))
+
+
+def dataset_schema(
+    ctx: typer.Context, file: str = typer.Argument(..., help="Dataset file path.")
+) -> None:
+    """Show the schema of a dataset file."""
+    try:
+        with get_client(ctx) as client:
+            view = client.dataset_schema(file)
+    except BeaconCliError as exc:
+        fail(exc)
+    console.print(schema_to_rich(view.get("fields", []), title=file))
+
+
+def functions(
+    ctx: typer.Context,
+    table: bool = typer.Option(False, "--table", help="List table-valued functions instead."),
+) -> None:
+    """List available scalar/aggregate (or table) functions."""
+    try:
+        with get_client(ctx) as client:
+            rows = client.functions(table)
+    except BeaconCliError as exc:
+        fail(exc)
+    console.print(functions_to_rich(rows))
+
+
+def info(ctx: typer.Context) -> None:
+    """Show Beacon server/system information."""
+    try:
+        with get_client(ctx) as client:
+            console.print_json(data=client.info())
+    except BeaconCliError as exc:
+        fail(exc)
+
+
+def metrics(
+    ctx: typer.Context, query_id: str = typer.Argument(..., help="A prior query id.")
+) -> None:
+    """Show execution metrics for a previously run query."""
+    try:
+        with get_client(ctx) as client:
+            console.print_json(data=client.metrics(query_id))
+    except BeaconCliError as exc:
+        fail(exc)
+
+
+def register(app: typer.Typer) -> None:
+    app.command()(tables)
+    app.command()(schema)
+    app.command()(datasets)
+    app.command(name="dataset-schema")(dataset_schema)
+    app.command()(functions)
+    app.command()(info)
+    app.command()(metrics)

--- a/clients/beacon-cli/beacon_cli/commands/query.py
+++ b/clients/beacon-cli/beacon_cli/commands/query.py
@@ -1,0 +1,113 @@
+"""The ``query`` and ``export`` commands: run SQL, render or write results."""
+
+from __future__ import annotations
+
+import typer
+
+from ..errors import BeaconCliError
+from ..formats import build_output_format, infer_format_name
+from ..render import (
+    DEFAULT_MAX_ROWS,
+    footer,
+    table_to_json,
+    table_to_records,
+    table_to_rich,
+    truncation_note,
+)
+from ._shared import console, err_console, fail, get_client, read_sql
+
+
+def query(
+    ctx: typer.Context,
+    sql: str | None = typer.Argument(None, help="SQL statement (or use --file / stdin)."),
+    file: str | None = typer.Option(None, "--file", "-f", help="Read SQL from a file."),
+    max_rows: int = typer.Option(
+        DEFAULT_MAX_ROWS, "--max-rows", help="Max rows to render (-1 = all)."
+    ),
+    fetch_all: bool = typer.Option(
+        False, "--all", "-a", help="Fetch the whole result instead of stopping at the render limit."
+    ),
+    expand: bool = typer.Option(
+        False, "--expand", "-x", help="Render rows vertically (field/value) — good for wide tables."
+    ),
+    as_json: bool = typer.Option(False, "--json", help="Print rows as JSON instead of a table."),
+) -> None:
+    """Run a query and render the results in the terminal.
+
+    By default only enough rows to fill the render limit are streamed from the
+    server; pass --all (or --max-rows -1) to fetch the entire result. Use
+    --expand for wide tables, where the grid layout squeezes columns too small.
+    """
+    statement = read_sql(sql, file)
+    # row budget: None => fetch everything; otherwise stop once we exceed max_rows.
+    row_limit = None if (fetch_all or max_rows < 0) else max_rows
+    try:
+        with get_client(ctx) as client:
+            result = client.query(statement, row_limit=row_limit)
+    except BeaconCliError as exc:
+        fail(exc)
+
+    # In JSON mode the footer goes to stderr so stdout stays valid JSON.
+    footer_console = err_console if as_json else console
+
+    # A side-effecting statement (DDL/DML, CREATE/RUN CRAWLER, REFRESH, ...) comes
+    # back with no schema at all; report success rather than an empty grid.
+    if result.is_empty:
+        if as_json:
+            console.print_json(data=[])
+        else:
+            console.print("[green]OK[/green]")
+        footer_console.print(footer(0, result.elapsed, result.query_id))
+        return
+
+    if as_json:
+        console.print_json(table_to_json(result.table, max_rows))
+    else:
+        if expand:
+            console.print(table_to_records(result.table, max_rows))
+        else:
+            console.print(table_to_rich(result.table, max_rows))
+        if not result.truncated:
+            note = truncation_note(result.num_rows, max_rows)
+            if note:
+                console.print(f"[dim]{note}[/dim]")
+
+    if result.truncated:
+        shown = result.num_rows if max_rows < 0 else min(max_rows, result.num_rows)
+        footer_console.print(footer(shown, result.elapsed, result.query_id, more=True))
+    else:
+        footer_console.print(footer(result.num_rows, result.elapsed, result.query_id))
+
+
+def export(
+    ctx: typer.Context,
+    sql: str | None = typer.Argument(None, help="SQL SELECT (or use --file / stdin)."),
+    output: str = typer.Option(..., "--output", "-o", help="Destination file path."),
+    fmt: str | None = typer.Option(
+        None, "--format", help="Output format (inferred from -o extension if omitted)."
+    ),
+    file: str | None = typer.Option(None, "--file", "-f", help="Read SQL from a file."),
+    dimension_columns: list[str] | None = typer.Option(
+        None, "--dimension-columns", help="Dimension columns for nd_netcdf."
+    ),
+    lon: str | None = typer.Option(None, "--lon", help="Longitude column for geoparquet."),
+    lat: str | None = typer.Option(None, "--lat", help="Latitude column for geoparquet."),
+) -> None:
+    """Run a query and write the results to a file (CSV/Parquet/Arrow/NetCDF/...)."""
+    statement = read_sql(sql, file)
+    try:
+        name = infer_format_name(output, fmt)
+        output_format = build_output_format(
+            name, dimension_columns=dimension_columns, lon=lon, lat=lat
+        )
+        with get_client(ctx) as client:
+            written = client.query_to_file(statement, output_format, output)
+    except (BeaconCliError, ValueError, OSError) as exc:
+        fail(exc)
+
+    console.print(f"[green]wrote[/green] {output} [dim]({name}, {written} bytes)[/dim]")
+
+
+def register(app: typer.Typer) -> None:
+    app.command()(query)
+    app.command()(export)

--- a/clients/beacon-cli/beacon_cli/config.py
+++ b/clients/beacon-cli/beacon_cli/config.py
@@ -1,0 +1,54 @@
+"""Connection configuration for beacon-cli.
+
+Mirrors the Beacon server defaults (host ``0.0.0.0``, port ``5001``, admin
+basic-auth ``beacon-admin`` / ``beacon-password``) and honours the same
+``BEACON_*`` environment variables so the CLI lines up with a local server out
+of the box.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+DEFAULT_URL = "http://localhost:5001"
+DEFAULT_TIMEOUT = 600.0
+
+
+@dataclass
+class ClientConfig:
+    """Everything the HTTP client needs to talk to a Beacon server."""
+
+    url: str = DEFAULT_URL
+    username: str | None = None
+    password: str | None = None
+    timeout: float = DEFAULT_TIMEOUT
+
+    def __post_init__(self) -> None:
+        self.url = self.url.rstrip("/")
+
+    @property
+    def auth(self) -> tuple[str, str] | None:
+        """Basic-auth pair, or ``None`` for an anonymous (read-only) session.
+
+        Supplying credentials elevates requests to super-user, enabling DDL/DML.
+        """
+        if self.username is not None and self.password is not None:
+            return (self.username, self.password)
+        return None
+
+    @classmethod
+    def resolve(
+        cls,
+        url: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        timeout: float | None = None,
+    ) -> ClientConfig:
+        """Build a config from explicit values, falling back to env vars."""
+        return cls(
+            url=url or os.environ.get("BEACON_URL", DEFAULT_URL),
+            username=username if username is not None else os.environ.get("BEACON_ADMIN_USERNAME"),
+            password=password if password is not None else os.environ.get("BEACON_ADMIN_PASSWORD"),
+            timeout=timeout if timeout is not None else DEFAULT_TIMEOUT,
+        )

--- a/clients/beacon-cli/beacon_cli/errors.py
+++ b/clients/beacon-cli/beacon_cli/errors.py
@@ -30,6 +30,22 @@ class ConnectionFailedError(BeaconCliError):
         super().__init__(f"could not connect to beacon at {url}: {detail}")
 
 
+class StreamInterruptedError(BeaconCliError):
+    """The server closed the response stream before it was complete.
+
+    Typically means the query failed server-side *after* the response started
+    (e.g. an execution error mid-stream), so no clean error body was returned.
+    """
+
+    def __init__(self, url: str, detail: str):
+        self.url = url
+        self.detail = detail
+        super().__init__(
+            f"the server at {url} closed the connection before the response "
+            f"completed; the query likely failed during execution ({detail})"
+        )
+
+
 def _trim(body: str, limit: int = 500) -> str:
     body = body.strip()
     # The server wraps error strings in JSON quotes; unwrap a plain quoted string.

--- a/clients/beacon-cli/beacon_cli/errors.py
+++ b/clients/beacon-cli/beacon_cli/errors.py
@@ -1,0 +1,43 @@
+"""Error types for beacon-cli, with messages safe to show end users."""
+
+from __future__ import annotations
+
+
+class BeaconCliError(RuntimeError):
+    """Base class for errors that should be printed without a traceback."""
+
+
+class QueryError(BeaconCliError):
+    """A query (or metadata request) returned a non-2xx status.
+
+    The server returns its error as a JSON string body
+    (``Json(err.to_string())``); we surface it verbatim, trimmed to keep
+    terminal output readable.
+    """
+
+    def __init__(self, status_code: int, body: str):
+        self.status_code = status_code
+        self.body = body
+        super().__init__(f"beacon request failed [{status_code}]: {_trim(body)}")
+
+
+class ConnectionFailedError(BeaconCliError):
+    """The server could not be reached at the configured URL."""
+
+    def __init__(self, url: str, detail: str):
+        self.url = url
+        self.detail = detail
+        super().__init__(f"could not connect to beacon at {url}: {detail}")
+
+
+def _trim(body: str, limit: int = 500) -> str:
+    body = body.strip()
+    # The server wraps error strings in JSON quotes; unwrap a plain quoted string.
+    if len(body) >= 2 and body[0] == '"' and body[-1] == '"':
+        try:
+            import json
+
+            body = json.loads(body)
+        except ValueError:
+            pass
+    return body if len(body) <= limit else body[: limit - 3] + "..."

--- a/clients/beacon-cli/beacon_cli/formats.py
+++ b/clients/beacon-cli/beacon_cli/formats.py
@@ -1,0 +1,70 @@
+"""Output-format selection for the ``export`` command and ``\\export`` REPL verb.
+
+Maps a user-facing format name (or output-file extension) to the JSON value the
+server expects under ``output.format``. The supported formats mirror the
+``OutputFormat`` enum in ``beacon-core/src/query/output.rs``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+# Simple (string) formats keyed by canonical name.
+SIMPLE_FORMATS = {"csv", "ipc", "parquet", "netcdf", "odv"}
+
+# File-extension -> canonical format name.
+EXT_TO_FORMAT = {
+    ".csv": "csv",
+    ".parquet": "parquet",
+    ".arrow": "ipc",
+    ".ipc": "ipc",
+    ".nc": "netcdf",
+    ".geoparquet": "geoparquet",
+    ".odv": "odv",
+}
+
+# Aliases accepted on the --format flag.
+FORMAT_ALIASES = {"arrow": "ipc", "nc": "netcdf"}
+
+
+class ExportFormatError(ValueError):
+    """Raised when a format cannot be determined or is misconfigured."""
+
+
+def infer_format_name(path: str, override: str | None) -> str:
+    """Resolve the canonical format name from ``--format`` or the file extension."""
+    if override:
+        name = override.lower()
+        return FORMAT_ALIASES.get(name, name)
+    ext = os.path.splitext(path)[1].lower()
+    if ext in EXT_TO_FORMAT:
+        return EXT_TO_FORMAT[ext]
+    raise ExportFormatError(
+        f"cannot infer output format from '{path}'; pass --format "
+        f"(csv, parquet, ipc/arrow, netcdf, nd_netcdf, geoparquet, odv)"
+    )
+
+
+def build_output_format(
+    name: str,
+    *,
+    dimension_columns: list[str] | None = None,
+    lon: str | None = None,
+    lat: str | None = None,
+) -> Any:
+    """Build the JSON value for ``output.format`` from a format name + options."""
+    name = FORMAT_ALIASES.get(name.lower(), name.lower())
+
+    if name in SIMPLE_FORMATS:
+        return name
+    if name == "geoparquet":
+        return {"geoparquet": {"longitude_column": lon, "latitude_column": lat}}
+    if name == "nd_netcdf":
+        if not dimension_columns:
+            raise ExportFormatError("nd_netcdf requires --dimension-columns")
+        return {"nd_netcdf": {"dimension_columns": dimension_columns}}
+    raise ExportFormatError(
+        f"unknown output format '{name}'; expected one of: "
+        f"csv, parquet, ipc/arrow, netcdf, nd_netcdf, geoparquet, odv"
+    )

--- a/clients/beacon-cli/beacon_cli/render/__init__.py
+++ b/clients/beacon-cli/beacon_cli/render/__init__.py
@@ -1,0 +1,37 @@
+"""Rendering helpers: turn pyarrow tables and Beacon JSON into rich views.
+
+Split across :mod:`results` (query result sets) and :mod:`metadata` (catalog
+views); both are re-exported here so callers can simply ``from .render import X``.
+"""
+
+from __future__ import annotations
+
+from .metadata import (
+    datasets_to_rich,
+    functions_to_rich,
+    schema_to_rich,
+    tables_detail_to_rich,
+    tables_to_rich,
+)
+from .results import (
+    DEFAULT_MAX_ROWS,
+    footer,
+    table_to_json,
+    table_to_records,
+    table_to_rich,
+    truncation_note,
+)
+
+__all__ = [
+    "DEFAULT_MAX_ROWS",
+    "datasets_to_rich",
+    "footer",
+    "functions_to_rich",
+    "schema_to_rich",
+    "table_to_json",
+    "table_to_records",
+    "table_to_rich",
+    "tables_detail_to_rich",
+    "tables_to_rich",
+    "truncation_note",
+]

--- a/clients/beacon-cli/beacon_cli/render/metadata.py
+++ b/clients/beacon-cli/beacon_cli/render/metadata.py
@@ -1,0 +1,101 @@
+"""Rendering for catalog metadata (schemas, tables, datasets, functions)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.table import Table as RichTable
+
+
+def schema_to_rich(fields: list[dict[str, Any]], title: str | None = None) -> RichTable:
+    """Render a list of schema fields (``{name, data_type, nullable}``)."""
+    rt = RichTable(title=title, show_header=True, header_style="bold cyan")
+    rt.add_column("column")
+    rt.add_column("type")
+    rt.add_column("nullable", justify="center")
+    for field in fields:
+        rt.add_row(
+            str(field.get("name", "")),
+            str(field.get("data_type", "")),
+            "yes" if field.get("nullable") else "",
+        )
+    return rt
+
+
+def tables_to_rich(names: list[str]) -> RichTable:
+    rt = RichTable(show_header=True, header_style="bold cyan")
+    rt.add_column("table")
+    for name in names:
+        rt.add_row(str(name))
+    return rt
+
+
+# Friendly labels for the server's internal ``definition_type`` discriminators
+# (see beacon-datafusion-ext table definitions). Unknown values fall through
+# unchanged so new definition kinds are never hidden.
+_KIND_LABELS = {
+    "listing_table": "external (files)",
+    "remote_table": "external (remote)",
+    "view_table": "view",
+    "materialized_view": "materialized view",
+    "logical": "logical",
+}
+
+
+def friendly_kind(definition_type: str) -> str:
+    """Map a raw ``definition_type`` to a human label, else return it unchanged."""
+    return _KIND_LABELS.get(definition_type, definition_type)
+
+
+def tables_detail_to_rich(entries: list[tuple[str, dict[str, Any]]]) -> RichTable:
+    """Render tables with their kind/format/location from ``/api/table-config``.
+
+    ``entries`` is a list of ``(table_name, config)`` pairs; an empty config
+    (e.g. the built-in ``default`` table) renders blank metadata cells.
+    """
+    rt = RichTable(show_header=True, header_style="bold cyan")
+    rt.add_column("table")
+    rt.add_column("kind")
+    rt.add_column("format")
+    rt.add_column("location", overflow="fold")
+    rt.add_column("partitions")
+    for name, cfg in entries:
+        partitions = cfg.get("partition_cols") or []
+        rt.add_row(
+            str(name),
+            friendly_kind(str(cfg.get("definition_type", ""))),
+            str(cfg.get("file_type", "")),
+            str(cfg.get("location", "")),
+            ", ".join(str(p) for p in partitions),
+        )
+    return rt
+
+
+def datasets_to_rich(datasets: list[dict[str, Any]]) -> RichTable:
+    rt = RichTable(show_header=True, header_style="bold cyan")
+    rt.add_column("path", overflow="fold")
+    rt.add_column("format")
+    rt.add_column("inspect", justify="center")
+    for ds in datasets:
+        rt.add_row(
+            str(ds.get("file_path", "")),
+            str(ds.get("format", "")),
+            "yes" if ds.get("can_inspect") else "",
+        )
+    return rt
+
+
+def functions_to_rich(functions: list[dict[str, Any]]) -> RichTable:
+    rt = RichTable(show_header=True, header_style="bold cyan")
+    rt.add_column("function")
+    rt.add_column("returns")
+    rt.add_column("description", overflow="fold")
+    for fn in functions:
+        params = ", ".join(p.get("name", "") for p in fn.get("params", []))
+        name = fn.get("function_name", "")
+        rt.add_row(
+            f"{name}({params})",
+            str(fn.get("return_type", "")),
+            str(fn.get("description", "")),
+        )
+    return rt

--- a/clients/beacon-cli/beacon_cli/render/results.py
+++ b/clients/beacon-cli/beacon_cli/render/results.py
@@ -1,0 +1,129 @@
+"""Rendering for query result sets (pyarrow tables -> rich / JSON)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.compute as pc
+from rich import box
+from rich.console import Group, RenderableType
+from rich.table import Table as RichTable
+
+DEFAULT_MAX_ROWS = 100
+
+
+def table_to_rich(table: pa.Table, max_rows: int = DEFAULT_MAX_ROWS) -> RichTable:
+    """Render a ``pyarrow.Table`` as a rich table, capped at ``max_rows`` rows."""
+    rt = RichTable(show_header=True, header_style="bold cyan", show_lines=False)
+
+    if table.num_columns == 0:
+        rt.add_column("(no columns)")
+        return rt
+
+    for field in table.schema:
+        rt.add_column(f"{field.name}\n[dim]{field.type}[/dim]", overflow="fold")
+
+    shown = table.slice(0, max_rows) if max_rows >= 0 else table
+    rows = _to_rows(shown)
+    columns = [f.name for f in table.schema]
+    for row in rows:
+        rt.add_row(*[_fmt_cell(row.get(col)) for col in columns])
+
+    return rt
+
+
+def table_to_records(table: pa.Table, max_rows: int = DEFAULT_MAX_ROWS) -> RenderableType:
+    """Render rows vertically, one record per block (``field | value``).
+
+    This 'expanded' layout (à la psql ``\\x``) keeps very wide results readable:
+    column count no longer competes for terminal width, so each value gets the
+    full line.
+    """
+    if table.num_columns == 0:
+        return RichTable()  # empty; nothing to expand
+
+    shown = table.slice(0, max_rows) if max_rows >= 0 else table
+    rows = _to_rows(shown)
+    names = table.column_names
+
+    blocks: list[RenderableType] = []
+    for i, row in enumerate(rows, start=1):
+        rec = RichTable(
+            show_header=False,
+            box=box.SIMPLE,
+            title=f"[dim]record {i}[/dim]",
+            title_justify="left",
+            pad_edge=False,
+        )
+        rec.add_column("field", style="bold cyan", no_wrap=True)
+        rec.add_column("value", overflow="fold")
+        for name in names:
+            rec.add_row(name, _fmt_cell(row.get(name)))
+        blocks.append(rec)
+
+    return Group(*blocks)
+
+
+def truncation_note(num_rows: int, max_rows: int) -> str | None:
+    if 0 <= max_rows < num_rows:
+        return f"... {num_rows - max_rows} more row(s) not shown (use --max-rows)"
+    return None
+
+
+def footer(num_rows: int, elapsed: float, query_id: str | None, *, more: bool = False) -> str:
+    """Summary line. With ``more=True``, ``num_rows`` is the number shown and the
+    full result has additional rows that were not fetched."""
+    count = f"first {num_rows} rows (more available)" if more else f"{num_rows} row(s)"
+    parts = [count, f"{elapsed * 1000:.0f} ms"]
+    if query_id:
+        parts.append(f"query {query_id}")
+    return "[dim](" + " | ".join(parts) + ")[/dim]"
+
+
+def table_to_json(table: pa.Table, max_rows: int = -1) -> str:
+    shown = table.slice(0, max_rows) if max_rows >= 0 else table
+    return json.dumps(_to_rows(shown), default=str, indent=2)
+
+
+def _to_rows(table: pa.Table) -> list[dict[str, Any]]:
+    """``Table.to_pylist`` with temporal columns rendered as strings.
+
+    pyarrow refuses to convert nanosecond timestamps (and similar high-precision
+    temporal values) to Python ``datetime`` when they fall outside its range, so
+    cast those columns to their string form first — which is what we want to show
+    anyway.
+    """
+    return _stringify_temporal(table).to_pylist()
+
+
+def _stringify_temporal(table: pa.Table) -> pa.Table:
+    columns = []
+    changed = False
+    for field in table.schema:
+        column = table.column(field.name)
+        if _is_temporal(field.type):
+            try:
+                column = pc.cast(column, pa.string())
+                changed = True
+            except (pa.ArrowInvalid, pa.ArrowNotImplementedError):
+                pass
+        columns.append(column)
+    return pa.table(columns, names=table.column_names) if changed else table
+
+
+def _is_temporal(dtype: pa.DataType) -> bool:
+    return (
+        pa.types.is_timestamp(dtype)
+        or pa.types.is_time(dtype)
+        or pa.types.is_duration(dtype)
+    )
+
+
+def _fmt_cell(value: Any) -> str:
+    if value is None:
+        return "[dim]NULL[/dim]"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, default=str)
+    return str(value)

--- a/clients/beacon-cli/beacon_cli/repl/__init__.py
+++ b/clients/beacon-cli/beacon_cli/repl/__init__.py
@@ -1,0 +1,57 @@
+"""Interactive REPL shell for beacon-cli (prompt_toolkit + rich).
+
+SQL statements are executed via the no-``output`` path (so both SELECTs and DDL
+work) and rendered as tables. Lines beginning with ``\\`` are psql-style
+meta-commands. The pieces are split across submodules:
+
+* :mod:`reader`  — history, the prompt callable, multi-line statement reads
+* :mod:`runner`  — execute one SQL statement and render the outcome
+* :mod:`meta`    — backslash meta-command dispatch
+* :mod:`state`   — per-session settings
+* :mod:`help`    — the ``\\help`` text
+"""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+from ..client import BeaconClient
+from .meta import handle_meta
+from .reader import make_prompt_fn, read_statement
+from .runner import run_sql
+from .state import ReplState
+
+__all__ = ["run_repl"]
+
+
+def run_repl(client: BeaconClient, console: Console) -> None:
+    state = ReplState()
+    prompt_fn = make_prompt_fn()
+
+    console.print(
+        f"[bold]beacon-cli[/bold] -> [cyan]{client.config.url}[/cyan]  "
+        "(type [bold]\\help[/bold] for commands, [bold]\\q[/bold] to quit)"
+    )
+
+    while True:
+        try:
+            statement = read_statement(prompt_fn)
+        except KeyboardInterrupt:
+            continue  # Ctrl-C clears the current line
+        except EOFError:
+            break  # Ctrl-D exits
+
+        if statement is None:
+            continue
+        statement = statement.strip()
+        if not statement:
+            continue
+
+        if statement.startswith("\\") or statement.lower() in {"quit", "exit"}:
+            if handle_meta(statement, client, console, state) == "quit":
+                break
+            continue
+
+        run_sql(statement, client, console, state)
+
+    console.print("[dim]exiting[/dim]")

--- a/clients/beacon-cli/beacon_cli/repl/help.py
+++ b/clients/beacon-cli/beacon_cli/repl/help.py
@@ -1,0 +1,24 @@
+"""Help text for the interactive shell's meta-commands."""
+
+HELP_TEXT = """\
+[bold]Meta-commands[/bold]
+  \\dt                list tables
+  \\dt+               list tables with kind / format / location
+  \\d <table>         show a table's schema
+  \\df                list scalar/aggregate functions
+  \\dft               list table functions
+  \\datasets (pat)    list datasets (optional glob)
+  \\crawlers          list crawlers (SHOW CRAWLERS)
+  \\run-crawler <n>   run a crawler once (admin)
+  \\refresh <t>       refresh a table / materialized view (admin)
+  \\info              server info
+  \\format <fmt>      set export format (csv, parquet, ipc, netcdf, geoparquet, odv)
+  \\export <file>     run the last statement and write it to <file>
+  \\o <file>          alias for \\export
+  \\limit <n>         max rows to render (-1 = all)
+  \\x                 toggle expanded (field/value) display — good for wide tables
+  \\timing            toggle timing display
+  \\help, \\?          this help
+  \\q, quit, exit     leave the shell
+
+Anything else is sent as SQL; end a statement with ';' (or a blank line)."""

--- a/clients/beacon-cli/beacon_cli/repl/meta.py
+++ b/clients/beacon-cli/beacon_cli/repl/meta.py
@@ -1,0 +1,127 @@
+"""Dispatch and handlers for the shell's backslash meta-commands."""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+from ..client import BeaconClient
+from ..errors import BeaconCliError
+from ..formats import build_output_format, infer_format_name
+from ..render import (
+    datasets_to_rich,
+    functions_to_rich,
+    schema_to_rich,
+    tables_detail_to_rich,
+    tables_to_rich,
+)
+from .help import HELP_TEXT
+from .runner import run_sql
+from .state import ReplState
+
+
+def handle_meta(line: str, client: BeaconClient, console: Console, state: ReplState) -> str | None:
+    """Handle a meta-command line. Returns ``"quit"`` to leave the shell."""
+    parts = line.strip().split()
+    cmd = parts[0].lower()
+    args = parts[1:]
+
+    if cmd in {"\\q", "quit", "exit"}:
+        return "quit"
+    if cmd in {"\\help", "\\?"}:
+        console.print(HELP_TEXT)
+        return None
+
+    try:
+        _dispatch(cmd, args, client, console, state)
+    except BeaconCliError as exc:
+        console.print(f"[red]error:[/red] {exc}")
+    return None
+
+
+def _dispatch(
+    cmd: str, args: list[str], client: BeaconClient, console: Console, state: ReplState
+) -> None:
+    if cmd == "\\dt":
+        console.print(tables_to_rich(client.tables()))
+    elif cmd == "\\dt+":
+        console.print(tables_detail_to_rich(client.tables_with_config()))
+    elif cmd == "\\d":
+        if not args:
+            console.print("[yellow]usage: \\d <table>[/yellow]")
+        else:
+            view = client.table_schema(args[0])
+            console.print(schema_to_rich(view.get("fields", []), title=args[0]))
+    elif cmd == "\\df":
+        console.print(functions_to_rich(client.functions(table=False)))
+    elif cmd == "\\dft":
+        console.print(functions_to_rich(client.functions(table=True)))
+    elif cmd == "\\datasets":
+        pattern = args[0] if args else None
+        console.print(datasets_to_rich(client.datasets(pattern)))
+    elif cmd == "\\crawlers":
+        run_sql("SHOW CRAWLERS", client, console, state)
+    elif cmd == "\\run-crawler":
+        if not args:
+            console.print("[yellow]usage: \\run-crawler <name>[/yellow]")
+        else:
+            run_sql(f"RUN CRAWLER {args[0]}", client, console, state)
+    elif cmd == "\\refresh":
+        if not args:
+            console.print("[yellow]usage: \\refresh <table>[/yellow]")
+        else:
+            run_sql(f"REFRESH TABLE {args[0]}", client, console, state)
+    elif cmd == "\\info":
+        console.print_json(data=client.info())
+    elif cmd == "\\format":
+        _set_format(args, console, state)
+    elif cmd in {"\\export", "\\o"}:
+        _export_last(args, client, console, state)
+    elif cmd == "\\limit":
+        _set_limit(args, console, state)
+    elif cmd == "\\timing":
+        state.timing = not state.timing
+        console.print(f"timing [bold]{'on' if state.timing else 'off'}[/bold]")
+    elif cmd == "\\x":
+        state.expand = not state.expand
+        mode = "expanded (field/value)" if state.expand else "table"
+        console.print(f"display [bold]{mode}[/bold]")
+    else:
+        console.print(f"[yellow]unknown command: {cmd}[/yellow] (try \\help)")
+
+
+def _set_format(args: list[str], console: Console, state: ReplState) -> None:
+    if not args:
+        current = state.export_format or "(from file extension)"
+        console.print(f"export format is [bold]{current}[/bold]")
+        return
+    state.export_format = args[0].lower()
+    console.print(f"export format -> [bold]{state.export_format}[/bold]")
+
+
+def _set_limit(args: list[str], console: Console, state: ReplState) -> None:
+    if not args:
+        console.print(f"render limit is [bold]{state.max_rows}[/bold]")
+        return
+    try:
+        state.max_rows = int(args[0])
+        console.print(f"render limit -> [bold]{state.max_rows}[/bold]")
+    except ValueError:
+        console.print("[yellow]usage: \\limit <n>[/yellow]")
+
+
+def _export_last(args: list[str], client: BeaconClient, console: Console, state: ReplState) -> None:
+    if not args:
+        console.print("[yellow]usage: \\export <file>[/yellow]")
+        return
+    if not state.last_statement:
+        console.print("[yellow]no statement to export yet[/yellow]")
+        return
+    path = args[0]
+    try:
+        name = infer_format_name(path, state.export_format)
+        output_format = build_output_format(name)
+        written = client.query_to_file(state.last_statement, output_format, path)
+    except (BeaconCliError, ValueError, OSError) as exc:
+        console.print(f"[red]error:[/red] {exc}")
+        return
+    console.print(f"[green]wrote[/green] {path} [dim]({name}, {written} bytes)[/dim]")

--- a/clients/beacon-cli/beacon_cli/repl/reader.py
+++ b/clients/beacon-cli/beacon_cli/repl/reader.py
@@ -1,0 +1,58 @@
+"""Input handling for the shell: history, the prompt callable, and statement reads."""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+from prompt_toolkit import PromptSession
+from prompt_toolkit.history import FileHistory
+
+
+def history_path() -> Path:
+    if os.name == "nt":
+        base = Path(os.environ.get("APPDATA", Path.home())) / "beacon-cli"
+    else:
+        base = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "beacon-cli"
+    base.mkdir(parents=True, exist_ok=True)
+    return base / "history"
+
+
+def make_prompt_fn() -> Callable[[str], str]:
+    """Return a ``prompt(text) -> line`` callable.
+
+    Uses prompt_toolkit (history + line editing) when attached to a real
+    terminal, and falls back to the builtin ``input`` for pipes / CI / any
+    context where prompt_toolkit cannot create a terminal session.
+    """
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        try:
+            session: PromptSession = PromptSession(history=FileHistory(str(history_path())))
+            return session.prompt
+        except Exception:
+            pass
+    return input
+
+
+def read_statement(prompt_fn: Callable[[str], str]) -> str | None:
+    """Read one statement, continuing across lines until ';' or a blank line.
+
+    Meta-commands (starting with '\\') are returned immediately as a single line.
+    """
+    lines: list[str] = []
+    prompt = "beacon> "
+    while True:
+        line = prompt_fn(prompt)
+        if not lines and line.strip().startswith("\\"):
+            return line
+        if not lines and line.strip().lower() in {"quit", "exit"}:
+            return line
+        lines.append(line)
+        stripped = line.rstrip()
+        if stripped.endswith(";"):
+            return "\n".join(lines).rstrip().rstrip(";")
+        if stripped == "":
+            return "\n".join(lines).strip()
+        prompt = "   ...> "

--- a/clients/beacon-cli/beacon_cli/repl/runner.py
+++ b/clients/beacon-cli/beacon_cli/repl/runner.py
@@ -1,0 +1,45 @@
+"""Execute a SQL statement in the shell and render the outcome."""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+from ..client import BeaconClient
+from ..errors import BeaconCliError
+from ..render import footer, table_to_records, table_to_rich, truncation_note
+from .state import ReplState
+
+
+def run_sql(statement: str, client: BeaconClient, console: Console, state: ReplState) -> None:
+    """Run ``statement`` (no output format), render rows or ``OK``, and record it.
+
+    Only enough rows to fill the render limit are streamed; set ``\\limit -1`` to
+    fetch the whole result.
+    """
+    state.last_statement = statement
+    row_limit = None if state.max_rows < 0 else state.max_rows
+    try:
+        result = client.query(statement, row_limit=row_limit)
+    except BeaconCliError as exc:
+        console.print(f"[red]error:[/red] {exc}")
+        return
+
+    if result.is_empty:
+        console.print("[green]OK[/green]")
+    else:
+        if state.expand:
+            console.print(table_to_records(result.table, state.max_rows))
+        else:
+            console.print(table_to_rich(result.table, state.max_rows))
+        if result.truncated:
+            console.print("[dim]... more rows available (\\limit -1 to fetch all)[/dim]")
+        else:
+            note = truncation_note(result.num_rows, state.max_rows)
+            if note:
+                console.print(f"[dim]{note}[/dim]")
+    if state.timing:
+        if result.truncated:
+            shown = result.num_rows if state.max_rows < 0 else min(state.max_rows, result.num_rows)
+            console.print(footer(shown, result.elapsed, result.query_id, more=True))
+        else:
+            console.print(footer(result.num_rows, result.elapsed, result.query_id))

--- a/clients/beacon-cli/beacon_cli/repl/state.py
+++ b/clients/beacon-cli/beacon_cli/repl/state.py
@@ -1,0 +1,16 @@
+"""Mutable per-session state for the interactive shell."""
+
+from __future__ import annotations
+
+from ..render import DEFAULT_MAX_ROWS
+
+
+class ReplState:
+    """Settings and history carried across statements within one shell session."""
+
+    def __init__(self) -> None:
+        self.max_rows = DEFAULT_MAX_ROWS
+        self.timing = True
+        self.expand = False  # vertical (field/value) rendering for wide tables
+        self.export_format: str | None = None  # None -> infer from file extension
+        self.last_statement: str | None = None

--- a/clients/beacon-cli/pyproject.toml
+++ b/clients/beacon-cli/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "beacon-cli"
+version = "0.1.0"
+description = "Terminal client for the Beacon data lake: run SQL, explore tables/datasets, render results, and export to CSV/Parquet/Arrow/NetCDF."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "Beacon" }]
+keywords = ["beacon", "datalake", "sql", "arrow", "cli"]
+dependencies = [
+    "httpx>=0.27",
+    "pyarrow>=14.0",
+    "rich>=13.0",
+    "prompt_toolkit>=3.0",
+    "typer>=0.12",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "respx>=0.21",
+    "ruff>=0.6",
+]
+
+[project.scripts]
+beacon-cli = "beacon_cli.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["beacon_cli"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+
+[tool.ruff.lint.flake8-bugbear]
+# Typer relies on calling Option()/Argument() in parameter defaults.
+extend-immutable-calls = ["typer.Option", "typer.Argument"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/clients/beacon-cli/tests/test_arrow_io.py
+++ b/clients/beacon-cli/tests/test_arrow_io.py
@@ -1,0 +1,32 @@
+"""Tests for Arrow IPC decoding and the QueryResult wrapper."""
+
+from __future__ import annotations
+
+import io
+
+import pyarrow as pa
+
+from beacon_cli.arrow_io import QueryResult, decode_ipc_stream
+
+
+def _ipc_stream(table: pa.Table) -> bytes:
+    sink = io.BytesIO()
+    with pa.ipc.new_stream(sink, table.schema) as writer:
+        writer.write_table(table)
+    return sink.getvalue()
+
+
+def test_decode_roundtrip():
+    table = pa.table({"a": [1, 2, 3]})
+    decoded = decode_ipc_stream(_ipc_stream(table))
+    assert decoded.num_rows == 3
+    assert decoded.column_names == ["a"]
+
+
+def test_decode_empty_is_empty_table():
+    assert decode_ipc_stream(b"").num_columns == 0
+
+
+def test_query_result_is_empty():
+    assert QueryResult(pa.table({}), None, 0.0).is_empty
+    assert not QueryResult(pa.table({"a": [1]}), "q", 0.1).is_empty

--- a/clients/beacon-cli/tests/test_client.py
+++ b/clients/beacon-cli/tests/test_client.py
@@ -1,0 +1,175 @@
+"""Tests for BeaconClient using respx to mock the HTTP layer."""
+
+from __future__ import annotations
+
+import io
+
+import httpx
+import pyarrow as pa
+import pytest
+import respx
+
+from beacon_cli.client import QUERY_ID_HEADER, BeaconClient
+from beacon_cli.config import ClientConfig
+from beacon_cli.errors import ConnectionFailedError, QueryError
+
+BASE = "http://beacon.test"
+
+
+def _client() -> BeaconClient:
+    return BeaconClient(ClientConfig(url=BASE))
+
+
+def _ipc_stream(table: pa.Table) -> bytes:
+    sink = io.BytesIO()
+    with pa.ipc.new_stream(sink, table.schema) as writer:
+        writer.write_table(table)
+    return sink.getvalue()
+
+
+def _multi_batch_ipc(num_batches: int, rows_per_batch: int) -> bytes:
+    """An IPC stream with several record batches (to exercise incremental reads)."""
+    schema = pa.schema([("a", pa.int64())])
+    sink = io.BytesIO()
+    with pa.ipc.new_stream(sink, schema) as writer:
+        for b in range(num_batches):
+            start = b * rows_per_batch
+            writer.write_batch(
+                pa.record_batch({"a": list(range(start, start + rows_per_batch))}, schema=schema)
+            )
+    return sink.getvalue()
+
+
+@respx.mock
+def test_query_decodes_ipc_stream():
+    table = pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    respx.post(f"{BASE}/api/query").mock(
+        return_value=httpx.Response(
+            200, content=_ipc_stream(table), headers={QUERY_ID_HEADER: "q-123"}
+        )
+    )
+    with _client() as client:
+        result = client.query("SELECT * FROM default")
+    assert result.num_rows == 3
+    assert result.query_id == "q-123"
+    assert result.table.column_names == ["a", "b"]
+
+
+@respx.mock
+def test_query_row_limit_stops_early_and_flags_truncated():
+    # 3 batches x 2 rows = 6 rows total; a budget of 1 reads only the first batch.
+    respx.post(f"{BASE}/api/query").mock(
+        return_value=httpx.Response(200, content=_multi_batch_ipc(3, 2))
+    )
+    with _client() as client:
+        result = client.query("SELECT * FROM default", row_limit=1)
+    assert result.truncated is True
+    assert result.num_rows == 2  # only the first batch was decoded
+
+
+@respx.mock
+def test_query_no_limit_reads_all():
+    respx.post(f"{BASE}/api/query").mock(
+        return_value=httpx.Response(200, content=_multi_batch_ipc(3, 2))
+    )
+    with _client() as client:
+        result = client.query("SELECT * FROM default", row_limit=None)
+    assert result.truncated is False
+    assert result.num_rows == 6
+
+
+@respx.mock
+def test_query_limit_at_or_above_total_not_truncated():
+    respx.post(f"{BASE}/api/query").mock(
+        return_value=httpx.Response(200, content=_multi_batch_ipc(3, 2))
+    )
+    with _client() as client:
+        result = client.query("SELECT * FROM default", row_limit=10)
+    assert result.truncated is False
+    assert result.num_rows == 6
+
+
+@respx.mock
+def test_query_empty_body_is_empty_table():
+    # DDL/DML returns an empty stream; should become a 0-row, 0-col table.
+    respx.post(f"{BASE}/api/query").mock(return_value=httpx.Response(200, content=b""))
+    with _client() as client:
+        result = client.query("CREATE EXTERNAL TABLE t ...")
+    assert result.num_rows == 0
+    assert result.table.num_columns == 0
+
+
+@respx.mock
+def test_query_error_surfaces_server_message():
+    respx.post(f"{BASE}/api/query").mock(
+        return_value=httpx.Response(400, text='"unknown column foo"')
+    )
+    with _client() as client:
+        with pytest.raises(QueryError) as exc:
+            client.query("SELECT foo")
+    assert exc.value.status_code == 400
+    assert "unknown column foo" in str(exc.value)
+
+
+@respx.mock
+def test_query_to_file_streams_bytes(tmp_path):
+    respx.post(f"{BASE}/api/query").mock(
+        return_value=httpx.Response(200, content=b"a,b\n1,2\n")
+    )
+    out = tmp_path / "out.csv"
+    with _client() as client:
+        written = client.query_to_file("SELECT * FROM default", "csv", str(out))
+    assert written == len(b"a,b\n1,2\n")
+    assert out.read_bytes() == b"a,b\n1,2\n"
+
+
+@respx.mock
+def test_build_body_passthrough_and_output():
+    captured = {}
+
+    def _capture(request):
+        import json
+
+        captured.update(json.loads(request.content))
+        table = pa.table({"a": [1]})
+        return httpx.Response(200, content=_ipc_stream(table))
+
+    respx.post(f"{BASE}/api/query").mock(side_effect=_capture)
+    with _client() as client:
+        client.query({"select": [{"column": "a"}], "from": {"table": "default"}})
+    assert "output" not in captured  # in-terminal query never sets output
+    assert captured["select"] == [{"column": "a"}]
+
+
+@respx.mock
+def test_metadata_get_json():
+    respx.get(f"{BASE}/api/tables").mock(return_value=httpx.Response(200, json=["default", "obs"]))
+    with _client() as client:
+        assert client.tables() == ["default", "obs"]
+
+
+@respx.mock
+def test_tables_with_config_pairs_and_tolerates_404():
+    respx.get(f"{BASE}/api/tables").mock(
+        return_value=httpx.Response(200, json=["wod", "default"])
+    )
+
+    def _config(request):
+        if request.url.params.get("table_name") == "wod":
+            return httpx.Response(200, json={"definition_type": "listing_table", "file_type": "NC"})
+        return httpx.Response(404, text='"Table default not found"')
+
+    respx.get(f"{BASE}/api/table-config").mock(side_effect=_config)
+    with _client() as client:
+        entries = client.tables_with_config()
+    assert entries[0][0] == "wod" and entries[0][1]["file_type"] == "NC"
+    assert entries[1] == ("default", {})  # 404 -> empty config, not an error
+
+
+@respx.mock
+def test_connection_error_is_friendly():
+    respx.post(f"{BASE}/api/query").mock(side_effect=httpx.ConnectError("refused"))
+    with _client() as client:
+        with pytest.raises(ConnectionFailedError) as exc:
+            client.query("SELECT 1")
+    assert BASE in str(exc.value)

--- a/clients/beacon-cli/tests/test_client.py
+++ b/clients/beacon-cli/tests/test_client.py
@@ -11,7 +11,7 @@ import respx
 
 from beacon_cli.client import QUERY_ID_HEADER, BeaconClient
 from beacon_cli.config import ClientConfig
-from beacon_cli.errors import ConnectionFailedError, QueryError
+from beacon_cli.errors import ConnectionFailedError, QueryError, StreamInterruptedError
 
 BASE = "http://beacon.test"
 
@@ -173,3 +173,15 @@ def test_connection_error_is_friendly():
         with pytest.raises(ConnectionFailedError) as exc:
             client.query("SELECT 1")
     assert BASE in str(exc.value)
+
+
+@respx.mock
+def test_midstream_close_is_friendly():
+    # Server aborts the response mid-stream (e.g. EXPLAIN ANALYZE execution error).
+    respx.post(f"{BASE}/api/query").mock(
+        side_effect=httpx.RemoteProtocolError("peer closed connection")
+    )
+    with _client() as client:
+        with pytest.raises(StreamInterruptedError) as exc:
+            client.query("EXPLAIN ANALYZE SELECT * FROM wod")
+    assert "closed the connection" in str(exc.value)

--- a/clients/beacon-cli/tests/test_config.py
+++ b/clients/beacon-cli/tests/test_config.py
@@ -1,0 +1,38 @@
+"""Tests for connection config resolution and auth handling."""
+
+from __future__ import annotations
+
+from beacon_cli.config import DEFAULT_URL, ClientConfig
+
+
+def test_defaults_when_nothing_set(monkeypatch):
+    for var in ("BEACON_URL", "BEACON_ADMIN_USERNAME", "BEACON_ADMIN_PASSWORD"):
+        monkeypatch.delenv(var, raising=False)
+    cfg = ClientConfig.resolve()
+    assert cfg.url == DEFAULT_URL
+    assert cfg.auth is None  # anonymous / read-only by default
+
+
+def test_trailing_slash_stripped():
+    assert ClientConfig(url="http://h:5001/").url == "http://h:5001"
+
+
+def test_explicit_overrides_env(monkeypatch):
+    monkeypatch.setenv("BEACON_URL", "http://from-env:1")
+    cfg = ClientConfig.resolve(url="http://explicit:2")
+    assert cfg.url == "http://explicit:2"
+
+
+def test_env_fallback(monkeypatch):
+    monkeypatch.setenv("BEACON_URL", "http://from-env:1")
+    monkeypatch.setenv("BEACON_ADMIN_USERNAME", "admin")
+    monkeypatch.setenv("BEACON_ADMIN_PASSWORD", "secret")
+    cfg = ClientConfig.resolve()
+    assert cfg.url == "http://from-env:1"
+    assert cfg.auth == ("admin", "secret")
+
+
+def test_auth_requires_both_parts():
+    assert ClientConfig(username="admin").auth is None
+    assert ClientConfig(password="secret").auth is None
+    assert ClientConfig(username="admin", password="secret").auth == ("admin", "secret")

--- a/clients/beacon-cli/tests/test_formats.py
+++ b/clients/beacon-cli/tests/test_formats.py
@@ -1,0 +1,49 @@
+"""Tests for output-format inference and spec building."""
+
+from __future__ import annotations
+
+import pytest
+
+from beacon_cli.formats import (
+    ExportFormatError,
+    build_output_format,
+    infer_format_name,
+)
+
+
+def test_infer_format_from_extension():
+    assert infer_format_name("o.csv", None) == "csv"
+    assert infer_format_name("o.parquet", None) == "parquet"
+    assert infer_format_name("o.arrow", None) == "ipc"
+    assert infer_format_name("o.nc", None) == "netcdf"
+    assert infer_format_name("o.geoparquet", None) == "geoparquet"
+
+
+def test_infer_format_override_and_alias():
+    assert infer_format_name("o.bin", "arrow") == "ipc"
+    assert infer_format_name("o.bin", "nc") == "netcdf"
+
+
+def test_infer_format_unknown_raises():
+    with pytest.raises(ExportFormatError):
+        infer_format_name("o.unknownext", None)
+
+
+def test_build_output_format_simple():
+    assert build_output_format("csv") == "csv"
+    assert build_output_format("parquet") == "parquet"
+    assert build_output_format("arrow") == "ipc"
+
+
+def test_build_output_format_structured():
+    assert build_output_format("geoparquet", lon="lon", lat="lat") == {
+        "geoparquet": {"longitude_column": "lon", "latitude_column": "lat"}
+    }
+    assert build_output_format("nd_netcdf", dimension_columns=["t", "x"]) == {
+        "nd_netcdf": {"dimension_columns": ["t", "x"]}
+    }
+
+
+def test_nd_netcdf_requires_dimensions():
+    with pytest.raises(ExportFormatError):
+        build_output_format("nd_netcdf")

--- a/clients/beacon-cli/tests/test_render.py
+++ b/clients/beacon-cli/tests/test_render.py
@@ -1,0 +1,60 @@
+"""Tests for result rendering helpers."""
+
+from __future__ import annotations
+
+import pyarrow as pa
+from rich.console import Console
+
+from beacon_cli.render import (
+    table_to_json,
+    table_to_records,
+    table_to_rich,
+    truncation_note,
+)
+
+
+def test_table_to_rich_columns_match():
+    table = pa.table({"a": [1, 2], "b": ["x", "y"]})
+    rt = table_to_rich(table, max_rows=10)
+    assert rt.row_count == 2
+    assert len(rt.columns) == 2
+
+
+def test_table_to_rich_respects_max_rows():
+    table = pa.table({"a": list(range(10))})
+    rt = table_to_rich(table, max_rows=3)
+    assert rt.row_count == 3
+    assert truncation_note(10, 3) is not None
+    assert truncation_note(3, 10) is None
+
+
+def test_table_to_json_roundtrip():
+    table = pa.table({"a": [1], "b": ["x"]})
+    out = table_to_json(table)
+    assert '"a": 1' in out and '"b": "x"' in out
+
+
+def test_table_to_records_expanded_layout():
+    # Each row becomes a field/value block; every column name appears once per row.
+    table = pa.table({"alpha": [1, 2], "beta": ["x", "y"]})
+    out = _render_to_text(table_to_records(table, max_rows=10))
+    assert out.count("alpha") == 2  # one per record
+    assert out.count("beta") == 2
+    assert "record 1" in out and "record 2" in out
+
+
+def _render_to_text(renderable) -> str:
+    console = Console(width=120, no_color=True, record=True)
+    console.print(renderable)
+    return console.export_text()
+
+
+def test_renders_nanosecond_timestamps_out_of_datetime_range():
+    # Nanosecond timestamps that overflow Python datetime must not crash; they are
+    # stringified for display instead.
+    ts = pa.array([2**62, 2**62 + 1], type=pa.timestamp("ns"))
+    table = pa.table({"t": ts, "v": [1, 2]})
+    rt = table_to_rich(table, max_rows=10)  # must not raise
+    assert rt.row_count == 2
+    out = table_to_json(table)  # must not raise
+    assert '"v": 1' in out

--- a/clients/beacon-cli/tests/test_render_metadata.py
+++ b/clients/beacon-cli/tests/test_render_metadata.py
@@ -1,0 +1,33 @@
+"""Tests for catalog metadata rendering."""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+from beacon_cli.render.metadata import friendly_kind, tables_detail_to_rich
+
+
+def _text(renderable) -> str:
+    console = Console(width=200, no_color=True, record=True)
+    console.print(renderable)
+    return console.export_text()
+
+
+def test_tables_detail_renders_kind_format_location():
+    entries = [
+        ("wod", {"definition_type": "listing_table", "file_type": "NC", "location": "wod.nc"}),
+        ("default", {}),  # no config -> blank metadata
+    ]
+    out = _text(tables_detail_to_rich(entries))
+    # raw "listing_table" is mapped to a friendly label
+    assert "external (files)" in out and "listing_table" not in out
+    assert "wod" in out and "NC" in out and "wod.nc" in out
+    assert "default" in out  # still listed even with empty config
+
+
+def test_friendly_kind_maps_known_and_passes_through_unknown():
+    assert friendly_kind("listing_table") == "external (files)"
+    assert friendly_kind("remote_table") == "external (remote)"
+    assert friendly_kind("materialized_view") == "materialized view"
+    assert friendly_kind("something_new") == "something_new"  # unknown -> unchanged
+    assert friendly_kind("") == ""


### PR DESCRIPTION
## Summary

Adds **`beacon-cli`** (`clients/beacon-cli/`) — a self-contained Python terminal client for Beacon. It runs SQL against a running `beacon-api` server, explores tables/datasets/schemas, renders results as tables, and exports to CSV / Parquet / Arrow IPC / NetCDF. It talks to the existing `/api/*` HTTP endpoints and decodes the zstd-compressed Arrow IPC result stream with `pyarrow`. No server-side changes.

## Features

- **Subcommands** (Typer): `query`, `export`, `tables`, `schema`, `datasets`, `dataset-schema`, `functions`, `info`, `metrics`; running with no subcommand opens an interactive **REPL** (`prompt_toolkit` + psql-style `\` meta-commands).
- **Incremental fetching**: `query` streams record batches and stops once it has more than the render limit, so previewing a huge table is fast; `--all` (or `--max-rows -1`) fetches the whole result.
- **Wide tables**: `--expand` / REPL `\x` renders rows vertically (field/value), so column count stops competing for width.
- **Catalog metadata**: `tables --detail` / `\dt+` shows each table's kind (friendly-labelled), format, location and partitions from `/api/table-config`.
- **Raw SQL passthrough**: supports DDL/DML and Beacon statements (`SHOW CRAWLERS`, `CREATE CRAWLER`, `REFRESH`, ...), with HTTP basic-auth for admin operations.
- **Exports**: server-materialized CSV/Parquet/Arrow/NetCDF/GeoParquet/ODV, streamed to disk; format inferred from extension or `--format`.

## Install

```bash
pip install -e clients/beacon-cli
beacon-cli --help
```
