### PR TITLE
Add EXPLAIN ANALYZE pgjson endpoint (/api/explain-analyze-query)

### DIFF
--- a/beacon-api/src/axum/client/mod.rs
+++ b/beacon-api/src/axum/client/mod.rs
@@ -32,6 +32,7 @@ pub(crate) fn setup_client_router() -> (Router<Arc<Runtime>>, utoipa::openapi::O
         .routes(routes!(query::parse_query))
         .routes(routes!(query::query_metrics))
         .routes(routes!(query::explain_query))
+        .routes(routes!(query::explain_analyze_query))
         .routes(routes!(query::available_columns))
         .routes(routes!(datasets::datasets))
         .routes(routes!(datasets::list_datasets))

--- a/beacon-api/src/axum/client/query.rs
+++ b/beacon-api/src/axum/client/query.rs
@@ -369,13 +369,30 @@ pub(crate) async fn explain_analyze_query(
     headers: HeaderMap,
     Json(query_obj): Json<QueryRequest>,
 ) -> Result<Response<Body>, (StatusCode, Json<String>)> {
-    // EXPLAIN ANALYZE executes the query, so it resolves admin vs anonymous the
-    // same way `/api/query` does: anonymous is read-only, valid admin basic auth
-    // elevates to super-user (allowing DDL/DML, with the same side effects).
+    let query = query_obj.into_query().map_err(|err| {
+        tracing::error!("Error parsing beacon query: {}", err);
+        (StatusCode::BAD_REQUEST, Json(err.to_string()))
+    })?;
+
+    // EXPLAIN ANALYZE executes the query, so it is gated by `sql.enable` exactly
+    // like `/api/query` (JSON is always allowed). Without this, SQL could be run
+    // through this endpoint while SQL is disabled, bypassing the restriction.
+    if matches!(query.inner, beacon_core::query::InnerQuery::Sql(_))
+        && !state.config().sql.enable
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json("SQL queries are not enabled".to_string()),
+        ));
+    }
+
+    // It also resolves admin vs anonymous the same way `/api/query` does:
+    // anonymous is read-only, valid admin basic auth elevates to super-user
+    // (allowing DDL/DML, with the same side effects).
     let is_super_user = resolve_super_user(&headers, &state.config().admin)
         .map_err(|status| (status, Json("invalid admin credentials".to_string())))?;
     let result = state
-        .explain_analyze_client_query(query_obj, is_super_user)
+        .explain_analyze_client_query(query, is_super_user)
         .await;
     match result {
         Ok(explanation) => Ok((

--- a/beacon-api/src/axum/client/query.rs
+++ b/beacon-api/src/axum/client/query.rs
@@ -339,6 +339,60 @@ pub(crate) async fn explain_query(
     }
 }
 
+/// Runs the supplied query and returns its physical plan annotated with per-node
+/// runtime metrics as PostgreSQL-style JSON (pgjson) — the `EXPLAIN ANALYZE`
+/// analog of `/api/explain-query`. Unlike that endpoint, the query is executed.
+#[tracing::instrument(level = "info", skip(state, headers))]
+#[utoipa::path(
+    tag = "query",
+    post,
+    path = "/api/explain-analyze-query",
+    request_body = Query,
+    responses(
+        (
+            status = 200,
+            description = "pgjson explanation of the query's physical plan annotated \
+                with per-node runtime metrics (the query IS executed to collect them)",
+            content_type = "application/json"
+        ),
+        (status = 400, description = "Invalid or unsupported query"),
+        (status = 401, description = "Basic credentials were supplied but are invalid"),
+    ),
+    security(
+        (),
+        ("basic-auth" = []),
+        ("bearer" = [])
+    )
+)]
+pub(crate) async fn explain_analyze_query(
+    State(state): State<Arc<Runtime>>,
+    headers: HeaderMap,
+    Json(query_obj): Json<QueryRequest>,
+) -> Result<Response<Body>, (StatusCode, Json<String>)> {
+    // EXPLAIN ANALYZE executes the query, so it resolves admin vs anonymous the
+    // same way `/api/query` does: anonymous is read-only, valid admin basic auth
+    // elevates to super-user (allowing DDL/DML, with the same side effects).
+    let is_super_user = resolve_super_user(&headers, &state.config().admin)
+        .map_err(|status| (status, Json("invalid admin credentials".to_string())))?;
+    let result = state
+        .explain_analyze_client_query(query_obj, is_super_user)
+        .await;
+    match result {
+        Ok(explanation) => Ok((
+            [
+                (header::CONTENT_TYPE, "application/json"),
+                (header::CONTENT_DISPOSITION, "attachment"),
+            ],
+            Body::from(explanation),
+        )
+            .into_response()),
+        Err(err) => {
+            tracing::error!("Error explain-analyzing beacon query: {}", err);
+            Err((StatusCode::BAD_REQUEST, Json(err.to_string())))
+        }
+    }
+}
+
 /// Backward-compatible endpoint for clients that still request the default schema as column names.
 #[tracing::instrument(level = "info", skip(state))]
 #[utoipa::path(

