### PR TITLE
Add per-query execution-time and output-size limits for non-admin queries

### DIFF
--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -58,6 +58,17 @@ pub struct RuntimeConfig {
     pub st_within_point_cache_size: usize,
     pub enable_sys_info: bool,
     pub batch_size: usize,
+    /// Per-query execution-time limit (seconds) for non-admin queries. `None`
+    /// disables the limit. Counts only active node-execution time. Under
+    /// parallelism this is accumulated across partitions, so it behaves closer
+    /// to CPU-time than wall-clock.
+    pub query_timeout_secs: Option<u64>,
+    /// Maximum number of result rows a non-admin query may produce before it is
+    /// aborted. `None` disables the limit.
+    pub max_output_rows: Option<u64>,
+    /// Maximum result size in bytes a non-admin query may produce before it is
+    /// aborted. `None` disables the limit.
+    pub max_output_bytes: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -208,6 +219,12 @@ struct RawConfig {
     sql_stream_coalesce_max_rows: usize,
     #[envconfig(from = "BEACON_ST_WITHIN_POINT_CACHE_SIZE", default = "10000")]
     st_within_point_cache_size: usize,
+    #[envconfig(from = "BEACON_QUERY_TIMEOUT_SECS")]
+    query_timeout_secs: Option<u64>,
+    #[envconfig(from = "BEACON_MAX_OUTPUT_ROWS")]
+    max_output_rows: Option<u64>,
+    #[envconfig(from = "BEACON_MAX_OUTPUT_BYTES")]
+    max_output_bytes: Option<u64>,
     #[envconfig(from = "BEACON_WORKER_THREADS", default = "8")]
     worker_threads: usize,
     #[envconfig(from = "BEACON_BASE_PATH", default = "")]
@@ -338,6 +355,9 @@ impl From<RawConfig> for Config {
                 st_within_point_cache_size: raw.st_within_point_cache_size,
                 enable_sys_info: raw.enable_sys_info,
                 batch_size: raw.beacon_batch_size,
+                query_timeout_secs: raw.query_timeout_secs,
+                max_output_rows: raw.max_output_rows,
+                max_output_bytes: raw.max_output_bytes,
             },
             sql: SqlConfig {
                 enable: raw.enable_sql,

--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -258,9 +258,21 @@ impl Runtime {
         let plan = self.lower_query(inner).await?;
         crate::statement_plan::validate_query_plan(&plan, is_super_user)?;
 
+        // Execution limits apply to non-admin queries only; super-users are
+        // exempt (`None`).
+        let limits = (!is_super_user)
+            .then(|| crate::statement_plan::QueryLimits::from(&self.config.runtime))
+            .filter(crate::statement_plan::QueryLimits::is_active);
+
         match output {
-            Some(output) => self.run_query_to_file(plan, output, query_id, query_json).await,
-            None => self.run_query_to_stream(plan, query_id, query_json).await,
+            Some(output) => {
+                self.run_query_to_file(plan, output, query_id, query_json, limits)
+                    .await
+            }
+            None => {
+                self.run_query_to_stream(plan, query_id, query_json, limits)
+                    .await
+            }
         }
     }
 
@@ -271,8 +283,10 @@ impl Runtime {
         plan: datafusion::logical_expr::LogicalPlan,
         query_id: uuid::Uuid,
         query_json: serde_json::Value,
+        limits: Option<crate::statement_plan::QueryLimits>,
     ) -> anyhow::Result<QueryResult> {
-        let stream = crate::statement_plan::execute_statement_plan(&self.session_ctx, plan).await?;
+        let stream =
+            crate::statement_plan::execute_statement_plan(&self.session_ctx, plan, limits).await?;
         let metrics = MetricsTracker::new(query_json, query_id);
         let output_stream = ArrowOutputStream {
             stream,
@@ -294,6 +308,7 @@ impl Runtime {
         output: crate::query::output::Output,
         query_id: uuid::Uuid,
         query_json: serde_json::Value,
+        limits: Option<crate::statement_plan::QueryLimits>,
     ) -> anyhow::Result<QueryResult> {
         // `Output::parse` wraps the (already validated) plan in a `COPY TO` the
         // temp file; this COPY is beacon-generated, so it is not re-validated.
@@ -304,7 +319,8 @@ impl Runtime {
 
         let metrics = MetricsTracker::new(query_json, query_id);
         let mut stream =
-            crate::statement_plan::execute_statement_plan(&self.session_ctx, copy_plan).await?;
+            crate::statement_plan::execute_statement_plan(&self.session_ctx, copy_plan, limits)
+                .await?;
         // The COPY emits a single `count` row; drain it to complete the write.
         while let Some(batch) = stream.try_next().await? {
             let counts = batch.column(0).as_primitive::<UInt64Type>();

--- a/beacon-core/src/statement_plan/metering.rs
+++ b/beacon-core/src/statement_plan/metering.rs
@@ -1,0 +1,353 @@
+//! Per-query execution limits for non-admin queries.
+//!
+//! Admins can cap how long a query executes and how large its result may grow
+//! (see [`beacon_config::RuntimeConfig`]). Enforcement is a transparent physical
+//! node, [`MeteredExec`], inserted into the plan after planning by
+//! [`insert_meter`]; the [`MeteredStream`] it produces accumulates *active
+//! execution time* (the wall-clock spent inside the child's `poll_next`, which
+//! excludes client backpressure and the planning phase) plus running row/byte
+//! counts, and aborts the query the moment a configured limit is breached.
+//!
+//! Placement makes the "count compute, not the write" rule fall out: for a
+//! file-output query (a `COPY TO`, i.e. a [`DataSinkExec`] root) the meter wraps
+//! the sink's *input*, so the format-writer/file-write time is not counted and
+//! the meter sees the real result batches; for a streaming query it wraps the
+//! root.
+
+use std::any::Any;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+use arrow::datatypes::SchemaRef;
+use arrow::record_batch::RecordBatch;
+use datafusion::datasource::sink::DataSinkExec;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, RecordBatchStream,
+};
+use futures::{Stream, StreamExt};
+
+/// The per-query limits applied to non-admin queries. A `None` field means that
+/// dimension is unlimited.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct QueryLimits {
+    /// Maximum active execution time before the query is aborted.
+    pub timeout: Option<Duration>,
+    /// Maximum number of result rows before the query is aborted.
+    pub max_rows: Option<u64>,
+    /// Maximum result size in bytes before the query is aborted.
+    pub max_bytes: Option<u64>,
+}
+
+impl QueryLimits {
+    /// At least one limit is set, so a meter is worth inserting.
+    pub(crate) fn is_active(&self) -> bool {
+        self.timeout.is_some() || self.max_rows.is_some() || self.max_bytes.is_some()
+    }
+}
+
+impl From<&beacon_config::RuntimeConfig> for QueryLimits {
+    fn from(cfg: &beacon_config::RuntimeConfig) -> Self {
+        Self {
+            timeout: cfg.query_timeout_secs.map(Duration::from_secs),
+            max_rows: cfg.max_output_rows,
+            max_bytes: cfg.max_output_bytes,
+        }
+    }
+}
+
+/// Shared, mutable budget for one query. A single instance is shared by every
+/// partition stream of a [`MeteredExec`], so under parallelism the counters
+/// accumulate across partitions (execution time then behaves closer to CPU-time
+/// than wall-clock).
+#[derive(Debug)]
+struct MeterState {
+    limits: QueryLimits,
+    elapsed_nanos: AtomicU64,
+    rows: AtomicU64,
+    bytes: AtomicU64,
+}
+
+impl MeterState {
+    fn new(limits: QueryLimits) -> Arc<Self> {
+        Arc::new(Self {
+            limits,
+            elapsed_nanos: AtomicU64::new(0),
+            rows: AtomicU64::new(0),
+            bytes: AtomicU64::new(0),
+        })
+    }
+
+    /// Return an error if any configured limit has been exceeded.
+    fn check(&self) -> Result<()> {
+        if let Some(timeout) = self.limits.timeout {
+            if self.elapsed_nanos.load(Ordering::Relaxed) > timeout.as_nanos() as u64 {
+                return Err(DataFusionError::Execution(format!(
+                    "query exceeded execution-time limit of {}s",
+                    timeout.as_secs()
+                )));
+            }
+        }
+        if let Some(max_rows) = self.limits.max_rows {
+            if self.rows.load(Ordering::Relaxed) > max_rows {
+                return Err(DataFusionError::Execution(format!(
+                    "query exceeded output-row limit of {max_rows}"
+                )));
+            }
+        }
+        if let Some(max_bytes) = self.limits.max_bytes {
+            if self.bytes.load(Ordering::Relaxed) > max_bytes {
+                return Err(DataFusionError::Execution(format!(
+                    "query exceeded output-byte limit of {max_bytes}"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A record-batch stream that meters the wrapped stream against a [`MeterState`].
+struct MeteredStream {
+    inner: SendableRecordBatchStream,
+    schema: SchemaRef,
+    state: Arc<MeterState>,
+    done: bool,
+}
+
+impl MeteredStream {
+    fn new(inner: SendableRecordBatchStream, state: Arc<MeterState>) -> Self {
+        let schema = inner.schema();
+        Self {
+            inner,
+            schema,
+            state,
+            done: false,
+        }
+    }
+}
+
+impl Stream for MeteredStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.done {
+            return Poll::Ready(None);
+        }
+
+        // Count only the time the child spends actively producing this batch;
+        // time the consumer is not polling (backpressure) is never charged.
+        let started = Instant::now();
+        let poll = this.inner.poll_next_unpin(cx);
+        this.state
+            .elapsed_nanos
+            .fetch_add(started.elapsed().as_nanos() as u64, Ordering::Relaxed);
+
+        if let Poll::Ready(Some(Ok(batch))) = &poll {
+            this.state
+                .rows
+                .fetch_add(batch.num_rows() as u64, Ordering::Relaxed);
+            this.state
+                .bytes
+                .fetch_add(batch.get_array_memory_size() as u64, Ordering::Relaxed);
+        }
+
+        if let Err(err) = this.state.check() {
+            this.done = true;
+            return Poll::Ready(Some(Err(err)));
+        }
+
+        poll
+    }
+}
+
+impl RecordBatchStream for MeteredStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+/// A transparent physical node that wraps each partition stream of its input in
+/// a [`MeteredStream`] sharing one [`MeterState`]. All plan properties are
+/// inherited from the input, so it is invisible to partitioning/ordering.
+#[derive(Debug)]
+pub(crate) struct MeteredExec {
+    input: Arc<dyn ExecutionPlan>,
+    state: Arc<MeterState>,
+    cache: Arc<PlanProperties>,
+}
+
+impl MeteredExec {
+    fn new(input: Arc<dyn ExecutionPlan>, state: Arc<MeterState>) -> Self {
+        let cache = input.properties().clone();
+        Self {
+            input,
+            state,
+            cache,
+        }
+    }
+}
+
+impl DisplayAs for MeteredExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MeteredExec")
+    }
+}
+
+impl ExecutionPlan for MeteredExec {
+    fn name(&self) -> &str {
+        "MeteredExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(Self::new(
+            children.swap_remove(0),
+            self.state.clone(),
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let inner = self.input.execute(partition, context)?;
+        Ok(Box::pin(MeteredStream::new(inner, self.state.clone())))
+    }
+}
+
+/// Insert a [`MeteredExec`] enforcing `limits` into `plan`.
+///
+/// For a `COPY TO` plan (a [`DataSinkExec`] root) the meter is placed on the
+/// sink's input so the file write is excluded from the budget; otherwise it
+/// wraps the root.
+pub(crate) fn insert_meter(
+    plan: Arc<dyn ExecutionPlan>,
+    limits: QueryLimits,
+) -> Arc<dyn ExecutionPlan> {
+    let state = MeterState::new(limits);
+
+    if plan.as_any().is::<DataSinkExec>() {
+        let children = plan.children();
+        if children.len() == 1 {
+            let metered: Arc<dyn ExecutionPlan> =
+                Arc::new(MeteredExec::new(children[0].clone(), state.clone()));
+            // Rebuild the sink with the metered input. `with_new_children`
+            // preserves the sink; only its child is swapped.
+            if let Ok(rebuilt) = plan.clone().with_new_children(vec![metered]) {
+                return rebuilt;
+            }
+        }
+    }
+
+    Arc::new(MeteredExec::new(plan, state))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Int32Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+    use futures::TryStreamExt;
+
+    fn test_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]))
+    }
+
+    fn batch(n: usize) -> RecordBatch {
+        let schema = test_schema();
+        let array = Int32Array::from((0..n as i32).collect::<Vec<_>>());
+        RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap()
+    }
+
+    /// Build a `MeteredStream` over a fixed set of batches with the given limits.
+    fn metered(batches: Vec<RecordBatch>, limits: QueryLimits) -> MeteredStream {
+        let schema = test_schema();
+        let inner: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::iter(batches.into_iter().map(Ok)),
+        ));
+        MeteredStream::new(inner, MeterState::new(limits))
+    }
+
+    #[tokio::test]
+    async fn no_limits_passes_all_rows() {
+        let stream = metered(
+            vec![batch(100), batch(100)],
+            QueryLimits::default(),
+        );
+        let out: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        assert_eq!(out.iter().map(|b| b.num_rows()).sum::<usize>(), 200);
+    }
+
+    #[tokio::test]
+    async fn row_limit_aborts() {
+        let stream = metered(
+            vec![batch(100), batch(100), batch(100)],
+            QueryLimits {
+                max_rows: Some(150),
+                ..Default::default()
+            },
+        );
+        let err = stream.try_collect::<Vec<_>>().await.unwrap_err();
+        assert!(err.to_string().contains("output-row limit"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn byte_limit_aborts() {
+        let stream = metered(
+            vec![batch(1000), batch(1000)],
+            QueryLimits {
+                max_bytes: Some(1),
+                ..Default::default()
+            },
+        );
+        let err = stream.try_collect::<Vec<_>>().await.unwrap_err();
+        assert!(err.to_string().contains("output-byte limit"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn time_limit_aborts_with_slow_inner() {
+        // Each batch is produced by synchronous work inside `poll_next` (a
+        // blocking sleep stands in for CPU-bound compute), so the accumulated
+        // active poll-time crosses the tiny budget. Async waits would register
+        // as `Pending` and — correctly — not be charged, so we block here.
+        let schema = test_schema();
+        let inner: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::iter(0..10).map(|_| {
+                std::thread::sleep(Duration::from_millis(20));
+                Ok(batch(1))
+            }),
+        ));
+        let stream = MeteredStream::new(
+            inner,
+            MeterState::new(QueryLimits {
+                timeout: Some(Duration::from_millis(10)),
+                ..Default::default()
+            }),
+        );
+        let err = stream.try_collect::<Vec<_>>().await.unwrap_err();
+        assert!(err.to_string().contains("execution-time limit"), "{err}");
+    }
+}

--- a/beacon-core/src/statement_plan/mod.rs
+++ b/beacon-core/src/statement_plan/mod.rs
@@ -16,9 +16,12 @@ pub(crate) mod crawler;
 mod logical;
 mod lower;
 pub(crate) mod materialized_view;
+mod metering;
 mod physical;
 mod query_planner;
 mod stream_coalescer;
+
+pub(crate) use metering::QueryLimits;
 
 use std::sync::{Arc, OnceLock, Weak};
 
@@ -158,10 +161,17 @@ pub(crate) fn show_crawlers_plan() -> LogicalPlan {
 pub(crate) async fn execute_statement_plan(
     session_ctx: &Arc<SessionContext>,
     plan: LogicalPlan,
+    limits: Option<QueryLimits>,
 ) -> anyhow::Result<SendableRecordBatchStream> {
     use futures::TryStreamExt;
 
     let physical_plan = session_ctx.state().create_physical_plan(&plan).await?;
+    // Non-admin queries carry execution limits; insert a metering node that
+    // aborts the query when a limit is breached (admin/internal pass `None`).
+    let physical_plan = match limits {
+        Some(limits) if limits.is_active() => metering::insert_meter(physical_plan, limits),
+        _ => physical_plan,
+    };
     let stream = datafusion::physical_plan::execute_stream(physical_plan, session_ctx.task_ctx())?;
     let stream = stream_coalescer::coalesce_sql_stream(session_ctx, stream);
 


### PR DESCRIPTION
## Summary

Adds admin-configurable, startup-global guard-rails that bound how much **compute/time** a client query can consume. Limits apply **only to non-admin (non-super-user) queries**; super-users and internal queries (materialized-view refresh, crawlers) run unmetered.

| Env var | Effect |
|---|---|
| `BEACON_QUERY_TIMEOUT_SECS` | Abort after N seconds of *active node execution* |
| `BEACON_MAX_OUTPUT_ROWS` | Abort once the result exceeds N rows |
| `BEACON_MAX_OUTPUT_BYTES` | Abort once the result exceeds N bytes |

Unset = no limit, so default behaviour is unchanged.

## How it works

- **Config** (`beacon-config`): three `Option<u64>` fields on `RuntimeConfig`, wired through `RawConfig`/`From` (envconfig, no default → `None`).
- **Metering** (new `beacon-core/src/statement_plan/metering.rs`): a transparent `MeteredExec` physical node + `MeteredStream` that charges **only active poll-time** — the wall-clock spent inside the child's `poll_next`. This excludes client backpressure, query planning, and async I/O waits, so the budget tracks real compute. It also tallies result rows/bytes.
- **Placement** (`insert_meter`): for file-download queries (`COPY TO` → `DataSinkExec` root) the meter wraps the **sink's input**, so the file write is excluded ("count compute, not the write") while the meter still sees the real result batches; for streaming queries it wraps the root.
- **Gating** (`runtime.rs`): `run_query` derives limits only when `!is_super_user` and threads them through `execute_statement_plan`.

Covers all transports (HTTP `/api/query`, file download, Flight SQL) since they funnel through `run_query`.

## Caveats

- Under parallel execution the time budget accumulates across partitions (closer to CPU-time than wall-clock) — size `BEACON_QUERY_TIMEOUT_SECS` accordingly.
- Planning time is not bounded (by design — time is counted only while nodes execute).
- A mid-stream breach on an HTTP streaming response truncates the Arrow IPC stream rather than returning a clean 4xx (status already sent); file-output breaches surface before the download starts.

## Testing

- `cargo build -p beacon-config -p beacon-core -p beacon-api` — clean.
- `cargo test -p beacon-core --lib statement_plan::metering` — 4/4 pass (no-limit pass-through, row limit, byte limit, time limit).

> Note: based on `features/config-admin` to keep the diff scoped to this feature. Retarget to `main` if that branch merges first.