### PR TITLE
Add TypeScript/JavaScript SDK (clients/beacon-ts)

### DIFF
--- a/.github/workflows/client-ts.yml
+++ b/.github/workflows/client-ts.yml
@@ -1,0 +1,44 @@
+name: TypeScript client
+
+on:
+  push:
+    paths:
+      - "clients/beacon-ts/**"
+      - ".github/workflows/client-ts.yml"
+  pull_request:
+    paths:
+      - "clients/beacon-ts/**"
+      - ".github/workflows/client-ts.yml"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: clients/beacon-ts
+
+jobs:
+  build:
+    name: Typecheck, test, and build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/clients/beacon-ts/.gitignore
+++ b/clients/beacon-ts/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.tsbuildinfo
+# Fetched at codegen time; the committed generated/schema.d.ts is the source of truth.
+openapi.json

--- a/clients/beacon-ts/README.md
+++ b/clients/beacon-ts/README.md
@@ -1,0 +1,188 @@
+# @beacon/client
+
+Isomorphic TypeScript SDK for managing and querying a [Beacon](../../README.md)
+instance. Runs in Node.js (18+) and the browser, built on the global `fetch`.
+
+## Install
+
+```bash
+npm install @beacon/client
+```
+
+`apache-arrow` (the result decoder) and `fzstd` (a tiny pure-JS zstd
+decompressor) are regular dependencies, installed automatically — no extra
+setup. Beacon's results are zstd-compressed Arrow IPC; the SDK registers an
+fzstd-backed zstd codec with apache-arrow so they decode out of the box.
+
+## Quick start
+
+```ts
+import { BeaconClient } from "@beacon/client";
+
+const beacon = new BeaconClient({ url: "http://localhost:5001" });
+
+// Run SQL and get plain JS row objects (decoded from the Arrow stream).
+const { rows, queryId, table } = await beacon.query(
+  "SELECT TEMP, PSAL FROM read_netcdf(['file.nc']) LIMIT 5",
+);
+
+// Or use the structured JSON query DSL.
+const result = await beacon.query({
+  select: [{ column: "TEMP", alias: "temperature" }, "PSAL"],
+  filter: { column: "depth", gt_eq: 0, lt_eq: 100 },
+  limit: 100,
+});
+
+// Inspect the catalog.
+const tables = await beacon.tables();
+const info = await beacon.info();
+```
+
+## Query builder (EF Core / LINQ-style)
+
+A fluent builder produces the JSON DSL for you. JavaScript can't overload
+operators, so predicates use methods (`col("d").gte(0)`) rather than `d >= 0`;
+otherwise it reads like EF Core's method syntax.
+
+```ts
+import { column, func } from "@beacon/client";
+
+const { rows } = await beacon
+  .from({ netcdf: { paths: ["argo.nc"] } })       // or .fromNetcdf("argo.nc"), .fromTable("t")
+  .select("TEMP", column("PSAL", "salinity"), func("avg", ["TEMP"], "mean"))
+  .where((x) => x.depth.gte(0).and(x.depth.lte(100)))  // x.<col> → comparison methods
+  .orderByDescending("TEMP")
+  .skip(0)
+  .take(100)
+  .execute();                                     // → { rows, queryId, table }
+
+// EF-style terminals:
+const list = await beacon.from("ctd").select("*").toArray();      // just rows
+const one = await beacon.select("TEMP").where(col("id").eq(7)).first();
+
+// Other outputs from the same builder:
+const table = await beacon.from("ctd").select("TEMP").toArrow();  // Arrow Table
+for await (const batch of beacon.from("ctd").select("TEMP").stream()) { /* RecordBatch */ }
+
+// Inspect or reuse the DSL without running it:
+const dsl = beacon.from("ctd").select("TEMP").where(col("d").gte(0)).build();
+```
+
+Predicate building blocks (importable): `col(name)` →
+`.eq/.neq/.gt/.gte/.lt/.lte/.between/.isNull/.isNotNull`, combined with
+`.and(...)`, `.or(...)` or the free functions `and(...)`, `or(...)`. There is no
+`not` (Beacon's DSL has none) — use `neq` / `isNotNull`. Projection helpers:
+`column(name, alias?)`, `func(name, args, alias?)`, `literal(value, alias?)`.
+
+### Optional typed columns and completion
+
+Typing is **opt-in**. By default the builder is fully untyped — no type
+parameter, no annotations, every column name and comparison value accepted:
+
+```ts
+// Works as-is, no types required:
+const { rows } = await beacon
+  .from("ctd")
+  .select("TEMP")
+  .where((x) => x.depth.gte(0))   // `x` is inferred; no annotation needed
+  .execute();
+```
+
+*If* you want completion and checking, pass a row type — then `where`, `select`,
+`orderBy`/`thenBy`, and `distinct` all complete column names, and `where`
+comparison values are checked against each column's type:
+
+```ts
+interface Ctd { TEMP: number; depth: number; station: string }
+
+beacon.from<Ctd>("ctd")
+  .select("TEMP", "depth")        // ✅ completes TEMP | depth | station
+  .where((x) => x.depth.gte(0))   // ✅ `x.` completes columns; gte() wants a number
+  .where((x) => x.dpeth.gte(0))   // ❌ no column `dpeth`
+  .where((x) => x.TEMP.gte("hi")) // ❌ TEMP is a number, not a string
+  .orderByDescending("TEMP");     // ✅ completes columns
+```
+
+`where(x => …)` is strict — a misspelled column is a compile error. `select`,
+`orderBy`, and `distinct` complete known columns but still accept any string, so
+`"*"`, aliases, and expressions keep working. Without a type argument the builder
+is fully untyped (any column name, any comparison value) — the escape hatch for
+ad-hoc queries.
+
+### Authenticated (admin) operations
+
+Supplying credentials elevates every request to super-user, enabling DDL/DML over
+`query()` and the `admin.*` endpoints:
+
+```ts
+const beacon = new BeaconClient({
+  url: "http://localhost:5001",
+  username: "beacon-admin",
+  password: "beacon-password",
+});
+
+await beacon.query("CREATE EXTERNAL TABLE ... STORED AS PARQUET ...");
+
+const crawlers = await beacon.admin.listCrawlers();
+await beacon.admin.runCrawler("my-crawler");
+await beacon.admin.createExternalTable({ /* spec */ });
+```
+
+## Result formats
+
+Beacon's default `/api/query` response is a **zstd-compressed Arrow IPC stream**,
+which the SDK decodes via `apache-arrow` + the auto-registered `fzstd` zstd
+codec. There is **no JSON output format**; CSV is the dependency-light
+alternative.
+
+| Method | Server output | Returns |
+| --- | --- | --- |
+| `query()` | default Arrow stream | `{ rows, queryId, table }` — plain objects + the Arrow `table` |
+| `query(q, { format: "csv" })` | `csv` | `{ rows, queryId }` — all values are strings |
+| `queryArrow()` | default Arrow stream | an `apache-arrow` `Table` |
+| `queryStream()` | default Arrow stream | `AsyncGenerator<RecordBatch>` — streamed, unbuffered |
+| `queryCsv()` | `csv` | `{ rows, queryId }` — string-valued rows |
+| `queryRaw(query, format?)` | any (or default stream) | the raw `fetch` `Response` |
+
+Use `queryRaw` to stream large results or write a materialized format (CSV,
+Parquet, NetCDF, GeoParquet, ODV, …) to disk:
+
+```ts
+import { createWriteStream } from "node:fs";
+import { Readable } from "node:stream";
+
+const res = await beacon.queryRaw("SELECT * FROM big_table", "parquet");
+await new Promise((resolve, reject) => {
+  Readable.fromWeb(res.body!).pipe(createWriteStream("out.parquet")).on("finish", resolve).on("error", reject);
+});
+```
+
+## Typed schemas from your server
+
+The hand-written types in [`src/types.ts`](src/types.ts) cover the query DSL and
+common shapes. For exact request/response types generated from a specific
+server's OpenAPI document:
+
+```bash
+BEACON_URL=http://localhost:5001 npm run codegen
+```
+
+This writes `src/generated/schema.d.ts` from that server's `/openapi.json`.
+
+## Development
+
+```bash
+npm install
+npm run typecheck
+npm test
+npm run build
+```
+
+## API surface
+
+- **Query builder:** `from`, `select` → fluent `QueryBuilder` (see above)
+- **Query:** `query`, `queryArrow`, `queryStream`, `queryCsv`, `queryRaw`, `parseQuery`, `explainQuery`, `queryMetrics`
+- **Tables:** `tables`, `tablesWithSchema`, `tableSchema`, `tableConfig`, `defaultTable`, `defaultTableSchema`
+- **Datasets:** `datasets`, `datasetSchema`, `totalDatasets`
+- **Functions / info:** `functions`, `tableFunctions`, `info`, `health`
+- **Admin (`beacon.admin`):** `check`, `listCrawlers`, `createCrawler`, `getCrawler`, `runCrawler`, `dropCrawler`, `createExternalTable`

--- a/clients/beacon-ts/package-lock.json
+++ b/clients/beacon-ts/package-lock.json
@@ -1,0 +1,3491 @@
+{
+  "name": "@beacon/client",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@beacon/client",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "apache-arrow": "21.1.0",
+        "fzstd": "0.1.1"
+      },
+      "devDependencies": {
+        "@types/node": "22.10.2",
+        "openapi-typescript": "7.4.4",
+        "tsup": "8.3.5",
+        "tsx": "4.19.2",
+        "typescript": "5.7.2",
+        "vitest": "2.1.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.15",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.15.tgz",
+      "integrity": "sha512-HAwCnNyKcs5XGQqms+9t7OdAPM/5TDstmhF+0i7tdCFato2QKuYIlyWETwkXd8c5zbltr1oB+6y9NTeQLr2d6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "8.11.2",
+        "@redocly/config": "0.22.0",
+        "colorette": "1.4.0",
+        "https-proxy-agent": "7.0.6",
+        "js-levenshtein": "1.1.6",
+        "js-yaml": "4.1.1",
+        "minimatch": "5.1.9",
+        "pluralize": "8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
+      "integrity": "sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.8.tgz",
+      "integrity": "sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.8.tgz",
+      "integrity": "sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.8",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.8.tgz",
+      "integrity": "sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.8",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
+      "integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
+      "integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.8",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/apache-arrow": {
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
+      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^24.0.3",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^25.1.24",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
+      "license": "MIT"
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/openapi-typescript": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.4.4.tgz",
+      "integrity": "sha512-7j3nktnRzlQdlHnHsrcr6Gqz8f80/RhfA2I8s1clPI+jkY0hLNmnYVKBfuUEli5EEgK1B6M+ibdS5REasPlsUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.25.9",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.1.0",
+        "supports-color": "^9.4.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/supports-color": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "deprecated": "The work that was done in this beta branch won't be included in future versions",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsup": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.3.5.tgz",
+      "integrity": "sha512-Tunf6r6m6tnZsG9GYWndg0z8dEV7fD733VBFzFJ5Vcm1FtlXB8xBD/rtrBi2a3YKEV7hHtxiZtW5EAVADoe1pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.0.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.1",
+        "consola": "^3.2.3",
+        "debug": "^4.3.7",
+        "esbuild": "^0.24.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.24.0",
+        "source-map": "0.8.0-beta.0",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.1",
+        "tinyglobby": "^0.2.9",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.2.tgz",
+      "integrity": "sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.23.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.8.tgz",
+      "integrity": "sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.8.tgz",
+      "integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.8",
+        "@vitest/mocker": "2.1.8",
+        "@vitest/pretty-format": "^2.1.8",
+        "@vitest/runner": "2.1.8",
+        "@vitest/snapshot": "2.1.8",
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.8",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.8",
+        "@vitest/ui": "2.1.8",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/clients/beacon-ts/package.json
+++ b/clients/beacon-ts/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@beacon/client",
+  "version": "0.1.0",
+  "description": "Isomorphic TypeScript SDK for managing and querying a Beacon instance.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "sideEffects": false,
+  "dependencies": {
+    "apache-arrow": "21.1.0",
+    "fzstd": "0.1.1"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "codegen": "tsx scripts/fetch-openapi.ts && openapi-typescript ./openapi.json -o ./src/generated/schema.d.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
+    "@types/node": "22.10.2",
+    "openapi-typescript": "7.4.4",
+    "tsup": "8.3.5",
+    "tsx": "4.19.2",
+    "typescript": "5.7.2",
+    "vitest": "2.1.8"
+  }
+}

--- a/clients/beacon-ts/scripts/fetch-openapi.ts
+++ b/clients/beacon-ts/scripts/fetch-openapi.ts
@@ -1,0 +1,21 @@
+/**
+ * Fetches the OpenAPI document from a running Beacon server and writes it to
+ * `openapi.json` for `openapi-typescript` to consume.
+ *
+ * Usage: `BEACON_URL=http://localhost:5001 npm run codegen`
+ */
+
+import { writeFile } from "node:fs/promises";
+
+const url = process.env.BEACON_URL ?? "http://localhost:5001";
+const specUrl = `${url.replace(/\/+$/, "")}/openapi.json`;
+
+const res = await fetch(specUrl);
+if (!res.ok) {
+  console.error(`Failed to fetch ${specUrl}: ${res.status} ${res.statusText}`);
+  process.exit(1);
+}
+
+const spec = await res.text();
+await writeFile("openapi.json", spec);
+console.log(`Wrote openapi.json from ${specUrl}`);

--- a/clients/beacon-ts/src/admin.ts
+++ b/clients/beacon-ts/src/admin.ts
@@ -1,0 +1,52 @@
+/** Authenticated administrative endpoints (`/api/admin/*`). */
+
+import type { Http } from "./http.js";
+import type { Crawler, ExternalTableSpec } from "./types.js";
+
+/**
+ * Sub-client for Beacon's admin surface. All endpoints require basic-auth
+ * credentials, configured via `username`/`password` on the parent client.
+ * Reachable as `client.admin`.
+ */
+export class AdminClient {
+  constructor(private readonly http: Http) {}
+
+  /** Verifies the configured admin credentials (`GET /api/admin/check`). */
+  async check(): Promise<void> {
+    await this.http.fetchRaw("GET", "/api/admin/check");
+  }
+
+  // -- crawlers ---------------------------------------------------------------
+
+  /** Lists all defined crawlers (`GET /api/admin/crawlers`). */
+  listCrawlers<T = Crawler[]>(): Promise<T> {
+    return this.http.fetchJson<T>("GET", "/api/admin/crawlers");
+  }
+
+  /** Creates/defines a crawler (`POST /api/admin/crawlers`). */
+  createCrawler<T = Crawler>(definition: Crawler): Promise<T> {
+    return this.http.fetchJson<T>("POST", "/api/admin/crawlers", { json: definition });
+  }
+
+  /** Gets a single crawler by name (`GET /api/admin/crawlers/{name}`). */
+  getCrawler<T = Crawler>(name: string): Promise<T> {
+    return this.http.fetchJson<T>("GET", `/api/admin/crawlers/${encodeURIComponent(name)}`);
+  }
+
+  /** Runs a crawler on demand (`POST /api/admin/crawlers/{name}/run`). */
+  async runCrawler(name: string): Promise<void> {
+    await this.http.fetchRaw("POST", `/api/admin/crawlers/${encodeURIComponent(name)}/run`);
+  }
+
+  /** Deletes a crawler (`DELETE /api/admin/crawlers/{name}`). */
+  async dropCrawler(name: string): Promise<void> {
+    await this.http.fetchRaw("DELETE", `/api/admin/crawlers/${encodeURIComponent(name)}`);
+  }
+
+  // -- external tables --------------------------------------------------------
+
+  /** Creates an external table (`POST /api/admin/external-tables`). */
+  createExternalTable<T = unknown>(spec: ExternalTableSpec): Promise<T> {
+    return this.http.fetchJson<T>("POST", "/api/admin/external-tables", { json: spec });
+  }
+}

--- a/clients/beacon-ts/src/arrow.ts
+++ b/clients/beacon-ts/src/arrow.ts
@@ -1,0 +1,79 @@
+/**
+ * Bridge to `apache-arrow` (a required dependency) with zstd support.
+ *
+ * Beacon's default in-memory query response is a *zstd-compressed* Arrow IPC
+ * stream. apache-arrow 21+ decodes compressed IPC, but only once a codec is
+ * registered for the compression type (it bundles no zstd implementation). We
+ * register one backed by `fzstd` — a tiny, pure-JS, isomorphic zstd
+ * decompressor — the first time the decoder is loaded.
+ *
+ * The imports are dynamic so callers that only hit metadata endpoints don't pull
+ * Arrow into their bundle until the first query.
+ */
+
+/** Minimal structural view of an apache-arrow `Table`, to avoid a type dependency. */
+export interface ArrowTable {
+  readonly numRows: number;
+  readonly numCols: number;
+  toArray(): unknown[];
+}
+
+/** Minimal structural view of an apache-arrow `RecordBatch`. */
+export interface ArrowRecordBatch {
+  readonly numRows: number;
+  toArray(): unknown[];
+}
+
+interface ArrowDecoder {
+  /** Decodes a complete Arrow IPC payload (stream or file) into a Table. */
+  tableFromIPC(bytes: Uint8Array): ArrowTable;
+  /** Opens a streaming reader over a chunked Arrow IPC source. */
+  readStream(source: AsyncIterable<Uint8Array>): Promise<AsyncIterable<ArrowRecordBatch>>;
+}
+
+// Shape of the bits of the apache-arrow module we touch.
+interface ArrowModule {
+  tableFromIPC(bytes: Uint8Array): ArrowTable;
+  RecordBatchReader: {
+    from(source: unknown): Promise<AsyncIterable<ArrowRecordBatch>> | AsyncIterable<ArrowRecordBatch>;
+  };
+  CompressionType: { ZSTD: number };
+  compressionRegistry: {
+    get(type: number): { decode?: (b: Uint8Array) => Uint8Array } | null;
+    set(type: number, codec: { decode?: (b: Uint8Array) => Uint8Array }): void;
+  };
+}
+
+let loaded: ArrowDecoder | undefined;
+
+/** Loads apache-arrow (and registers the zstd codec on first use). */
+export async function getArrowDecoder(): Promise<ArrowDecoder> {
+  if (loaded) return loaded;
+  const arrow = (await import("apache-arrow")) as unknown as ArrowModule;
+  await registerZstd(arrow);
+  loaded = {
+    tableFromIPC: (bytes) => arrow.tableFromIPC(bytes),
+    readStream: async (source) => arrow.RecordBatchReader.from(source),
+  };
+  return loaded;
+}
+
+/** Registers an fzstd-backed ZSTD decode codec with apache-arrow (idempotent). */
+async function registerZstd(arrow: ArrowModule): Promise<void> {
+  const zstdType = arrow.CompressionType.ZSTD;
+  if (arrow.compressionRegistry.get(zstdType)?.decode) return;
+  const { decompress } = (await import("fzstd")) as { decompress: (b: Uint8Array) => Uint8Array };
+  arrow.compressionRegistry.set(zstdType, { decode: (b) => decompress(b) });
+}
+
+/** Converts an Arrow Table to plain JS row objects. */
+export function rowsFromTable<T>(table: ArrowTable): T[] {
+  return table.toArray().map(toPlainRow) as T[];
+}
+
+function toPlainRow(row: unknown): unknown {
+  if (row && typeof (row as { toJSON?: unknown }).toJSON === "function") {
+    return (row as { toJSON: () => unknown }).toJSON();
+  }
+  return { ...(row as object) };
+}

--- a/clients/beacon-ts/src/client.ts
+++ b/clients/beacon-ts/src/client.ts
@@ -1,0 +1,258 @@
+/** The main Beacon client: query execution and metadata discovery. */
+
+import { AdminClient } from "./admin.js";
+import {
+  getArrowDecoder,
+  rowsFromTable,
+  type ArrowRecordBatch,
+  type ArrowTable,
+} from "./arrow.js";
+import { parseCsv } from "./csv.js";
+import { Http, type ClientOptions } from "./http.js";
+import { QueryBuilder } from "./query-builder.js";
+import { responseByteStream } from "./stream.js";
+import type {
+  From,
+  Output,
+  OutputFormat,
+  QueryInput,
+  QueryMetricsView,
+  Row,
+  Select,
+} from "./types.js";
+
+const QUERY_ID_HEADER = "x-beacon-query-id";
+
+/** A query result decoded into rows, with the server-assigned query id. */
+export interface QueryResult<T = Row> {
+  rows: T[];
+  /** Server-assigned UUID for this query (from the `x-beacon-query-id` header). */
+  queryId: string | null;
+  /**
+   * The decoded Arrow Table, present when the Arrow path was used (i.e.
+   * `apache-arrow` is installed). Absent when the CSV fallback produced the rows.
+   */
+  table?: ArrowTable;
+}
+
+/** Options for `query()`. */
+export interface QueryOptions {
+  /**
+   * Force a decode path. `"arrow"` requires `apache-arrow`; `"csv"` uses the
+   * dependency-free CSV fallback. Omit to use Arrow when available and fall back
+   * to CSV otherwise.
+   */
+  format?: "arrow" | "csv";
+  signal?: AbortSignal;
+}
+
+/**
+ * Client for a single Beacon server.
+ *
+ * ```ts
+ * const beacon = new BeaconClient({ url: "http://localhost:5001" });
+ * const { rows } = await beacon.query("SELECT 1 AS n");
+ * ```
+ *
+ * Supplying `username`/`password` elevates every request to super-user, enabling
+ * DDL/DML over `query()` and the `admin` endpoints.
+ */
+export class BeaconClient {
+  private readonly http: Http;
+  /** Authenticated administrative endpoints (`/api/admin/*`). */
+  readonly admin: AdminClient;
+
+  constructor(options: ClientOptions) {
+    this.http = new Http(options);
+    this.admin = new AdminClient(this.http);
+  }
+
+  // -- query ------------------------------------------------------------------
+
+  /** Starts a fluent query against `source` (a table name or `{ format: { paths } }`). */
+  from<T = Row>(source?: From): QueryBuilder<T> {
+    return new QueryBuilder<T>(this, source);
+  }
+
+  /** Starts a fluent query with the given projection (shorthand for `from().select(...)`). */
+  select<T = Row>(...items: Array<string | Select>): QueryBuilder<T> {
+    return new QueryBuilder<T>(this).select(...items);
+  }
+
+  /**
+   * Runs a query and returns the rows as plain JS objects.
+   *
+   * Decodes the server's zstd-compressed Arrow IPC stream via `apache-arrow`
+   * (the result also exposes the Arrow `table`). Pass `{ format: "csv" }` to
+   * fetch CSV output instead and parse it (all values become strings, `table`
+   * is absent). Works for SELECTs; DDL/DML yields an empty `rows`.
+   */
+  async query<T = Row>(query: QueryInput, options: QueryOptions = {}): Promise<QueryResult<T>> {
+    if (options.format === "csv") {
+      const res = await this.queryRaw(query, "csv", options.signal);
+      return { rows: parseCsv(await res.text()) as T[], queryId: res.headers.get(QUERY_ID_HEADER) };
+    }
+    const decoder = await getArrowDecoder();
+    const res = await this.queryRaw(query, undefined, options.signal);
+    const queryId = res.headers.get(QUERY_ID_HEADER);
+    const table = decoder.tableFromIPC(new Uint8Array(await res.arrayBuffer()));
+    return { rows: rowsFromTable<T>(table), queryId, table };
+  }
+
+  /**
+   * Runs a query and decodes the default zstd-compressed Arrow IPC stream into
+   * an `apache-arrow` Table.
+   */
+  async queryArrow(query: QueryInput, signal?: AbortSignal): Promise<ArrowTable> {
+    const decoder = await getArrowDecoder();
+    const res = await this.queryRaw(query, undefined, signal);
+    return decoder.tableFromIPC(new Uint8Array(await res.arrayBuffer()));
+  }
+
+  /**
+   * Runs a query and yields Arrow `RecordBatch`es as they arrive, without
+   * buffering the whole result in memory. Each batch's rows are available via
+   * `batch.toArray()`.
+   */
+  async *queryStream(query: QueryInput, signal?: AbortSignal): AsyncGenerator<ArrowRecordBatch> {
+    const decoder = await getArrowDecoder();
+    const res = await this.queryRaw(query, undefined, signal);
+    const reader = await decoder.readStream(responseByteStream(res));
+    for await (const batch of reader) yield batch;
+  }
+
+  /**
+   * Runs a query asking the server for CSV output and parses it into row objects
+   * (all values are strings).
+   */
+  async queryCsv(
+    query: QueryInput,
+    signal?: AbortSignal,
+  ): Promise<QueryResult<Record<string, string>>> {
+    const res = await this.queryRaw(query, "csv", signal);
+    const queryId = res.headers.get(QUERY_ID_HEADER);
+    return { rows: parseCsv(await res.text()), queryId };
+  }
+
+  /**
+   * Runs a query asking the server to materialize `format`, and returns the raw
+   * `Response`. Use this to stream large results, write to a file, or handle any
+   * output format (including the default compressed Arrow stream when `format`
+   * is omitted) yourself.
+   */
+  queryRaw(query: QueryInput, format?: OutputFormat, signal?: AbortSignal): Promise<Response> {
+    const output = format === undefined ? undefined : { format };
+    return this.http.fetchRaw("POST", "/api/query", { json: buildBody(query, output), signal });
+  }
+
+  /**
+   * Validates a query body without executing it (`POST /api/parse-query`).
+   * Returns true when the payload is well-formed.
+   */
+  async parseQuery(query: QueryInput): Promise<boolean> {
+    try {
+      await this.http.fetchRaw("POST", "/api/parse-query", { json: buildBody(query) });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Returns the planner's explanation of a query without running it. */
+  explainQuery<T = unknown>(query: QueryInput): Promise<T> {
+    return this.http.fetchJson<T>("POST", "/api/explain-query", { json: buildBody(query) });
+  }
+
+  /** Fetches recorded metrics for a previously executed query by its id. */
+  queryMetrics(queryId: string): Promise<QueryMetricsView> {
+    return this.http.fetchJson<QueryMetricsView>(
+      "GET",
+      `/api/query/metrics/${encodeURIComponent(queryId)}`,
+    );
+  }
+
+  // -- tables -----------------------------------------------------------------
+
+  /** Lists registered table names (`GET /api/tables`). */
+  tables(): Promise<string[]> {
+    return this.http.fetchJson<string[]>("GET", "/api/tables");
+  }
+
+  /** Lists registered tables together with their Arrow schemas. */
+  tablesWithSchema<T = unknown[]>(): Promise<T> {
+    return this.http.fetchJson<T>("GET", "/api/tables-with-schema");
+  }
+
+  /** Gets the Arrow schema of a table (`GET /api/table-schema`). */
+  tableSchema<T = unknown>(tableName: string): Promise<T> {
+    return this.http.fetchJson<T>("GET", "/api/table-schema", { query: { table_name: tableName } });
+  }
+
+  /** Gets a table's configuration (`GET /api/table-config`). */
+  tableConfig<T = unknown>(tableName: string): Promise<T> {
+    return this.http.fetchJson<T>("GET", "/api/table-config", { query: { table_name: tableName } });
+  }
+
+  /** Gets the default table (`GET /api/default-table`). */
+  defaultTable<T = unknown>(): Promise<T> {
+    return this.http.fetchJson<T>("GET", "/api/default-table");
+  }
+
+  /** Gets the default table's schema (`GET /api/default-table-schema`). */
+  defaultTableSchema<T = unknown>(): Promise<T> {
+    return this.http.fetchJson<T>("GET", "/api/default-table-schema");
+  }
+
+  // -- datasets ---------------------------------------------------------------
+
+  /** Lists datasets with format metadata (`GET /api/list-datasets`). */
+  datasets<T = unknown[]>(opts: { pattern?: string; limit?: number } = {}): Promise<T> {
+    return this.http.fetchJson<T>("GET", "/api/list-datasets", {
+      query: { pattern: opts.pattern, limit: opts.limit },
+    });
+  }
+
+  /** Gets the schema of a single dataset file (`GET /api/dataset-schema`). */
+  datasetSchema<T = unknown>(file: string): Promise<T> {
+    return this.http.fetchJson<T>("GET", "/api/dataset-schema", { query: { file } });
+  }
+
+  /** Counts the total number of datasets (`GET /api/total-datasets`). */
+  totalDatasets(): Promise<number> {
+    return this.http.fetchJson<number>("GET", "/api/total-datasets");
+  }
+
+  // -- functions & info -------------------------------------------------------
+
+  /** Lists available scalar/aggregate functions (`GET /api/functions`). */
+  functions<T = unknown[]>(): Promise<T> {
+    return this.http.fetchJson<T>("GET", "/api/functions");
+  }
+
+  /** Lists available table-valued functions (`GET /api/table-functions`). */
+  tableFunctions<T = unknown[]>(): Promise<T> {
+    return this.http.fetchJson<T>("GET", "/api/table-functions");
+  }
+
+  /** Returns runtime system information — version, host, resources (`GET /api/info`). */
+  info<T = unknown>(): Promise<T> {
+    return this.http.fetchJson<T>("GET", "/api/info");
+  }
+
+  /** Liveness probe (`GET /api/health`). Resolves when the server returns 200. */
+  async health(): Promise<boolean> {
+    try {
+      await this.http.fetchRaw("GET", "/api/health");
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/** Builds the `/api/query` request body from any accepted query input. */
+function buildBody(query: QueryInput, output?: Output): Record<string, unknown> {
+  const body: Record<string, unknown> = typeof query === "string" ? { sql: query } : { ...query };
+  if (output !== undefined) body.output = output;
+  return body;
+}

--- a/clients/beacon-ts/src/client.ts
+++ b/clients/beacon-ts/src/client.ts
@@ -38,9 +38,9 @@ export interface QueryResult<T = Row> {
 /** Options for `query()`. */
 export interface QueryOptions {
   /**
-   * Force a decode path. `"arrow"` requires `apache-arrow`; `"csv"` uses the
-   * dependency-free CSV fallback. Omit to use Arrow when available and fall back
-   * to CSV otherwise.
+   * The decode path. Defaults to `"arrow"`, decoding Beacon's native (zstd)
+   * Arrow IPC stream. Set `"csv"` to instead request CSV output and parse it
+   * (all values become strings, and the result's `table` is absent).
    */
   format?: "arrow" | "csv";
   signal?: AbortSignal;

--- a/clients/beacon-ts/src/csv.ts
+++ b/clients/beacon-ts/src/csv.ts
@@ -1,0 +1,76 @@
+/**
+ * A small RFC 4180 CSV parser for the `query()` CSV fallback (used when
+ * `apache-arrow` is not installed). Handles quoted fields, escaped quotes
+ * (`""`), and commas/newlines inside quotes. All values are returned as
+ * strings — the server's CSV output carries no type information.
+ */
+
+/** Parses CSV text into row objects keyed by the header row. */
+export function parseCsv(text: string): Record<string, string>[] {
+  const rows = parseCsvRows(text);
+  const header = rows[0];
+  if (!header) return [];
+  return rows.slice(1).map((cells) => {
+    const obj: Record<string, string> = {};
+    header.forEach((name, i) => {
+      obj[name] = cells[i] ?? "";
+    });
+    return obj;
+  });
+}
+
+/** Parses CSV text into a 2D array of cell strings. */
+export function parseCsvRows(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  let sawContent = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+      continue;
+    }
+    switch (c) {
+      case '"':
+        inQuotes = true;
+        sawContent = true;
+        break;
+      case ",":
+        row.push(field);
+        field = "";
+        sawContent = true;
+        break;
+      case "\r":
+        break; // part of CRLF; the \n ends the row
+      case "\n":
+        row.push(field);
+        rows.push(row);
+        row = [];
+        field = "";
+        sawContent = false;
+        break;
+      default:
+        field += c;
+        sawContent = true;
+    }
+  }
+
+  // Flush the trailing field/row unless the input ended exactly on a newline.
+  if (sawContent || field !== "" || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  return rows;
+}

--- a/clients/beacon-ts/src/errors.ts
+++ b/clients/beacon-ts/src/errors.ts
@@ -1,0 +1,42 @@
+/** Error types thrown by the Beacon client. */
+
+/** Base class for every error raised by this SDK. */
+export class BeaconError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = new.target.name;
+  }
+}
+
+/** The server could not be reached (DNS, connection refused, or the request timed out). */
+export class ConnectionError extends BeaconError {
+  constructor(
+    readonly url: string,
+    readonly cause: unknown,
+  ) {
+    super(`failed to reach Beacon at ${url}: ${describe(cause)}`);
+  }
+}
+
+/** The request timed out before the server responded. */
+export class TimeoutError extends ConnectionError {}
+
+/**
+ * The server returned a non-2xx status. `status` is the HTTP code and `body` is
+ * the (best-effort decoded) response body, which Beacon returns as a JSON-encoded
+ * error string for query failures.
+ */
+export class ApiError extends BeaconError {
+  constructor(
+    readonly status: number,
+    readonly body: string,
+    readonly url: string,
+  ) {
+    super(`Beacon returned ${status} for ${url}: ${body}`);
+  }
+}
+
+function describe(cause: unknown): string {
+  if (cause instanceof Error) return cause.message;
+  return String(cause);
+}

--- a/clients/beacon-ts/src/generated/schema.d.ts
+++ b/clients/beacon-ts/src/generated/schema.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Placeholder for the generated OpenAPI types.
+ *
+ * Run `BEACON_URL=http://localhost:5001 npm run codegen` against a running
+ * Beacon server to overwrite this file with the exact request/response schemas
+ * from that server's `/openapi.json`. The hand-written types in `../types.ts`
+ * cover the ergonomic surface in the meantime.
+ */
+
+export type paths = Record<string, never>;
+export type components = Record<string, never>;

--- a/clients/beacon-ts/src/http.ts
+++ b/clients/beacon-ts/src/http.ts
@@ -1,0 +1,163 @@
+/** Low-level isomorphic HTTP transport for the Beacon API. */
+
+import { ApiError, ConnectionError, TimeoutError } from "./errors.js";
+
+/** A fetch-compatible function. Defaults to the global `fetch`. */
+export type FetchLike = typeof fetch;
+
+export interface ClientOptions {
+  /** Base URL of the Beacon server, e.g. `http://localhost:5001`. */
+  url: string;
+  /**
+   * Admin basic-auth credentials. Sent on every request when provided, which
+   * elevates the request to super-user (allowing DDL/DML and admin endpoints).
+   */
+  username?: string;
+  password?: string;
+  /**
+   * URL prefix the server is mounted under (Beacon's `BEACON_BASE_PATH`).
+   * Prepended to every API path. Defaults to "".
+   */
+  basePath?: string;
+  /** Per-request timeout in milliseconds. Defaults to 60000. Set to 0 to disable. */
+  timeoutMs?: number;
+  /** Custom fetch implementation (e.g. for testing or a proxy). */
+  fetch?: FetchLike;
+  /** Extra headers attached to every request. */
+  headers?: Record<string, string>;
+}
+
+/** Builds an HTTP Basic `Authorization` header value, isomorphically. */
+export function basicAuthHeader(username: string, password: string): string {
+  const raw = `${username}:${password}`;
+  // `btoa` exists in browsers and modern Node; fall back to Buffer on older Node.
+  const encode =
+    typeof globalThis.btoa === "function"
+      ? globalThis.btoa
+      : (s: string) => Buffer.from(s, "binary").toString("base64");
+  return `Basic ${encode(raw)}`;
+}
+
+/** The resolved transport shared by the client and its sub-clients. */
+export class Http {
+  readonly baseUrl: string;
+  private readonly fetchImpl: FetchLike;
+  private readonly timeoutMs: number;
+  private readonly authHeader?: string;
+  private readonly extraHeaders: Record<string, string>;
+
+  constructor(options: ClientOptions) {
+    const base = options.url.replace(/\/+$/, "");
+    const prefix = (options.basePath ?? "").replace(/\/+$/, "");
+    this.baseUrl = `${base}${prefix}`;
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    if (typeof this.fetchImpl !== "function") {
+      throw new Error(
+        "global fetch is unavailable; pass a `fetch` implementation in ClientOptions (Node < 18).",
+      );
+    }
+    this.timeoutMs = options.timeoutMs ?? 60_000;
+    this.extraHeaders = options.headers ?? {};
+    if (options.username != null && options.password != null) {
+      this.authHeader = basicAuthHeader(options.username, options.password);
+    }
+  }
+
+  /** Whether admin credentials are configured. */
+  get authenticated(): boolean {
+    return this.authHeader != null;
+  }
+
+  /**
+   * Issues a request and returns the raw `Response` (after asserting a 2xx
+   * status). The caller owns the body — use this for streaming/binary results.
+   */
+  async fetchRaw(
+    method: string,
+    path: string,
+    init: {
+      query?: Record<string, string | number | undefined>;
+      json?: unknown;
+      headers?: Record<string, string>;
+      signal?: AbortSignal;
+    } = {},
+  ): Promise<Response> {
+    const url = this.buildUrl(path, init.query);
+    const headers: Record<string, string> = { ...this.extraHeaders, ...init.headers };
+    if (this.authHeader) headers["Authorization"] = this.authHeader;
+
+    let body: string | undefined;
+    if (init.json !== undefined) {
+      headers["Content-Type"] = "application/json";
+      body = JSON.stringify(init.json);
+    }
+
+    const { signal, cancel } = this.withTimeout(init.signal);
+    let res: Response;
+    try {
+      res = await this.fetchImpl(url, { method, headers, body, signal });
+    } catch (err) {
+      if (isAbortError(err)) throw new TimeoutError(url, err);
+      throw new ConnectionError(url, err);
+    } finally {
+      cancel();
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new ApiError(res.status, decodeErrorBody(text), url);
+    }
+    return res;
+  }
+
+  /** Issues a request and decodes the JSON response body. */
+  async fetchJson<T>(
+    method: string,
+    path: string,
+    init: Parameters<Http["fetchRaw"]>[2] = {},
+  ): Promise<T> {
+    const res = await this.fetchRaw(method, path, init);
+    return (await res.json()) as T;
+  }
+
+  private buildUrl(path: string, query?: Record<string, string | number | undefined>): string {
+    const url = new URL(`${this.baseUrl}${path}`);
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value !== undefined) url.searchParams.set(key, String(value));
+      }
+    }
+    return url.toString();
+  }
+
+  private withTimeout(external?: AbortSignal): { signal: AbortSignal; cancel: () => void } {
+    if (this.timeoutMs <= 0) {
+      return { signal: external ?? new AbortController().signal, cancel: () => {} };
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    if (external) {
+      if (external.aborted) controller.abort();
+      else external.addEventListener("abort", () => controller.abort(), { once: true });
+    }
+    return { signal: controller.signal, cancel: () => clearTimeout(timer) };
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+/**
+ * Beacon returns query errors as a JSON-encoded string (`"some message"`).
+ * Unwrap that to the bare message when possible; otherwise return as-is.
+ */
+function decodeErrorBody(text: string): string {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (typeof parsed === "string") return parsed;
+  } catch {
+    /* not JSON; fall through */
+  }
+  return text;
+}

--- a/clients/beacon-ts/src/http.ts
+++ b/clients/beacon-ts/src/http.ts
@@ -29,13 +29,24 @@ export interface ClientOptions {
 
 /** Builds an HTTP Basic `Authorization` header value, isomorphically. */
 export function basicAuthHeader(username: string, password: string): string {
-  const raw = `${username}:${password}`;
-  // `btoa` exists in browsers and modern Node; fall back to Buffer on older Node.
-  const encode =
-    typeof globalThis.btoa === "function"
-      ? globalThis.btoa
-      : (s: string) => Buffer.from(s, "binary").toString("base64");
-  return `Basic ${encode(raw)}`;
+  return `Basic ${base64Utf8(`${username}:${password}`)}`;
+}
+
+/**
+ * Base64-encodes a string's UTF-8 bytes, in both the browser and Node.
+ *
+ * `btoa` operates on Latin-1 code points and throws on characters outside that
+ * range, so we encode to UTF-8 bytes first — credentials may contain any
+ * Unicode character.
+ */
+function base64Utf8(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(bytes).toString("base64");
+  }
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return globalThis.btoa(binary);
 }
 
 /** The resolved transport shared by the client and its sub-clients. */
@@ -92,12 +103,16 @@ export class Http {
       body = JSON.stringify(init.json);
     }
 
-    const { signal, cancel } = this.withTimeout(init.signal);
+    const { signal, cancel, timedOut } = this.withTimeout(init.signal);
     let res: Response;
     try {
       res = await this.fetchImpl(url, { method, headers, body, signal });
     } catch (err) {
-      if (isAbortError(err)) throw new TimeoutError(url, err);
+      // Our internal controller aborted the request: classify why.
+      if (signal.aborted) {
+        if (timedOut()) throw new TimeoutError(url, err);
+        throw err; // external cancellation — preserve the caller's AbortError/reason
+      }
       throw new ConnectionError(url, err);
     } finally {
       cancel();
@@ -130,22 +145,41 @@ export class Http {
     return url.toString();
   }
 
-  private withTimeout(external?: AbortSignal): { signal: AbortSignal; cancel: () => void } {
-    if (this.timeoutMs <= 0) {
-      return { signal: external ?? new AbortController().signal, cancel: () => {} };
-    }
+  /**
+   * Composes the request's abort signal: the configured timeout plus any
+   * caller-supplied signal. Returns `timedOut()` so the caller can tell a
+   * timeout abort apart from an external cancellation (the abort reason is not
+   * reliably propagated across runtimes, so we track it explicitly).
+   */
+  private withTimeout(external?: AbortSignal): {
+    signal: AbortSignal;
+    cancel: () => void;
+    timedOut: () => boolean;
+  } {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
-    if (external) {
-      if (external.aborted) controller.abort();
-      else external.addEventListener("abort", () => controller.abort(), { once: true });
-    }
-    return { signal: controller.signal, cancel: () => clearTimeout(timer) };
-  }
-}
+    let timedOut = false;
 
-function isAbortError(err: unknown): boolean {
-  return err instanceof Error && err.name === "AbortError";
+    // Forward an external abort to our controller, preserving its reason.
+    const onExternalAbort = () => controller.abort(external?.reason);
+    if (external) {
+      if (external.aborted) controller.abort(external.reason);
+      else external.addEventListener("abort", onExternalAbort, { once: true });
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    if (this.timeoutMs > 0) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        controller.abort(new DOMException("Request timed out", "TimeoutError"));
+      }, this.timeoutMs);
+    }
+
+    const cancel = () => {
+      if (timer !== undefined) clearTimeout(timer);
+      external?.removeEventListener("abort", onExternalAbort);
+    };
+    return { signal: controller.signal, cancel, timedOut: () => timedOut };
+  }
 }
 
 /**

--- a/clients/beacon-ts/src/index.ts
+++ b/clients/beacon-ts/src/index.ts
@@ -1,0 +1,51 @@
+/** Public API for the Beacon TypeScript SDK. */
+
+export { BeaconClient } from "./client.js";
+export type { QueryResult, QueryOptions } from "./client.js";
+export { AdminClient } from "./admin.js";
+export { Http, basicAuthHeader } from "./http.js";
+export type { ClientOptions, FetchLike } from "./http.js";
+export { BeaconError, ApiError, ConnectionError, TimeoutError } from "./errors.js";
+export { rowsFromTable } from "./arrow.js";
+export type { ArrowTable, ArrowRecordBatch } from "./arrow.js";
+export { parseCsv, parseCsvRows } from "./csv.js";
+export {
+  QueryBuilder,
+  ColumnRef,
+  FilterNode,
+  col,
+  and,
+  or,
+  column,
+  func,
+  literal,
+} from "./query-builder.js";
+export type {
+  Predicate,
+  Fields,
+  ColumnName,
+  FilterValueOf,
+  QueryRunner,
+} from "./query-builder.js";
+export type {
+  Literal,
+  FilterValue,
+  Select,
+  Filter,
+  ComparisonFilter,
+  From,
+  Sort,
+  Distinct,
+  OutputFormat,
+  SimpleOutputFormat,
+  GeoParquetOptions,
+  Output,
+  QueryBody,
+  SqlQuery,
+  StructuredQuery,
+  QueryInput,
+  Row,
+  QueryMetricsView,
+  Crawler,
+  ExternalTableSpec,
+} from "./types.js";

--- a/clients/beacon-ts/src/query-builder.ts
+++ b/clients/beacon-ts/src/query-builder.ts
@@ -331,7 +331,8 @@ export class QueryBuilder<T = Row> {
   }
   /** Executes and returns the first row, or `null` if there are none. */
   async first(signal?: AbortSignal): Promise<T | null> {
-    const rows = await this.take(1).toArray(signal);
+    // Build with `limit: 1` without mutating this builder's own state.
+    const { rows } = await this.runner().query<T>({ ...this.build(), limit: 1 }, { signal });
     return rows[0] ?? null;
   }
   /** Executes and decodes the result into an Arrow Table. */

--- a/clients/beacon-ts/src/query-builder.ts
+++ b/clients/beacon-ts/src/query-builder.ts
@@ -1,0 +1,366 @@
+/**
+ * A fluent, EF Core / LINQ-style builder that produces Beacon's JSON query DSL.
+ *
+ * JavaScript has no operator overloading, so predicates use method chaining
+ * (`col("depth").gte(0)`) rather than `x.depth >= 0`. Otherwise the shape mirrors
+ * EF Core's method syntax: `from(...).where(...).orderBy(...).take(...)`.
+ *
+ * ```ts
+ * const { rows } = await beacon
+ *   .from({ netcdf: { paths: ["argo.nc"] } })
+ *   .select("TEMP", column("PSAL", "salinity"))
+ *   .where((x) => x.depth.gte(0).and(x.depth.lte(100)))
+ *   .orderByDescending("TEMP")
+ *   .take(100)
+ *   .execute();
+ * ```
+ */
+
+import type { ArrowRecordBatch, ArrowTable } from "./arrow.js";
+import type {
+  Distinct,
+  Filter,
+  FilterValue,
+  From,
+  OutputFormat,
+  QueryInput,
+  Row,
+  Select,
+  Sort,
+  StructuredQuery,
+} from "./types.js";
+
+/** The subset of `BeaconClient` a builder needs to execute itself. */
+export interface QueryRunner {
+  query<T>(query: QueryInput, options?: { format?: "arrow" | "csv"; signal?: AbortSignal }): Promise<{
+    rows: T[];
+    queryId: string | null;
+    table?: ArrowTable;
+  }>;
+  queryArrow(query: QueryInput, signal?: AbortSignal): Promise<ArrowTable>;
+  queryStream(query: QueryInput, signal?: AbortSignal): AsyncGenerator<ArrowRecordBatch>;
+  queryCsv(
+    query: QueryInput,
+    signal?: AbortSignal,
+  ): Promise<{ rows: Record<string, string>[]; queryId: string | null }>;
+}
+
+// -- filter expression builder ------------------------------------------------
+
+/** A composable filter expression. Combine with `.and()` / `.or()`. */
+export class FilterNode {
+  constructor(readonly filter: Filter) {}
+
+  /** Logical AND of this node and the others. */
+  and(...others: FilterNode[]): FilterNode {
+    return new FilterNode({ and: [this.filter, ...others.map((o) => o.filter)] });
+  }
+
+  /** Logical OR of this node and the others. */
+  or(...others: FilterNode[]): FilterNode {
+    return new FilterNode({ or: [this.filter, ...others.map((o) => o.filter)] });
+  }
+
+  /** The underlying DSL filter object. */
+  build(): Filter {
+    return this.filter;
+  }
+}
+
+/**
+ * A column reference; call a comparison method to produce a `FilterNode`.
+ *
+ * Generic over the column's value type `V` so that, with a typed row, the
+ * comparison argument is checked (`x.TEMP.gte(0)` ok, `x.TEMP.gte("x")` errors).
+ * Untyped columns default to any `FilterValue` (number or string).
+ */
+export class ColumnRef<V extends FilterValue = FilterValue> {
+  constructor(private readonly name: string) {}
+
+  eq(value: V): FilterNode {
+    return new FilterNode({ column: this.name, eq: value });
+  }
+  neq(value: V): FilterNode {
+    return new FilterNode({ column: this.name, neq: value });
+  }
+  gt(value: V): FilterNode {
+    return new FilterNode({ column: this.name, gt: value });
+  }
+  gte(value: V): FilterNode {
+    return new FilterNode({ column: this.name, gt_eq: value });
+  }
+  lt(value: V): FilterNode {
+    return new FilterNode({ column: this.name, lt: value });
+  }
+  lte(value: V): FilterNode {
+    return new FilterNode({ column: this.name, lt_eq: value });
+  }
+  /** Inclusive range: `min <= column <= max`. */
+  between(min: V, max: V): FilterNode {
+    return new FilterNode({ column: this.name, gt_eq: min, lt_eq: max });
+  }
+  isNull(): FilterNode {
+    return new FilterNode({ is_null: { column: this.name } });
+  }
+  isNotNull(): FilterNode {
+    return new FilterNode({ is_not_null: { column: this.name } });
+  }
+}
+
+/** Starts a filter predicate for `name`, e.g. `col("depth").gte(0)`. */
+export function col(name: string): ColumnRef {
+  return new ColumnRef(name);
+}
+
+/** Logical AND of every node. */
+export function and(...nodes: FilterNode[]): FilterNode {
+  return new FilterNode({ and: nodes.map((n) => n.filter) });
+}
+
+/** Logical OR of every node. */
+export function or(...nodes: FilterNode[]): FilterNode {
+  return new FilterNode({ or: nodes.map((n) => n.filter) });
+}
+
+/** Maps a column's declared type to the value type its comparisons accept. */
+export type FilterValueOf<X> = X extends number ? number : X extends string ? string : FilterValue;
+
+/**
+ * The entity passed to a `where(x => ...)` predicate: every property access
+ * (`x.depth`) yields a `ColumnRef` typed by that column's value type.
+ *
+ * When the builder is given a row type (e.g. `beacon.from<Ctd>(...)`), this maps
+ * to exactly that type's columns, so editors complete column names, typos are
+ * type errors, and comparison values are checked against each column's type.
+ * With the default untyped row (`Row = Record<string, unknown>`), `keyof` is
+ * `string`, so any column name is accepted (no completion) and comparisons take
+ * any `FilterValue` — the escape hatch for ad-hoc/aliased columns.
+ */
+export type Fields<T> = { [K in keyof T & string]: ColumnRef<FilterValueOf<T[K]>> };
+
+/** A `where` argument: a node, a raw filter, or `x => node`. */
+export type Predicate<T> = FilterNode | Filter | ((x: Fields<T>) => FilterNode | Filter);
+
+function fieldsProxy<T>(): Fields<T> {
+  return new Proxy(
+    {},
+    { get: (_t, prop) => new ColumnRef(String(prop)) },
+  ) as Fields<T>;
+}
+
+function resolvePredicate<T>(pred: Predicate<T>): Filter {
+  const value = typeof pred === "function" ? pred(fieldsProxy<T>()) : pred;
+  return value instanceof FilterNode ? value.build() : value;
+}
+
+// -- select helpers -----------------------------------------------------------
+
+/** A column projection, optionally aliased: `column("TEMP", "temperature")`. */
+export function column(name: string, alias?: string): Select {
+  return alias === undefined ? name : { column: name, alias };
+}
+
+/** A function projection: `func("avg", ["TEMP"], "mean")`. */
+export function func(name: string, args: Array<string | Select>, alias?: string): Select {
+  return { function: name, args, alias };
+}
+
+/** A literal projection: `literal(0, "zero")`. */
+export function literal(value: string | number | boolean | null, alias?: string): Select {
+  return { value, alias };
+}
+
+/**
+ * A column-name string for projection/ordering. When the builder has a row type,
+ * editors complete `T`'s keys, but any string is still accepted (for `"*"`,
+ * aliases, and expressions). The `string & {}` arm preserves completion of the
+ * key literals while widening the type to all strings.
+ */
+export type ColumnName<T> = (keyof T & string) | (string & {});
+
+// -- query builder ------------------------------------------------------------
+
+/** Fluent builder for a structured (JSON DSL) query. */
+export class QueryBuilder<T = Row> {
+  private _select: Select[] = [];
+  private _filters: Filter[] = [];
+  private _from?: From;
+  private _sort: Sort[] = [];
+  private _distinct?: Distinct;
+  private _offset?: number;
+  private _limit?: number;
+  private _output?: OutputFormat;
+
+  constructor(
+    private readonly client?: QueryRunner,
+    from?: From,
+  ) {
+    this._from = from;
+  }
+
+  // -- source --
+  /** Sets the data source (a table name or a `{ format: { paths } }` object). */
+  from(source: From): this {
+    this._from = source;
+    return this;
+  }
+  /** Reads from a registered table by name. */
+  fromTable(name: string): this {
+    this._from = name;
+    return this;
+  }
+  fromParquet(paths: string | string[]): this {
+    this._from = { parquet: { paths: toArray(paths) } };
+    return this;
+  }
+  fromCsv(paths: string | string[], delimiter?: string): this {
+    this._from = { csv: { paths: toArray(paths), delimiter } };
+    return this;
+  }
+  fromArrow(paths: string | string[]): this {
+    this._from = { arrow: { paths: toArray(paths) } };
+    return this;
+  }
+  fromNetcdf(paths: string | string[]): this {
+    this._from = { netcdf: { paths: toArray(paths) } };
+    return this;
+  }
+  fromOdv(paths: string | string[]): this {
+    this._from = { odv: { paths: toArray(paths) } };
+    return this;
+  }
+  fromZarr(paths: string | string[]): this {
+    this._from = { zarr: { paths: toArray(paths) } };
+    return this;
+  }
+  fromTiff(paths: string | string[]): this {
+    this._from = { tiff: { paths: toArray(paths) } };
+    return this;
+  }
+  fromBbf(paths: string | string[]): this {
+    this._from = { bbf: { paths: toArray(paths) } };
+    return this;
+  }
+
+  // -- projection --
+  /** Adds projected items (column names, `column()`, `func()`, `literal()`). */
+  select(...items: Array<ColumnName<T> | Select>): this {
+    this._select.push(...items);
+    return this;
+  }
+
+  /** Adds a DISTINCT clause keyed by `on`, projecting `select` (defaults to `on`). */
+  distinct(on: Array<ColumnName<T> | Select>, select?: Array<ColumnName<T> | Select>): this {
+    this._distinct = { on, select: select ?? on };
+    return this;
+  }
+
+  // -- filtering --
+  /** Adds a filter. Multiple `where` calls are combined with AND. */
+  where(predicate: Predicate<T>): this {
+    this._filters.push(resolvePredicate(predicate));
+    return this;
+  }
+
+  // -- ordering --
+  orderBy(column: ColumnName<T>): this {
+    this._sort.push({ Asc: column });
+    return this;
+  }
+  orderByDescending(column: ColumnName<T>): this {
+    this._sort.push({ Desc: column });
+    return this;
+  }
+  /** Alias of `orderBy`, for chaining additional sort keys. */
+  thenBy(column: ColumnName<T>): this {
+    return this.orderBy(column);
+  }
+  /** Alias of `orderByDescending`, for chaining additional sort keys. */
+  thenByDescending(column: ColumnName<T>): this {
+    return this.orderByDescending(column);
+  }
+
+  // -- paging --
+  /** Skips the first `n` rows (DSL `offset`). */
+  skip(n: number): this {
+    this._offset = n;
+    return this;
+  }
+  /** Limits the result to `n` rows (DSL `limit`). */
+  take(n: number): this {
+    this._limit = n;
+    return this;
+  }
+
+  // -- output --
+  /** Sets a materialized output format (for `raw()` downloads). */
+  output(format: OutputFormat): this {
+    this._output = format;
+    return this;
+  }
+
+  // -- build --
+  /** Builds the JSON DSL query object. */
+  build(): StructuredQuery {
+    const query: StructuredQuery = { select: this._select };
+    const filter = combineFilters(this._filters);
+    if (filter) query.filter = filter;
+    if (this._from !== undefined) query.from = this._from;
+    if (this._sort.length) query.sort_by = this._sort;
+    if (this._distinct) query.distinct = this._distinct;
+    if (this._offset !== undefined) query.offset = this._offset;
+    if (this._limit !== undefined) query.limit = this._limit;
+    if (this._output !== undefined) query.output = { format: this._output };
+    return query;
+  }
+
+  /** Alias of `build()` so `JSON.stringify(builder)` emits the DSL. */
+  toJSON(): StructuredQuery {
+    return this.build();
+  }
+
+  // -- execution (require a bound client) --
+  /** Executes and returns rows plus metadata. */
+  execute(options?: { format?: "arrow" | "csv"; signal?: AbortSignal }) {
+    return this.runner().query<T>(this.build(), options);
+  }
+  /** Executes and returns just the row array (EF `ToList()`-style). */
+  async toArray(signal?: AbortSignal): Promise<T[]> {
+    const { rows } = await this.runner().query<T>(this.build(), { signal });
+    return rows;
+  }
+  /** Executes and returns the first row, or `null` if there are none. */
+  async first(signal?: AbortSignal): Promise<T | null> {
+    const rows = await this.take(1).toArray(signal);
+    return rows[0] ?? null;
+  }
+  /** Executes and decodes the result into an Arrow Table. */
+  toArrow(signal?: AbortSignal): Promise<ArrowTable> {
+    return this.runner().queryArrow(this.build(), signal);
+  }
+  /** Executes and streams Arrow RecordBatches. */
+  stream(signal?: AbortSignal): AsyncGenerator<ArrowRecordBatch> {
+    return this.runner().queryStream(this.build(), signal);
+  }
+  /** Executes asking for CSV output and returns parsed string rows. */
+  toCsv(signal?: AbortSignal) {
+    return this.runner().queryCsv(this.build(), signal);
+  }
+
+  private runner(): QueryRunner {
+    if (!this.client) {
+      throw new Error("This QueryBuilder is not bound to a client; use build() to get the DSL.");
+    }
+    return this.client;
+  }
+}
+
+function combineFilters(filters: Filter[]): Filter | undefined {
+  if (filters.length === 0) return undefined;
+  if (filters.length === 1) return filters[0];
+  return { and: filters };
+}
+
+function toArray(value: string | string[]): string[] {
+  return Array.isArray(value) ? value : [value];
+}

--- a/clients/beacon-ts/src/stream.ts
+++ b/clients/beacon-ts/src/stream.ts
@@ -1,0 +1,25 @@
+/** Isomorphic helpers for consuming a `fetch` `Response` body as bytes. */
+
+/**
+ * Adapts a `Response` body to an `AsyncIterable<Uint8Array>`.
+ *
+ * Node's `ReadableStream` is async-iterable, but browsers' is not (yet), so we
+ * drive the reader manually for portability.
+ */
+export async function* responseByteStream(res: Response): AsyncGenerator<Uint8Array> {
+  if (!res.body) {
+    // Some runtimes omit a streaming body; fall back to a single chunk.
+    yield new Uint8Array(await res.arrayBuffer());
+    return;
+  }
+  const reader = res.body.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) yield value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/clients/beacon-ts/src/types.ts
+++ b/clients/beacon-ts/src/types.ts
@@ -1,0 +1,154 @@
+/**
+ * Hand-written ergonomic types for the Beacon query DSL and metadata responses.
+ *
+ * These mirror the structures in `beacon-core` (`query::Query`, `QueryBody`,
+ * `Select`, `Filter`, `Output`). For the exhaustive, always-up-to-date schema
+ * generated from the running server's OpenAPI document, run `npm run codegen`
+ * and import from `./generated/schema`.
+ */
+
+/** A scalar literal usable in a `select` or `filter`. */
+export type Literal = string | number | boolean | null;
+
+/**
+ * A single projected item in a structured query's `select`.
+ *
+ * - a bare column name: `"temperature"`
+ * - a column with an alias: `{ column: "temp", alias: "t" }`
+ * - a function call: `{ function: "avg", args: ["temp"], alias: "mean" }`
+ * - a literal: `{ value: 0, alias: "zero" }`
+ */
+export type Select =
+  | string
+  | { column: string; alias?: string }
+  | { function: string; args: Select[]; alias?: string }
+  | { value: Literal; alias?: string };
+
+/** A value usable in a comparison filter (number, string, or ISO timestamp). */
+export type FilterValue = number | string;
+
+/**
+ * A row filter expression, matching `beacon-core`'s `Filter` enum. Comparison
+ * predicates target a `column` and are matched by their fields; `and`/`or`
+ * combine sub-filters; `is_null`/`is_not_null` are tagged. (There is no `not`
+ * combinator — use `neq`/`is_not_null`.) The trailing index signature keeps the
+ * type open for shapes not enumerated here (e.g. the GeoJSON predicate).
+ */
+export type Filter =
+  | ComparisonFilter
+  | { is_null: { column: string } }
+  | { is_not_null: { column: string } }
+  | { and: Filter[] }
+  | { or: Filter[] }
+  | Record<string, unknown>;
+
+/** A leaf comparison predicate over a single `column`. */
+export interface ComparisonFilter {
+  column: string;
+  eq?: FilterValue;
+  neq?: FilterValue;
+  gt?: FilterValue;
+  gt_eq?: FilterValue;
+  lt?: FilterValue;
+  lt_eq?: FilterValue;
+}
+
+/**
+ * A data source: either a registered table name (a bare string) or a single-key
+ * object keyed by file format, e.g. `{ netcdf: { paths: ["a.nc"] } }` or
+ * `{ csv: { paths: [...], delimiter: ";" } }`. Supported formats: `csv`,
+ * `parquet`, `arrow`, `netcdf`, `odv`, `tiff`, `zarr`, `bbf`.
+ */
+export type From = string | Record<string, unknown>;
+
+/**
+ * Sort specification for a single column. Serializes as an externally-tagged
+ * enum: `{ "Asc": "col" }` or `{ "Desc": "col" }`.
+ */
+export type Sort = { Asc: string } | { Desc: string };
+
+/** Distinct-on specification. */
+export interface Distinct {
+  on: Select[];
+  select: Select[];
+}
+
+/**
+ * A materialized output format, matching `beacon-core`'s `OutputFormat` enum.
+ *
+ * Omitting `output` entirely yields the default zstd-compressed Arrow IPC
+ * stream (decoded by `query()` / `queryArrow()`). Note there is **no JSON
+ * output format**. The parameterized formats are single-key objects.
+ */
+export type OutputFormat =
+  | SimpleOutputFormat
+  | { ndnetcdf: { dimension_columns: string[] } }
+  | { nd_netcdf: { dimension_columns: string[] } }
+  | { geoparquet: GeoParquetOptions }
+  | { odv: Record<string, unknown> };
+
+/** Output formats expressed as a bare string. `arrow` is an alias for `ipc`. */
+export type SimpleOutputFormat = "csv" | "ipc" | "arrow" | "parquet" | "netcdf";
+
+export interface GeoParquetOptions {
+  longitude_column?: string | null;
+  latitude_column?: string | null;
+}
+
+export interface Output {
+  format: OutputFormat;
+}
+
+/** The fields of a structured (non-SQL) query. */
+export interface QueryBody {
+  /** Columns, functions, or literals to project. */
+  select: Select[];
+  /** Row filter to apply. */
+  filter?: Filter;
+  /** Data source to read from. Defaults to the runtime's default table. */
+  from?: From;
+  /** Ordering to apply to the result. */
+  sort_by?: Sort[];
+  /** Distinct-on specification. */
+  distinct?: Distinct;
+  /** Number of rows to skip. */
+  offset?: number;
+  /** Maximum number of rows to return. */
+  limit?: number;
+}
+
+/** A raw SQL query body. */
+export interface SqlQuery {
+  sql: string;
+  output?: Output;
+}
+
+/** A structured JSON query body (DSL fields at the top level). */
+export interface StructuredQuery extends QueryBody {
+  output?: Output;
+}
+
+/**
+ * Anything accepted by the query helpers: a raw SQL string, a `{ sql }` object,
+ * or a structured DSL query. An `output` format may be attached to the object
+ * forms; the high-level helpers set it for you.
+ */
+export type QueryInput = string | SqlQuery | StructuredQuery;
+
+/** A decoded result row from `query()` (JSON output). */
+export type Row = Record<string, unknown>;
+
+/** Planner/execution metrics returned by `GET /api/query/metrics/{id}`. */
+export interface QueryMetricsView {
+  input_rows: number;
+  input_bytes: number;
+  result_num_rows: number;
+  result_size_in_bytes: number;
+  [key: string]: unknown;
+}
+
+/** A registered crawler definition. Shape mirrors the admin crawler payload. */
+export type Crawler = Record<string, unknown>;
+
+/** A request to create an external table via the admin API. */
+export type ExternalTableSpec = Record<string, unknown>;

--- a/clients/beacon-ts/src/types.ts
+++ b/clients/beacon-ts/src/types.ts
@@ -135,7 +135,7 @@ export interface StructuredQuery extends QueryBody {
  */
 export type QueryInput = string | SqlQuery | StructuredQuery;
 
-/** A decoded result row from `query()` (JSON output). */
+/** A decoded result row from `query()` (from the Arrow stream, or CSV). */
 export type Row = Record<string, unknown>;
 
 /** Planner/execution metrics returned by `GET /api/query/metrics/{id}`. */

--- a/clients/beacon-ts/test/client.test.ts
+++ b/clients/beacon-ts/test/client.test.ts
@@ -1,0 +1,150 @@
+import { tableFromArrays, tableToIPC } from "apache-arrow";
+import { describe, expect, it, vi } from "vitest";
+
+import { ApiError, BeaconClient, basicAuthHeader } from "../src/index.js";
+
+/** Builds a fetch stub that records calls and returns a fresh `response` each time. */
+function stubFetch(makeResponse: () => Response) {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const fn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    return makeResponse();
+  });
+  return { fn: fn as unknown as typeof fetch, calls };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json", ...init.headers },
+    ...init,
+  });
+}
+
+/** An uncompressed Arrow IPC stream the way the server (minus zstd) would emit. */
+function arrowResponse(columns: Record<string, unknown[]>): Response {
+  const ipc = tableToIPC(tableFromArrays(columns), "stream");
+  return new Response(ipc, {
+    status: 200,
+    headers: { "x-beacon-query-id": "q-1" },
+  });
+}
+
+describe("basicAuthHeader", () => {
+  it("base64-encodes credentials", () => {
+    expect(basicAuthHeader("admin", "secret")).toBe("Basic YWRtaW46c2VjcmV0");
+  });
+});
+
+describe("BeaconClient.query (Arrow path)", () => {
+  it("posts the default body and decodes the Arrow stream into rows", async () => {
+    const { fn, calls } = stubFetch(() =>
+      arrowResponse({ n: Int32Array.from([1, 2]), label: ["a", "b"] }),
+    );
+    const client = new BeaconClient({ url: "http://beacon.test", fetch: fn });
+
+    const result = await client.query("SELECT 1");
+
+    expect(result.rows).toEqual([
+      { n: 1, label: "a" },
+      { n: 2, label: "b" },
+    ]);
+    expect(result.queryId).toBe("q-1");
+    expect(result.table?.numRows).toBe(2);
+    // No output format => default (compressed) Arrow stream requested.
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body).toEqual({ sql: "SELECT 1" });
+  });
+
+  it("queryArrow returns the decoded Table", async () => {
+    const { fn } = stubFetch(() => arrowResponse({ n: Int32Array.from([7]) }));
+    const client = new BeaconClient({ url: "http://beacon.test", fetch: fn });
+    const table = await client.queryArrow("SELECT 7");
+    expect(table.numRows).toBe(1);
+  });
+});
+
+describe("BeaconClient.query (CSV fallback / queryCsv)", () => {
+  it("requests CSV and parses rows when format: 'csv'", async () => {
+    const { fn, calls } = stubFetch(
+      () =>
+        new Response('a,b\n1,"x,y"\n2,"line\nbreak"\n', {
+          status: 200,
+          headers: { "x-beacon-query-id": "csv-1" },
+        }),
+    );
+    const client = new BeaconClient({ url: "http://beacon.test", fetch: fn });
+
+    const result = await client.query("SELECT 1", { format: "csv" });
+
+    expect(result.rows).toEqual([
+      { a: "1", b: "x,y" },
+      { a: "2", b: "line\nbreak" },
+    ]);
+    expect(result.queryId).toBe("csv-1");
+    expect(result.table).toBeUndefined();
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      sql: "SELECT 1",
+      output: { format: "csv" },
+    });
+  });
+
+  it("returns no rows for an empty (DDL) CSV response", async () => {
+    const { fn } = stubFetch(() => new Response("", { status: 200 }));
+    const client = new BeaconClient({ url: "http://beacon.test", fetch: fn });
+    const result = await client.query("CREATE TABLE t (a INT)", { format: "csv" });
+    expect(result.rows).toEqual([]);
+  });
+});
+
+describe("BeaconClient structured queries", () => {
+  it("sends a structured DSL body verbatim", async () => {
+    const { fn, calls } = stubFetch(() => arrowResponse({ temp: Float64Array.from([1.5]) }));
+    const client = new BeaconClient({ url: "http://beacon.test", fetch: fn });
+    await client.query({ select: ["temp"], limit: 10 });
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ select: ["temp"], limit: 10 });
+  });
+});
+
+describe("BeaconClient error handling", () => {
+  it("throws ApiError with the unwrapped message on non-2xx", async () => {
+    const { fn } = stubFetch(() => new Response(JSON.stringify("bad query"), { status: 400 }));
+    const client = new BeaconClient({ url: "http://beacon.test", fetch: fn });
+    await expect(client.query("SELECT bogus")).rejects.toMatchObject({
+      constructor: ApiError,
+      status: 400,
+      body: "bad query",
+    });
+  });
+});
+
+describe("BeaconClient auth", () => {
+  it("attaches a basic-auth header when credentials are configured", async () => {
+    const { fn, calls } = stubFetch(() => jsonResponse([]));
+    const client = new BeaconClient({
+      url: "http://beacon.test",
+      username: "admin",
+      password: "secret",
+      fetch: fn,
+    });
+    await client.tables();
+    const headers = new Headers(calls[0]!.init.headers);
+    expect(headers.get("authorization")).toBe(basicAuthHeader("admin", "secret"));
+  });
+});
+
+describe("BeaconClient metadata paths", () => {
+  it("encodes query params for table-schema", async () => {
+    const { fn, calls } = stubFetch(() => jsonResponse({}));
+    const client = new BeaconClient({ url: "http://beacon.test", fetch: fn });
+    await client.tableSchema("my table");
+    expect(calls[0]!.url).toBe("http://beacon.test/api/table-schema?table_name=my+table");
+  });
+
+  it("respects basePath", async () => {
+    const { fn, calls } = stubFetch(() => jsonResponse([]));
+    const client = new BeaconClient({ url: "http://beacon.test", basePath: "/beacon", fetch: fn });
+    await client.tables();
+    expect(calls[0]!.url).toBe("http://beacon.test/beacon/api/tables");
+  });
+});

