### PR TITLE
Fix EXPLAIN ANALYZE panic over external NetCDF/nd-array tables

### DIFF
--- a/beacon-core/tests/explain_analyze_external_netcdf.rs
+++ b/beacon-core/tests/explain_analyze_external_netcdf.rs
@@ -1,0 +1,85 @@
+//! Regression test: `EXPLAIN ANALYZE` over an external NetCDF table.
+//!
+//! `EXPLAIN ANALYZE` runs the full plan and then formats it with per-node
+//! metrics, aggregating them by name across partitions. The NetCDF reader used
+//! to register its batch counter as a generic `counter("output_batches", ..)`,
+//! which collides with the typed `MetricValue::OutputBatches` that DataFusion's
+//! `FileStream` already records under that reserved name. Aggregating the two
+//! different variants panicked, aborting the query mid-stream (over HTTP the
+//! response body was dropped). This drives the same path through the runtime to
+//! ensure it now completes and returns the annotated plan.
+
+use std::sync::Arc;
+
+use beacon_core::runtime::Runtime;
+use datafusion::arrow::array::{Array, StringArray};
+use datafusion::arrow::record_batch::RecordBatch;
+use futures::TryStreamExt;
+
+async fn collect(runtime: &Runtime, sql: &str) -> anyhow::Result<Vec<RecordBatch>> {
+    Ok(runtime
+        .run_query(beacon_core::query::Query::sql(sql.to_string()), true)
+        .await?
+        .into_record_stream()?
+        .try_collect::<Vec<_>>()
+        .await?)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn explain_analyze_over_external_netcdf_returns_metrics() {
+    let runtime = Runtime::new(Arc::new(beacon_config::Config::load().unwrap()))
+        .await
+        .expect("runtime should boot");
+
+    // Copy the WOD CTD fixture into the datasets dir so it can back an external
+    // table addressed by a datasets-relative location.
+    let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("beacon-file-formats/beacon-arrow-netcdf/test_files/wod_ctd_1964.nc");
+    let rel = format!("explain_analyze_external_{}.nc", std::process::id());
+    let dst = beacon_config::DATASETS_DIR_PATH.join(&rel);
+    std::fs::copy(&src, &dst).expect("copy NetCDF fixture into datasets dir");
+
+    let table = format!("wod_explain_{}", std::process::id());
+    let _ = collect(&runtime, &format!("DROP TABLE IF EXISTS {table}")).await;
+    collect(
+        &runtime,
+        &format!("CREATE EXTERNAL TABLE {table} STORED AS NC LOCATION '{rel}'"),
+    )
+    .await
+    .expect("create external NetCDF table");
+
+    // Sanity: a plain scan works (this never panicked — only the analyze path did).
+    collect(&runtime, &format!("SELECT * FROM {table} LIMIT 3"))
+        .await
+        .expect("plain SELECT over the external table should work");
+
+    // The regression: this used to panic in metric aggregation and abort.
+    let batches = collect(
+        &runtime,
+        &format!("EXPLAIN ANALYZE SELECT * FROM {table} LIMIT 10"),
+    )
+    .await
+    .expect("EXPLAIN ANALYZE over the external table should complete");
+
+    // It should yield the annotated plan ("plan_type", "plan"): one row whose
+    // plan text carries the collected metrics.
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 1, "EXPLAIN ANALYZE should return a single plan row");
+    let plan_text = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("plan column should be Utf8")
+        .value(0)
+        .to_string();
+    assert!(
+        plan_text.contains("metrics=") && plan_text.contains("output_batches"),
+        "annotated plan should include collected metrics, got:\n{plan_text}"
+    );
+
+    // Best-effort cleanup so the shared on-disk tables store does not leak.
+    let _ = collect(&runtime, &format!("DROP TABLE {table}")).await;
+    let _ = std::fs::remove_file(&dst);
+}

