### PR TITLE
Add admin REST endpoints for crawlers and external tables

### DIFF
--- a/beacon-api/src/axum/admin/check.rs
+++ b/beacon-api/src/axum/admin/check.rs
@@ -9,11 +9,8 @@ use ::axum::Json;
     get,
     path = "/api/admin/check",
     responses((status = 200, description = "Admin API is reachable")),
-    security(
-        ("basic-auth" = []),
-        ("bearer" = [])
-    ))
-]
+    security(("basic-auth" = []))
+)]
 pub async fn check() -> Json<CheckResponse> {
     let check = CheckResponse { is_admin: true };
     Json(check)

--- a/beacon-api/src/axum/admin/crawlers.rs
+++ b/beacon-api/src/axum/admin/crawlers.rs
@@ -23,10 +23,7 @@ use super::bad_request;
         (status = 200, description = "Crawler created"),
         (status = 400, description = "Invalid crawler definition")
     ),
-    security(
-        ("basic-auth" = []),
-        ("bearer" = [])
-    )
+    security(("basic-auth" = []))
 )]
 pub(crate) async fn create_crawler(
     State(state): State<Arc<Runtime>>,
@@ -42,10 +39,7 @@ pub(crate) async fn create_crawler(
     get,
     path = "/api/admin/crawlers",
     responses((status = 200, description = "List of crawlers", body = [CrawlerView])),
-    security(
-        ("basic-auth" = []),
-        ("bearer" = [])
-    )
+    security(("basic-auth" = []))
 )]
 pub(crate) async fn list_crawlers(State(state): State<Arc<Runtime>>) -> Json<Vec<CrawlerView>> {
     Json(state.list_crawlers())
@@ -62,10 +56,7 @@ pub(crate) async fn list_crawlers(State(state): State<Arc<Runtime>>) -> Json<Vec
         (status = 200, description = "Crawler definition", body = CrawlerView),
         (status = 404, description = "Crawler not found")
     ),
-    security(
-        ("basic-auth" = []),
-        ("bearer" = [])
-    )
+    security(("basic-auth" = []))
 )]
 pub(crate) async fn get_crawler(
     State(state): State<Arc<Runtime>>,
@@ -88,10 +79,7 @@ pub(crate) async fn get_crawler(
         (status = 200, description = "Crawl report", body = CrawlReportView),
         (status = 400, description = "Crawler does not exist or failed to run")
     ),
-    security(
-        ("basic-auth" = []),
-        ("bearer" = [])
-    )
+    security(("basic-auth" = []))
 )]
 pub(crate) async fn run_crawler(
     State(state): State<Arc<Runtime>>,
@@ -115,10 +103,7 @@ pub(crate) async fn run_crawler(
         (status = 200, description = "Crawler dropped"),
         (status = 400, description = "Crawler does not exist")
     ),
-    security(
-        ("basic-auth" = []),
-        ("bearer" = [])
-    )
+    security(("basic-auth" = []))
 )]
 pub(crate) async fn drop_crawler(
     State(state): State<Arc<Runtime>>,

--- a/beacon-api/src/axum/admin/crawlers.rs
+++ b/beacon-api/src/axum/admin/crawlers.rs
@@ -1,0 +1,128 @@
+//! Admin endpoints for managing crawlers (create, list, get, run, drop).
+
+use std::sync::Arc;
+
+use ::axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use beacon_core::api::{CrawlReportView, CrawlerView, CreateCrawlerRequest};
+use beacon_core::runtime::Runtime;
+
+use super::bad_request;
+
+/// Defines (or replaces) a crawler and starts its triggers.
+#[tracing::instrument(level = "info", skip(state))]
+#[utoipa::path(
+    tag = "admin",
+    post,
+    path = "/api/admin/crawlers",
+    request_body = CreateCrawlerRequest,
+    responses(
+        (status = 200, description = "Crawler created"),
+        (status = 400, description = "Invalid crawler definition")
+    ),
+    security(
+        ("basic-auth" = []),
+        ("bearer" = [])
+    )
+)]
+pub(crate) async fn create_crawler(
+    State(state): State<Arc<Runtime>>,
+    Json(req): Json<CreateCrawlerRequest>,
+) -> Result<(), (StatusCode, String)> {
+    state.create_crawler(req).await.map_err(bad_request)
+}
+
+/// Lists all defined crawlers.
+#[tracing::instrument(level = "info", skip(state))]
+#[utoipa::path(
+    tag = "admin",
+    get,
+    path = "/api/admin/crawlers",
+    responses((status = 200, description = "List of crawlers", body = [CrawlerView])),
+    security(
+        ("basic-auth" = []),
+        ("bearer" = [])
+    )
+)]
+pub(crate) async fn list_crawlers(State(state): State<Arc<Runtime>>) -> Json<Vec<CrawlerView>> {
+    Json(state.list_crawlers())
+}
+
+/// Returns a single crawler by name, or 404 if it is not defined.
+#[tracing::instrument(level = "info", skip(state))]
+#[utoipa::path(
+    tag = "admin",
+    get,
+    path = "/api/admin/crawlers/{name}",
+    params(("name" = String, Path, description = "Crawler name")),
+    responses(
+        (status = 200, description = "Crawler definition", body = CrawlerView),
+        (status = 404, description = "Crawler not found")
+    ),
+    security(
+        ("basic-auth" = []),
+        ("bearer" = [])
+    )
+)]
+pub(crate) async fn get_crawler(
+    State(state): State<Arc<Runtime>>,
+    Path(name): Path<String>,
+) -> Result<Json<CrawlerView>, (StatusCode, String)> {
+    match state.get_crawler(&name) {
+        Some(crawler) => Ok(Json(crawler)),
+        None => Err((StatusCode::NOT_FOUND, format!("crawler '{name}' not found"))),
+    }
+}
+
+/// Runs a crawler once on demand and returns its report.
+#[tracing::instrument(level = "info", skip(state))]
+#[utoipa::path(
+    tag = "admin",
+    post,
+    path = "/api/admin/crawlers/{name}/run",
+    params(("name" = String, Path, description = "Crawler name")),
+    responses(
+        (status = 200, description = "Crawl report", body = CrawlReportView),
+        (status = 400, description = "Crawler does not exist or failed to run")
+    ),
+    security(
+        ("basic-auth" = []),
+        ("bearer" = [])
+    )
+)]
+pub(crate) async fn run_crawler(
+    State(state): State<Arc<Runtime>>,
+    Path(name): Path<String>,
+) -> Result<Json<CrawlReportView>, (StatusCode, String)> {
+    state
+        .run_crawler(&name)
+        .await
+        .map(Json)
+        .map_err(bad_request)
+}
+
+/// Removes a crawler definition and stops its triggers. Crawled tables are left in place.
+#[tracing::instrument(level = "info", skip(state))]
+#[utoipa::path(
+    tag = "admin",
+    delete,
+    path = "/api/admin/crawlers/{name}",
+    params(("name" = String, Path, description = "Crawler name")),
+    responses(
+        (status = 200, description = "Crawler dropped"),
+        (status = 400, description = "Crawler does not exist")
+    ),
+    security(
+        ("basic-auth" = []),
+        ("bearer" = [])
+    )
+)]
+pub(crate) async fn drop_crawler(
+    State(state): State<Arc<Runtime>>,
+    Path(name): Path<String>,
+) -> Result<(), (StatusCode, String)> {
+    state.drop_crawler(&name).await.map_err(bad_request)
+}

