### PR TITLE
Enrich REST API OpenAPI documentation

### DIFF
--- a/beacon-api/src/axum/admin/check.rs
+++ b/beacon-api/src/axum/admin/check.rs
@@ -8,7 +8,7 @@ use ::axum::Json;
     tag = "admin",
     get,
     path = "/api/admin/check",
-    responses((status = 200, description = "Admin API is reachable")),
+    responses((status = 200, description = "Admin API is reachable", body = CheckResponse)),
     security(("basic-auth" = []))
 )]
 pub async fn check() -> Json<CheckResponse> {
@@ -19,5 +19,6 @@ pub async fn check() -> Json<CheckResponse> {
 /// Minimal response payload for the admin connectivity check.
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 pub struct CheckResponse {
+    /// Always `true`: reaching this endpoint means the caller passed admin auth.
     is_admin: bool,
 }

--- a/beacon-api/src/axum/admin/mod.rs
+++ b/beacon-api/src/axum/admin/mod.rs
@@ -18,7 +18,12 @@ mod external_tables;
 
 /// OpenAPI document marker for the admin surface.
 #[derive(OpenApi)]
-#[openapi(modifiers(&SecurityAddon))]
+#[openapi(
+    modifiers(&SecurityAddon),
+    tags(
+        (name = "admin", description = "Authenticated administrative endpoints (HTTP Basic auth) for managing crawlers and external tables.")
+    )
+)]
 pub struct AdminApiDoc;
 
 /// Builds the admin router and attaches basic-auth middleware.

--- a/beacon-api/src/axum/client/datasets.rs
+++ b/beacon-api/src/axum/client/datasets.rs
@@ -14,8 +14,11 @@ use utoipa::{IntoParams, ToSchema};
 /// Pagination and filter parameters shared by the dataset listing endpoints.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, IntoParams)]
 pub struct ListDatasetsQuery {
+    /// Optional glob pattern to filter dataset paths (e.g. `argo/**/*.parquet`).
     pub pattern: Option<String>,
+    /// Maximum number of entries to return.
     pub limit: Option<usize>,
+    /// Number of entries to skip before returning results.
     pub offset: Option<usize>,
 }
 
