### PR TITLE
Auto-select broadcast-compatible dimensions for SELECT * on netCDF & Zarr

### DIFF
--- a/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/reader.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/reader.rs
@@ -72,7 +72,10 @@ pub async fn open_dataset(
 ///
 /// When `read_dimensions` is provided the dataset is projected to only
 /// include variables that belong to those dimensions before deriving the
-/// Arrow schema.
+/// Arrow schema. When it is absent, a broadcast-compatible default dimension
+/// set is auto-selected (see [`beacon_nd_array::dataset::resolve_read_dimensions`])
+/// so the schema matches
+/// what `SELECT *` can actually return.
 pub async fn fetch_schema(
     object_store: Arc<DatasetsStore>,
     object: ObjectMeta,
@@ -88,7 +91,11 @@ pub async fn fetch_schema(
             ))
         })?;
 
-    let dataset = if let Some(dims) = read_dimensions {
+    let dataset = if let Some(dims) = beacon_nd_array::dataset::resolve_read_dimensions(
+        &dataset,
+        read_dimensions,
+        Some("read_netcdf"),
+    ) {
         let proj = beacon_nd_array::projection::DatasetProjection {
             dimension_projection: Some(dims),
             index_projection: None,

--- a/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/source.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/source.rs
@@ -257,7 +257,12 @@ impl NetCDFOpener {
                 ))
             })?;
 