--- a/clients/beacon-ts/test/decode.test.ts
+++ b/clients/beacon-ts/test/decode.test.ts
@@ -1,0 +1,45 @@
+import {
+  CompressionType,
+  compressionRegistry,
+  tableFromArrays,
+  tableToIPC,
+} from "apache-arrow";
+import { describe, expect, it, vi } from "vitest";
+
+import { BeaconClient, parseCsv } from "../src/index.js";
+
+describe("parseCsv", () => {
+  it("parses a simple table", () => {
+    expect(parseCsv("a,b\n1,2\n3,4\n")).toEqual([
+      { a: "1", b: "2" },
+      { a: "3", b: "4" },
+    ]);
+  });
+
+  it("handles quoted fields with commas, newlines, and escaped quotes", () => {
+    const csv = 'name,note\n"Doe, Jane","say ""hi""\nthere"\n';
+    expect(parseCsv(csv)).toEqual([{ name: "Doe, Jane", note: 'say "hi"\nthere' }]);
+  });
+
+  it("returns [] for empty input and header-only input", () => {
+    expect(parseCsv("")).toEqual([]);
+    expect(parseCsv("a,b\n")).toEqual([]);
+  });
+
+  it("tolerates a missing trailing newline and short rows", () => {
+    expect(parseCsv("a,b,c\n1,2")).toEqual([{ a: "1", b: "2", c: "" }]);
+  });
+});
+
+describe("zstd codec registration", () => {
+  it("registers a ZSTD decode codec with apache-arrow on the Arrow path", async () => {
+    const ipc = tableToIPC(tableFromArrays({ n: Int32Array.from([1]) }), "stream");
+    const fn = vi.fn(async () => new Response(ipc)) as unknown as typeof fetch;
+    const client = new BeaconClient({ url: "http://beacon.test", fetch: fn });
+
+    await client.query("SELECT 1");
+
+    const codec = compressionRegistry.get(CompressionType.ZSTD);
+    expect(typeof codec?.decode).toBe("function");
+  });
+});