@@ -29,7 +32,10 @@ pub struct ListDatasetsQuery {
     get, 
     path = "/api/datasets", 
     params(ListDatasetsQuery),
-    responses((status = 200, description = "List of datasets")),
+    responses(
+        (status = 200, description = "List of dataset file paths", body = Vec<String>),
+        (status = 500, description = "Failed to list datasets"),
+    ),
     security(
         (),
         ("basic-auth" = []),
@@ -64,7 +70,10 @@ pub(crate) async fn datasets(
     get,
     path = "/api/list-datasets",
     params(ListDatasetsQuery),
-    responses((status = 200, description = "List of datasets including interpreted file format")),
+    responses(
+        (status = 200, description = "List of datasets including interpreted file format", body = Vec<DatasetInfo>),
+        (status = 500, description = "Failed to list datasets"),
+    ),
     security(
         (),
         ("basic-auth" = []),
@@ -94,6 +103,7 @@ pub(crate) async fn list_datasets(
 /// Query parameters for [`list_dataset_schema`].
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, IntoParams)]
 pub struct ListDatasetSchemaQuery {
+    /// Datasets-store-relative path of the file to inspect.
     pub file: String,
 }
 
@@ -102,9 +112,12 @@ pub struct ListDatasetSchemaQuery {
 #[utoipa::path(
     tag = "datasets",
     get, 
-    path = "/api/dataset-schema", 
+    path = "/api/dataset-schema",
     params(ListDatasetSchemaQuery),
-    responses((status = 200, description = "List the schema/available columns")),
+    responses(
+        (status = 200, description = "The Arrow schema produced when reading the dataset", body = SchemaView),
+        (status = 500, description = "Failed to read the dataset schema"),
+    ),
     security(
         (),
         ("basic-auth" = []),
@@ -135,7 +148,10 @@ pub(crate) async fn list_dataset_schema(
     tag = "datasets",
     get,
     path = "/api/total-datasets",
-    responses((status = 200, description = "List the total amount of datasets available")),
+    responses(
+        (status = 200, description = "Total number of datasets available", body = usize),
+        (status = 500, description = "Failed to count datasets"),
+    ),
     security(
         (),
         ("basic-auth" = []),

--- a/beacon-api/src/axum/client/functions.rs
+++ b/beacon-api/src/axum/client/functions.rs
@@ -11,8 +11,8 @@ use beacon_core::runtime::Runtime;
 #[utoipa::path(
     tag = "functions",
     get, 
-    path = "/api/functions", 
-    responses((status = 200, description = "List of available functions with documentation")),
+    path = "/api/functions",
+    responses((status = 200, description = "Available scalar/aggregate functions with documentation", body = Vec<FunctionInfo>)),
     security(
         (),
         ("basic-auth" = []),
@@ -30,7 +30,7 @@ pub(crate) async fn list_functions(State(state): State<Arc<Runtime>>) -> Json<Ve
     tag = "functions",
     get,
     path = "/api/table-functions",
-    responses((status = 200, description = "List of available table functions with documentation")),
+    responses((status = 200, description = "Available table-valued functions with documentation", body = Vec<FunctionInfo>)),
     security(
         (),
         ("basic-auth" = []),

--- a/beacon-api/src/axum/client/info.rs
+++ b/beacon-api/src/axum/client/info.rs
@@ -10,8 +10,8 @@ use beacon_core::{runtime::Runtime, sys::SystemInfo};
 #[utoipa::path(
     tag = "system",
     get, 
-    path = "/api/info", 
-    responses((status = 200, description = "Returns Beacon system information")),
+    path = "/api/info",
+    responses((status = 200, description = "Beacon runtime system information", body = SystemInfo)),
     security(
         (),
         ("basic-auth" = []),

--- a/beacon-api/src/axum/client/mod.rs
+++ b/beacon-api/src/axum/client/mod.rs
@@ -61,20 +61,31 @@ mod tests {
     fn client_openapi_includes_query_schema() {
         #[allow(deprecated)]
         let (_router, openapi) = setup_client_router();
-        let spec = openapi.to_json().expect("openapi serializes to JSON");
+        let spec: serde_json::Value =
+            serde_json::to_value(&openapi).expect("openapi serializes to JSON");
 
-        // The structured query body and its nested types are present as components.
-        for schema in ["QueryBody", "Filter", "Select", "OutputFormat"] {
+        // The structured query body and its nested types are registered as
+        // component schemas (not merely mentioned in a description or example).
+        let schemas = spec
+            .pointer("/components/schemas")
+            .and_then(|s| s.as_object())
+            .expect("components.schemas object");
+        for schema in ["Query", "QueryBody", "Filter", "Select", "OutputFormat"] {
             assert!(
-                spec.contains(schema),
-                "expected `{schema}` schema in client OpenAPI document"
+                schemas.contains_key(schema),
+                "expected `{schema}` in components.schemas"
             );
         }
 
-        // The query endpoint references the real Query type, not an opaque object.
-        assert!(
-            spec.contains("#/components/schemas/Query"),
-            "expected /api/query to reference the Query schema"
+        // The /api/query request body references the real Query schema rather
+        // than an opaque object.
+        let request_ref = spec.pointer(
+            "/paths/~1api~1query/post/requestBody/content/application~1json/schema/$ref",
+        );
+        assert_eq!(
+            request_ref.and_then(|r| r.as_str()),
+            Some("#/components/schemas/Query"),
+            "expected /api/query requestBody to $ref the Query schema"
         );
     }
 }

--- a/beacon-api/src/axum/client/mod.rs
+++ b/beacon-api/src/axum/client/mod.rs
@@ -15,7 +15,13 @@ mod tables;
 
 /// OpenAPI document marker for the client surface.
 #[derive(utoipa::OpenApi)]
-#[openapi()]
+#[openapi(tags(
+    (name = "query", description = "Execute, validate, explain, and inspect metrics of queries."),
+    (name = "datasets", description = "Discover dataset files in the datasets store and inspect their schemas."),
+    (name = "tables", description = "List registered tables and inspect their schemas and configuration."),
+    (name = "functions", description = "Browse the scalar, aggregate, and table-valued functions available in queries."),
+    (name = "system", description = "Beacon runtime version and host information.")
+))]
 pub struct ClientApiDoc;
 
 /// Builds the client router and returns the generated OpenAPI document alongside it.
@@ -41,4 +47,34 @@ pub(crate) fn setup_client_router() -> (Router<Arc<Runtime>>, utoipa::openapi::O
         .routes(routes!(functions::list_table_functions))
         .routes(routes!(info::system_info))
         .split_for_parts()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The client OpenAPI document assembles without panicking and surfaces the
+    /// structured query schema tree (which uses untagged enums and `flatten`).
+    /// This guards the `request_body = Query` wiring and the un-hidden output
+    /// formats against regressions.
+    #[test]
+    fn client_openapi_includes_query_schema() {
+        #[allow(deprecated)]
+        let (_router, openapi) = setup_client_router();
+        let spec = openapi.to_json().expect("openapi serializes to JSON");
+
+        // The structured query body and its nested types are present as components.
+        for schema in ["QueryBody", "Filter", "Select", "OutputFormat"] {
+            assert!(
+                spec.contains(schema),
+                "expected `{schema}` schema in client OpenAPI document"
+            );
+        }
+
+        // The query endpoint references the real Query type, not an opaque object.
+        assert!(
+            spec.contains("#/components/schemas/Query"),
+            "expected /api/query to reference the Query schema"
+        );
+    }
 }

--- a/beacon-api/src/axum/client/query.rs
+++ b/beacon-api/src/axum/client/query.rs
@@ -60,7 +60,7 @@ fn resolve_super_user(
             status = 200,
             description = "Query results in the format requested by the query. The \
                 default is a zstd-compressed Arrow IPC stream; file output formats \
-                (CSV, Parquet, Arrow, JSON, ODV, NetCDF, GeoParquet) are returned as \
+                (CSV, Parquet, Arrow, ODV, NetCDF, GeoParquet) are returned as \
                 a file download. The result's query id is returned in the \
                 `x-beacon-query-id` response header.",
             content_type = "application/vnd.apache.arrow.stream"

--- a/beacon-api/src/axum/client/query.rs
+++ b/beacon-api/src/axum/client/query.rs
@@ -10,6 +10,7 @@ use ::axum::{
 use beacon_core::runtime::Runtime;
 use beacon_core::{
     api::{QueryMetricsView, QueryRequest},
+    query::Query,
     query_result::QueryOutputFile,
 };
 use futures::TryStreamExt;
@@ -53,8 +54,19 @@ fn resolve_super_user(
     tag = "query",
     post,
     path = "/api/query",
+    request_body = Query,
     responses(
-        (status=200, description="Response containing the query results in the format specified by the query"),
+        (
+            status = 200,
+            description = "Query results in the format requested by the query. The \
+                default is a zstd-compressed Arrow IPC stream; file output formats \
+                (CSV, Parquet, Arrow, JSON, ODV, NetCDF, GeoParquet) are returned as \
+                a file download. The result's query id is returned in the \
+                `x-beacon-query-id` response header.",
+            content_type = "application/vnd.apache.arrow.stream"
+        ),
+        (status = 400, description = "Invalid, unsupported, or disabled query"),
+        (status = 401, description = "Basic credentials were supplied but are invalid"),
     ),
     security(
         (),
@@ -227,8 +239,10 @@ async fn file_stream_response(
     tag = "query",
     post,
     path = "/api/parse-query",
+    request_body = Query,
     responses(
-        (status=200, description="Valid Query"),
+        (status = 200, description = "The query body is valid (it was not executed)"),
+        (status = 400, description = "Malformed query body"),
     ),
     security(
         (),
@@ -246,8 +260,13 @@ pub(crate) async fn parse_query(Json(_query_obj): Json<QueryRequest>) -> StatusC
     tag = "query",
     get,
     path = "/api/query/metrics/{query_id}",
+    params(
+        ("query_id" = String, Path, description = "UUID of a previously executed query")
+    ),
     responses(
-        (status=200, description="Response containing the query metrics"),
+        (status = 200, description = "Recorded metrics for the query", body = QueryMetricsView),
+        (status = 400, description = "The query id is not a valid UUID"),
+        (status = 404, description = "No metrics recorded for the given query id"),
     ),
     security(
         (),
@@ -283,8 +302,15 @@ pub(crate) async fn query_metrics(
     tag = "query",
     post,
     path = "/api/explain-query",
+    request_body = Query,
     responses(
-        (status=200, description="Explains the produced plan of a given query"),
+        (
+            status = 200,
+            description = "JSON explanation of the plan the runtime would produce \
+                for the query (the query is not executed)",
+            content_type = "application/json"
+        ),
+        (status = 400, description = "Invalid or unsupported query"),
     ),
     security(
         (),
@@ -320,7 +346,7 @@ pub(crate) async fn explain_query(
     get,
     path = "/api/query/available-columns",
     responses(
-        (status=200, description="Response containing the available columns in the default table schema"),
+        (status = 200, description = "Column names of the default table schema", body = Vec<String>),
     ),
     security(
         (),

--- a/beacon-api/src/axum/client/tables.rs
+++ b/beacon-api/src/axum/client/tables.rs
@@ -16,8 +16,8 @@ use utoipa::{IntoParams, ToSchema};
 #[utoipa::path(
     tag = "tables",
     get, 
-    path = "/api/tables", 
-    responses((status = 200, description = "List of tables")),
+    path = "/api/tables",
+    responses((status = 200, description = "List of registered table names", body = Vec<String>)),
     security(
         (),
         ("basic-auth" = []),
@@ -30,9 +30,11 @@ pub(crate) async fn list_tables(State(state): State<Arc<Runtime>>) -> Json<Vec<S
 }
 
 /// Response entry pairing a table name with its Arrow schema.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct TableWithSchema {
+    /// Registered table name.
     table_name: String,
+    /// Arrow schema fields (name, data type, nullability, metadata) of the table.
     columns: Vec<SchemaFieldView>,
 }
 
@@ -41,8 +43,8 @@ pub(crate) struct TableWithSchema {
 #[utoipa::path(
     tag = "tables",
     get, 
-    path = "/api/tables-with-schema", 
-    responses((status = 200, description = "List of tables with schema")),
+    path = "/api/tables-with-schema",
+    responses((status = 200, description = "Registered tables with their Arrow schemas", body = Vec<TableWithSchema>)),
     security(
         (),
         ("basic-auth" = []),
@@ -69,6 +71,7 @@ pub(crate) async fn list_tables_with_schema(
 /// Query parameters for [`list_table_schema`].
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, IntoParams)]
 pub struct ListTableSchemaQuery {
+    /// Name of the registered table to inspect.
     pub table_name: String,
 }
 
@@ -77,9 +80,12 @@ pub struct ListTableSchemaQuery {
 #[utoipa::path(
     tag = "tables",
     get, 
-    path = "/api/table-schema", 
-    params(ListTableSchemaQuery) ,
-    responses((status = 200, description = "List of schema of a table")),
+    path = "/api/table-schema",
+    params(ListTableSchemaQuery),
+    responses(
+        (status = 200, description = "The Arrow schema of the table", body = SchemaView),
+        (status = 404, description = "Table not found"),
+    ),
     security(
         (),
         ("basic-auth" = []),
@@ -107,6 +113,7 @@ pub(crate) async fn list_table_schema(
 /// Query parameters for [`list_table_config`].
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, IntoParams)]
 pub struct ListTableConfigQuery {
+    /// Name of the registered table whose configuration to return.
     pub table_name: String,
 }
 
@@ -115,9 +122,12 @@ pub struct ListTableConfigQuery {
 #[utoipa::path(
     tag = "tables",
     get, 
-    path = "/api/table-config", 
-    params(ListTableConfigQuery) ,
-    responses((status = 200, description = "List of schema of a table")),
+    path = "/api/table-config",
+    params(ListTableConfigQuery),
+    responses(
+        (status = 200, description = "The storage format and configuration of the table", body = TableConfigView),
+        (status = 404, description = "Table not found"),
+    ),
     security(
         (),
         ("basic-auth" = []),
@@ -148,7 +158,7 @@ pub(crate) async fn list_table_config(
     tag = "tables",
     get,
     path = "/api/default-table-schema",
-    responses((status = 200, description = "List of schema of the default table")),
+    responses((status = 200, description = "The Arrow schema of the default table", body = SchemaView)),
     security(
         (),
         ("basic-auth" = []),
@@ -168,7 +178,7 @@ pub(crate) async fn default_table_schema(
     tag = "tables",
     get,
     path = "/api/default-table",
-    responses((status = 200, description = "Name of the default table")),
+    responses((status = 200, description = "Name of the default table", body = String)),
     security(
         (),
         ("basic-auth" = []),

--- a/beacon-core/src/api.rs
+++ b/beacon-core/src/api.rs
@@ -128,7 +128,7 @@ impl From<&Schema> for SchemaView {
 /// with the desired output format. The object is flattened, so its keys appear at
 /// the top level of the request body rather than under a `query` field.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
-#[schema(example = json!({ "sql": "SELECT 1", "output": { "format": "json" } }))]
+#[schema(example = json!({ "sql": "SELECT 1", "output": { "format": "csv" } }))]
 pub struct QueryRequest {
     /// The flattened query object (JSON or SQL query plus output options).
     #[schema(value_type = Object)]

--- a/beacon-core/src/api.rs
+++ b/beacon-core/src/api.rs
@@ -9,21 +9,35 @@ use beacon_datafusion_ext::format_ext::DatasetMetadata;
 use beacon_datafusion_ext::table_ext::TableDefinition;
 use beacon_functions::function_doc::FunctionDoc;
 use crate::metrics::ConsolidatedMetrics;
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value};
 use utoipa::ToSchema;
 
+/// A single parameter of a registered function.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct FunctionParameterInfo {
+    /// Parameter name as used in the function signature.
+    #[schema(example = "input")]
     pub name: String,
+    /// Human-readable description of the parameter's purpose.
     pub description: String,
+    /// SQL/Arrow data type accepted by the parameter (e.g. `Float64`, `Utf8`).
+    #[schema(example = "Float64")]
     pub data_type: String,
 }
 
+/// Documentation for a single function registered with the runtime
+/// (scalar, aggregate, or table-valued).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct FunctionInfo {
+    /// The name the function is invoked by in queries.
+    #[schema(example = "abs")]
     pub function_name: String,
+    /// Human-readable description of what the function does.
     pub description: String,
+    /// The data type the function returns (e.g. `Float64`).
+    #[schema(example = "Float64")]
     pub return_type: String,
+    /// Ordered list of the function's parameters.
     pub params: Vec<FunctionParameterInfo>,
 }
 
@@ -35,11 +49,18 @@ impl TryFrom<FunctionDoc> for FunctionInfo {
     }
 }
 
+/// Metadata about a single dataset file discovered in the datasets store.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct DatasetInfo {
+    /// Datasets-store-relative path of the file.
+    #[schema(example = "argo/floats.parquet")]
     pub file_path: String,
+    /// Detected file format identifier (e.g. `parquet`, `nc`, `csv`).
+    #[schema(example = "parquet")]
     pub format: String,
+    /// Whether the runtime can read this file's schema for inspection.
     pub can_inspect: bool,
+    /// Whether the file supports partial (predicate/column-pushdown) exploration.
     pub can_partial_explore: bool,
 }
 
@@ -54,11 +75,18 @@ impl From<DatasetMetadata> for DatasetInfo {
     }
 }
 
+/// A single field (column) of an Arrow schema, projected for the API.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct SchemaFieldView {
+    /// Column name.
+    #[schema(example = "temperature")]
     pub name: String,
+    /// Arrow data type rendered as a string (e.g. `Float64`, `Utf8`, `Timestamp(...)`).
+    #[schema(example = "Float64")]
     pub data_type: String,
+    /// Whether the column may contain null values.
     pub nullable: bool,
+    /// Arbitrary field-level metadata carried on the Arrow field.
     pub metadata: BTreeMap<String, String>,
 }
 
@@ -73,9 +101,12 @@ impl From<&Field> for SchemaFieldView {
     }
 }
 
+/// An Arrow schema (the ordered fields plus schema-level metadata), projected for the API.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct SchemaView {
+    /// The schema's fields (columns), in order.
     pub fields: Vec<SchemaFieldView>,
+    /// Arbitrary schema-level metadata key/value pairs.
     pub metadata: BTreeMap<String, String>,
 }
 
@@ -92,8 +123,14 @@ impl From<&Schema> for SchemaView {
     }
 }
 
+/// A Beacon query request body. The payload is a free-form JSON object describing
+/// either a structured JSON query or a SQL query (`{"sql": "SELECT ..."}`), along
+/// with the desired output format. The object is flattened, so its keys appear at
+/// the top level of the request body rather than under a `query` field.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+#[schema(example = json!({ "sql": "SELECT 1", "output": { "format": "json" } }))]
 pub struct QueryRequest {
+    /// The flattened query object (JSON or SQL query plus output options).
     #[schema(value_type = Object)]
     #[serde(flatten)]
     pub query: BTreeMap<String, Value>,
@@ -107,18 +144,35 @@ impl QueryRequest {
     }
 }
 
+/// Planner and execution metrics recorded for a previously executed query,
+/// retrievable by query id via `GET /api/query/metrics/{query_id}`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct QueryMetricsView {
+    /// Total rows scanned from the input sources.
     pub input_rows: u64,
+    /// Total bytes scanned from the input sources.
     pub input_bytes: u64,
+    /// Number of rows in the query result.
     pub result_num_rows: u64,
+    /// Size of the query result in bytes.
     pub result_size_in_bytes: u64,
+    /// Source file paths touched while executing the query.
     pub file_paths: Vec<String>,
+    /// Wall-clock execution time in milliseconds.
     pub execution_time_ms: u64,
+    /// The original query payload that produced these metrics.
+    #[schema(value_type = Object)]
     pub query: Value,
+    /// The query's unique identifier (UUID).
     pub query_id: String,
+    /// The logical plan as parsed, before optimization (JSON).
+    #[schema(value_type = Object)]
     pub parsed_logical_plan: Value,
+    /// The logical plan after the optimizer ran (JSON).
+    #[schema(value_type = Object)]
     pub optimized_logical_plan: Value,
+    /// Per-node execution metrics from the physical plan (JSON).
+    #[schema(value_type = Object)]
     pub node_metrics: Value,
 }
 
@@ -142,8 +196,11 @@ impl TryFrom<ConsolidatedMetrics> for QueryMetricsView {
     }
 }
 
+/// The storage format and options of a registered table, as a flattened
+/// configuration object. Internal (double-underscore) option keys are stripped.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct TableConfigView {
+    /// The flattened table configuration (type, location, options, ...).
     #[schema(value_type = Object)]
     #[serde(flatten)]
     pub config: BTreeMap<String, Value>,
@@ -270,13 +327,22 @@ impl From<CreateCrawlerRequest> for CrawlerDefinition {
 /// A crawler definition as returned to API clients. Mirrors [`CrawlerDefinition`].
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct CrawlerView {
+    /// Unique crawler name.
     pub name: String,
+    /// Datasets-store prefix the crawler scans, e.g. `argo/`.
     pub target_prefix: String,
+    /// Format identifiers discovery is restricted to, or `null` to crawl every
+    /// registered format.
     pub format_filter: Option<Vec<String>>,
+    /// How discovered groups are turned into table names.
     pub table_naming: TableNamingView,
+    /// Whether Hive-style `key=value/` partitions are detected.
     pub detect_partitions: bool,
+    /// Periodic crawl interval in seconds, or `null` for no timer.
     pub schedule_secs: Option<u64>,
+    /// Whether the crawler subscribes to datasets-store events for incremental crawls.
     pub event_driven: bool,
+    /// Extra format options forwarded into every discovered table's `OPTIONS`.
     pub options: HashMap<String, String>,
 }
 

--- a/beacon-core/src/query/filter/and.rs
+++ b/beacon-core/src/query/filter/and.rs
@@ -5,6 +5,9 @@ use datafusion::{
 };
 
 #[derive(Debug, Clone, utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
+// `Filter` -> `And` -> `Filter` is a recursive cycle; break it so utoipa's schema
+// generation does not inline forever and overflow the stack.
+#[schema(no_recursion)]
 pub struct And(pub Vec<super::Filter>);
 
 impl And {

--- a/beacon-core/src/query/filter/mod.rs
+++ b/beacon-core/src/query/filter/mod.rs
@@ -25,11 +25,19 @@ pub mod lte;
 pub mod neq;
 pub mod or;
 
+/// A row filter expression for a structured query.
+///
+/// Boolean combinators (`and`, `or`) nest other filters; the remaining variants
+/// are leaf predicates over a single column. Comparison predicates (`eq`, `neq`,
+/// `gt`, `gt_eq`, `lt`, `lt_eq`, `between`) and the GeoJSON predicate are matched
+/// by their fields rather than a wrapping tag.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Filter {
+    /// All of the contained filters must match.
     #[serde(alias = "and")]
     And(And),
+    /// Any of the contained filters must match.
     #[serde(alias = "or")]
     Or(Or),
     #[serde(

--- a/beacon-core/src/query/filter/or.rs
+++ b/beacon-core/src/query/filter/or.rs
@@ -7,6 +7,9 @@ use datafusion::{
 use super::Filter;
 
 #[derive(Debug, Clone, utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
+// `Filter` -> `Or` -> `Filter` is a recursive cycle; break it so utoipa's schema
+// generation does not inline forever and overflow the stack.
+#[schema(no_recursion)]
 pub struct Or(pub Vec<Filter>);
 
 impl Or {

--- a/beacon-core/src/query/mod.rs
+++ b/beacon-core/src/query/mod.rs
@@ -17,11 +17,24 @@ pub mod output;
 
 pub use compiler::compile_json_query;
 
+/// A Beacon query request body.
+///
+/// The query is either a raw SQL string (`{"sql": "SELECT ..."}`) or a structured
+/// JSON query (the fields of [`QueryBody`]: `select`, `filter`, `from`, ...). The
+/// `inner` query is flattened, so its fields appear at the top level of the body.
+/// An optional [`Output`] selects the result format (the default is an Arrow IPC
+/// stream).
 #[derive(Debug, serde::Serialize, serde::Deserialize, ToSchema)]
+#[schema(example = json!({
+    "select": [{ "column": "temperature" }, { "column": "depth" }],
+    "filter": { "column": "depth", "gt_eq": 0, "lt_eq": 100 },
+    "output": { "format": "csv" }
+}))]
 pub struct Query {
+    /// The query itself: either SQL or a structured JSON query.
     #[serde(flatten)]
     pub inner: InnerQuery,
-    #[schema(value_type = Object)]
+    /// Result output format. Omit for the default zstd-compressed Arrow IPC stream.
     pub output: Option<Output>,
 }
 
@@ -35,28 +48,39 @@ impl Query {
     }
 }
 
+/// The query itself: a SQL string or a structured JSON query.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, ToSchema)]
 pub enum InnerQuery {
+    /// A raw SQL query: `{ "sql": "SELECT ..." }`.
     #[serde(rename = "sql")]
     Sql(String),
+    /// A structured JSON query (the fields of [`QueryBody`] at the top level).
     #[serde(untagged)]
     Json(QueryBody),
 }
 
+/// A structured (non-SQL) query.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct QueryBody {
+    /// Columns, functions, or literals to project.
     #[serde(alias = "query_parameters")]
     select: Vec<Select>,
+    /// Row filter to apply (a single, possibly nested, filter expression).
     filter: Option<Filter>,
     // To Support legacy queries
     #[schema(ignore)]
     filters: Option<Vec<Filter>>,
+    /// Data source to read from. Defaults to the runtime's default table.
     #[serde(default)]
     from: Option<crate::query::from::From>,
+    /// Ordering to apply to the result.
     sort_by: Option<Vec<Sort>>,
+    /// Distinct-on specification.
     distinct: Option<Distinct>,
+    /// Number of rows to skip.
     offset: Option<usize>,
+    /// Maximum number of rows to return.
     limit: Option<usize>,
 }
 
@@ -66,20 +90,29 @@ pub struct Distinct {
     pub select: Vec<Select>,
 }
 
+/// A single projected item in a query's `select`.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(untagged)]
 pub enum Select {
+    /// A bare column name (`"temperature"`).
     ColumnName(String),
+    /// A column with an optional alias (`{ "column": "temp", "alias": "t" }`).
     Column {
         #[serde(alias = "column_name")]
         column: String,
         alias: Option<String>,
     },
+    /// A function call over other select items
+    /// (`{ "function": "avg", "args": ["temp"] }`).
     Function {
         function: String,
+        // `Select` -> `Function` -> `Select` is recursive; break it so utoipa's
+        // schema generation terminates instead of overflowing the stack.
+        #[schema(no_recursion)]
         args: Vec<Select>,
         alias: Option<String>,
     },
+    /// A literal value (`{ "value": 0, "alias": "zero" }`).
     Literal {
         value: Literal,
         alias: Option<String>,

--- a/beacon-core/src/query/output.rs
+++ b/beacon-core/src/query/output.rs
@@ -83,7 +83,10 @@ pub enum OutputFormat {
     Parquet,
     // Json,
     // Odv(OdvOptions),
+    /// Flat (record-oriented) NetCDF format.
     NetCDF,
+    /// Multi-dimensional (nd-array) NetCDF format. The named columns become the
+    /// output dimensions; must not be empty.
     #[serde(alias = "nd_netcdf")]
     NdNetCDF {
         /// Columns to use as dimensions for the ND NetCDF output.
@@ -96,6 +99,7 @@ pub enum OutputFormat {
         /// Name of the latitude column, if any.
         latitude_column: Option<String>,
     },
+    /// Ocean Data View (ODV) archive, configured by [`OdvOptions`].
     Odv(OdvOptions),
 }
 

--- a/beacon-core/src/sys.rs
+++ b/beacon-core/src/sys.rs
@@ -1,6 +1,12 @@
-#[derive(Debug, serde::Serialize)]
+/// Beacon runtime system information returned by `GET /api/info`.
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
 pub struct SystemInfo {
+    /// The running Beacon build version (the `beacon-core` crate version).
     pub beacon_version: String,
+    /// Host resource snapshot (CPUs, memory, processes) gathered via `sysinfo`.
+    /// Present only when the runtime is configured to expose host metrics;
+    /// otherwise `null`.
+    #[schema(value_type = Option<Object>)]
     pub system_info: Option<sysinfo::System>,
 }
 


### PR DESCRIPTION
## Summary

The Beacon REST API (`beacon-api`, Axum + `utoipa`) annotated all endpoints but the generated spec was thin: most client endpoints declared no response body or error responses, many DTO fields had no descriptions, two response types were missing `ToSchema` entirely, and the all-important query object rendered as an opaque `Object`. This PR makes `/swagger`, `/scalar/`, and `/openapi.json` fully describe each endpoint and payload.

## Changes

- **Fix the two missing `ToSchema` derives** — `SystemInfo` and `TableWithSchema` no longer fall back to an empty schema.
- **Document the DTOs** — struct/field doc comments (and a few `#[schema(example = …)]`) across `beacon-core/src/api.rs`, plus the query-parameter structs.
- **Wire up the endpoints** — concrete `body = Type`, error responses (400/404/500), request-body content types, and param descriptions on every client endpoint.
- **Tag-group descriptions** for the client and admin OpenAPI documents.
- **Surface the real query object** — point the query endpoints' `request_body` at `beacon_core::query::Query` and un-hide `Query.output`, so the structured query DSL (`select`/`filter`/`from`/`output`) renders instead of an opaque object.

## Note on the recursion fix

The query types `Filter` (via `And`/`Or`) and `Select` (via `Function.args`) are self-recursive, and `utoipa` inlines untagged enums rather than emitting `$ref` — so the first build of the spec **stack-overflowed**. This would have crashed the live server at startup / on `/openapi.json`, not just in tests. Fixed by breaking each cycle with `#[schema(no_recursion)]`. A regression test (`client_openapi_includes_query_schema`) now assembles the client OpenAPI document and asserts the query schema tree is present, guarding against a recurrence.

## Caveat

The untagged enums (`Select`, the comparison filters, `InnerQuery::Json`) render as `oneOf` without a discriminator — a large improvement over `Object`, but worth a glance in the Scalar/Swagger UI.

## Testing

- `cargo build -p beacon-core -p beacon-api` — clean.
- `cargo test -p beacon-api` — all 10 tests pass, including the new OpenAPI assembly test.