-        // Apply dimension projection before deriving the file schema.
+        // Apply dimension projection before deriving the file schema. When no
+        // explicit dimensions were requested, fall back to the dataset's
+        // auto-selected default (matching `fetch_schema`). No log label here:
+        // this runs per file/partition, so logging would spam.
+        let read_dimensions =
+            beacon_nd_array::dataset::resolve_read_dimensions(&dataset, read_dimensions, None);
         let dataset = if let Some(dims) = read_dimensions {
             let proj = DatasetProjection {
                 dimension_projection: Some(dims),

--- a/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
@@ -11,6 +11,8 @@ use arrow::datatypes::SchemaRef;
 use beacon_common::super_typing::super_type_schema;
 use beacon_datafusion_ext::format_ext::{DatasetMetadata, FileFormatFactoryExt};
 use beacon_nd_array::arrow::schema::any_dataset_to_arrow_schema;
+use beacon_nd_array::dataset::resolve_read_dimensions;
+use beacon_nd_array::projection::DatasetProjection;
 use datafusion::{
     catalog::{Session, memory::DataSourceExec},
     common::{GetExt, Statistics},
@@ -65,9 +67,17 @@ impl FileFormatFactory for ZarrFormatFactory {
     fn create(
         &self,
         _state: &dyn Session,
-        _format_options: &std::collections::HashMap<String, String>,
+        format_options: &std::collections::HashMap<String, String>,
     ) -> datafusion::error::Result<Arc<dyn FileFormat>> {
-        Ok(Arc::new(ZarrFormat::default()))
+        // Per-table override from `CREATE EXTERNAL TABLE ... OPTIONS (...)`.
+        let read_dimensions = format_options.get("read_dimensions").map(|value| {
+            value
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        });
+        Ok(Arc::new(ZarrFormat::new(read_dimensions)))
     }
 
     fn default(&self) -> Arc<dyn FileFormat> {
@@ -117,7 +127,21 @@ impl FileFormatFactoryExt for ZarrFormatFactory {
 // ─── Format ──────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Default)]
-pub struct ZarrFormat;
+pub struct ZarrFormat {
+    /// Explicit dimensions requested via `read_zarr(paths, ['dims'])` or a
+    /// `CREATE EXTERNAL TABLE ... OPTIONS (read_dimensions '...')`. When set,
+    /// only variables whose dimensions are a subset of these are read; when
+    /// `None`, a broadcast-compatible default is auto-selected.
+    pub read_dimensions: Option<Vec<String>>,
+}
+
+impl ZarrFormat {
+    /// Build a format that reads only the variables belonging to
+    /// `read_dimensions` (or auto-selects a default when `None`).
+    pub fn new(read_dimensions: Option<Vec<String>>) -> Self {
+        Self { read_dimensions }
+    }
+}
 
 #[async_trait::async_trait]
 impl FileFormat for ZarrFormat {
@@ -186,6 +210,24 @@ impl FileFormat for ZarrFormat {
                         "Failed to read Zarr group as dataset: {e}"
                     ))
                 })?;
+
+                // Apply explicit dimensions, or narrow to a broadcast-compatible
+                // default so the inferred schema matches what the scan returns.
+                let any = match resolve_read_dimensions(
+                    &any,
+                    self.read_dimensions.clone(),
+                    Some("read_zarr"),
+                ) {
+                    Some(dims) => any
+                        .project(&DatasetProjection::new_with_dimension_projection(dims))
+                        .map_err(|e| {
+                            datafusion::error::DataFusionError::Execution(format!(
+                                "Failed to project Zarr dataset with dimensions: {e}"
+                            ))
+                        })?,
+                    None => any,
+                };
+
                 let schema = any_dataset_to_arrow_schema(&any).map_err(|e| {
                     datafusion::error::DataFusionError::Execution(format!(
                         "Failed to derive Zarr Arrow schema: {e}"
@@ -250,7 +292,9 @@ impl FileFormat for ZarrFormat {
         // Preserve a projection that the scan pushed down into the incoming
         // source — rebuilding the source below would otherwise drop it.
         let projection = conf.file_source().projection().cloned();
-        let source = ZarrSource::new(table_schema).with_projection(projection);
+        let source = ZarrSource::new(table_schema)
+            .with_read_dimensions(self.read_dimensions.clone())
+            .with_projection(projection);
         let conf = FileScanConfigBuilder::from(conf)
             .with_file_groups(file_groups)
             .with_source(Arc::new(source))
@@ -262,7 +306,7 @@ impl FileFormat for ZarrFormat {
         &self,
         table_schema: datafusion::datasource::table_schema::TableSchema,
     ) -> Arc<dyn FileSource> {
-        Arc::new(ZarrSource::new(table_schema))
+        Arc::new(ZarrSource::new(table_schema).with_read_dimensions(self.read_dimensions.clone()))
     }
 }
 
@@ -402,6 +446,60 @@ mod tests {
         let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(rows, 10, "LIMIT 10 should yield exactly 10 rows");
         assert_eq!(batches[0].num_columns(), 4);
+    }
+
+    /// An explicit `read_dimensions` projects the schema down to only the
+    /// variables whose dimensions are a subset of those requested.
+    #[tokio::test]
+    async fn explicit_read_dimensions_limits_schema() {
+        use datafusion::catalog::TableProvider;
+
+        let ctx = SessionContext::new();
+        let store_dir = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_files/gridded-example.zarr/"
+        );
+        let table_path = ListingTableUrl::parse(format!("file://{store_dir}")).unwrap();
+
+        let format: Arc<dyn FileFormat> = Arc::new(ZarrFormat::new(Some(vec!["time".to_string()])));
+        let listing_options = ListingOptions::new(format).with_file_extension("zarr.json");
+        let config = ListingTableConfig::new(table_path)
+            .with_listing_options(listing_options)
+            .infer_schema(&ctx.state())
+            .await
+            .unwrap();
+        let table = ListingTable::try_new(config).unwrap();
+        ctx.register_table("gridded_time", Arc::new(table)).unwrap();
+
+        let provider = ctx.table_provider("gridded_time").await.unwrap();
+        let names: Vec<String> = provider
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+        assert!(names.contains(&"time".to_string()), "time present: {names:?}");
+        assert!(
+            !names.contains(&"analysed_sst".to_string()),
+            "analysed_sst depends on lat/lon and must be excluded: {names:?}"
+        );
+        assert!(
+            !names.contains(&"lat".to_string()),
+            "lat is on a different dimension and must be excluded: {names:?}"
+        );
+
+        // The narrowed scan still executes and returns the time column.
+        let rows: usize = ctx
+            .sql("SELECT time FROM gridded_time LIMIT 5")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap()
+            .iter()
+            .map(|b| b.num_rows())
+            .sum();
+        assert!(rows > 0, "should read some time rows");
     }
 
     #[tokio::test]

--- a/beacon-file-formats/beacon-arrow-zarr/src/datafusion/source.rs
+++ b/beacon-file-formats/beacon-arrow-zarr/src/datafusion/source.rs
@@ -13,6 +13,7 @@ use beacon_nd_array::{
         batch::any_dataset_as_record_batch_stream, metrics::DatasetReadMetrics,
         pushdown_filter::PushdownFilter, schema::any_dataset_to_arrow_schema,
     },
+    dataset::resolve_read_dimensions,
     projection::DatasetProjection,
 };
 use datafusion::{
@@ -49,6 +50,8 @@ pub struct ZarrSource {
     execution_plan_metrics: ExecutionPlanMetricsSet,
     batch_size: usize,
     predicate: Option<Arc<dyn PhysicalExpr>>,
+    /// Explicit dimensions to read, or `None` to auto-select a default.
+    read_dimensions: Option<Vec<String>>,
     /// Projection pushed down by the scan, applied on top of the table schema.
     projection: Option<ProjectionExprs>,
 }
@@ -61,8 +64,16 @@ impl ZarrSource {
             execution_plan_metrics: ExecutionPlanMetricsSet::new(),
             batch_size: usize::MAX,
             predicate: None,
+            read_dimensions: None,
             projection: None,
         }
+    }
+
+    /// Returns a copy of this source that reads only the variables belonging to
+    /// `read_dimensions` (or auto-selects a default when `None`).
+    pub fn with_read_dimensions(mut self, read_dimensions: Option<Vec<String>>) -> Self {
+        self.read_dimensions = read_dimensions;
+        self
     }
 
     /// Returns a copy of this source carrying the given projection. Used to
@@ -88,6 +99,7 @@ impl FileSource for ZarrSource {
             projected_schema,
             predicate: self.predicate.clone(),
             batch_size: self.batch_size,
+            read_dimensions: self.read_dimensions.clone(),
             metrics: self.execution_plan_metrics.clone(),
             partition,
         }))
@@ -181,6 +193,7 @@ struct ZarrOpener {
     projected_schema: SchemaRef,
     predicate: Option<Arc<dyn PhysicalExpr>>,
     batch_size: usize,
+    read_dimensions: Option<Vec<String>>,
     metrics: ExecutionPlanMetricsSet,
     partition: usize,
 }
@@ -195,6 +208,7 @@ impl FileOpener for ZarrOpener {
         let projected_schema = self.projected_schema.clone();
         let predicate = self.predicate.clone();
         let batch_size = self.batch_size;
+        let read_dimensions = self.read_dimensions.clone();
         let metrics = Some(DatasetReadMetrics::new(&self.metrics, self.partition));
 
         let fut = async move {
@@ -214,6 +228,22 @@ impl FileOpener for ZarrOpener {
             let full = dataset_from_group(&group, None).await.map_err(|e| {
                 DataFusionError::Execution(format!("Failed to read Zarr group as dataset: {e}"))
             })?;
+
+            // Apply explicit dimensions, or narrow to a broadcast-compatible
+            // default so `SELECT *` cannot fail when variables live on
+            // incompatible dimension sets. No log label: this runs per
+            // file/partition (logging happens in schema inference).
+            let full = match resolve_read_dimensions(&full, read_dimensions, None) {
+                Some(dims) => full
+                    .project(&DatasetProjection::new_with_dimension_projection(dims))
+                    .map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "Failed to project Zarr dataset with dimensions: {e}"
+                        ))
+                    })?,
+                None => full,
+            };
+
             let file_schema: SchemaRef = Arc::new(any_dataset_to_arrow_schema(&full).map_err(
                 |e| DataFusionError::Execution(format!("Failed to derive Zarr Arrow schema: {e}")),
             )?);

--- a/beacon-file-formats/beacon-arrow-zarr/src/datafusion/table_function.rs
+++ b/beacon-file-formats/beacon-arrow-zarr/src/datafusion/table_function.rs
@@ -4,7 +4,11 @@ use arrow::datatypes::{DataType, Field};
 use beacon_common::{listing_url::parse_listing_table_url, super_table::SuperListingTable};
 use crate::datafusion::ZarrFormat;
 use datafusion::{
-    catalog::TableFunctionImpl, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
+    catalog::TableFunctionImpl,
+    common::plan_err,
+    execution::object_store::ObjectStoreUrl,
+    prelude::{Expr, SessionContext},
+    scalar::ScalarValue,
 };
 
 use beacon_common::table_function::BeaconTableFunctionImpl;
@@ -65,6 +69,30 @@ impl TableFunctionImpl for ReadZarrFunc {
     ) -> datafusion::error::Result<std::sync::Arc<dyn datafusion::catalog::TableProvider>> {
         let glob_paths = beacon_common::table_function::parse_glob_paths_arg(args, "read_zarr")?;
 
+        // Optional second argument: an explicit list of dimensions to read.
+        let mut dimensions: Vec<String> = vec![];
+        if let Some(dimensions_arg) = args.get(1) {
+            if let Expr::Literal(ScalarValue::List(values), _) = dimensions_arg {
+                let string_array = values.as_ref().values();
+                match string_array
+                    .as_any()
+                    .downcast_ref::<arrow::array::StringArray>()
+                {
+                    Some(str_arr) => {
+                        dimensions = str_arr
+                            .iter()
+                            .filter_map(|opt_str| opt_str.map(|s| s.to_string()))
+                            .collect();
+                    }
+                    None => {
+                        return plan_err!(
+                            "read_zarr second argument must be a List<Utf8> of dimension names"
+                        );
+                    }
+                }
+            }
+        }
+
         tracing::debug!("read_zarr glob paths: {:?}", glob_paths);
 
         let mut listing_urls = vec![];
@@ -75,7 +103,8 @@ impl TableFunctionImpl for ReadZarrFunc {
 
         // Predicate pushdown is handled automatically by the shared engine, so
         // no manual statistics/column selection is needed.
-        let file_format = ZarrFormat::default();
+        let read_dimensions = (!dimensions.is_empty()).then_some(dimensions);
+        let file_format = ZarrFormat::new(read_dimensions);
         let super_listing_table = tokio::task::block_in_place(|| {
             self.runtime_handle.block_on(async move {
                 SuperListingTable::new(

--- a/beacon-file-formats/beacon-nd-array/src/arrow/batch.rs
+++ b/beacon-file-formats/beacon-nd-array/src/arrow/batch.rs
@@ -766,6 +766,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_default_broadcast_dimensions_makes_select_star_safe() {
+        // `temp(a,b,c)` is the highest-dimensionality variable, plus a
+        // CF-bounds-style `bnds(b,d)` whose `d` dimension is absent from the
+        // main grid. A naive SELECT * (all variables) cannot broadcast `bnds`
+        // onto `(a,b,c)` and fails.
+        let temp = NdArray::<f64>::try_new_from_vec_in_mem(
+            (0..8).map(|v| v as f64).collect(),
+            vec![2, 2, 2],
+            vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            None,
+        )
+        .unwrap();
+        let a = NdArray::<f64>::try_new_from_vec_in_mem(
+            vec![0.0, 1.0],
+            vec![2],
+            vec!["a".to_string()],
+            None,
+        )
+        .unwrap();
+        let bnds = NdArray::<f64>::try_new_from_vec_in_mem(
+            vec![0.0, 1.0, 2.0, 3.0],
+            vec![2, 2],
+            vec!["b".to_string(), "d".to_string()],
+            None,
+        )
+        .unwrap();
+
+        let ds = make_dataset(vec![
+            ("temp", Arc::new(temp)),
+            ("a", Arc::new(a)),
+            ("bnds", Arc::new(bnds)),
+        ])
+        .await;
+
+        // Naive SELECT * over all variables errors at the broadcast step.
+        let naive: Vec<anyhow::Result<RecordBatch>> =
+            dataset_as_record_batch_stream(ds.clone(), usize::MAX, None, None)
+                .collect()
+                .await;
+        assert!(
+            naive.iter().any(|r| r.is_err()),
+            "expected broadcast error without dimension narrowing"
+        );
+
+        // The default selection keeps the variable group that retains the most
+        // variables: the `(a,b,c)` grid, dropping the incompatible `bnds`.
+        let default_dims = ds
+            .default_broadcast_dimensions()
+            .expect("incompatible dataset should narrow");
+        assert_eq!(default_dims, vec!["a", "b", "c"]);
+
+        let projected = ds.project_with_dimensions(&default_dims).unwrap();
+        let batches: Vec<RecordBatch> =
+            dataset_as_record_batch_stream(projected, usize::MAX, None, None)
+                .try_collect()
+                .await
+                .expect("SELECT * succeeds after default dimension narrowing");
+
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 8); // 2 * 2 * 2
+        assert!(batches[0].column_by_name("temp").is_some());
+        assert!(batches[0].column_by_name("a").is_some());
+        assert!(
+            batches[0].column_by_name("bnds").is_none(),
+            "incompatible variable must be excluded"
+        );
+    }
+
+    #[tokio::test]
     async fn test_dimension_mismatch_error() {
         let nd1 = NdArray::<i32>::try_new_from_vec_in_mem(
             vec![1, 2, 3],

--- a/beacon-file-formats/beacon-nd-array/src/dataset/any.rs
+++ b/beacon-file-formats/beacon-nd-array/src/dataset/any.rs
@@ -126,6 +126,20 @@ impl AnyDataset {
         }
     }
 
+    /// Broadcast-compatible default dimension set for `SELECT *` reads.
+    ///
+    /// Only regular datasets need this: they broadcast every variable onto a
+    /// shared shape and can fail when variables live on incompatible dimension
+    /// sets. Ragged datasets null-pad instead of broadcasting (and reject
+    /// dimension projection altogether — see [`AnyDataset::project`]), so they
+    /// are unaffected and always return `None`.
+    pub fn default_broadcast_dimensions(&self) -> Option<Vec<String>> {
+        match self {
+            Self::Regular(ds) => ds.default_broadcast_dimensions(),
+            Self::Ragged { .. } => None,
+        }
+    }
+
     pub fn project(&self, projection: &DatasetProjection) -> anyhow::Result<Self> {
         match self {
             Self::Regular(ds) => {

--- a/beacon-file-formats/beacon-nd-array/src/dataset/mod.rs
+++ b/beacon-file-formats/beacon-nd-array/src/dataset/mod.rs
@@ -66,6 +66,81 @@ impl Dataset {
         })
     }
 
+    /// Compute a broadcast-compatible *default* dimension set for `SELECT *`
+    /// style reads, used when no explicit dimensions were requested.
+    ///
+    /// A regular dataset combines all of its variables into a single Arrow
+    /// table by broadcasting each one onto the dimensions of the
+    /// highest-dimensionality variable. When variables live on mutually
+    /// incompatible dimension sets (e.g. `temp(time,lat,lon)` alongside a CF
+    /// bounds variable `lat_bnds(lat,nv)`) that broadcast cannot succeed.
+    ///
+    /// This picks the variable dimension set that retains the **most**
+    /// variables (tie-break: higher dimensionality, then first-encountered
+    /// order for determinism). Projecting the dataset to the returned set is
+    /// guaranteed to be broadcast-safe: the set is itself some variable's
+    /// dimensions, so that variable survives and becomes the max-dimensionality
+    /// array, and every other survivor has dimensions that are a subset of it.
+    ///
+    /// Returns `None` when no narrowing is needed — i.e. every variable already
+    /// broadcasts onto the highest-dimensionality variable — so callers can
+    /// skip projection entirely.
+    pub fn default_broadcast_dimensions(&self) -> Option<Vec<String>> {
+        // Highest-dimensionality array's dimension set.
+        let max_dims = self
+            .arrays
+            .values()
+            .max_by_key(|array| array.dimensions().len())
+            .map(|array| array.dimensions())?;
+
+        // Already broadcast-safe: every variable's dims fit inside `max_dims`.
+        let needs_narrowing = self.arrays.values().any(|array| {
+            !array
+                .dimensions()
+                .iter()
+                .all(|dim| max_dims.contains(dim))
+        });
+        if !needs_narrowing {
+            return None;
+        }
+
+        // Candidate targets: each variable's (non-empty) dimension set, deduped
+        // in first-encountered order.
+        let mut candidates: Vec<Vec<String>> = Vec::new();
+        for array in self.arrays.values() {
+            let dims = array.dimensions();
+            if dims.is_empty() {
+                continue;
+            }
+            if !candidates.iter().any(|c| c == &dims) {
+                candidates.push(dims);
+            }
+        }
+
+        // Score each candidate by how many variables it retains (variables whose
+        // dimensions are all contained in the candidate). Pick the highest score,
+        // breaking ties by larger dimensionality, then first-encountered order.
+        let score = |c: &[String]| -> usize {
+            self.arrays
+                .values()
+                .filter(|array| array.dimensions().iter().all(|d| c.contains(d)))
+                .count()
+        };
+        let mut best: Option<(usize, usize, Vec<String>)> = None;
+        for candidate in candidates {
+            let key = (score(&candidate), candidate.len());
+            let is_better = match &best {
+                // Strictly greater key wins; equal keys keep the earlier candidate.
+                Some((best_score, best_len, _)) => key > (*best_score, *best_len),
+                None => true,
+            };
+            if is_better {
+                best = Some((key.0, key.1, candidate));
+            }
+        }
+        best.map(|(_, _, dims)| dims)
+    }
+
     pub fn project(&self, indices: &[usize]) -> anyhow::Result<Dataset> {
         let mut arrays = indexmap::IndexMap::new();
         for &index in indices {
@@ -102,6 +177,55 @@ impl Dataset {
             DatasetType::Regular
         }
     }
+}
+
+/// Resolve the dimension projection to apply to a freshly-opened dataset for a
+/// `SELECT *`-style read.
+///
+/// An explicit `read_dimensions` (e.g. a table-function argument or format
+/// option) always wins. When none is given, fall back to the dataset's
+/// auto-selected broadcast-compatible default (see
+/// [`AnyDataset::default_broadcast_dimensions`]) so that combining all variables
+/// into a single table cannot fail at the broadcast step for files whose
+/// variables live on mutually-incompatible dimension sets.
+///
+/// `None` means "apply no dimension projection" — explicit and default both
+/// absent (ragged datasets, or files that are already broadcast-safe).
+///
+/// When `log_label` is `Some(label)` and the default narrowing actually excludes
+/// variables, a single `info` line prefixed with `label` names them. Pass
+/// `Some(..)` only from schema inference (runs once per query) and `None` from
+/// the per-file execution path to avoid log spam.
+pub fn resolve_read_dimensions(
+    dataset: &AnyDataset,
+    read_dimensions: Option<Vec<String>>,
+    log_label: Option<&str>,
+) -> Option<Vec<String>> {
+    if let Some(dims) = read_dimensions {
+        return Some(dims);
+    }
+
+    let default_dims = dataset.default_broadcast_dimensions()?;
+
+    if let Some(label) = log_label {
+        let dropped: Vec<&String> = dataset
+            .dataset()
+            .arrays
+            .iter()
+            .filter(|(_, array)| !array.dimensions().iter().all(|d| default_dims.contains(d)))
+            .map(|(name, _)| name)
+            .collect();
+        if !dropped.is_empty() {
+            tracing::info!(
+                "{label}: SELECT * auto-selected dimensions {:?}; excluded variables {:?} \
+                 have incompatible dimensions and were omitted.",
+                default_dims,
+                dropped
+            );
+        }
+    }
+
+    Some(default_dims)
 }
 
 #[cfg(test)]
@@ -879,5 +1003,124 @@ mod tests {
         assert_eq!(ds.arrays.len(), 1);
         assert!(ds.get_array("beta").is_some());
         assert!(ds.get_array("alpha").is_none());
+    }
+
+    // ── default_broadcast_dimensions ─────────────────────────────────
+
+    /// Helper: f64 array with the given dims (shape filled with 1s).
+    async fn arr(dims: &[&str]) -> Arc<dyn NdArrayD> {
+        let shape: Vec<usize> = vec![1; dims.len()];
+        let len: usize = shape.iter().product();
+        let dim_names: Vec<String> = dims.iter().map(|d| d.to_string()).collect();
+        Arc::new(
+            NdArray::<f64>::try_new_from_vec_in_mem(vec![0.0; len], shape, dim_names, None).unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_default_dims_already_safe_returns_none() {
+        // 2D var plus a 1D subset — already broadcast-safe.
+        let ds = make_dataset(
+            "safe",
+            vec![("grid", arr(&["x", "y"]).await), ("scale", arr(&["y"]).await)],
+        )
+        .await;
+        assert_eq!(ds.default_broadcast_dimensions(), None);
+    }
+
+    #[tokio::test]
+    async fn test_default_dims_picks_group_with_most_variables() {
+        // `temp(x,y,z)` is the highest-dimensionality variable; a CF-bounds-style
+        // `bnds(y,nv)` has an extra `nv` dim. Several coords sit on (x,y,z) subsets.
+        let ds = make_dataset(
+            "incompatible",
+            vec![
+                ("temp", arr(&["x", "y", "z"]).await),
+                ("bnds", arr(&["y", "nv"]).await),
+                ("x", arr(&["x"]).await),
+                ("y", arr(&["y"]).await),
+                ("z", arr(&["z"]).await),
+            ],
+        )
+        .await;
+        assert_eq!(
+            ds.default_broadcast_dimensions(),
+            Some(vec!["x".to_string(), "y".to_string(), "z".to_string()])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_dims_tie_on_count_prefers_higher_dimensionality() {
+        // Two incompatible groups retaining the same number of variables, but
+        // one is higher-dimensional → it should win.
+        let ds = make_dataset(
+            "tie",
+            vec![
+                ("a3", arr(&["a", "b", "c"]).await),
+                ("d2", arr(&["d", "e"]).await),
+            ],
+        )
+        .await;
+        assert_eq!(
+            ds.default_broadcast_dimensions(),
+            Some(vec!["a".to_string(), "b".to_string(), "c".to_string()])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_dims_full_tie_is_deterministic_first_encountered() {
+        // Equal variable count and equal dimensionality → first-encountered wins.
+        let ds = make_dataset(
+            "fulltie",
+            vec![("first", arr(&["a", "b"]).await), ("second", arr(&["c", "d"]).await)],
+        )
+        .await;
+        assert_eq!(
+            ds.default_broadcast_dimensions(),
+            Some(vec!["a".to_string(), "b".to_string()])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_dims_all_scalar_returns_none() {
+        let scalar = NdArray::<f64>::try_new_from_vec_in_mem(
+            vec![1.0],
+            vec![1],
+            vec![] as Vec<String>,
+            None,
+        )
+        .unwrap();
+        let ds = make_dataset("scalars", vec![("attr", Arc::new(scalar))]).await;
+        assert_eq!(ds.default_broadcast_dimensions(), None);
+    }
+
+    #[tokio::test]
+    async fn test_default_dims_empty_dataset_returns_none() {
+        let ds = make_dataset("empty", vec![]).await;
+        assert_eq!(ds.default_broadcast_dimensions(), None);
+    }
+
+    #[tokio::test]
+    async fn test_any_default_dims_ragged_returns_none() {
+        let ds = make_ragged_dataset().await;
+        let any = AnyDataset::try_from_dataset(ds).await.unwrap();
+        assert_eq!(any.default_broadcast_dimensions(), None);
+    }
+
+    #[tokio::test]
+    async fn test_any_default_dims_regular_delegates() {
+        let ds = make_dataset(
+            "incompatible",
+            vec![
+                ("temp", arr(&["x", "y", "z"]).await),
+                ("bnds", arr(&["y", "nv"]).await),
+            ],
+        )
+        .await;
+        let any = AnyDataset::try_from_dataset(ds).await.unwrap();
+        assert_eq!(
+            any.default_broadcast_dimensions(),
+            Some(vec!["x".to_string(), "y".to_string(), "z".to_string()])
+        );
     }
 }


### PR DESCRIPTION
## Problem

`SELECT * FROM read_netcdf('file.nc')` (and `read_zarr(...)`) could fail or return nothing when a file's variables live on **mutually-incompatible dimension sets**. The reader combines all variables into one Arrow table by broadcasting them to the dimensions of the highest-dimensionality variable; any variable whose dimensions aren't a subset of that target fails in `NdArray::broadcast` (`BroadcastDimensions`), aborting the query. A common trigger is CF gridded files with bounds variables (e.g. `lat_bnds(lat, nv)` whose `nv` dim isn't in the main grid).

## Fix

When no explicit dimensions are requested, auto-select a broadcast-compatible default dimension group instead of failing.

- **Core heuristic** (`beacon-nd-array`): `Dataset::default_broadcast_dimensions()` / `AnyDataset::default_broadcast_dimensions()` pick the variable dimension group that **retains the most variables** (tie-break: more dims, then first-encountered for determinism). Returns `None` when the dataset is already broadcast-safe or is ragged.
- **Shared wiring**: `resolve_read_dimensions(dataset, read_dimensions, log_label)` — explicit dims win; otherwise fall back to the default. Logs excluded variables once at schema-inference time.
- Applied at **both** schema-inference and execution sites of **netCDF** and **Zarr** so the schema matches what the scan returns.
- **Ragged datasets are unaffected** — they null-pad instead of broadcasting and never hit this path.

## Explicit override (Zarr parity with netCDF)

Zarr now also accepts an explicit dimension list, matching `read_netcdf`:

- `read_zarr('store.zarr', ['time','lat','lon'])`
- `CREATE EXTERNAL TABLE ... STORED AS ZARR OPTIONS (read_dimensions 'time, lat, lon')`

Precedence: explicit dims (arg or option) win; otherwise the broadcast-compatible default is auto-selected.

## Tests

- `beacon-nd-array`: 8 unit tests for the heuristic (most-retained, ties, scalars, empty, ragged→None) + a regression test proving a dataset that errors today now streams with the incompatible variable dropped.
- `beacon-arrow-zarr`: new `explicit_read_dimensions_limits_schema` end-to-end test.
- Full suites pass: nd-array 94, netcdf 14, zarr 14 — 0 failures.

## Notes

- The default selection silently drops incompatible variables (with an `info` log naming them); pass explicit dimensions to read a different group.
- Atlas/TIFF share the same streaming path and could adopt the helper later if needed.