--- a/clients/beacon-ts/test/http.test.ts
+++ b/clients/beacon-ts/test/http.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { BeaconClient, TimeoutError, basicAuthHeader } from "../src/index.js";
+
+describe("basicAuthHeader", () => {
+  it("base64-encodes the UTF-8 bytes of credentials (non-Latin1 safe)", () => {
+    const expected = "Basic " + Buffer.from("admin:pä$$wörd", "utf-8").toString("base64");
+    expect(basicAuthHeader("admin", "pä$$wörd")).toBe(expected);
+  });
+});
+
+/** A fetch that never resolves on its own; it rejects only when the signal aborts. */
+const hangingFetch = ((_url: string | URL | Request, init?: RequestInit) =>
+  new Promise<Response>((_resolve, reject) => {
+    const signal = init?.signal;
+    const fail = () => reject(signal?.reason ?? new DOMException("Aborted", "AbortError"));
+    if (signal?.aborted) fail();
+    else signal?.addEventListener("abort", fail, { once: true });
+  })) as unknown as typeof fetch;
+
+describe("abort classification", () => {
+  it("raises TimeoutError when the request times out", async () => {
+    const client = new BeaconClient({ url: "http://beacon.test", fetch: hangingFetch, timeoutMs: 10 });
+    await expect(client.query("SELECT 1", { format: "csv" })).rejects.toBeInstanceOf(TimeoutError);
+  });
+
+  it("preserves the caller's AbortError on external cancellation (not a TimeoutError)", async () => {
+    const client = new BeaconClient({ url: "http://beacon.test", fetch: hangingFetch, timeoutMs: 0 });
+    const ac = new AbortController();
+    const promise = client.query("SELECT 1", { format: "csv", signal: ac.signal });
+    ac.abort();
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+    await expect(promise).rejects.not.toBeInstanceOf(TimeoutError);
+  });
+});