--- a/beacon-api/src/axum/admin/external_tables.rs
+++ b/beacon-api/src/axum/admin/external_tables.rs
@@ -21,10 +21,7 @@ use super::bad_request;
         (status = 200, description = "External table created"),
         (status = 400, description = "Invalid request or registration failed")
     ),
-    security(
-        ("basic-auth" = []),
-        ("bearer" = [])
-    )
+    security(("basic-auth" = []))
 )]
 pub(crate) async fn create_external_table(
     State(state): State<Arc<Runtime>>,

--- a/beacon-api/src/axum/admin/external_tables.rs
+++ b/beacon-api/src/axum/admin/external_tables.rs
@@ -1,0 +1,34 @@
+//! Admin endpoint for creating external tables from structured fields.
+
+use std::sync::Arc;
+
+use ::axum::{extract::State, http::StatusCode, Json};
+use beacon_core::api::CreateExternalTableRequest;
+use beacon_core::runtime::Runtime;
+
+use super::bad_request;
+
+/// Creates an external table over files in the datasets store. The runtime
+/// assembles and runs the equivalent `CREATE EXTERNAL TABLE` statement, so all
+/// `STORED AS` variants and catalog persistence behave exactly as the SQL form.
+#[tracing::instrument(level = "info", skip(state))]
+#[utoipa::path(
+    tag = "admin",
+    post,
+    path = "/api/admin/external-tables",
+    request_body = CreateExternalTableRequest,
+    responses(
+        (status = 200, description = "External table created"),
+        (status = 400, description = "Invalid request or registration failed")
+    ),
+    security(
+        ("basic-auth" = []),
+        ("bearer" = [])
+    )
+)]
+pub(crate) async fn create_external_table(
+    State(state): State<Arc<Runtime>>,
+    Json(req): Json<CreateExternalTableRequest>,
+) -> Result<(), (StatusCode, String)> {
+    state.create_external_table(req).await.map_err(bad_request)
+}