--- a/beacon-core/tests/explain_analyze_external_netcdf.rs
+++ b/beacon-core/tests/explain_analyze_external_netcdf.rs
@@ -27,9 +27,13 @@ async fn collect(runtime: &Runtime, sql: &str) -> anyhow::Result<Vec<RecordBatch
 
 #[tokio::test(flavor = "multi_thread")]
 async fn explain_analyze_over_external_netcdf_returns_metrics() {
-    let runtime = Runtime::new(Arc::new(beacon_config::Config::load().unwrap()))
-        .await
-        .expect("runtime should boot");
+    let config = Arc::new(beacon_config::Config::load().unwrap());
+    // Resolve the datasets dir from the same config the runtime uses: a
+    // datasets-relative `LOCATION` is resolved against `storage.datasets_dir`,
+    // which can differ from the global `DATASETS_DIR_PATH` (e.g. when
+    // `BEACON_DATA_DIR` is set), so the fixture must land where the runtime looks.
+    let datasets_dir = config.storage.datasets_dir.clone();
+    let runtime = Runtime::new(config).await.expect("runtime should boot");
 
     // Copy the WOD CTD fixture into the datasets dir so it can back an external
     // table addressed by a datasets-relative location.
@@ -38,7 +42,7 @@ async fn explain_analyze_over_external_netcdf_returns_metrics() {
         .unwrap()
         .join("beacon-file-formats/beacon-arrow-netcdf/test_files/wod_ctd_1964.nc");
     let rel = format!("explain_analyze_external_{}.nc", std::process::id());
-    let dst = beacon_config::DATASETS_DIR_PATH.join(&rel);
+    let dst = datasets_dir.join(&rel);
     std::fs::copy(&src, &dst).expect("copy NetCDF fixture into datasets dir");
 
     let table = format!("wod_explain_{}", std::process::id());

--- a/beacon-file-formats/beacon-nd-array/src/arrow/metrics.rs
+++ b/beacon-file-formats/beacon-nd-array/src/arrow/metrics.rs
@@ -21,7 +21,14 @@ impl DatasetReadMetrics {
     pub fn new(metrics: &ExecutionPlanMetricsSet, partition: usize) -> Self {
         Self {
             output_rows: MetricBuilder::new(metrics).output_rows(partition),
-            output_batches: MetricBuilder::new(metrics).counter("output_batches", partition),
+            // Use the dedicated typed builder (matching `output_rows` above) rather
+            // than a generic `counter("output_batches", ..)`. `output_batches` is a
+            // reserved DataFusion metric name: `FileStream`'s `BaselineMetrics`
+            // already registers a typed `MetricValue::OutputBatches` under it. A
+            // generic `Count` under the same name produces two metrics that share a
+            // name but differ in variant, which panics when DataFusion aggregates
+            // metrics by name for display (e.g. `EXPLAIN ANALYZE`).
+            output_batches: MetricBuilder::new(metrics).output_batches(partition),
             rows_pruned: MetricBuilder::new(metrics).counter("rows_pruned", partition),
             batches_pruned: MetricBuilder::new(metrics).counter("batches_pruned", partition),
         }


### PR DESCRIPTION
## Summary

`EXPLAIN ANALYZE` over an external NetCDF (or any nd-array-backed) table aborted the query mid-stream — over the HTTP client API the response body was dropped, so clients saw `peer closed connection without sending complete message body (incomplete chunked read)`. The cause was a **panic**, not a normal error, which is why no error status/body was sent.

### Root cause

The nd-array reader registers per-scan metrics in `beacon-nd-array/src/arrow/metrics.rs`. The batch counter was created with a generic builder:

```rust
output_batches: MetricBuilder::new(metrics).counter("output_batches", partition),
```

`output_batches` is a **reserved DataFusion metric name** — `FileStream`'s `BaselineMetrics` (active for every `FileSource`/`DataSourceExec` scan) already registers a *typed* `MetricValue::OutputBatches` under it. The set then holds two metrics with the same name but different variants. That only collides when metrics are **aggregated by name** for display, which only `AnalyzeExec` (i.e. `EXPLAIN ANALYZE`) does. `MetricValue::aggregate` then panics:

```
Mismatched metric types. Can not aggregate OutputBatches(Count { value: 1 })
with value Count { name: "output_batches", count: Count { value: 1 } }
```

Plain `SELECT` never aggregates metrics, so only `EXPLAIN ANALYZE` over an nd-array scan hit it (`EXPLAIN ANALYZE SELECT 1` and plain scans were fine).

### Fix

Use the dedicated typed builder, matching the adjacent `output_rows` line that was already correct:

```rust
output_batches: MetricBuilder::new(metrics).output_batches(partition),
```

Now beacon's metric is the same `OutputBatches` variant DataFusion expects, so aggregation merges cleanly. `EXPLAIN ANALYZE` returns the annotated plan instead of dropping the connection.

## Testing

- New regression test `beacon-core/tests/explain_analyze_external_netcdf.rs` drives `EXPLAIN ANALYZE` over an external NetCDF table through the runtime and asserts it returns the plan-with-metrics row. Fails (panics) before the fix, passes after.
- `beacon-nd-array`, `beacon-arrow-netcdf` (121 tests), and `beacon-arrow-zarr` build/pass.

## Notes

- The streaming handler in `beacon-api/src/axum/client/query.rs` still cannot surface a *genuine* mid-stream error once the `200` + Arrow-IPC headers are sent (the IPC stream format has no error frame). Fixing the panic resolves the reported case; the general "errors after streaming begins" limitation is left for a follow-up.
- The regression test requires the `beacon-file-formats/beacon-binary-format` submodule to be checked out (`git submodule update --init --recursive`).