--- a/clients/beacon-ts/test/query-builder.test.ts
+++ b/clients/beacon-ts/test/query-builder.test.ts
@@ -98,6 +98,24 @@ describe("QueryBuilder.build", () => {
 });
 
 describe("BeaconClient builder integration", () => {
+  it("first() requests limit 1 without mutating the builder", async () => {
+    const ipc = tableToIPC(tableFromArrays({ TEMP: Float64Array.from([1]) }), "stream");
+    const bodies: unknown[] = [];
+    const fn = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      bodies.push(JSON.parse(init?.body as string));
+      return new Response(ipc);
+    }) as unknown as typeof fetch;
+    const client = new BeaconClient({ url: "http://beacon.test", fetch: fn });
+
+    const builder = client.from("ctd").select("TEMP");
+    await builder.first();
+    await builder.execute();
+
+    expect(bodies[0]).toEqual({ select: ["TEMP"], from: "ctd", limit: 1 }); // first() → limit 1
+    expect(bodies[1]).toEqual({ select: ["TEMP"], from: "ctd" }); // builder unchanged → no limit
+    expect(builder.build().limit).toBeUndefined();
+  });
+
   it("from().where().execute() posts the built DSL and decodes rows", async () => {
     const ipc = tableToIPC(tableFromArrays({ TEMP: Float64Array.from([4.2]) }), "stream");
     const calls: RequestInit[] = [];

--- a/clients/beacon-ts/test/query-builder.test.ts
+++ b/clients/beacon-ts/test/query-builder.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import { tableFromArrays, tableToIPC } from "apache-arrow";
+
+import { BeaconClient, QueryBuilder, and, col, column, func } from "../src/index.js";
+
+/** Build the DSL without a client. */
+function qb() {
+  return new QueryBuilder();
+}
+
+describe("QueryBuilder.build", () => {
+  it("emits a minimal select", () => {
+    expect(qb().select("TEMP", "PSAL").build()).toEqual({ select: ["TEMP", "PSAL"] });
+  });
+
+  it("maps from-helpers to the DSL source shape", () => {
+    expect(qb().select("a").fromParquet(["x.parquet"]).build().from).toEqual({
+      parquet: { paths: ["x.parquet"] },
+    });
+    expect(qb().select("a").fromTable("t").build().from).toBe("t");
+    expect(qb().select("a").fromCsv("y.csv", ";").build().from).toEqual({
+      csv: { paths: ["y.csv"], delimiter: ";" },
+    });
+  });
+
+  it("translates a single where predicate", () => {
+    const built = qb()
+      .select("TEMP")
+      .where((x) => x.depth.gte(0))
+      .build();
+    expect(built.filter).toEqual({ column: "depth", gt_eq: 0 });
+  });
+
+  it("combines chained comparisons via and()", () => {
+    const built = qb()
+      .select("TEMP")
+      .where((x) => x.depth.gte(0).and(x.depth.lte(100)))
+      .build();
+    expect(built.filter).toEqual({
+      and: [
+        { column: "depth", gt_eq: 0 },
+        { column: "depth", lt_eq: 100 },
+      ],
+    });
+  });
+
+  it("ANDs multiple where() calls together", () => {
+    const built = qb()
+      .select("a")
+      .where(col("x").eq(1))
+      .where(col("y").neq("z"))
+      .build();
+    expect(built.filter).toEqual({
+      and: [
+        { column: "x", eq: 1 },
+        { column: "y", neq: "z" },
+      ],
+    });
+  });
+
+  it("supports between, isNull, and free-standing and()", () => {
+    const built = qb()
+      .select("a")
+      .where(and(col("d").between(0, 10), col("flag").isNull()))
+      .build();
+    expect(built.filter).toEqual({
+      and: [
+        { column: "d", gt_eq: 0, lt_eq: 10 },
+        { is_null: { column: "flag" } },
+      ],
+    });
+  });
+
+  it("builds ordering, paging, distinct, and aliased/function projections", () => {
+    const built = qb()
+      .select(column("TEMP", "t"), func("avg", ["PSAL"], "mean"))
+      .orderBy("TEMP")
+      .thenByDescending("PSAL")
+      .skip(5)
+      .take(10)
+      .distinct(["TEMP"])
+      .build();
+    expect(built).toEqual({
+      select: [
+        { column: "TEMP", alias: "t" },
+        { function: "avg", args: ["PSAL"], alias: "mean" },
+      ],
+      sort_by: [{ Asc: "TEMP" }, { Desc: "PSAL" }],
+      offset: 5,
+      limit: 10,
+      distinct: { on: ["TEMP"], select: ["TEMP"] },
+    });
+  });
+
+  it("throws if executed without a bound client", async () => {
+    await expect(qb().select("a").toArray()).rejects.toThrow(/not bound to a client/);
+  });
+});
+
+describe("BeaconClient builder integration", () => {
+  it("from().where().execute() posts the built DSL and decodes rows", async () => {
+    const ipc = tableToIPC(tableFromArrays({ TEMP: Float64Array.from([4.2]) }), "stream");
+    const calls: RequestInit[] = [];
+    const fn = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      calls.push(init ?? {});
+      return new Response(ipc);
+    }) as unknown as typeof fetch;
+    const client = new BeaconClient({ url: "http://beacon.test", fetch: fn });
+
+    const { rows } = await client
+      .from({ netcdf: { paths: ["a.nc"] } })
+      .select("TEMP")
+      .where((x) => x.depth.gte(0))
+      .take(1)
+      .execute();
+
+    expect(rows).toEqual([{ TEMP: 4.2 }]);
+    expect(JSON.parse(calls[0]!.body as string)).toEqual({
+      select: ["TEMP"],
+      filter: { column: "depth", gt_eq: 0 },
+      from: { netcdf: { paths: ["a.nc"] } },
+      limit: 1,
+    });
+  });
+});