--- a/beacon-api/src/axum/admin/mod.rs
+++ b/beacon-api/src/axum/admin/mod.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use ::axum::Router;
+use ::axum::{http::StatusCode, Router};
 use beacon_core::runtime::Runtime;
 use utoipa::{
     openapi::security::{Http, HttpAuthScheme, SecurityScheme},
@@ -13,6 +13,8 @@ use utoipa_axum::{router::OpenApiRouter, routes};
 use crate::axum::auth::basic_auth;
 
 mod check;
+mod crawlers;
+mod external_tables;
 
 /// OpenAPI document marker for the admin surface.
 #[derive(OpenApi)]
@@ -23,10 +25,24 @@ pub struct AdminApiDoc;
 pub(crate) fn setup_admin_router() -> (Router<Arc<Runtime>>, utoipa::openapi::OpenApi) {
     let (admin_router, admin_api) = OpenApiRouter::with_openapi(AdminApiDoc::openapi())
         .routes(routes!(check::check))
+        .routes(routes!(crawlers::create_crawler, crawlers::list_crawlers))
+        .routes(routes!(
+            crawlers::get_crawler,
+            crawlers::drop_crawler
+        ))
+        .routes(routes!(crawlers::run_crawler))
+        .routes(routes!(external_tables::create_external_table))
         .layer(::axum::middleware::from_fn(basic_auth))
         .split_for_parts();
 
     (admin_router, admin_api)
+}
+
+/// Map a runtime error to a `400 Bad Request` carrying the error text, the shared
+/// failure shape for the admin write endpoints.
+pub(super) fn bad_request(error: anyhow::Error) -> (StatusCode, String) {
+    tracing::error!(?error, "admin request failed");
+    (StatusCode::BAD_REQUEST, error.to_string())
 }
 
 /// Injects the auth schemes used by admin endpoints into the OpenAPI document.

--- a/beacon-api/src/axum/admin/mod.rs
+++ b/beacon-api/src/axum/admin/mod.rs
@@ -45,7 +45,10 @@ pub(super) fn bad_request(error: anyhow::Error) -> (StatusCode, String) {
     (StatusCode::BAD_REQUEST, error.to_string())
 }
 
-/// Injects the auth schemes used by admin endpoints into the OpenAPI document.
+/// Injects the auth scheme used by admin endpoints into the OpenAPI document.
+///
+/// The admin surface is gated solely by the `basic_auth` middleware, which only
+/// accepts HTTP Basic credentials — so only the `basic-auth` scheme is advertised.
 struct SecurityAddon;
 
 impl Modify for SecurityAddon {
@@ -53,11 +56,7 @@ impl Modify for SecurityAddon {
         if let Some(components) = openapi.components.as_mut() {
             components.add_security_scheme(
                 "basic-auth",
-                SecurityScheme::Http(Http::new(utoipa::openapi::security::HttpAuthScheme::Basic)),
-            );
-            components.add_security_scheme(
-                "bearer",
-                SecurityScheme::Http(Http::new(HttpAuthScheme::Bearer)),
+                SecurityScheme::Http(Http::new(HttpAuthScheme::Basic)),
             );
         }
     }

--- a/beacon-core/src/api.rs
+++ b/beacon-core/src/api.rs
@@ -1,14 +1,15 @@
 //! Beacon-core-owned contracts for outer layers such as beacon-api.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use arrow::datatypes::{Field, Schema};
+use beacon_data_lake::crawler::{CrawlReport, CrawlerDefinition, TableNaming};
 use beacon_datafusion_ext::format_ext::DatasetMetadata;
 use beacon_datafusion_ext::table_ext::TableDefinition;
 use beacon_functions::function_doc::FunctionDoc;
 use crate::metrics::ConsolidatedMetrics;
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 use utoipa::ToSchema;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
@@ -169,4 +170,196 @@ impl TryFrom<Arc<dyn TableDefinition>> for TableConfigView {
             )),
         }
     }