--- a/beacon-core/src/metrics.rs
+++ b/beacon-core/src/metrics.rs
@@ -202,6 +202,70 @@ fn collect_metrics_json(plan: &dyn ExecutionPlan) -> NodeMetrics {
     }
 }
 
+/// Render an executed physical plan as PostgreSQL-style pgjson annotated with
+/// per-node runtime metrics — DataFusion's "Plan with Metrics" shape.
+///
+/// The output is the array form consumed by pgjson visualizers (e.g. dalibo):
+/// a single-element array wrapping the root `"Plan"` node, with children nested
+/// recursively under `"Plans"`. Newer DataFusion produces this natively via
+/// `EXPLAIN (ANALYZE, FORMAT pgjson)`, which the pinned DataFusion 53 rejects;
+/// this backports the same shape by walking the already-executed plan.
+///
+/// The plan must have been run to completion first so its metrics are populated.
+pub fn explain_analyze_pg_json(plan: &dyn ExecutionPlan) -> serde_json::Value {
+    serde_json::json!([{ "Plan": node_to_pg_json(plan) }])
+}
+
+/// Convert a single physical plan node (and its subtree) into a pgjson node.
+fn node_to_pg_json(plan: &dyn ExecutionPlan) -> serde_json::Value {
+    let details = format!(
+        "{}",
+        datafusion::physical_plan::displayable(plan).one_line()
+    );
+
+    let mut node = serde_json::json!({
+        "Node Type": plan.name(),
+        // `one_line` renders with a trailing newline; trim it for a clean detail.
+        "Details": details.trim_end(),
+    });
+
+    if let Some(metrics_set) = plan.metrics() {
+        // Aggregate across partitions, mirroring how `AnalyzeExec` reports metrics.
+        let metrics_set = metrics_set.aggregate_by_name();
+
+        if let Some(rows) = metrics_set.output_rows() {
+            node["Actual Rows"] = serde_json::json!(rows);
+        }
+        // `elapsed_compute` is nanoseconds; PostgreSQL's "Actual Total Time" is ms.
+        if let Some(nanos) = metrics_set.elapsed_compute() {
+            node["Actual Total Time"] = serde_json::json!(nanos as f64 / 1_000_000.0);
+        }
+
+        // Every remaining metric goes under `Extras` (the two promoted above are
+        // excluded so they are not duplicated).
+        let mut extras = serde_json::Map::new();
+        for metric in metrics_set.iter() {
+            let name = metric.value().name();
+            if name == "output_rows" || name == "elapsed_compute" {
+                continue;
+            }
+            extras.insert(name.to_string(), serde_json::json!(metric.value().as_usize()));
+        }
+        if !extras.is_empty() {
+            node["Extras"] = serde_json::Value::Object(extras);
+        }
+    }
+
+    let children: Vec<serde_json::Value> = plan
+        .children()
+        .into_iter()
+        .map(|child| node_to_pg_json(child.as_ref()))
+        .collect();
+    node["Plans"] = serde_json::Value::Array(children);
+
+    node
+}
+
 /// Extended:
 /// Extend the metrics tracker to expose the files as a tracer we can use for BBF
 impl MetricsTracker {

--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -404,10 +404,12 @@ impl Runtime {
     /// runs the plan, has the same side effects as `/api/query`.
     pub async fn explain_analyze_client_query(
         &self,
-        query: QueryRequest,
+        query: crate::query::Query,
         is_super_user: bool,
     ) -> anyhow::Result<String> {
-        let plan = self.lower_query(query.into_query()?.inner).await?;
+        // `output` (file format) is meaningless for EXPLAIN ANALYZE — only the
+        // query body is planned and executed for its metrics.
+        let plan = self.lower_query(query.inner).await?;
         crate::statement_plan::validate_query_plan(&plan, is_super_user)?;
 
         // Build the physical plan and keep the `Arc` so its metrics can be read

--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -393,6 +393,37 @@ impl Runtime {
         Ok(json)
     }
 
+    /// Run the query and return its physical plan as pgjson annotated with
+    /// per-node runtime metrics (the `EXPLAIN ANALYZE` analog of
+    /// [`Self::explain_client_query`]).
+    ///
+    /// Unlike `explain_client_query`, this executes the plan to completion to
+    /// populate the metrics, so it applies the same permission gate the client
+    /// query path uses: anonymous callers are read-only, while a super-user
+    /// (valid admin basic auth) may also analyze DDL/DML — which, since this
+    /// runs the plan, has the same side effects as `/api/query`.
+    pub async fn explain_analyze_client_query(
+        &self,
+        query: QueryRequest,
+        is_super_user: bool,
+    ) -> anyhow::Result<String> {
+        let plan = self.lower_query(query.into_query()?.inner).await?;
+        crate::statement_plan::validate_query_plan(&plan, is_super_user)?;
+
+        // Build the physical plan and keep the `Arc` so its metrics can be read
+        // after the stream drains. `execute_statement_plan` discards the plan,
+        // so the create/execute steps are inlined here.
+        let physical_plan = self.session_ctx.state().create_physical_plan(&plan).await?;
+        let mut stream = datafusion::physical_plan::execute_stream(
+            physical_plan.clone(),
+            self.session_ctx.task_ctx(),
+        )?;
+        // Drain to completion so each node's metrics are fully recorded.
+        while stream.try_next().await?.is_some() {}
+
+        Ok(crate::metrics::explain_analyze_pg_json(physical_plan.as_ref()).to_string())
+    }
+
     pub fn list_functions(&self) -> Vec<FunctionInfo> {
         self.list_runtime_functions()
             .into_iter()

--- a/beacon-core/tests/explain_analyze_pg_json.rs
+++ b/beacon-core/tests/explain_analyze_pg_json.rs
@@ -3,13 +3,13 @@
 
 use std::sync::Arc;
 
-use beacon_core::api::QueryRequest;
+use beacon_core::query::Query;
 use beacon_core::runtime::Runtime;
 use futures::TryStreamExt;
 
 async fn run_sql(runtime: &Runtime, sql: &str) {
     runtime
-        .run_query(beacon_core::query::Query::sql(sql.to_string()), true)
+        .run_query(Query::sql(sql.to_string()), true)
         .await
         .expect("sql should run")
         .into_record_stream()
@@ -19,11 +19,8 @@ async fn run_sql(runtime: &Runtime, sql: &str) {
         .expect("sql should drain");
 }
 
-fn sql_request(sql: &str) -> QueryRequest {
-    // `QueryRequest` is `#[serde(flatten)]`, so the body is the query object
-    // itself (`{"sql": "..."}`), not nested under a `query` field.
-    serde_json::from_value(serde_json::json!({ "sql": sql }))
-        .expect("query request should deserialize")
+fn sql_query(sql: &str) -> Query {
+    Query::sql(sql.to_string())
 }
 
 /// `explain_analyze_client_query` returns the pgjson "Plan with Metrics" shape:
@@ -41,7 +38,7 @@ async fn explain_analyze_returns_pg_json_with_metrics() {
     run_sql(&runtime, &format!("INSERT INTO {table} VALUES (1), (2), (3)")).await;
 
     let json_str = runtime
-        .explain_analyze_client_query(sql_request(&format!("SELECT a FROM {table}")), false)
+        .explain_analyze_client_query(sql_query(&format!("SELECT a FROM {table}")), false)
         .await
         .expect("explain analyze should succeed");
 
@@ -97,7 +94,7 @@ async fn explain_analyze_gates_ddl_by_privilege() {
     // which rejects it before any execution with a "DDL not supported" error.
     let err = runtime
         .explain_analyze_client_query(
-            sql_request(&format!("CREATE TABLE {table} (a BIGINT)")),
+            sql_query(&format!("CREATE TABLE {table} (a BIGINT)")),
             false,
         )
         .await
@@ -111,7 +108,7 @@ async fn explain_analyze_gates_ddl_by_privilege() {
     // Super-user: the same DDL passes the gate and is analyzed (and executed).
     runtime
         .explain_analyze_client_query(
-            sql_request(&format!("CREATE TABLE {table} (a BIGINT)")),
+            sql_query(&format!("CREATE TABLE {table} (a BIGINT)")),
             true,
         )
         .await

--- a/beacon-core/tests/explain_analyze_pg_json.rs
+++ b/beacon-core/tests/explain_analyze_pg_json.rs
@@ -1,0 +1,121 @@
+//! Tests for `explain_analyze_client_query`: running a query and returning its
+//! physical plan as pgjson annotated with per-node runtime metrics.
+
+use std::sync::Arc;
+
+use beacon_core::api::QueryRequest;
+use beacon_core::runtime::Runtime;
+use futures::TryStreamExt;
+
+async fn run_sql(runtime: &Runtime, sql: &str) {
+    runtime
+        .run_query(beacon_core::query::Query::sql(sql.to_string()), true)
+        .await
+        .expect("sql should run")
+        .into_record_stream()
+        .expect("streamed result")
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("sql should drain");
+}
+
+fn sql_request(sql: &str) -> QueryRequest {
+    // `QueryRequest` is `#[serde(flatten)]`, so the body is the query object
+    // itself (`{"sql": "..."}`), not nested under a `query` field.
+    serde_json::from_value(serde_json::json!({ "sql": sql }))
+        .expect("query request should deserialize")
+}
+
+/// `explain_analyze_client_query` returns the pgjson "Plan with Metrics" shape:
+/// a single-element array wrapping a `Plan` node that carries the operator name,
+/// actual row count, and a nested `Plans` array of children.
+#[tokio::test(flavor = "multi_thread")]
+async fn explain_analyze_returns_pg_json_with_metrics() {
+    let runtime = Runtime::new(Arc::new(beacon_config::Config::load().unwrap()))
+        .await
+        .expect("runtime should boot");
+
+    let suffix = uuid::Uuid::new_v4().simple();
+    let table = format!("explain_analyze_pgjson_{suffix}");
+    run_sql(&runtime, &format!("CREATE TABLE {table} (a BIGINT)")).await;
+    run_sql(&runtime, &format!("INSERT INTO {table} VALUES (1), (2), (3)")).await;
+
+    let json_str = runtime
+        .explain_analyze_client_query(sql_request(&format!("SELECT a FROM {table}")), false)
+        .await
+        .expect("explain analyze should succeed");
+
+    let value: serde_json::Value =
+        serde_json::from_str(&json_str).expect("output should be valid JSON");
+
+    // Top level is a one-element array `[{ "Plan": { ... } }]`.
+    let plan = value
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|first| first.get("Plan"))
+        .expect("output should be [{ \"Plan\": ... }]");
+
+    assert!(
+        plan.get("Node Type").and_then(|v| v.as_str()).is_some(),
+        "root plan node should carry a `Node Type`, got: {plan}"
+    );
+    assert!(
+        plan.get("Plans").and_then(|v| v.as_array()).is_some(),
+        "root plan node should carry a `Plans` array, got: {plan}"
+    );
+
+    // Some node in the tree should report `Actual Rows` (the scan/projection that
+    // produced the three inserted rows).
+    fn has_actual_rows(node: &serde_json::Value) -> bool {
+        node.get("Actual Rows").is_some()
+            || node
+                .get("Plans")
+                .and_then(|v| v.as_array())
+                .is_some_and(|children| children.iter().any(has_actual_rows))
+    }
+    assert!(
+        has_actual_rows(plan),
+        "annotated plan should include `Actual Rows` metrics, got:\n{json_str}"
+    );
+
+    let _ = run_sql(&runtime, &format!("DROP TABLE {table}")).await;
+}
+
+/// The endpoint honors admin vs anonymous: an anonymous (non-super-user) call
+/// rejects DDL before execution, while a super-user call is permitted — mirroring
+/// the `/api/query` permission gate.
+#[tokio::test(flavor = "multi_thread")]
+async fn explain_analyze_gates_ddl_by_privilege() {
+    let runtime = Runtime::new(Arc::new(beacon_config::Config::load().unwrap()))
+        .await
+        .expect("runtime should boot");
+
+    let suffix = uuid::Uuid::new_v4().simple();
+    let table = format!("explain_analyze_ddl_{suffix}");
+
+    // Anonymous (read-only): standard DDL is gated by DataFusion's `verify_plan`,
+    // which rejects it before any execution with a "DDL not supported" error.
+    let err = runtime
+        .explain_analyze_client_query(
+            sql_request(&format!("CREATE TABLE {table} (a BIGINT)")),
+            false,
+        )
+        .await
+        .err()
+        .expect("anonymous explain analyze of DDL should be rejected");
+    assert!(
+        err.to_string().contains("DDL not supported"),
+        "unexpected error: {err}"
+    );
+
+    // Super-user: the same DDL passes the gate and is analyzed (and executed).
+    runtime
+        .explain_analyze_client_query(
+            sql_request(&format!("CREATE TABLE {table} (a BIGINT)")),
+            true,
+        )
+        .await
+        .expect("super-user explain analyze of DDL should be permitted");
+
+    let _ = run_sql(&runtime, &format!("DROP TABLE {table}")).await;
+}


### PR DESCRIPTION
## Summary

Adds a new read-only endpoint **`POST /api/explain-analyze-query`** — the `EXPLAIN ANALYZE` analog of the existing `/api/explain-query`. It runs the query and returns its **physical plan as PostgreSQL-style JSON (pgjson) annotated with per-node runtime metrics** (the "Plan with Metrics" shape consumed by PG plan visualizers like [dalibo](https://explain.dalibo.com)).

`/api/explain-query` returns the non-executed *logical* plan as pgjson; this returns the *executed physical* plan with metrics.

## Changes
- **`beacon-core/src/metrics.rs`** — `explain_analyze_pg_json(&dyn ExecutionPlan)` walks the executed plan emitting `[{ "Plan": { "Node Type", "Details", "Actual Rows", "Actual Total Time", "Extras", "Plans": [...] } }]`. Promotes `output_rows` → `Actual Rows` and `elapsed_compute` (ns) → `Actual Total Time` (ms); all other metrics go under `Extras`. Aggregates across partitions via `MetricsSet::aggregate_by_name()`.
- **`beacon-core/src/runtime.rs`** — `explain_analyze_client_query(query, is_super_user)` lowers the query, applies the same permission gate as `/api/query` (anonymous = read-only, valid admin basic auth = super-user, may analyze DDL/DML), builds the physical plan, drains it to populate metrics, and serializes.
- **`beacon-api`** — `explain_analyze_query` handler (resolves super-user from the `Authorization` header, same as `/api/query`) + route and OpenAPI registration.
- **Tests** — pgjson structure + `Actual Rows`; privilege gate (anonymous rejects DDL, super-user permitted).