--- a/clients/beacon-ts/test/types.ts
+++ b/clients/beacon-ts/test/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Compile-time tests for the query builder's typing. Checked by
+ * `npm run typecheck` (this file is in tsconfig's `include`). The
+ * `@ts-expect-error` lines fail the build if they ever stop erroring.
+ */
+
+import { BeaconClient } from "../src/index.js";
+
+const beacon = new BeaconClient({ url: "http://x" });
+
+interface Ctd {
+  TEMP: number;
+  depth: number;
+  station: string;
+}
+
+// --- where() predicate ---
+
+// Untyped: any column name is accepted (escape hatch, no completion).
+void beacon.from("ctd").select("TEMP").where((x) => x.anything.gte(0));
+
+// Typed: known columns resolve and complete, and chain with and()/or().
+void beacon.from<Ctd>("ctd").select("TEMP").where((x) => x.TEMP.gte(0).and(x.depth.lte(100)));
+
+// Typed: comparison values are checked against the column's type.
+void beacon.from<Ctd>("ctd").where((x) => x.station.eq("BTL01"));
+
+// Typed: a misspelled column is a compile error.
+// @ts-expect-error - `tmep` is not a column of Ctd
+void beacon.from<Ctd>("ctd").where((x) => x.tmep.gte(0));
+
+// Typed: a wrong-typed comparison value is a compile error.
+// @ts-expect-error - TEMP is a number, not a string
+void beacon.from<Ctd>("ctd").where((x) => x.TEMP.gte("hot"));
+
+// --- select() / orderBy() / distinct() column completion ---
+
+// Typed columns complete and are accepted.
+void beacon.from<Ctd>("ctd").select("TEMP", "depth").orderBy("TEMP").thenByDescending("depth");
+
+// Any string is still allowed (for "*", aliases, expressions) — no error.
+void beacon.from<Ctd>("ctd").select("*", "TEMP AS t").orderBy("some_alias");

--- a/clients/beacon-ts/tsconfig.json
+++ b/clients/beacon-ts/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2021", "DOM"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "types": ["node"],
+    "outDir": "dist"
+  },
+  "include": ["src", "scripts", "test/types.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/clients/beacon-ts/tsup.config.ts
+++ b/clients/beacon-ts/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  treeshake: true,
+  // Loaded lazily at runtime; keep them out of the bundle.
+  external: ["apache-arrow", "fzstd"],
+});