+}
+
+/// How a crawler turns a discovered group of files into a table name. Mirrors the
+/// data-lake [`TableNaming`] so the API surface need not depend on its internals.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TableNamingView {
+    /// Use the leaf component of the group's base prefix (`argo/floats` -> `floats`).
+    #[default]
+    LeafPrefix,
+    /// Prefix the leaf with the crawler name (`<crawler>_<leaf>`).
+    CrawlerPrefixed,
+}
+
+impl From<TableNaming> for TableNamingView {
+    fn from(value: TableNaming) -> Self {
+        match value {
+            TableNaming::LeafPrefix => Self::LeafPrefix,
+            TableNaming::CrawlerPrefixed => Self::CrawlerPrefixed,
+        }
+    }
+}
+
+impl From<TableNamingView> for TableNaming {
+    fn from(value: TableNamingView) -> Self {
+        match value {
+            TableNamingView::LeafPrefix => Self::LeafPrefix,
+            TableNamingView::CrawlerPrefixed => Self::CrawlerPrefixed,
+        }
+    }
+}
+
+/// Request body to define (or replace) a crawler. Mirrors the SQL `CREATE CRAWLER`
+/// surface as structured JSON; maps into a data-lake [`CrawlerDefinition`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+#[schema(example = json!({
+    "name": "argo",
+    "target_prefix": "argo/",
+    "format_filter": ["parquet", "nc"],
+    "table_naming": "crawler_prefixed",
+    "detect_partitions": true,
+    "schedule_secs": 900,
+    "event_driven": false,
+    "options": { "read_dimensions": "lat,lon" }
+}))]
+pub struct CreateCrawlerRequest {
+    /// Unique crawler name.
+    #[schema(example = "argo")]
+    pub name: String,
+    /// Datasets-store prefix to scan, e.g. `argo/`.
+    #[schema(example = "argo/")]
+    pub target_prefix: String,
+    /// Restrict discovery to these format identifiers (e.g. `["parquet", "nc"]`).
+    /// Omit (or `null`) to crawl every registered format.
+    #[serde(default)]
+    #[schema(example = json!(["parquet", "nc"]))]
+    pub format_filter: Option<Vec<String>>,
+    /// How discovered groups are named.
+    #[serde(default)]
+    pub table_naming: TableNamingView,
+    /// Detect Hive-style `key=value/` partitions (default `true`).
+    #[serde(default = "default_true")]
+    #[schema(default = true, example = true)]
+    pub detect_partitions: bool,
+    /// Periodic crawl interval, in seconds. Omit for no timer.
+    #[serde(default)]
+    #[schema(example = 900)]
+    pub schedule_secs: Option<u64>,
+    /// Subscribe to datasets-store events under `target_prefix` for incremental crawls.
+    #[serde(default)]
+    #[schema(default = false, example = false)]
+    pub event_driven: bool,
+    /// Extra format options forwarded into every discovered table's `OPTIONS`.
+    #[serde(default)]
+    #[schema(example = json!({ "read_dimensions": "lat,lon" }))]
+    pub options: HashMap<String, String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl From<CreateCrawlerRequest> for CrawlerDefinition {
+    fn from(value: CreateCrawlerRequest) -> Self {
+        CrawlerDefinition {
+            name: value.name,
+            target_prefix: value.target_prefix,
+            format_filter: value.format_filter,
+            table_naming: value.table_naming.into(),
+            detect_partitions: value.detect_partitions,
+            schedule_secs: value.schedule_secs,
+            event_driven: value.event_driven,
+            options: value.options,
+        }
+    }
+}
+
+/// A crawler definition as returned to API clients. Mirrors [`CrawlerDefinition`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+pub struct CrawlerView {
+    pub name: String,
+    pub target_prefix: String,
+    pub format_filter: Option<Vec<String>>,
+    pub table_naming: TableNamingView,
+    pub detect_partitions: bool,
+    pub schedule_secs: Option<u64>,
+    pub event_driven: bool,
+    pub options: HashMap<String, String>,
+}
+
+impl From<CrawlerDefinition> for CrawlerView {
+    fn from(value: CrawlerDefinition) -> Self {
+        Self {
+            name: value.name,
+            target_prefix: value.target_prefix,
+            format_filter: value.format_filter,
+            table_naming: value.table_naming.into(),
+            detect_partitions: value.detect_partitions,
+            schedule_secs: value.schedule_secs,
+            event_driven: value.event_driven,
+            options: value.options,
+        }
+    }
+}
+
+/// The outcome of a single crawler run. Mirrors the data-lake [`CrawlReport`].
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, ToSchema)]
+pub struct CrawlReportView {
+    /// Crawler name.
+    pub crawler: String,
+    /// Candidate tables discovered.
+    pub discovered: usize,
+    /// Newly registered tables.
+    pub created: Vec<String>,
+    /// Existing crawler-owned tables that were refreshed.
+    pub updated: Vec<String>,
+    /// Tables left untouched because they are not owned by this crawler.
+    pub skipped: Vec<String>,
+    /// Per-table failures as `[name, error message]` pairs.
+    pub failed: Vec<(String, String)>,
+    /// Files that did not match any crawlable format.
+    pub skipped_files: usize,
+}
+
+impl From<CrawlReport> for CrawlReportView {
+    fn from(value: CrawlReport) -> Self {
+        Self {
+            crawler: value.crawler,
+            discovered: value.discovered,
+            created: value.created,
+            updated: value.updated,
+            skipped: value.skipped,
+            failed: value.failed,
+            skipped_files: value.skipped_files,
+        }
+    }
+}
+
+/// Request body to create an external table from structured fields. The runtime
+/// assembles the equivalent `CREATE EXTERNAL TABLE` statement and runs it through
+/// the same DDL path as SQL.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+#[schema(example = json!({
+    "name": "observations",
+    "location": "obs/",
+    "file_type": "PARQUET",
+    "partition_cols": ["year", "month"],
+    "options": {},
+    "if_not_exists": false
+}))]
+pub struct CreateExternalTableRequest {
+    /// Logical table name.
+    #[schema(example = "observations")]
+    pub name: String,
+    /// Datasets-store-relative location or glob (e.g. `obs/` or `data/**/*.parquet`),
+    /// or a scheme-qualified location for `REMOTE`/`DELTA` types.
+    #[schema(example = "obs/")]
+    pub location: String,
+    /// Storage type, e.g. `PARQUET`, `CSV`, `DELTA`, `REMOTE`.
+    #[schema(example = "PARQUET")]
+    pub file_type: String,
+    /// Hive-style partition columns, in path order.
+    #[serde(default)]
+    #[schema(example = json!(["year", "month"]))]
+    pub partition_cols: Vec<String>,
+    /// Format-specific options forwarded to the table's `OPTIONS`.
+    #[serde(default)]
+    pub options: HashMap<String, String>,
+    /// Skip creation (instead of erroring) when the table already exists.
+    #[serde(default)]
+    #[schema(default = false, example = false)]
+    pub if_not_exists: bool,
 }

--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -28,7 +28,10 @@ use futures::TryStreamExt;
 use parking_lot::Mutex;
 
 use crate::{
-    api::{DatasetInfo, FunctionInfo, QueryMetricsView, QueryRequest, SchemaView, TableConfigView},
+    api::{
+        CrawlReportView, CrawlerView, CreateCrawlerRequest, CreateExternalTableRequest, DatasetInfo,
+        FunctionInfo, QueryMetricsView, QueryRequest, SchemaView, TableConfigView,
+    },
     parser::{beacon_parser::BeaconParser, statement::BeaconStatement},
     query_result::{ArrowOutputStream, QueryOutput, QueryOutputFile, QueryResult},
     sys::{self, SystemInfo},
@@ -597,10 +600,130 @@ impl Runtime {
         Ok(SchemaView::from(schema.as_ref()))
     }
 
+    /// Define (or replace) a crawler. Mirrors `CREATE CRAWLER` but takes a
+    /// structured request; delegates to the crawler manager, which persists the
+    /// definition and (re)starts its scheduled/event triggers.
+    pub async fn create_crawler(&self, req: CreateCrawlerRequest) -> anyhow::Result<()> {
+        self.crawler_manager.create(req.into()).await
+    }
+
+    /// List all defined crawlers. Mirrors `SHOW CRAWLERS`.
+    pub fn list_crawlers(&self) -> Vec<CrawlerView> {
+        self.crawler_manager
+            .list()
+            .into_iter()
+            .map(CrawlerView::from)
+            .collect()
+    }
+
+    /// Return a single crawler definition by name, or `None` if it is not defined.
+    pub fn get_crawler(&self, name: &str) -> Option<CrawlerView> {
+        self.crawler_manager
+            .list()
+            .into_iter()
+            .find(|crawler| crawler.name == name)
+            .map(CrawlerView::from)
+    }
+
+    /// Run a crawler once on demand and return its report. Mirrors `RUN CRAWLER`.
+    pub async fn run_crawler(&self, name: &str) -> anyhow::Result<CrawlReportView> {
+        Ok(self.crawler_manager.run(name).await?.into())
+    }
+
+    /// Remove a crawler definition and stop its triggers (crawled tables are left
+    /// in place). Mirrors `DROP CRAWLER`.
+    pub async fn drop_crawler(&self, name: &str) -> anyhow::Result<()> {
+        self.crawler_manager.drop_crawler(name).await
+    }
+
+    /// Create an external table from structured fields. Assembles the equivalent
+    /// `CREATE EXTERNAL TABLE` statement and runs it through the same super-user DDL
+    /// path as SQL, so all `STORED AS` variants (listing/Delta/Remote) and catalog
+    /// persistence are reused. The statement produces an empty result stream that is
+    /// drained here to drive the registration to completion.
+    pub async fn create_external_table(
+        &self,
+        req: CreateExternalTableRequest,
+    ) -> anyhow::Result<()> {
+        let sql = build_create_external_table_sql(&req)?;
+        self.run_query(crate::query::Query::sql(sql), true)
+            .await?
+            .into_record_stream()?
+            .try_collect::<Vec<_>>()
+            .await?;
+        Ok(())
+    }
+
     fn parse_beacon_statement(sql: &str) -> anyhow::Result<BeaconStatement> {
         let mut parser = BeaconParser::new(sql)?;
         parser.parse_statement().map_err(Into::into)
     }
+}
+
+/// Assemble an injection-safe `CREATE EXTERNAL TABLE` statement from a structured
+/// request. Identifiers (table name, `STORED AS` type, partition columns) are
+/// validated as bare words; `LOCATION` and `OPTIONS` values are emitted as escaped
+/// string literals. Options are rendered in sorted key order so the output is stable.
+fn build_create_external_table_sql(req: &CreateExternalTableRequest) -> anyhow::Result<String> {
+    ensure_bare_ident("table name", &req.name)?;
+    ensure_bare_ident("file_type", &req.file_type)?;
+    for col in &req.partition_cols {
+        ensure_bare_ident("partition column", col)?;
+    }
+
+    let mut sql = String::from("CREATE EXTERNAL TABLE ");
+    if req.if_not_exists {
+        sql.push_str("IF NOT EXISTS ");
+    }
+    sql.push_str(&req.name);
+    sql.push_str(" STORED AS ");
+    sql.push_str(&req.file_type);
+    sql.push_str(" LOCATION ");
+    sql.push_str(&sql_string_literal(&req.location));
+
+    if !req.partition_cols.is_empty() {
+        sql.push_str(" PARTITIONED BY (");
+        sql.push_str(&req.partition_cols.join(", "));
+        sql.push(')');
+    }
+
+    if !req.options.is_empty() {
+        let mut opts: Vec<(&String, &String)> = req.options.iter().collect();
+        opts.sort_by(|a, b| a.0.cmp(b.0));
+        let rendered = opts
+            .iter()
+            .map(|(key, value)| {
+                format!("{} {}", sql_string_literal(key), sql_string_literal(value))
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        sql.push_str(" OPTIONS (");
+        sql.push_str(&rendered);
+        sql.push(')');
+    }
+
+    Ok(sql)
+}
+
+/// Validate that `value` is a safe bare SQL identifier (`[A-Za-z_][A-Za-z0-9_]*`),
+/// so it can be interpolated into generated DDL without quoting or injection risk.
+fn ensure_bare_ident(kind: &str, value: &str) -> anyhow::Result<()> {
+    let mut chars = value.chars();
+    let valid = match chars.next() {
+        Some(first) if first.is_ascii_alphabetic() || first == '_' => {
+            chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+        }
+        _ => false,
+    };
+    if !valid {
+        anyhow::bail!("invalid {kind} '{value}': must match [A-Za-z_][A-Za-z0-9_]*");
+    }
+    Ok(())
+}
+
+/// Render a SQL single-quoted string literal, escaping embedded quotes by doubling.
+fn sql_string_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
 }
 
 #[cfg(test)]
@@ -994,5 +1117,131 @@ mod restart_tests {
         let _ = restarted
             .run_query(crate::query::Query::sql(format!("DROP TABLE {base}")), true)
             .await;
+    }
+}
+
+#[cfg(test)]
+mod external_table_sql_tests {
+    use super::build_create_external_table_sql;
+    use crate::api::CreateExternalTableRequest;
+    use std::collections::HashMap;
+
+    fn req(name: &str, file_type: &str, location: &str) -> CreateExternalTableRequest {
+        CreateExternalTableRequest {
+            name: name.to_string(),
+            location: location.to_string(),
+            file_type: file_type.to_string(),
+            partition_cols: vec![],
+            options: HashMap::new(),
+            if_not_exists: false,
+        }
+    }
+
+    #[test]
+    fn builds_minimal_statement() {
+        let sql = build_create_external_table_sql(&req("obs_ext", "PARQUET", "obs/")).unwrap();
+        assert_eq!(
+            sql,
+            "CREATE EXTERNAL TABLE obs_ext STORED AS PARQUET LOCATION 'obs/'"
+        );
+    }
+
+    #[test]
+    fn builds_with_if_not_exists_partitions_and_sorted_options() {
+        let mut r = req("argo", "NETCDF", "argo/**/*.nc");
+        r.if_not_exists = true;
+        r.partition_cols = vec!["year".to_string(), "month".to_string()];
+        r.options
+            .insert("read_dimensions".to_string(), "lat,lon".to_string());
+        r.options.insert("a_flag".to_string(), "true".to_string());
+
+        let sql = build_create_external_table_sql(&r).unwrap();
+        assert_eq!(
+            sql,
+            "CREATE EXTERNAL TABLE IF NOT EXISTS argo STORED AS NETCDF LOCATION 'argo/**/*.nc' \
+             PARTITIONED BY (year, month) OPTIONS ('a_flag' 'true', 'read_dimensions' 'lat,lon')"
+        );
+    }
+
+    #[test]
+    fn escapes_quotes_in_location_and_option_values() {
+        let mut r = req("t", "CSV", "weird'/path");
+        r.options.insert("delimiter".to_string(), "'".to_string());
+
+        let sql = build_create_external_table_sql(&r).unwrap();
+        assert_eq!(
+            sql,
+            "CREATE EXTERNAL TABLE t STORED AS CSV LOCATION 'weird''/path' OPTIONS ('delimiter' '''')"
+        );
+    }
+
+    #[test]
+    fn rejects_unsafe_identifiers() {
+        assert!(build_create_external_table_sql(&req("bad name", "PARQUET", "x/")).is_err());
+        assert!(
+            build_create_external_table_sql(&req("t; DROP TABLE u", "PARQUET", "x/")).is_err()
+        );
+        assert!(build_create_external_table_sql(&req("t", "PARQUET'", "x/")).is_err());
+
+        let mut r = req("t", "PARQUET", "x/");
+        r.partition_cols = vec!["year)".to_string()];
+        assert!(build_create_external_table_sql(&r).is_err());
+    }
+}
+
+#[cfg(test)]
+mod crawler_admin_tests {
+    use super::Runtime;
+    use crate::api::{CreateCrawlerRequest, TableNamingView};
+    use std::collections::HashMap;
+
+    /// The admin crawler API round-trips through the manager: create -> list/get ->
+    /// run (zero discovery over an empty prefix) -> drop (idempotency error on the
+    /// second drop). Uses a unique name so the shared on-disk store does not leak.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn crawler_create_list_get_run_drop_round_trip() {
+        let runtime = Runtime::new(std::sync::Arc::new(beacon_config::Config::load().unwrap()))
+            .await
+            .expect("runtime should start");
+
+        let name = format!("crawler_test_{}", uuid::Uuid::new_v4().simple());
+
+        runtime
+            .create_crawler(CreateCrawlerRequest {
+                name: name.clone(),
+                target_prefix: format!("{name}/"),
+                format_filter: Some(vec!["parquet".to_string()]),
+                table_naming: TableNamingView::CrawlerPrefixed,
+                detect_partitions: true,
+                schedule_secs: None,
+                event_driven: false,
+                options: HashMap::new(),
+            })
+            .await
+            .expect("create_crawler should succeed");
+
+        // Listed and individually retrievable, with fields preserved.
+        assert!(runtime.list_crawlers().iter().any(|c| c.name == name));
+        let got = runtime
+            .get_crawler(&name)
+            .expect("crawler should be retrievable");
+        assert_eq!(got.target_prefix, format!("{name}/"));
+        assert_eq!(got.table_naming, TableNamingView::CrawlerPrefixed);
+
+        // Runs on demand: an empty prefix yields a zero-discovery report.
+        let report = runtime
+            .run_crawler(&name)
+            .await
+            .expect("run_crawler should succeed");
+        assert_eq!(report.crawler, name);
+        assert_eq!(report.discovered, 0);
+
+        // Dropped: gone from the catalog, and a second drop errors.
+        runtime
+            .drop_crawler(&name)
+            .await
+            .expect("drop_crawler should succeed");
+        assert!(runtime.get_crawler(&name).is_none());
+        assert!(runtime.drop_crawler(&name).await.is_err());
     }
 }