--- a/clients/beacon-ts/vitest.config.ts
+++ b/clients/beacon-ts/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Adds an isomorphic **TypeScript/JavaScript SDK** for managing and querying a Beacon instance, living at `clients/beacon-ts` (`@beacon/client`) — the JS sibling to the existing Python `clients/beacon-cli`. It runs in Node 18+ and the browser on the global `fetch`, ships ESM+CJS+DTS via `tsup`, is tested with `vitest`, and has its own CI workflow (`.github/workflows/client-ts.yml`).

## What's included

**Query**
- `query()` — decodes Beacon's default **zstd-compressed Arrow IPC stream** via `apache-arrow` + an `fzstd`-backed zstd codec registered into apache-arrow's `compressionRegistry`; returns plain row objects and exposes the Arrow `table`.
- `queryArrow()` (Arrow `Table`), `queryStream()` (streamed `RecordBatch`es), `queryCsv()` (string rows), `queryRaw()` (raw `Response` for any output format).
- `parseQuery`, `explainQuery`, `queryMetrics`.
- There is **no JSON output** server-side; CSV is the dependency-light alternative.

**Metadata**: `tables`, schemas, `datasets`, `functions`, `info`, `health`.

**Admin** (HTTP basic-auth → super-user): crawlers (`create`/`list`/`get`/`run`/`drop`) and external tables.