--- a/docs/docs/1.7.3/api/exploring-data-lake.md
+++ b/docs/docs/1.7.3/api/exploring-data-lake.md
@@ -149,17 +149,46 @@ Write operations require the admin credentials (`BEACON_ADMIN_USERNAME` /
 
 ## Admin
 
-Beacon has no separate file-management API — creating, replacing, and removing
-tables is done through authenticated SQL DDL on `/api/query` (see
-[Table lifecycle](#table-lifecycle) above). The only dedicated admin endpoint is a
-connectivity check that verifies your admin credentials:
+All `/api/admin/*` endpoints require the admin credentials
+(`BEACON_ADMIN_USERNAME` / `BEACON_ADMIN_PASSWORD`) via HTTP basic auth;
+unauthenticated requests get `401`.
+
+Creating, replacing, and removing tables can still be done through authenticated
+SQL DDL on `/api/query` (see [Table lifecycle](#table-lifecycle) above). In
+addition, these dedicated, JSON-typed admin endpoints are available:
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| `GET` | `/api/admin/check` | Connectivity check; returns `{ "is_admin": true }` |
+| `POST` | `/api/admin/crawlers` | Define (or replace) a crawler |
+| `GET` | `/api/admin/crawlers` | List defined crawlers |
+| `GET` | `/api/admin/crawlers/{name}` | Get one crawler (or `404`) |
+| `POST` | `/api/admin/crawlers/{name}/run` | Run a crawler once; returns its crawl report |
+| `DELETE` | `/api/admin/crawlers/{name}` | Drop a crawler (crawled tables are left in place) |
+| `POST` | `/api/admin/external-tables` | Create an external table from structured fields |
+
+Create a crawler (the structured equivalent of [`CREATE CRAWLER`](../data-lake/crawlers.md)):
 
 ```http
-GET /api/admin/check
+POST /api/admin/crawlers
 Authorization: Basic <base64(username:password)>
+Content-Type: application/json
+
+{ "name": "argo", "target_prefix": "argo/", "format_filter": ["parquet"],
+  "schedule_secs": 900, "table_naming": "crawler_prefixed" }
 ```
 
-Returns `{ "is_admin": true }` when the credentials are valid, or `401` otherwise.
+Create an external table (the structured equivalent of
+[`CREATE EXTERNAL TABLE`](../sql/create-table.md)):
+
+```http
+POST /api/admin/external-tables
+Authorization: Basic <base64(username:password)>
+Content-Type: application/json
+
+{ "name": "observations", "file_type": "PARQUET", "location": "obs/",
+  "partition_cols": ["year", "month"] }
+```
 
 ## OpenAPI
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -57,7 +57,8 @@ pytest -v
 | ---- | ------ |
 | `test_health.py` | `/api/health`, `/swagger`, `beacon_version()`, `/api/datasets`, `list_datasets()` |
 | `test_queries_parquet.py` | `read_parquet()` counts/aggregates over a multi-file glob; equivalent JSON DSL; malformed-query 400 |
-| `test_external_tables.py` | `CREATE EXTERNAL TABLE` (admin); `SHOW TABLES` / `/api/tables`; no-auth → 400, bad-auth → 401 |
+| `test_external_tables.py` | `CREATE EXTERNAL TABLE` (admin SQL + `POST /api/admin/external-tables`); `SHOW TABLES` / `/api/tables`; no-auth → 400/401, bad-auth → 401 |
+| `test_admin_crawlers.py` | admin crawler CRUD + run (`/api/admin/crawlers*`): create/list/get/run/drop, 404 for unknown, 401 without auth |
 | `test_managed_tables.py` | managed-table `CREATE`/`INSERT`/`SELECT`/`UPDATE`/`DELETE`/`DROP`; writes need admin |
 
 ## How it works

--- a/integration-tests/beacon_client.py
+++ b/integration-tests/beacon_client.py
@@ -95,3 +95,27 @@ class BeaconHTTPClient:
 
     def tables(self) -> requests.Response:
         return self.get("/api/tables")
+
+    # -- admin endpoints (/api/admin/*) -----------------------------------------
+    # These require admin basic-auth; pass ``admin=False`` to assert the auth gate.
+    def admin_get(self, path: str, admin: bool = True) -> requests.Response:
+        return self._session.get(
+            f"{self.base_url}{path}",
+            auth=self._auth if admin else None,
+            timeout=self._timeout,
+        )
+
+    def admin_post(self, path: str, body: dict | None = None, admin: bool = True) -> requests.Response:
+        return self._session.post(
+            f"{self.base_url}{path}",
+            json=body,
+            auth=self._auth if admin else None,
+            timeout=self._timeout,
+        )
+
+    def admin_delete(self, path: str, admin: bool = True) -> requests.Response:
+        return self._session.delete(
+            f"{self.base_url}{path}",
+            auth=self._auth if admin else None,
+            timeout=self._timeout,
+        )

--- a/integration-tests/test_admin_crawlers.py
+++ b/integration-tests/test_admin_crawlers.py
@@ -1,0 +1,79 @@
+"""Admin crawler endpoints: create -> list -> get -> run -> drop over /api/admin/*.
+
+Also asserts the basic-auth gate: the admin surface rejects unauthenticated calls
+with 401 (it never silently downgrades to anonymous like the read-only query path).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+CRAWLER = "obs_crawler"
+
+
+@pytest.fixture
+def crawler(client):
+    """Define the crawler once per test, dropping it (and reruns' leftovers) around."""
+    client.admin_delete(f"/api/admin/crawlers/{CRAWLER}")  # idempotent pre-clean
+    body = {
+        "name": CRAWLER,
+        "target_prefix": "obs/",
+        "format_filter": ["parquet"],
+        "table_naming": "crawler_prefixed",
+    }
+    resp = client.admin_post("/api/admin/crawlers", body)
+    assert resp.status_code == 200, resp.text
+    yield CRAWLER
+    client.admin_delete(f"/api/admin/crawlers/{CRAWLER}")
+    # The crawl registers `<crawler>_obs`; drop it so it does not leak across runs.
+    client.execute(f"DROP TABLE IF EXISTS {CRAWLER}_obs", admin=True)
+
+
+def test_crawler_listed_and_retrievable(client, crawler):
+    listed = client.admin_get("/api/admin/crawlers")
+    assert listed.status_code == 200
+    names = [c["name"] for c in listed.json()]
+    assert crawler in names
+
+    single = client.admin_get(f"/api/admin/crawlers/{crawler}")
+    assert single.status_code == 200
+    body = single.json()
+    assert body["name"] == crawler
+    assert body["target_prefix"] == "obs/"
+    assert body["table_naming"] == "crawler_prefixed"
+    assert body["format_filter"] == ["parquet"]
+
+
+def test_get_unknown_crawler_is_404(client):
+    resp = client.admin_get("/api/admin/crawlers/does_not_exist")
+    assert resp.status_code == 404
+
+
+def test_run_crawler_discovers_and_registers_table(client, crawler):
+    resp = client.admin_post(f"/api/admin/crawlers/{crawler}/run")
+    assert resp.status_code == 200, resp.text
+    report = resp.json()
+    assert report["crawler"] == crawler
+    assert report["discovered"] >= 1
+    # The discovered obs parquet group becomes `<crawler>_obs`.
+    table = f"{crawler}_obs"
+    assert table in report["created"] or table in report["updated"]
+
+    tables = client.tables()
+    assert tables.status_code == 200
+    assert table in tables.json()
+
+
+def test_drop_crawler_removes_it(client, crawler):
+    assert client.admin_delete(f"/api/admin/crawlers/{crawler}").status_code == 200
+    assert client.admin_get(f"/api/admin/crawlers/{crawler}").status_code == 404
+    # Dropping a non-existent crawler is a 400 (the manager errors).
+    assert client.admin_delete(f"/api/admin/crawlers/{crawler}").status_code == 400
+
+
+def test_admin_crawler_endpoints_require_auth(client):
+    assert client.admin_get("/api/admin/crawlers", admin=False).status_code == 401
+    assert (
+        client.admin_post("/api/admin/crawlers", {"name": "x", "target_prefix": "obs/"}, admin=False).status_code
+        == 401
+    )

--- a/integration-tests/test_external_tables.py
+++ b/integration-tests/test_external_tables.py
@@ -68,3 +68,29 @@ def test_invalid_credentials_are_rejected(beacon_container):
         timeout=30,
     )
     assert resp.status_code == 401
+
+
+def test_admin_external_table_endpoint_creates_queryable_table(client, sample_data):
+    """The structured admin endpoint registers a table equivalent to the SQL form."""
+    name = "obs_ext_admin"
+    client.execute(f"DROP TABLE IF EXISTS {name}", admin=True)
+    try:
+        resp = client.admin_post(
+            "/api/admin/external-tables",
+            {"name": name, "file_type": "PARQUET", "location": "obs/"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        assert name in client.tables().json()
+        assert client.count(f"SELECT * FROM {name}") == sample_data["total"]
+    finally:
+        client.execute(f"DROP TABLE IF EXISTS {name}", admin=True)
+
+
+def test_admin_external_table_endpoint_requires_auth(client):
+    resp = client.admin_post(
+        "/api/admin/external-tables",
+        {"name": "nope", "file_type": "PARQUET", "location": "obs/"},
+        admin=False,
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Extends the Beacon REST API with first-class, JSON-typed **admin** endpoints for managing crawlers and creating external tables. These operations were previously only reachable via SQL DDL (`CREATE CRAWLER`, `CREATE EXTERNAL TABLE`, ...) over `POST /api/query` with admin basic-auth; the only dedicated admin endpoint was `GET /api/admin/check`.

New endpoints (all under the existing basic-auth admin middleware):

| Method | Path | Purpose |
|--------|------|---------|
| `POST` | `/api/admin/crawlers` | Define (or replace) a crawler |
| `GET` | `/api/admin/crawlers` | List crawlers |
| `GET` | `/api/admin/crawlers/{name}` | Get one crawler (404 if missing) |
| `POST` | `/api/admin/crawlers/{name}/run` | Run a crawler once; returns its crawl report |
| `DELETE` | `/api/admin/crawlers/{name}` | Drop a crawler |
| `POST` | `/api/admin/external-tables` | Create an external table from structured fields |

## Implementation

**`beacon-core`**
- `api.rs`: new `serde` + `utoipa::ToSchema` contract types (`CreateCrawlerRequest`, `CrawlerView`, `CrawlReportView`, `TableNamingView`, `CreateExternalTableRequest`) with `From`/`Into` conversions to/from the `beacon-data-lake` domain structs — following the existing `TableConfigView`/`SchemaView` mirror convention, so `beacon-data-lake` needs no `utoipa` dependency. The create structs carry OpenAPI examples/defaults.
- `runtime.rs`: 6 new public `Runtime` methods. Crawler methods delegate to the (crate-private) `crawler_manager`; `create_external_table` assembles an **injection-safe** `CREATE EXTERNAL TABLE` statement (validated bare identifiers, escaped string literals, sorted options) and runs it through the existing super-user DDL path, reusing all `STORED AS` variants + catalog persistence.

**`beacon-api`**
- New `axum/admin/crawlers.rs` (5 handlers) and `axum/admin/external_tables.rs` (1 handler), mirroring `admin/check.rs`. Registered in `admin/mod.rs` with a shared `bad_request` error mapper; the existing basic-auth middleware and OpenAPI security scheme cover them automatically. All endpoints appear in `/swagger` and `/openapi.json`.

## Tests & docs
- Unit tests in `beacon-core` (SQL-builder escaping/validation + a crawler create/list/get/run/drop round-trip) — passing.
- Integration tests: new `test_admin_crawlers.py` and admin external-table cases in `test_external_tables.py`, plus admin JSON helpers in `beacon_client.py`.
- Updated the API docs (`exploring-data-lake.md`) and the integration-tests README inventory.

## Verification
- `cargo build -p beacon-api` and `cargo test -p beacon-core` pass.
- The Python integration tests require a Docker image build and were not run locally; they are ready for CI.