**Query builder** — an EF Core / LINQ-style fluent builder that emits the JSON DSL:
\`\`\`ts
const { rows } = await beacon
  .from({ netcdf: { paths: ["argo.nc"] } })
  .select("TEMP", column("PSAL", "salinity"))
  .where((x) => x.depth.gte(0).and(x.depth.lte(100)))
  .orderByDescending("TEMP")
  .take(100)
  .execute();
\`\`\`
Predicates use method chaining (`col("d").gte(0)`) since JS has no operator overloading. Typing is **optional / opt-in**: untyped by default; pass a row type (`beacon.from<Ctd>(...)`) for column-name completion, typo errors, and `where()` value-type checking.

**Type generation**: hand-written ergonomic types plus an `openapi-typescript` pipeline (`npm run codegen`) that regenerates types from a live server's `/openapi.json`.

## Notes / decisions
- `apache-arrow` (21.1.0) and `fzstd` (0.1.1) are regular dependencies (kept external via dynamic `import()`), so metadata-only callers don't pull Arrow into their bundle until the first query.
- DSL shapes (filters, sort, sources, output formats) were verified against `beacon-core` (`query/filter/*`, `from.rs`, `query/mod.rs`), and routes against `beacon-api/src/axum/{client,admin}`.
- Package name `@beacon/client` is a placeholder — happy to rename to the org's npm scope.

## Verification
- `npm run typecheck` (includes compile-time typing tests in `test/types.ts`) — clean
- `npm test` — 24/24 passing (Arrow decode → rows, zstd codec registration, CSV parsing, builder → DSL + end-to-end)
- `npm run build` — ESM+CJS+DTS succeed; `apache-arrow`/`fzstd` confirmed external

## Test plan
- [ ] CI (`TypeScript client` workflow) passes typecheck/test/build
- [ ] Confirm desired npm package name/scope before publishing