### PR TITLE
Lance-backed managed table engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
             libnetcdf-dev \
             libsqlite3-dev \
             netcdf-bin \
+            protobuf-compiler \
             software-properties-common \
             sqlite3 \
             wget

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,7 +55,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "const-random",
  "getrandom 0.3.4",
  "once_cell",
@@ -107,10 +118,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -170,6 +225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "array-format"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,7 +244,7 @@ dependencies = [
  "indexmap 2.14.0",
  "lz4_flex 0.11.6",
  "moka",
- "ndarray",
+ "ndarray 0.17.2",
  "object_store 0.13.2",
  "rkyv 0.8.10",
  "tempfile",
@@ -894,6 +958,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +1002,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -982,6 +1069,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_cell"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447ab28afbb345f5408b120702a44e5529ebf90b1796ec76e9528df8e288e6c2"
+dependencies = [
+ "loom",
+]
+
+[[package]]
 name = "async_zip"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,7 +1102,7 @@ dependencies = [
  "futures",
  "indexmap 2.14.0",
  "lz4_flex 0.11.6",
- "ndarray",
+ "ndarray 0.17.2",
  "num_cpus",
  "object_store 0.13.2",
  "parking_lot",
@@ -1081,6 +1177,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-config"
+version = "1.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.1",
+ "sha1 0.10.6",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,6 +1242,328 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c82b3ac19f1431854f7ace3a7531674633e286bfdde21976893bfee36fd493b"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.1",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.104.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321000d2b4c5519ee573f73167f612efd7329322d9b26969ad1979f0427f1913"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.1",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.1",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.1",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.4.1",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.1",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.1",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "http 0.2.12",
+ "http 1.4.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,8 +1574,8 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -1129,7 +1590,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -1147,8 +1608,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -1168,9 +1629,20 @@ dependencies = [
  "axum",
  "bytes",
  "futures",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "tokio-stream",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -1180,7 +1652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "miniz_oxide",
  "object",
@@ -1193,6 +1665,22 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bb8"
@@ -1273,7 +1761,7 @@ dependencies = [
  "indexmap 2.14.0",
  "lz4_flex 0.11.6",
  "moka",
- "ndarray",
+ "ndarray 0.17.2",
  "object_store 0.13.2",
  "rmp-serde",
  "serde",
@@ -1377,7 +1865,7 @@ dependencies = [
  "indexmap 2.14.0",
  "julian",
  "moka",
- "ndarray",
+ "ndarray 0.17.2",
  "netcdf",
  "netcdf-sys",
  "num-traits",
@@ -1457,7 +1945,7 @@ dependencies = [
  "datafusion",
  "futures",
  "indexmap 2.14.0",
- "ndarray",
+ "ndarray 0.17.2",
  "object_store 0.13.2",
  "serde",
  "tokio",
@@ -1479,7 +1967,7 @@ dependencies = [
  "futures",
  "hifitime",
  "indexmap 2.14.0",
- "ndarray",
+ "ndarray 0.17.2",
  "object_store 0.13.2",
  "parking_lot",
  "regex",
@@ -1592,6 +2080,7 @@ dependencies = [
  "beacon-delta",
  "beacon-functions",
  "beacon-iceberg",
+ "beacon-lance",
  "beacon-nd-array",
  "beacon-object-storage",
  "beacon-sql-databases",
@@ -1613,7 +2102,7 @@ dependencies = [
  "pathdiff",
  "serde",
  "serde_json",
- "sysinfo",
+ "sysinfo 0.35.2",
  "tempfile",
  "tokio",
  "tracing",
@@ -1644,6 +2133,7 @@ dependencies = [
  "beacon-datafusion-ext",
  "beacon-delta",
  "beacon-iceberg",
+ "beacon-lance",
  "beacon-object-storage",
  "beacon-sql-databases",
  "datafusion",
@@ -1782,6 +2272,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "beacon-lance"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "arrow 58.3.0",
+ "arrow-schema 58.3.0",
+ "async-trait",
+ "beacon-config",
+ "beacon-datafusion-ext",
+ "beacon-object-storage",
+ "datafusion",
+ "futures",
+ "lance",
+ "lance-index",
+ "once_cell",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "typetag",
+]
+
+[[package]]
 name = "beacon-nd-array"
 version = "0.1.0"
 dependencies = [
@@ -1796,7 +2312,7 @@ dependencies = [
  "datafusion",
  "futures",
  "indexmap 2.14.0",
- "ndarray",
+ "ndarray 0.17.2",
  "pin-project",
  "rand 0.8.6",
  "rkyv 0.8.10",
@@ -1821,7 +2337,7 @@ dependencies = [
  "chrono",
  "criterion 0.5.1",
  "futures",
- "ndarray",
+ "ndarray 0.17.2",
  "pin-project",
  "rand 0.8.6",
  "serde",
@@ -1909,6 +2425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
+name = "bitpacking"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,7 +2463,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "constant_time_eq",
  "cpufeatures 0.3.0",
 ]
@@ -1959,6 +2484,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2055,6 +2589,17 @@ checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e308e67087593070530a666f7fe8815cbd2e61d8f5b7313b71b7d721d1dfde"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
 ]
 
 [[package]]
@@ -2194,6 +2739,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,6 +2764,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,6 +2783,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -2238,7 +2808,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cipher",
  "cpufeatures 0.2.17",
 ]
@@ -2249,7 +2819,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
@@ -2348,6 +2918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -2356,8 +2927,22 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex 1.1.0",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2389,6 +2974,21 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "combine"
@@ -2443,6 +3043,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -2465,6 +3071,21 @@ dependencies = [
  "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "const-str"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
 ]
 
 [[package]]
@@ -2518,12 +3139,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "countio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9702aee5d1d744c01d82f6915644f950f898e014903385464c773b96fefdecb"
+dependencies = [
+ "futures-io",
+]
+
+[[package]]
 name = "cpp_demangle"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -2574,7 +3204,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -2697,6 +3327,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,14 +3391,30 @@ dependencies = [
 
 [[package]]
 name = "ctor"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
+dependencies = [
+ "ctor-proc-macro 0.0.7",
+ "dtor 0.1.1",
+]
+
+[[package]]
+name = "ctor"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
 dependencies = [
- "ctor-proc-macro",
- "dtor",
+ "ctor-proc-macro 0.0.13",
+ "dtor 0.8.1",
  "link-section",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "ctor-proc-macro"
@@ -2850,7 +3506,7 @@ version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
@@ -3664,13 +4320,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "deepsize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb987ec36f6bf7bfbea3f928b75590b736fc42af8e54d97592481351b2b96c"
+dependencies = [
+ "deepsize_derive",
+]
+
+[[package]]
+name = "deepsize_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990101d41f3bc8c1a45641024377ee284ecc338e5ecf3ea0f0e236d897c72796"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "deltalake"
 version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2695b91fd02afd5b4726a190fd58019674492d824e30598391390b0307644da8"
 dependencies = [
  "buoyant_kernel",
- "ctor",
+ "ctor 0.10.1",
  "deltalake-core",
 ]
 
@@ -3694,7 +4402,7 @@ dependencies = [
  "async-trait",
  "buoyant_kernel",
  "bytes",
- "cfg-if",
+ "cfg-if 1.0.4",
  "chrono",
  "dashmap",
  "datafusion",
@@ -3739,6 +4447,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -3834,6 +4553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -3845,7 +4565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -3883,13 +4603,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
+name = "dtor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
+dependencies = [
+ "dtor-proc-macro 0.0.6",
+]
+
+[[package]]
 name = "dtor"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
 dependencies = [
- "dtor-proc-macro",
+ "dtor-proc-macro 0.0.13",
 ]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dtor-proc-macro"
@@ -3925,7 +4669,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -4014,6 +4758,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethnum"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4047,6 +4797,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4058,7 +4814,7 @@ version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
 ]
 
@@ -4184,6 +4940,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsst"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcd0ce0249ac12fd44fcde62d435c36d881952c2f0df4d1de24b45e1dbba5ddb"
+dependencies = [
+ "arrow-array 58.3.0",
+ "rand 0.9.4",
+]
+
+[[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
+dependencies = [
+ "utf8-ranges",
+]
+
+[[package]]
 name = "fundu"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4303,6 +5078,30 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "gearhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8cf82cf76cd16485e56295a1377c775ce708c9f1a0be6b029076d60a245d213"
+dependencies = [
+ "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.4",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4521,7 +5320,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -4534,7 +5333,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi 5.3.0",
@@ -4548,12 +5347,14 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4563,10 +5364,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "gsw"
@@ -4589,7 +5422,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.1",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -4604,7 +5437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
  "zerocopy",
@@ -4697,6 +5530,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapify"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0049b265b7f201ca9ab25475b22b47fe444060126a51abe00f77d986fc5cc52e"
+
+[[package]]
 name = "heapless"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4765,13 +5604,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hf-xet"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "430b33fa84f92796d4d263070b6c0d3ca219df7b9a0e1853ee431029b1612bcd"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.1",
+ "more-asserts",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "xet-client",
+ "xet-core-structures",
+ "xet-data",
+ "xet-runtime",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
- "cfg-if",
+ "cfg-if 1.0.4",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
@@ -4795,7 +5656,7 @@ version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "hickory-proto",
  "ipconfig",
@@ -4829,11 +5690,31 @@ dependencies = [
 
 [[package]]
 name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -4848,12 +5729,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -4864,8 +5756,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -4913,8 +5805,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -4930,7 +5822,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.1",
  "hyper",
  "hyper-util",
  "rustls",
@@ -4964,8 +5856,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "hyper",
  "ipnet",
  "libc",
@@ -4977,6 +5869,15 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hyperloglogplus"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5318,6 +6219,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array 0.14.7",
 ]
 
@@ -5334,6 +6236,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+dependencies = [
+ "bitflags 2.12.1",
+ "cfg-if 1.0.4",
+ "libc",
 ]
 
 [[package]]
@@ -5367,6 +6280,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5380,6 +6299,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -5400,12 +6328,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "js-sys",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-macros",
  "jni-sys",
@@ -5470,10 +6442,30 @@ version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonb"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb98fb29636087c40ad0d1274d9a30c0c1e83e03ae93f6e7e89247b37fcc6953"
+dependencies = [
+ "byteorder",
+ "ethnum",
+ "fast-float2",
+ "itoa",
+ "jiff",
+ "nom",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "zmij",
 ]
 
 [[package]]
@@ -5493,6 +6485,23 @@ checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
 dependencies = [
  "indexmap 2.14.0",
 ]
+
+[[package]]
+name = "konst"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f660d5f887e3562f9ab6f4a14988795b694099d66b4f5dedc02d197ba9becb1d"
+dependencies = [
+ "const_panic",
+ "konst_proc_macros",
+ "typewit",
+]
+
+[[package]]
+name = "konst_proc_macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
 name = "kqueue"
@@ -5515,10 +6524,504 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944aca86f4c78f4da04af1c2bf33e664a2826b7af72972ad200d6b9de59019f"
+dependencies = [
+ "arc-swap",
+ "arrow 58.3.0",
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-row 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "async-recursion",
+ "async-trait",
+ "async_cell",
+ "aws-credential-types",
+ "bitpacking",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crossbeam-queue",
+ "crossbeam-skiplist",
+ "dashmap",
+ "datafusion",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "deepsize",
+ "either",
+ "futures",
+ "half",
+ "humantime",
+ "itertools 0.13.0",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "lance-encoding",
+ "lance-file",
+ "lance-index",
+ "lance-io",
+ "lance-linalg",
+ "lance-namespace",
+ "lance-table",
+ "lance-tokenizer",
+ "log",
+ "moka",
+ "object_store 0.13.2",
+ "permutation",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "rand 0.9.4",
+ "rayon",
+ "roaring",
+ "semver",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lance-arrow"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "253f4a0a70580c985b91e65e9ca6cad644825a4078de28d8efbacf3ffbd7ecdc"
+dependencies = [
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "bytes",
+ "futures",
+ "getrandom 0.2.17",
+ "half",
+ "jsonb",
+ "num-traits",
+ "rand 0.9.4",
+]
+
+[[package]]
+name = "lance-bitpacking"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80c4d12521b1945041dd515a56aa0854973138e7ac12111c92572e33e4ecb593"
+dependencies = [
+ "arrayref",
+ "paste",
+ "seq-macro",
+]
+
+[[package]]
+name = "lance-core"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13f84020da5a484e2f07dd1796e09785ed7cd889857ebc4cb77e32ef214ee594"
+dependencies = [
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-schema 58.3.0",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "datafusion-common",
+ "datafusion-sql",
+ "deepsize",
+ "futures",
+ "itertools 0.13.0",
+ "lance-arrow",
+ "libc",
+ "log",
+ "moka",
+ "num_cpus",
+ "object_store 0.13.2",
+ "pin-project",
+ "prost",
+ "rand 0.9.4",
+ "roaring",
+ "serde_json",
+ "snafu",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "lance-datafusion"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7460597a66534a75987993d4dac5bc330586d99c5b79ae73367dbcbd4e29e576"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "async-trait",
+ "chrono",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "futures",
+ "jsonb",
+ "lance-arrow",
+ "lance-core",
+ "lance-datagen",
+ "lance-geo",
+ "log",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "lance-datagen"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046f5506ed2271cd941a050de7bf535dd3aedc291aadec836a63fa56c5926e3b"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-schema 58.3.0",
+ "chrono",
+ "futures",
+ "half",
+ "hex",
+ "rand 0.9.4",
+ "rand_distr",
+ "rand_xoshiro",
+ "random_word",
+]
+
+[[package]]
+name = "lance-encoding"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af54edf43dcf9d6a56cc636eb35d457e68373c6448dca3f0891b3325b4a24e6"
+dependencies = [
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "bytemuck",
+ "byteorder",
+ "bytes",
+ "fsst",
+ "futures",
+ "hex",
+ "hyperloglogplus",
+ "itertools 0.13.0",
+ "lance-arrow",
+ "lance-bitpacking",
+ "lance-core",
+ "log",
+ "lz4",
+ "num-traits",
+ "prost",
+ "prost-build",
+ "rand 0.9.4",
+ "strum 0.26.3",
+ "tokio",
+ "tracing",
+ "xxhash-rust",
+ "zstd",
+]
+
+[[package]]
+name = "lance-file"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0772ae2d6207995dc1eb28aff9507f78e90b3362b58f311da001e9dc25f3d736"
+dependencies = [
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "async-recursion",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "datafusion-common",
+ "deepsize",
+ "futures",
+ "lance-arrow",
+ "lance-core",
+ "lance-encoding",
+ "lance-io",
+ "log",
+ "num-traits",
+ "object_store 0.13.2",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "lance-geo"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5466cc6524104de7f07d70d4af57fb6912b0eb484f4ac939501c01dbfae572df"
+dependencies = [
+ "datafusion",
+ "geo-traits 0.3.0",
+ "geo-types",
+ "geoarrow-array",
+ "geoarrow-schema",
+ "geodatafusion",
+ "lance-core",
+ "serde",
+]
+
+[[package]]
+name = "lance-index"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e71fbfb51096a903cb524fe0da716f5f15fbc4a6b6f84cd6dec21abf319c5e84"
+dependencies = [
+ "arc-swap",
+ "arrow 58.3.0",
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "async-channel",
+ "async-recursion",
+ "async-trait",
+ "bitpacking",
+ "bitvec",
+ "bytes",
+ "chrono",
+ "crossbeam-queue",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "deepsize",
+ "dirs",
+ "fst",
+ "futures",
+ "geo-types",
+ "geoarrow-array",
+ "geoarrow-schema",
+ "half",
+ "itertools 0.13.0",
+ "jsonb",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "lance-datagen",
+ "lance-encoding",
+ "lance-file",
+ "lance-geo",
+ "lance-io",
+ "lance-linalg",
+ "lance-table",
+ "lance-tokenizer",
+ "libm",
+ "log",
+ "ndarray 0.16.1",
+ "num-traits",
+ "object_store 0.13.2",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "rand 0.9.4",
+ "rand_distr",
+ "rangemap",
+ "rayon",
+ "roaring",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "twox-hash",
+ "uuid",
+]
+
+[[package]]
+name = "lance-io"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab8c98ef1b870b20541d27f3ca4efdf7c9f5c25214233be07d231ba88900219"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "async-recursion",
+ "async-trait",
+ "aws-config",
+ "aws-credential-types",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "deepsize",
+ "futures",
+ "http 1.4.1",
+ "io-uring",
+ "lance-arrow",
+ "lance-core",
+ "lance-namespace",
+ "log",
+ "moka",
+ "object_store 0.13.2",
+ "object_store_opendal",
+ "opendal",
+ "path_abs",
+ "pin-project",
+ "prost",
+ "rand 0.9.4",
+ "serde",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "lance-linalg"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4c51cad0ac780b02dc4da48528479e7693c03e8d05390510bbc69ca2a9a1f1"
+dependencies = [
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-schema 58.3.0",
+ "cc",
+ "deepsize",
+ "half",
+ "lance-arrow",
+ "lance-core",
+ "num-traits",
+ "rand 0.9.4",
+]
+
+[[package]]
+name = "lance-namespace"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "014e8332ca0615506342e0d3af608639864b68396973be14239f09c9f21f1fc2"
+dependencies = [
+ "arrow 58.3.0",
+ "async-trait",
+ "bytes",
+ "lance-core",
+ "lance-namespace-reqwest-client",
+ "snafu",
+]
+
+[[package]]
+name = "lance-namespace-reqwest-client"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6369eee4682fb11edf538388b43c61ce288b8302fe89bb40944d7daa7faaae99"
+dependencies = [
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "url",
+]
+
+[[package]]
+name = "lance-table"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16f1355904aea4ebb04ffc70c58c97901e10bde44452b4b021de4a1f329250d"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-schema 58.3.0",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "deepsize",
+ "futures",
+ "lance-arrow",
+ "lance-core",
+ "lance-file",
+ "lance-io",
+ "log",
+ "object_store 0.13.2",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "rand 0.9.4",
+ "rangemap",
+ "roaring",
+ "semver",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lance-tokenizer"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39b7f5ed9d0c0b716bf599b559d888267ed1dfe4c4e29d3648b51d2a28940cf"
+dependencies = [
+ "rust-stemmers",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.8",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -5601,7 +7104,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link 0.2.1",
 ]
 
@@ -5696,6 +7199,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if 1.0.4",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5718,6 +7234,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
 
 [[package]]
 name = "lz4-sys"
@@ -5810,7 +7335,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
+ "num_cpus",
+ "once_cell",
  "rawpointer",
+ "thread-tree",
 ]
 
 [[package]]
@@ -5819,7 +7347,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "digest 0.10.7",
 ]
 
@@ -5829,8 +7357,17 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "mea"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2640d335e7273dacdcf51044026139b2e269c3bb0dfc3f8cb3496b85e3f6a42c"
+dependencies = [
+ "slab",
 ]
 
 [[package]]
@@ -5929,6 +7466,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "more-asserts"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
+
+[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5937,13 +7480,19 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 1.4.1",
  "httparse",
  "memchr",
  "mime",
  "spin 0.9.8",
  "version_check",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "munge"
@@ -6042,7 +7591,7 @@ dependencies = [
  "saturating",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "time",
@@ -6088,6 +7637,21 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "ndarray"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
@@ -6108,7 +7672,7 @@ source = "git+https://github.com/robinskil/netcdf.git#35cc74866e5f337f883fe8b70c
 dependencies = [
  "bitflags 2.12.1",
  "libc",
- "ndarray",
+ "ndarray 0.17.2",
  "netcdf-sys",
  "semver",
 ]
@@ -6140,8 +7704,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -6213,6 +7786,22 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -6363,7 +7952,7 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "futures",
- "http",
+ "http 1.4.1",
  "http-body-util",
  "humantime",
  "hyper",
@@ -6401,7 +7990,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.1",
  "http-body-util",
  "httparse",
  "humantime",
@@ -6428,6 +8017,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store_opendal"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08298874eee5935c95bcaa393148834f9c53d904461ca15584a041d8a1c907c2"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "mea",
+ "object_store 0.13.2",
+ "opendal",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6436,6 +8042,18 @@ dependencies = [
  "critical-section",
  "portable-atomic",
 ]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
 name = "oorandom"
@@ -6450,13 +8068,248 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "opendal"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b31d3d8e99a85d83b73ec26647f5607b80578ed9375810b6e44ffa3590a236"
+dependencies = [
+ "ctor 0.6.3",
+ "opendal-core",
+ "opendal-layer-concurrent-limit",
+ "opendal-layer-logging",
+ "opendal-layer-retry",
+ "opendal-layer-timeout",
+ "opendal-service-azblob",
+ "opendal-service-azdls",
+ "opendal-service-cos",
+ "opendal-service-gcs",
+ "opendal-service-hf",
+ "opendal-service-oss",
+ "opendal-service-s3",
+]
+
+[[package]]
+name = "opendal-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1849dd2687e173e776d3af5fce1ba3ae47b9dd37a09d1c4deba850ef45fe00ca"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bytes",
+ "futures",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "jiff",
+ "log",
+ "md-5 0.10.6",
+ "mea",
+ "percent-encoding",
+ "quick-xml 0.38.4",
+ "reqsign-core",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "opendal-layer-concurrent-limit"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048b1b29c503263bdd80a9afe46a68cd02ea9bd361185b1feab4b151078998e9"
+dependencies = [
+ "futures",
+ "http 1.4.1",
+ "mea",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-logging"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2645adc988b12eda106e2679ae529facfbbaa868ceb706f6f8125c6af15c47b"
+dependencies = [
+ "log",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-retry"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eac134ffa4ddda6131a640a84a5315996424b9416c85052f8c64c1a33b70ad4"
+dependencies = [
+ "backon",
+ "log",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-timeout"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619586ab7480c2e3009f6d18eabab18957bc094778fd130bcc38924970a90f4c"
+dependencies = [
+ "opendal-core",
+ "tokio",
+]
+
+[[package]]
+name = "opendal-service-azblob"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7452bf3ec61cfd81ac9ad9ada17825931e9e371d44a045c6bfab9596c0a2ac3b"
+dependencies = [
+ "base64",
+ "bytes",
+ "http 1.4.1",
+ "log",
+ "opendal-core",
+ "opendal-service-azure-common",
+ "quick-xml 0.38.4",
+ "reqsign-azure-storage",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "serde",
+ "sha2 0.10.9",
+ "uuid",
+]
+
+[[package]]
+name = "opendal-service-azdls"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9884c2d8cf8ba2bb077d79c877dac5863ba3bab9e2c9c1e41a2e0491404772"
+dependencies = [
+ "bytes",
+ "http 1.4.1",
+ "log",
+ "opendal-core",
+ "opendal-service-azure-common",
+ "quick-xml 0.38.4",
+ "reqsign-azure-storage",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "opendal-service-azure-common"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb0e45d6c8dcf66ce2da20e241bcb80e6e540e109a4ff20f318f6c9b4c54e0c"
+dependencies = [
+ "http 1.4.1",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-service-cos"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55a0765ba451b6effdbf514b7b50060530ff8a29e4231c4a3ab7792c016408e6"
+dependencies = [
+ "bytes",
+ "http 1.4.1",
+ "log",
+ "opendal-core",
+ "quick-xml 0.38.4",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "reqsign-tencent-cos",
+ "serde",
+]
+
+[[package]]
+name = "opendal-service-gcs"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a49477a10163431896d106136117f5670717f9c9e49cf6f710528800c6633a"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.1",
+ "log",
+ "opendal-core",
+ "percent-encoding",
+ "quick-xml 0.38.4",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "reqsign-google",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "opendal-service-hf"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2ab7a2a8a11dfe257ef4db5c0de798acbcd0d6429c37382dad2154bc06a388"
+dependencies = [
+ "bytes",
+ "hf-xet",
+ "http 1.4.1",
+ "log",
+ "opendal-core",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "opendal-service-oss"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c8a917829ad06d21b639558532cb0101fe49b040d946d673a73018683fac05"
+dependencies = [
+ "bytes",
+ "http 1.4.1",
+ "log",
+ "opendal-core",
+ "quick-xml 0.38.4",
+ "reqsign-aliyun-oss",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "serde",
+]
+
+[[package]]
+name = "opendal-service-s3"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dadddeb9bb50b0d30927dd914c298c4ddca47e4c1cfa7674d311f0cf9b051c8"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc32c",
+ "http 1.4.1",
+ "log",
+ "md-5 0.10.6",
+ "opendal-core",
+ "quick-xml 0.38.4",
+ "reqsign-aws-v4",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "serde",
+ "url",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.12.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "foreign-types",
  "libc",
  "openssl-macros",
@@ -6519,10 +8372,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "page_size"
@@ -6556,7 +8428,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -6606,10 +8478,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path_abs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ef02f6342ac01d8a93b65f96db53fe68a92a15f41144f97fb00a9e669633c3"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "std_prelude",
+ "stfu8",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
 
 [[package]]
 name = "pdqselect"
@@ -6628,6 +8522,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6638,6 +8541,12 @@ name = "percent-encoding-rfc3986"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3637c05577168127568a64e9dc5a6887da720efef07b3d9472d45f63ab191166"
+
+[[package]]
+name = "permutation"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df202b0b0f5b8e389955afd5f27b007b00fb948162953f1db9c70d2c7e3157d7"
 
 [[package]]
 name = "petgraph"
@@ -6713,6 +8622,50 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2 0.10.9",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "pkcs5",
+ "rand_core 0.6.4",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -6807,7 +8760,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
- "hmac",
+ "hmac 0.13.0",
  "md-5 0.11.0",
  "memchr",
  "rand 0.10.1",
@@ -6854,7 +8807,7 @@ checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
 dependencies = [
  "aligned-vec",
  "backtrace",
- "cfg-if",
+ "cfg-if 1.0.4",
  "findshlibs",
  "inferno",
  "libc",
@@ -6946,6 +8899,25 @@ checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
 ]
 
 [[package]]
@@ -7059,6 +9031,16 @@ name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
@@ -7257,6 +9239,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "random_word"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47a395bdb55442b883c89062d6bcff25dc90fa5f8369af81e0ac6d49d78cf81"
+dependencies = [
+ "ahash 0.8.12",
+ "brotli",
+ "paste",
+ "rand 0.9.4",
+ "unicase",
+]
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7309,6 +9329,15 @@ checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "redb"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7385,6 +9414,135 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqsign-aliyun-oss"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372266b4733756738eeb199a98188037d27a0989980e2600ae7ce1faf00a867d"
+dependencies = [
+ "anyhow",
+ "form_urlencoded",
+ "http 1.4.1",
+ "log",
+ "percent-encoding",
+ "reqsign-core",
+ "rust-ini",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "reqsign-aws-v4"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75624bd8a466e37ddc0a7b6c33ac859a85347c153a916e1dd9d0b68338f74a"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "http 1.4.1",
+ "log",
+ "percent-encoding",
+ "quick-xml 0.40.1",
+ "reqsign-core",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sha1 0.11.0",
+]
+
+[[package]]
+name = "reqsign-azure-storage"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b96928e73ad984de1d99e382749d09e5dab7dd707b767974f7e40aa926b82f"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "http 1.4.1",
+ "log",
+ "pem",
+ "percent-encoding",
+ "reqsign-core",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha1 0.11.0",
+]
+
+[[package]]
+name = "reqsign-core"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5fa5cb48808693614d1701fcd3db0b30fa292e0f18e122ae068b6d32eaeed3f"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures",
+ "hex",
+ "hmac 0.13.0",
+ "http 1.4.1",
+ "jiff",
+ "log",
+ "percent-encoding",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "reqsign-file-read-tokio"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a4b6f3a3fd29ffcc99a90aec585a65217783badfd73acddf847b63ae683bda9"
+dependencies = [
+ "anyhow",
+ "reqsign-core",
+ "tokio",
+]
+
+[[package]]
+name = "reqsign-google"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb215d0876a18b6bd9cdd380b589e5292aaa638ca15266de794b1122d898b6b2"
+dependencies = [
+ "form_urlencoded",
+ "http 1.4.1",
+ "log",
+ "percent-encoding",
+ "reqsign-aws-v4",
+ "reqsign-core",
+ "rsa",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "reqsign-tencent-cos"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84110aabba799fbcd48b3abb51fbbff4749f879252e5806b6f5d0cbe0fef6abb"
+dependencies = [
+ "anyhow",
+ "http 1.4.1",
+ "log",
+ "percent-encoding",
+ "reqsign-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7392,17 +9550,20 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -7422,7 +9583,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
 ]
 
@@ -7436,9 +9597,10 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -7452,16 +9614,34 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "serde",
+ "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.4.1",
+ "reqwest 0.13.4",
+ "thiserror 2.0.18",
+ "tower-service",
 ]
 
 [[package]]
@@ -7486,7 +9666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.17",
  "libc",
  "untrusted",
@@ -7598,6 +9778,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rstar"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7690,6 +9891,26 @@ checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2 0.10.9",
  "walkdir",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if 1.0.4",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -7833,6 +10054,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe-transmute"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7857,10 +10093,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "sea-query"
@@ -8064,9 +10317,20 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -8075,9 +10339,10 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+ "sha2-asm",
 ]
 
 [[package]]
@@ -8086,9 +10351,18 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -8098,6 +10372,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "bstr",
+ "dirs",
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -8114,6 +10399,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -8254,6 +10549,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "sqlparser"
 version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8288,11 +10593,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "psm",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
+
+[[package]]
+name = "std_prelude"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
+
+[[package]]
+name = "stfu8"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
 
 [[package]]
 name = "str_stack"
@@ -8322,6 +10655,9 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
 
 [[package]]
 name = "strum"
@@ -8446,7 +10782,21 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "serde",
- "windows",
+ "windows 0.61.3",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -8562,12 +10912,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-tree"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbd370cb847953a25954d9f63e14824a36113f8c72eecf6eccef5dc4b45d630"
+dependencies = [
+ "crossbeam-channel",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -8741,6 +11100,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-retry"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
+dependencies = [
+ "pin-project-lite",
+ "rand 0.10.1",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8829,8 +11199,8 @@ dependencies = [
  "base64",
  "bytes",
  "h2",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-timeout",
@@ -8883,12 +11253,13 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags 2.12.1",
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -8985,6 +11356,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8994,12 +11375,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -9037,11 +11421,11 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.1",
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 
@@ -9050,6 +11434,9 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.4",
+]
 
 [[package]]
 name = "typeid"
@@ -9086,6 +11473,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "unicase"
@@ -9174,10 +11567,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
@@ -9309,6 +11720,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9375,7 +11792,7 @@ version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "serde",
@@ -9452,6 +11869,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -9563,11 +11993,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -9577,6 +12019,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -9613,7 +12064,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -9658,6 +12120,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9798,6 +12270,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9953,7 +12434,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "serde",
  "windows-sys 0.48.0",
 ]
@@ -10116,6 +12597,165 @@ dependencies = [
 ]
 
 [[package]]
+name = "xet-client"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1e496dcbe6a09017acdfaf48e1a646735e7ff5b2a49e2c7e081cca77a59bc8"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64",
+ "bytes",
+ "clap 4.6.1",
+ "crc32fast",
+ "futures",
+ "http 1.4.1",
+ "hyper",
+ "lazy_static",
+ "more-asserts",
+ "rand 0.10.1",
+ "redb",
+ "reqwest 0.13.4",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "statrs",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-retry",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "urlencoding",
+ "web-time",
+ "xet-core-structures",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-core-structures"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb838aa8eb67d730af301584cf003caad407487606058292a6750711b603fbee"
+dependencies = [
+ "async-trait",
+ "base64",
+ "blake3",
+ "bytemuck",
+ "bytes",
+ "clap 4.6.1",
+ "countio",
+ "csv",
+ "futures",
+ "futures-util",
+ "getrandom 0.4.2",
+ "heapify",
+ "itertools 0.14.0",
+ "lazy_static",
+ "lz4_flex 0.13.1",
+ "more-asserts",
+ "rand 0.10.1",
+ "regex",
+ "safe-transmute",
+ "serde",
+ "static_assertions",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "web-time",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-data"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fd409bef621411a9d9013798540bb8036cb2678f03ab39af89a5e88034ed8c"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "clap 4.6.1",
+ "gearhash",
+ "http 1.4.1",
+ "itertools 0.14.0",
+ "lazy_static",
+ "more-asserts",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uuid",
+ "walkdir",
+ "xet-client",
+ "xet-core-structures",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-runtime"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d8f121c33866f7648b737abe70d0e2dd9c0af4ffdd7219207531d0283aa63d"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "colored",
+ "const-str",
+ "ctor 0.6.3",
+ "dirs",
+ "futures",
+ "git-version",
+ "humantime",
+ "konst",
+ "lazy_static",
+ "libc",
+ "more-asserts",
+ "oneshot",
+ "pin-project",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "sysinfo 0.38.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "whoami",
+ "winapi",
+]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10171,7 +12811,7 @@ dependencies = [
  "log",
  "lru 0.16.4",
  "moka",
- "ndarray",
+ "ndarray 0.17.2",
  "num",
  "num-complex",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,7 +2285,10 @@ dependencies = [
  "datafusion",
  "futures",
  "lance",
+ "lance-core",
  "lance-index",
+ "lance-io",
+ "object_store 0.13.2",
  "once_cell",
  "parking_lot",
  "serde",
@@ -2295,6 +2298,7 @@ dependencies = [
  "tokio",
  "tracing",
  "typetag",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,10 @@ lance = "=7.0.0"
 # Lance index types (IndexType, ScalarIndexParams) for managed-table indexing.
 # Version-locked to `lance` so the shared types are a single compilation.
 lance-index = "=7.0.0"
+# Lance IO + core: the ObjectStoreProvider/ObjectStoreRegistry mechanism used to
+# route Lance through beacon's tables object store. Version-locked to `lance`.
+lance-io = "=7.0.0"
+lance-core = "=7.0.0"
 
 arrow = { version = "^58", features = ["prettyprint"]}
 arrow-schema = { version = "^58", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["beacon-api", "beacon-file-formats/beacon-arrow-netcdf", "beacon-file-formats/beacon-arrow-odv", "beacon-common", "beacon-config", "beacon-core", "beacon-functions", "beacon-data-lake", "beacon-sql-databases", "beacon-file-formats/beacon-delta", "beacon-file-formats/beacon-arrow-zarr", "beacon-file-formats/beacon-binary-format", "beacon-object-storage", "beacon-file-formats/beacon-nd-arrow", "beacon-datafusion-ext", "beacon-file-formats/beacon-iceberg", "beacon-file-formats/beacon-nd-array", "beacon-file-formats/beacon-arrow-tiff", "beacon-file-formats/beacon-arrow-atlas", "beacon-file-formats/beacon-arrow-geoparquet", "beacon-file-formats/beacon-arrow-bbf", "beacon-file-formats/beacon-arrow-ipc", "beacon-file-formats/beacon-arrow-csv", "beacon-file-formats/beacon-arrow-parquet"]
+members = ["beacon-api", "beacon-file-formats/beacon-arrow-netcdf", "beacon-file-formats/beacon-arrow-odv", "beacon-common", "beacon-config", "beacon-core", "beacon-functions", "beacon-data-lake", "beacon-sql-databases", "beacon-file-formats/beacon-delta", "beacon-file-formats/beacon-arrow-zarr", "beacon-file-formats/beacon-binary-format", "beacon-object-storage", "beacon-file-formats/beacon-nd-arrow", "beacon-datafusion-ext", "beacon-file-formats/beacon-iceberg", "beacon-file-formats/beacon-lance", "beacon-file-formats/beacon-nd-array", "beacon-file-formats/beacon-arrow-tiff", "beacon-file-formats/beacon-arrow-atlas", "beacon-file-formats/beacon-arrow-geoparquet", "beacon-file-formats/beacon-arrow-bbf", "beacon-file-formats/beacon-arrow-ipc", "beacon-file-formats/beacon-arrow-csv", "beacon-file-formats/beacon-arrow-parquet"]
 exclude = ["beacon-file-formats/beacon-binary-format-toolbox"]
 
 [workspace.dependencies]
@@ -65,6 +65,15 @@ tonic = "0.14.1"
 iceberg-rust = "0.10"
 datafusion_iceberg = "0.10"
 iceberg-file-catalog = "0.10"
+
+# Lance managed-table engine. 7.0.0 pins arrow 58 / datafusion 53 / object_store
+# 0.13, matching our versions. Provides `lance::datafusion::LanceTableProvider`
+# plus the `Dataset` write/append/delete API used by beacon-lance. Requires
+# `protoc` at build time (Lance generates protobuf in its build script).
+lance = "=7.0.0"
+# Lance index types (IndexType, ScalarIndexParams) for managed-table indexing.
+# Version-locked to `lance` so the shared types are a single compilation.
+lance-index = "=7.0.0"
 
 arrow = { version = "^58", features = ["prettyprint"]}
 arrow-schema = { version = "^58", features = ["serde"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get install -y libclang-dev
 RUN apt-get install -y libsqlite3-dev
 RUN apt-get install -y cmake
 RUN apt-get install -y sqlite3
+# protoc: required at build time by the `lance` crate (beacon-lance managed tables)
+RUN apt-get install -y protobuf-compiler
 
 #Install Rust
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ COPY beacon-file-formats/beacon-arrow-geoparquet/ /beacon-file-formats/beacon-ar
 COPY beacon-file-formats/beacon-arrow-bbf/ /beacon-file-formats/beacon-arrow-bbf/
 COPY beacon-functions/ /beacon-functions/
 COPY beacon-file-formats/beacon-iceberg/ /beacon-file-formats/beacon-iceberg/
+COPY beacon-file-formats/beacon-lance/ /beacon-file-formats/beacon-lance/
 COPY beacon-file-formats/beacon-nd-array/ /beacon-file-formats/beacon-nd-array/
 COPY beacon-file-formats/beacon-nd-arrow/ /beacon-file-formats/beacon-nd-arrow/
 COPY beacon-object-storage/ /beacon-object-storage/

--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -69,6 +69,42 @@ pub struct SqlConfig {
     pub default_table: String,
     pub enable_pushdown_projection: bool,
     pub stream_coalesce: SqlStreamCoalesceConfig,
+    /// Storage engine used for managed `CREATE TABLE` when the statement does not
+    /// override it (via `SET beacon.table_engine = '…'`).
+    pub default_table_engine: TableEngine,
+}
+
+/// The storage engine backing a beacon-managed table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TableEngine {
+    /// Lance: local-filesystem, columnar, versioned (default).
+    #[default]
+    Lance,
+    /// Apache Iceberg: object-store-backed lakehouse table.
+    Iceberg,
+}
+
+impl TableEngine {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TableEngine::Lance => "lance",
+            TableEngine::Iceberg => "iceberg",
+        }
+    }
+}
+
+impl std::str::FromStr for TableEngine {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "lance" => Ok(TableEngine::Lance),
+            "iceberg" => Ok(TableEngine::Iceberg),
+            other => Err(format!(
+                "unknown table engine '{other}', expected 'lance' or 'iceberg'"
+            )),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -184,6 +220,8 @@ struct RawConfig {
     vm_memory_size: usize,
     #[envconfig(from = "BEACON_DEFAULT_TABLE", default = "default")]
     default_table: String,
+    #[envconfig(from = "BEACON_DEFAULT_TABLE_ENGINE", default = "lance")]
+    default_table_engine: String,
     #[envconfig(from = "BEACON_SANITIZE_SCHEMA", default = "false")]
     sanitize_schema: bool,
     #[envconfig(from = "BEACON_ENABLE_SQL", default = "true")]
@@ -365,6 +403,13 @@ impl From<RawConfig> for Config {
                     target_rows: raw.sql_stream_coalesce_target_rows,
                     flush_timeout_ms: raw.sql_stream_coalesce_flush_timeout_ms,
                     max_rows: raw.sql_stream_coalesce_max_rows,
+                },
+                default_table_engine: match raw.default_table_engine.parse() {
+                    Ok(engine) => engine,
+                    Err(e) => {
+                        tracing::warn!("invalid BEACON_DEFAULT_TABLE_ENGINE: {e}; defaulting to lance");
+                        TableEngine::default()
+                    }
                 },
             },
             flight_sql: FlightSqlConfig {

--- a/beacon-core/Cargo.toml
+++ b/beacon-core/Cargo.toml
@@ -50,6 +50,7 @@ beacon-object-storage = { path = "../beacon-object-storage" }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }
 beacon-common = { path = "../beacon-common" }
 beacon-iceberg = { path = "../beacon-file-formats/beacon-iceberg" }
+beacon-lance = { path = "../beacon-file-formats/beacon-lance" }
 beacon-delta = { path = "../beacon-file-formats/beacon-delta" }
 beacon-nd-array = { path = "../beacon-file-formats/beacon-nd-array" }
 beacon-sql-databases = { path = "../beacon-sql-databases" }

--- a/beacon-core/src/parser/beacon_parser.rs
+++ b/beacon-core/src/parser/beacon_parser.rs
@@ -7,8 +7,9 @@ use datafusion::sql::{
 };
 
 use super::statement::{
-    BeaconStatement, CreateCrawlerStatement, CreateMaterializedViewStatement, DropCrawlerStatement,
-    RefreshStatement, RunCrawlerStatement,
+    BeaconStatement, CreateCrawlerStatement, CreateIndexStatement, CreateMaterializedViewStatement,
+    DropCrawlerStatement, DropIndexStatement, RefreshStatement, RunCrawlerStatement,
+    ShowIndexesStatement,
 };
 
 /// A parser that extends `DFParser` with custom Beacon SQL syntax.
@@ -47,6 +48,18 @@ impl<'a> BeaconParser<'a> {
 
         if self.is_show_crawlers() {
             return self.parse_show_crawlers();
+        }
+
+        if self.is_create_index() {
+            return self.parse_create_index();
+        }
+
+        if self.is_drop_index() {
+            return self.parse_drop_index();
+        }
+
+        if self.is_show_indexes() {
+            return self.parse_show_indexes();
         }
 
         let df_statement = Box::new(self.df_parser.parse_statement()?);
@@ -147,6 +160,128 @@ impl<'a> BeaconParser<'a> {
         self.df_parser.parser.next_token(); // SHOW
         self.df_parser.parser.next_token(); // CRAWLERS
         Ok(BeaconStatement::ShowCrawlers)
+    }
+
+    fn is_create_index(&self) -> bool {
+        let t1 = &self.df_parser.parser.peek_nth_token(0).token;
+        let t2 = &self.df_parser.parser.peek_nth_token(1).token;
+        matches!(t1, Token::Word(w) if w.keyword == Keyword::CREATE)
+            && matches!(t2, Token::Word(w) if w.value.to_uppercase() == "INDEX")
+    }
+
+    fn is_drop_index(&self) -> bool {
+        let t1 = &self.df_parser.parser.peek_nth_token(0).token;
+        let t2 = &self.df_parser.parser.peek_nth_token(1).token;
+        matches!(t1, Token::Word(w) if w.keyword == Keyword::DROP)
+            && matches!(t2, Token::Word(w) if w.value.to_uppercase() == "INDEX")
+    }
+
+    fn is_show_indexes(&self) -> bool {
+        let t1 = &self.df_parser.parser.peek_nth_token(0).token;
+        let t2 = &self.df_parser.parser.peek_nth_token(1).token;
+        matches!(t1, Token::Word(w) if w.value.to_uppercase() == "SHOW")
+            && matches!(t2, Token::Word(w)
+                if matches!(w.value.to_uppercase().as_str(), "INDEXES" | "INDEX" | "INDICES"))
+    }
+
+    /// Parse: CREATE INDEX [<name>] ON <table> (<column>) [USING <type>]
+    fn parse_create_index(&mut self) -> Result<BeaconStatement> {
+        self.df_parser.parser.next_token(); // CREATE
+        self.df_parser.parser.next_token(); // INDEX
+
+        // An index name is present unless the next token is `ON`.
+        let name = if matches!(
+            &self.df_parser.parser.peek_nth_token(0).token,
+            Token::Word(w) if w.keyword == Keyword::ON
+        ) {
+            None
+        } else {
+            Some(
+                self.df_parser
+                    .parser
+                    .parse_object_name(false)
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?,
+            )
+        };
+
+        self.df_parser
+            .parser
+            .expect_keyword(Keyword::ON)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let table = self
+            .df_parser
+            .parser
+            .parse_object_name(false)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        self.df_parser
+            .parser
+            .expect_token(&Token::LParen)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let column = self.parse_string_value()?;
+        self.df_parser
+            .parser
+            .expect_token(&Token::RParen)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        let using = if matches!(
+            &self.df_parser.parser.peek_nth_token(0).token,
+            Token::Word(w) if w.keyword == Keyword::USING
+        ) {
+            self.df_parser.parser.next_token(); // USING
+            Some(self.parse_string_value()?)
+        } else {
+            None
+        };
+
+        Ok(BeaconStatement::CreateIndex(CreateIndexStatement {
+            name,
+            table,
+            column,
+            using,
+        }))
+    }
+
+    /// Parse: DROP INDEX <name> ON <table>
+    fn parse_drop_index(&mut self) -> Result<BeaconStatement> {
+        self.df_parser.parser.next_token(); // DROP
+        self.df_parser.parser.next_token(); // INDEX
+        let name = self
+            .df_parser
+            .parser
+            .parse_object_name(false)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        self.df_parser
+            .parser
+            .expect_keyword(Keyword::ON)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let table = self
+            .df_parser
+            .parser
+            .parse_object_name(false)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        Ok(BeaconStatement::DropIndex(DropIndexStatement { name, table }))
+    }
+
+    /// Parse: SHOW INDEXES [ON|FROM] <table>
+    fn parse_show_indexes(&mut self) -> Result<BeaconStatement> {
+        self.df_parser.parser.next_token(); // SHOW
+        self.df_parser.parser.next_token(); // INDEXES
+
+        // Optional `ON`/`FROM` before the table name.
+        if matches!(
+            &self.df_parser.parser.peek_nth_token(0).token,
+            Token::Word(w) if w.keyword == Keyword::ON || w.keyword == Keyword::FROM
+        ) {
+            self.df_parser.parser.next_token();
+        }
+
+        let table = self
+            .df_parser
+            .parser
+            .parse_object_name(false)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        Ok(BeaconStatement::ShowIndexes(ShowIndexesStatement { table }))
     }
 
     /// Read a single string value (single-quoted string, identifier, or number).

--- a/beacon-core/src/parser/statement.rs
+++ b/beacon-core/src/parser/statement.rs
@@ -12,6 +12,59 @@ pub enum BeaconStatement {
     RunCrawler(RunCrawlerStatement),
     DropCrawler(DropCrawlerStatement),
     ShowCrawlers,
+    CreateIndex(CreateIndexStatement),
+    DropIndex(DropIndexStatement),
+    ShowIndexes(ShowIndexesStatement),
+}
+
+/// CREATE INDEX [<name>] ON <table> (<column>) [USING <type>]
+#[derive(Debug, Clone)]
+pub struct CreateIndexStatement {
+    /// Optional index name; defaults to `<table>_<column>_idx` when omitted.
+    pub name: Option<ObjectName>,
+    pub table: ObjectName,
+    pub column: String,
+    /// Optional `USING <type>` (btree | bitmap | inverted); defaults to btree.
+    pub using: Option<String>,
+}
+
+impl Display for CreateIndexStatement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CREATE INDEX ")?;
+        if let Some(name) = &self.name {
+            write!(f, "{name} ")?;
+        }
+        write!(f, "ON {} ({})", self.table, self.column)?;
+        if let Some(using) = &self.using {
+            write!(f, " USING {using}")?;
+        }
+        Ok(())
+    }
+}
+
+/// DROP INDEX <name> ON <table>
+#[derive(Debug, Clone)]
+pub struct DropIndexStatement {
+    pub name: ObjectName,
+    pub table: ObjectName,
+}
+
+impl Display for DropIndexStatement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DROP INDEX {} ON {}", self.name, self.table)
+    }
+}
+
+/// SHOW INDEXES ON <table>
+#[derive(Debug, Clone)]
+pub struct ShowIndexesStatement {
+    pub table: ObjectName,
+}
+
+impl Display for ShowIndexesStatement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SHOW INDEXES ON {}", self.table)
+    }
 }
 
 /// CREATE CRAWLER <name> [ON '<prefix>'] [WITH (k 'v', ...)]
@@ -108,6 +161,9 @@ impl Display for BeaconStatement {
             Self::RunCrawler(s) => write!(f, "{s}"),
             Self::DropCrawler(s) => write!(f, "{s}"),
             Self::ShowCrawlers => write!(f, "SHOW CRAWLERS"),
+            Self::CreateIndex(s) => write!(f, "{s}"),
+            Self::DropIndex(s) => write!(f, "{s}"),
+            Self::ShowIndexes(s) => write!(f, "{s}"),
         }
     }
 }

--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -69,6 +69,7 @@ impl Runtime {
         let session_ctx = Self::init_ctx(
             memory_pool,
             object_stores.datasets.clone(),
+            object_stores.tables.clone(),
             config.clone(),
             crawler_handle.clone(),
         )?;
@@ -169,16 +170,15 @@ impl Runtime {
     fn init_ctx(
         memory_pool: Arc<FairSpillPool>,
         datasets_store: Arc<beacon_object_storage::DatasetsStore>,
+        tables_store: Arc<dyn object_store::ObjectStore>,
         app_config: Arc<beacon_config::Config>,
         crawler_handle: beacon_data_lake::crawler::CrawlerManagerHandle,
     ) -> anyhow::Result<Arc<SessionContext>> {
-        // Runtime-scoped Lance warehouse, threaded through the session so
-        // managed-table CRUD/index ops stay isolated per runtime — no process
-        // globals. Rooted in the (always-local) tables directory, alongside each
-        // table's `table.json`; S3 only ever applies to the datasets store.
-        let lance_warehouse = Arc::new(beacon_lance::LanceWarehouse::new(
-            app_config.storage.tables_dir.join("lance"),
-        ));
+        // Runtime-scoped Lance warehouse over beacon's tables object store,
+        // threaded through the session so managed-table CRUD/index ops stay
+        // isolated per runtime — no process globals. The tables store is the same
+        // (always-local) one used for each table's `table.json`.
+        let lance_warehouse = Arc::new(beacon_lance::LanceWarehouse::new(tables_store));
 
         let mut config = SessionConfig::new()
             .with_batch_size(app_config.runtime.batch_size)

--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -172,6 +172,14 @@ impl Runtime {
         app_config: Arc<beacon_config::Config>,
         crawler_handle: beacon_data_lake::crawler::CrawlerManagerHandle,
     ) -> anyhow::Result<Arc<SessionContext>> {
+        // Runtime-scoped Lance warehouse, threaded through the session so
+        // managed-table CRUD/index ops stay isolated per runtime — no process
+        // globals. Rooted in the (always-local) tables directory, alongside each
+        // table's `table.json`; S3 only ever applies to the datasets store.
+        let lance_warehouse = Arc::new(beacon_lance::LanceWarehouse::new(
+            app_config.storage.tables_dir.join("lance"),
+        ));
+
         let mut config = SessionConfig::new()
             .with_batch_size(app_config.runtime.batch_size)
             .with_coalesce_batches(true)
@@ -183,11 +191,18 @@ impl Runtime {
             // without a process-global accessor.
             .with_extension(datasets_store)
             .with_extension(app_config)
+            .with_extension(lance_warehouse)
             // The (late-filled) crawler manager handle, so DDL crawler actions can
             // reach it from session-scoped execution.
             .with_extension(crawler_handle);
 
         config.options_mut().sql_parser.enable_ident_normalization = false;
+        // Register beacon's session-scoped SQL options so `SET beacon.table_engine`
+        // can override the managed-table engine per session.
+        config
+            .options_mut()
+            .extensions
+            .insert(crate::statement_plan::table_engine::BeaconSqlOptions::default());
         config
             .options_mut()
             .execution
@@ -361,6 +376,15 @@ impl Runtime {
                 Ok(crate::statement_plan::drop_crawler_plan(statement))
             }
             BeaconStatement::ShowCrawlers => Ok(crate::statement_plan::show_crawlers_plan()),
+            BeaconStatement::CreateIndex(statement) => {
+                Ok(crate::statement_plan::create_index_plan(statement))
+            }
+            BeaconStatement::DropIndex(statement) => {
+                Ok(crate::statement_plan::drop_index_plan(statement))
+            }
+            BeaconStatement::ShowIndexes(statement) => {
+                Ok(crate::statement_plan::show_indexes_plan(statement))
+            }
             BeaconStatement::DFStatement(statement) => {
                 crate::statement_plan::lower_df_statement(&self.session_ctx, *statement).await
             }
@@ -1073,6 +1097,59 @@ mod client_query_tests {
             err.to_string().contains("super-user"),
             "unexpected error: {err}"
         );
+    }
+
+    /// End-to-end index lifecycle on a Lance-backed managed table: CREATE INDEX,
+    /// SHOW INDEXES (one row), DROP INDEX (zero rows) — exercising the parser,
+    /// planner, execs, and Lance index ops through the full SQL path.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn create_show_drop_index_round_trip() {
+        let runtime = Runtime::new(std::sync::Arc::new(beacon_config::Config::load().unwrap()))
+            .await
+            .expect("runtime should start");
+        let suffix = uuid::Uuid::new_v4().simple();
+        let table = format!("idx_{suffix}");
+
+        run_sql(&runtime, &format!("CREATE TABLE {table} (id BIGINT, name VARCHAR)")).await;
+        run_sql(&runtime, &format!("INSERT INTO {table} VALUES (1, 'a'), (2, 'b')")).await;
+        run_sql(
+            &runtime,
+            &format!("CREATE INDEX {table}_id_idx ON {table} (id) USING btree"),
+        )
+        .await;
+
+        let count_indexes = |sql: String| {
+            let runtime = &runtime;
+            async move {
+                runtime
+                    .run_query(crate::query::Query::sql(sql), true)
+                    .await
+                    .expect("show indexes should run")
+                    .into_record_stream()
+                    .expect("streamed result")
+                    .try_collect::<Vec<_>>()
+                    .await
+                    .expect("stream should drain")
+                    .iter()
+                    .map(|b| b.num_rows())
+                    .sum::<usize>()
+            }
+        };
+
+        assert_eq!(
+            count_indexes(format!("SHOW INDEXES ON {table}")).await,
+            1,
+            "one index should be listed"
+        );
+
+        run_sql(&runtime, &format!("DROP INDEX {table}_id_idx ON {table}")).await;
+        assert_eq!(
+            count_indexes(format!("SHOW INDEXES ON {table}")).await,
+            0,
+            "no indexes after drop"
+        );
+
+        run_sql(&runtime, &format!("DROP TABLE {table}")).await;
     }
 }
 

--- a/beacon-core/src/statement_plan/actions.rs
+++ b/beacon-core/src/statement_plan/actions.rs
@@ -29,7 +29,7 @@ use datafusion::{
     },
 };
 
-use super::logical::AlterTableSpec;
+use super::logical::{AlterTableSpec, Mutation};
 use super::materialized_view::delete_datasets_prefix;
 
 /// Drop a managed table, reclaiming its backing storage. Materialized views
@@ -386,25 +386,46 @@ pub(crate) async fn insert_into(
     Ok(stream)
 }
 
-/// Replace **all** rows of a managed table with the rows produced by `child`,
-/// then (for Iceberg) rebuild the registered provider so later scans see the new
-/// data. Used to implement `DELETE`/`UPDATE`: the caller passes the surviving
-/// rows. Rejects non-managed targets.
+/// Apply a `DELETE`/`UPDATE` to a managed table. Lance uses native row mutations
+/// (deletion vectors / fragment rewrite) when a [`Mutation`] spec was derived,
+/// else copy-on-write overwrite with `child`'s rows. Iceberg always uses
+/// copy-on-write (then rebuilds its provider). Rejects non-managed targets.
 pub(crate) async fn replace_table_contents(
     session: &Arc<SessionContext>,
     table: &TableReference,
     child: Arc<dyn ExecutionPlan>,
+    mutation: Option<Mutation>,
     task_ctx: &Arc<TaskContext>,
 ) -> anyhow::Result<()> {
     let provider = session.table_provider(table.clone()).await?;
 
-    // Lance: atomic overwrite with the surviving rows. The provider reopens the
-    // latest dataset version on each scan, so no rebuild is needed.
+    // Lance: prefer native delete/update; fall back to overwrite with the
+    // surviving/updated rows. The provider reopens the latest dataset version on
+    // each scan, so no rebuild is needed.
     if let Some(lance) = provider.as_any().downcast_ref::<beacon_lance::LanceTable>() {
         let location = lance.definition().location.clone();
         let warehouse = lance_warehouse(session)?;
-        let stream = execute_stream(child, task_ctx.clone())?;
-        beacon_lance::replace_table_contents(&warehouse, &location, stream).await?;
+        match mutation {
+            Some(Mutation::Delete { predicate }) => {
+                beacon_lance::delete_rows(&warehouse, &location, predicate.as_deref()).await?;
+            }
+            Some(Mutation::Update {
+                predicate,
+                assignments,
+            }) => {
+                beacon_lance::update_rows(
+                    &warehouse,
+                    &location,
+                    predicate.as_deref(),
+                    &assignments,
+                )
+                .await?;
+            }
+            None => {
+                let stream = execute_stream(child, task_ctx.clone())?;
+                beacon_lance::replace_table_contents(&warehouse, &location, stream).await?;
+            }
+        }
         return Ok(());
     }
 

--- a/beacon-core/src/statement_plan/actions.rs
+++ b/beacon-core/src/statement_plan/actions.rs
@@ -58,6 +58,12 @@ pub(crate) async fn drop_table(
             .downcast_ref::<beacon_iceberg::IcebergTable>()
             .map(|table| table.definition().clone())
     });
+    let lance_location = provider.as_ref().and_then(|provider| {
+        provider
+            .as_any()
+            .downcast_ref::<beacon_lance::LanceTable>()
+            .map(|table| table.definition().location.clone())
+    });
 
     session.deregister_table(name.clone())?;
 
@@ -68,6 +74,11 @@ pub(crate) async fn drop_table(
     if let Some(definition) = iceberg_definition {
         let store = beacon_iceberg::get_warehouse_store()?;
         beacon_iceberg::drop_iceberg_table(&store, &definition.namespace, &definition.name).await?;
+    }
+
+    if let Some(location) = lance_location {
+        let warehouse = lance_warehouse(session)?;
+        beacon_lance::drop_lance_table(&warehouse, &location).await?;
     }
 
     Ok(())
@@ -297,8 +308,9 @@ pub(crate) fn create_view(
     Ok(())
 }
 
-/// Create an Iceberg-backed managed table from `child`'s output schema and
-/// register it. For `CREATE TABLE AS SELECT` (`is_ctas`), also populate it from
+/// Create a managed table from `child`'s output schema and register it, using
+/// the engine resolved from session/global config (Lance by default, or
+/// Iceberg). For `CREATE TABLE AS SELECT` (`is_ctas`), also populate it from
 /// `child` and return the inserted-row count stream; otherwise return `None`.
 pub(crate) async fn create_table(
     session: &Arc<SessionContext>,
@@ -317,14 +329,39 @@ pub(crate) async fn create_table(
     }
 
     let arrow_schema = child.schema();
-    let catalog = beacon_iceberg::get_catalog()?;
-    let namespace = beacon_iceberg::beacon_namespace();
-    let table =
-        beacon_iceberg::create_iceberg_table(&catalog, &namespace, &table_name, &arrow_schema)
+
+    // Pick the storage engine: a session `SET beacon.table_engine` overrides the
+    // global default (Lance unless configured otherwise).
+    let engine = super::table_engine::resolve_table_engine(session)?;
+    let provider: Arc<dyn datafusion::catalog::TableProvider> = match engine {
+        beacon_config::TableEngine::Lance => {
+            // Lance managed tables live in the local tables directory, alongside
+            // their `table.json`. Beacon always backs the tables store with a
+            // local filesystem (S3 only ever applies to the datasets store), so
+            // this works regardless of the datasets backend.
+            let warehouse = lance_warehouse(session)?;
+            let namespace = beacon_lance::beacon_namespace();
+            let table =
+                beacon_lance::create_lance_table(warehouse, &namespace, &table_name, &arrow_schema)
+                    .await?;
+            Arc::new(table)
+        }
+        beacon_config::TableEngine::Iceberg => {
+            let catalog = beacon_iceberg::get_catalog()?;
+            let namespace = beacon_iceberg::beacon_namespace();
+            let table = beacon_iceberg::create_iceberg_table(
+                &catalog,
+                &namespace,
+                &table_name,
+                &arrow_schema,
+            )
             .await?;
+            Arc::new(table)
+        }
+    };
 
     // Registration persists the table's `table.json` pointer via the PersistentSchemaProvider.
-    session.register_table(name.clone(), Arc::new(table))?;
+    session.register_table(name.clone(), provider)?;
 
     if is_ctas {
         let stream = insert_into(session, &table_name, InsertOp::Append, child).await?;
@@ -349,9 +386,10 @@ pub(crate) async fn insert_into(
     Ok(stream)
 }
 
-/// Replace **all** rows of an Iceberg table with the rows produced by `child`
-/// (copy-on-write), then rebuild the registered provider so later scans see the
-/// new data. Rejects non-Iceberg targets.
+/// Replace **all** rows of a managed table with the rows produced by `child`,
+/// then (for Iceberg) rebuild the registered provider so later scans see the new
+/// data. Used to implement `DELETE`/`UPDATE`: the caller passes the surviving
+/// rows. Rejects non-managed targets.
 pub(crate) async fn replace_table_contents(
     session: &Arc<SessionContext>,
     table: &TableReference,
@@ -359,13 +397,24 @@ pub(crate) async fn replace_table_contents(
     task_ctx: &Arc<TaskContext>,
 ) -> anyhow::Result<()> {
     let provider = session.table_provider(table.clone()).await?;
+
+    // Lance: atomic overwrite with the surviving rows. The provider reopens the
+    // latest dataset version on each scan, so no rebuild is needed.
+    if let Some(lance) = provider.as_any().downcast_ref::<beacon_lance::LanceTable>() {
+        let location = lance.definition().location.clone();
+        let warehouse = lance_warehouse(session)?;
+        let stream = execute_stream(child, task_ctx.clone())?;
+        beacon_lance::replace_table_contents(&warehouse, &location, stream).await?;
+        return Ok(());
+    }
+
     let definition = provider
         .as_any()
         .downcast_ref::<beacon_iceberg::IcebergTable>()
         .map(|table| table.definition().clone())
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "Row mutations are only supported on Iceberg tables, but '{}' is not one",
+                "Row mutations are only supported on managed tables, but '{}' is not one",
                 table.table()
             )
         })?;
@@ -391,8 +440,9 @@ pub(crate) async fn replace_table_contents(
     Ok(())
 }
 
-/// Apply `ALTER TABLE` operations to an Iceberg table by mapping them to schema
-/// changes and rebuilding the table under the new schema.
+/// Apply `ALTER TABLE` operations to a managed table by mapping them to schema
+/// changes. Lance applies them natively (each an atomic version); Iceberg
+/// rebuilds the table under the new schema.
 pub(crate) async fn alter_table(
     session: &Arc<SessionContext>,
     spec: &AlterTableSpec,
@@ -400,16 +450,21 @@ pub(crate) async fn alter_table(
     let table_ref = TableReference::parse_str(&spec.name.to_string());
 
     let provider = session.table_provider(table_ref.clone()).await?;
-    let definition = provider
+    let lance_definition = provider
+        .as_any()
+        .downcast_ref::<beacon_lance::LanceTable>()
+        .map(|table| table.definition().clone());
+    let iceberg_definition = provider
         .as_any()
         .downcast_ref::<beacon_iceberg::IcebergTable>()
-        .map(|table| table.definition().clone())
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "ALTER TABLE is only supported on Iceberg tables, but '{}' is not one",
-                table_ref.table()
-            )
-        })?;
+        .map(|table| table.definition().clone());
+
+    if lance_definition.is_none() && iceberg_definition.is_none() {
+        anyhow::bail!(
+            "ALTER TABLE is only supported on managed tables, but '{}' is not one",
+            table_ref.table()
+        );
+    }
 
     let mut changes = Vec::new();
     for operation in &spec.operations {
@@ -458,6 +513,51 @@ pub(crate) async fn alter_table(
         }
     }
 
+    // Lance: apply the changes natively (each is its own atomic version), then
+    // rebuild the provider so its cached schema reflects the evolution.
+    if let Some(definition) = lance_definition {
+        let lance_changes = changes
+            .iter()
+            .map(|change| match change {
+                beacon_iceberg::SchemaChange::AddColumn { name, data_type } => {
+                    Ok(beacon_lance::SchemaChange::AddColumn {
+                        name: name.clone(),
+                        data_type: data_type.clone(),
+                    })
+                }
+                beacon_iceberg::SchemaChange::DropColumn { name } => {
+                    Ok(beacon_lance::SchemaChange::DropColumn { name: name.clone() })
+                }
+                beacon_iceberg::SchemaChange::RenameColumn { from, to } => {
+                    Ok(beacon_lance::SchemaChange::RenameColumn {
+                        from: from.clone(),
+                        to: to.clone(),
+                    })
+                }
+                beacon_iceberg::SchemaChange::AlterColumnType { name, data_type } => {
+                    Ok(beacon_lance::SchemaChange::AlterColumnType {
+                        name: name.clone(),
+                        data_type: data_type.clone(),
+                    })
+                }
+                #[allow(unreachable_patterns)]
+                _ => Err(anyhow::anyhow!(
+                    "unsupported ALTER operation for a Lance-backed table"
+                )),
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        let warehouse = lance_warehouse(session)?;
+        beacon_lance::alter_table(&warehouse, &definition.location, &lance_changes).await?;
+
+        let fresh = definition
+            .build_provider(session.clone(), &DATASETS_OBJECT_STORE_URL)
+            .await?;
+        session.register_table(table_ref, fresh)?;
+        return Ok(());
+    }
+
+    let definition = iceberg_definition.expect("a managed table definition was found above");
     let catalog = beacon_iceberg::get_catalog()?;
     let store = beacon_iceberg::get_warehouse_store()?;
     beacon_iceberg::alter_table_schema(
@@ -476,6 +576,93 @@ pub(crate) async fn alter_table(
     session.register_table(table_ref, fresh)?;
 
     Ok(())
+}
+
+/// Fetch the runtime-scoped Lance warehouse from the session config extensions.
+fn lance_warehouse(
+    session: &Arc<SessionContext>,
+) -> anyhow::Result<Arc<beacon_lance::LanceWarehouse>> {
+    session
+        .state()
+        .config()
+        .get_extension::<beacon_lance::LanceWarehouse>()
+        .ok_or_else(|| anyhow::anyhow!("Lance warehouse is unavailable"))
+}
+
+/// Resolve a managed table to the on-disk location of its Lance dataset, erroring
+/// if the table is not Lance-backed (indexes are a Lance-only feature).
+async fn lance_table_location(
+    session: &Arc<SessionContext>,
+    table: &str,
+) -> anyhow::Result<String> {
+    let provider = session.table_provider(table).await?;
+    provider
+        .as_any()
+        .downcast_ref::<beacon_lance::LanceTable>()
+        .map(|t| t.definition().location.clone())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Indexes are only supported on Lance-backed tables, but '{table}' is not one"
+            )
+        })
+}
+
+/// `CREATE INDEX [<name>] ON <table> (<column>) [USING <type>]`: build a scalar
+/// index on a Lance table. `using` defaults to `btree`; `name` defaults to
+/// `<table>_<column>_idx`.
+pub(crate) async fn create_index(
+    session: &Arc<SessionContext>,
+    table: &str,
+    column: &str,
+    name: Option<String>,
+    using: Option<String>,
+) -> anyhow::Result<()> {
+    let location = lance_table_location(session, table).await?;
+    let kind = match using {
+        Some(using) => using
+            .parse::<beacon_lance::ScalarIndexKind>()
+            .map_err(|e| anyhow::anyhow!(e))?,
+        None => beacon_lance::ScalarIndexKind::BTree,
+    };
+    let index_name = name.unwrap_or_else(|| format!("{table}_{column}_idx"));
+    let warehouse = lance_warehouse(session)?;
+    beacon_lance::create_index(&warehouse, &location, column, &index_name, kind).await
+}
+
+/// `DROP INDEX <name> ON <table>`: drop a Lance table's index by name.
+pub(crate) async fn drop_index(
+    session: &Arc<SessionContext>,
+    table: &str,
+    name: &str,
+) -> anyhow::Result<()> {
+    let location = lance_table_location(session, table).await?;
+    let warehouse = lance_warehouse(session)?;
+    beacon_lance::drop_index(&warehouse, &location, name).await
+}
+
+/// `SHOW INDEXES ON <table>`: list a Lance table's indexes as rows of
+/// `(index_name, columns)`.
+pub(crate) async fn list_indexes(
+    session: &Arc<SessionContext>,
+    table: &str,
+) -> anyhow::Result<arrow::record_batch::RecordBatch> {
+    let location = lance_table_location(session, table).await?;
+    let indices = beacon_lance::list_indices(&location).await?;
+
+    let names = indices.iter().map(|i| i.name.clone()).collect::<Vec<_>>();
+    let columns = indices
+        .iter()
+        .map(|i| i.columns.join(", "))
+        .collect::<Vec<_>>();
+
+    let batch = arrow::record_batch::RecordBatch::try_new(
+        super::logical::show_indexes_arrow_schema(),
+        vec![
+            Arc::new(arrow::array::StringArray::from_iter_values(names)),
+            Arc::new(arrow::array::StringArray::from_iter_values(columns)),
+        ],
+    )?;
+    Ok(batch)
 }
 
 /// Convert a SQL column definition's type to an Arrow type, reusing

--- a/beacon-core/src/statement_plan/actions.rs
+++ b/beacon-core/src/statement_plan/actions.rs
@@ -647,7 +647,8 @@ pub(crate) async fn list_indexes(
     table: &str,
 ) -> anyhow::Result<arrow::record_batch::RecordBatch> {
     let location = lance_table_location(session, table).await?;
-    let indices = beacon_lance::list_indices(&location).await?;
+    let warehouse = lance_warehouse(session)?;
+    let indices = beacon_lance::list_indices(&warehouse, &location).await?;
 
     let names = indices.iter().map(|i| i.name.clone()).collect::<Vec<_>>();
     let columns = indices

--- a/beacon-core/src/statement_plan/logical.rs
+++ b/beacon-core/src/statement_plan/logical.rs
@@ -354,6 +354,125 @@ impl UserDefinedLogicalNodeCore for ShowCrawlersNode {
     }
 }
 
+/// Arrow schema produced by `SHOW INDEXES`.
+pub(crate) fn show_indexes_arrow_schema() -> Arc<Schema> {
+    static SCHEMA: OnceLock<Arc<Schema>> = OnceLock::new();
+    SCHEMA
+        .get_or_init(|| {
+            Arc::new(Schema::new(vec![
+                Field::new("index_name", DataType::Utf8, false),
+                Field::new("columns", DataType::Utf8, false),
+            ]))
+        })
+        .clone()
+}
+
+fn show_indexes_df_schema() -> &'static DFSchemaRef {
+    static SCHEMA: OnceLock<DFSchemaRef> = OnceLock::new();
+    SCHEMA.get_or_init(|| {
+        Arc::new(
+            DFSchema::try_from(show_indexes_arrow_schema().as_ref().clone())
+                .expect("SHOW INDEXES schema is valid"),
+        )
+    })
+}
+
+/// Logical node for `CREATE INDEX [<name>] ON <table> (<column>) [USING <type>]`.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Hash)]
+pub(crate) struct CreateIndexNode {
+    pub(crate) table: String,
+    pub(crate) column: String,
+    pub(crate) name: Option<String>,
+    pub(crate) using: Option<String>,
+}
+
+impl UserDefinedLogicalNodeCore for CreateIndexNode {
+    fn name(&self) -> &str {
+        "CreateIndex"
+    }
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+    fn schema(&self) -> &DFSchemaRef {
+        empty_schema()
+    }
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+    fn fmt_for_explain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "CreateIndex: table={} column={}", self.table, self.column)
+    }
+    fn with_exprs_and_inputs(&self, _exprs: Vec<Expr>, _inputs: Vec<LogicalPlan>) -> Result<Self> {
+        Ok(Self {
+            table: self.table.clone(),
+            column: self.column.clone(),
+            name: self.name.clone(),
+            using: self.using.clone(),
+        })
+    }
+}
+
+/// Logical node for `DROP INDEX <name> ON <table>`.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Hash)]
+pub(crate) struct DropIndexNode {
+    pub(crate) table: String,
+    pub(crate) name: String,
+}
+
+impl UserDefinedLogicalNodeCore for DropIndexNode {
+    fn name(&self) -> &str {
+        "DropIndex"
+    }
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+    fn schema(&self) -> &DFSchemaRef {
+        empty_schema()
+    }
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+    fn fmt_for_explain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "DropIndex: table={} name={}", self.table, self.name)
+    }
+    fn with_exprs_and_inputs(&self, _exprs: Vec<Expr>, _inputs: Vec<LogicalPlan>) -> Result<Self> {
+        Ok(Self {
+            table: self.table.clone(),
+            name: self.name.clone(),
+        })
+    }
+}
+
+/// Logical node for `SHOW INDEXES ON <table>`. Produces rows, so it carries the
+/// listing schema.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Hash)]
+pub(crate) struct ShowIndexesNode {
+    pub(crate) table: String,
+}
+
+impl UserDefinedLogicalNodeCore for ShowIndexesNode {
+    fn name(&self) -> &str {
+        "ShowIndexes"
+    }
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+    fn schema(&self) -> &DFSchemaRef {
+        show_indexes_df_schema()
+    }
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+    fn fmt_for_explain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "ShowIndexes: table={}", self.table)
+    }
+    fn with_exprs_and_inputs(&self, _exprs: Vec<Expr>, _inputs: Vec<LogicalPlan>) -> Result<Self> {
+        Ok(Self {
+            table: self.table.clone(),
+        })
+    }
+}
+
 /// Logical node for the copy-on-write replacement that backs `DELETE` and
 /// `UPDATE`: `input` computes the table's full post-mutation contents, which
 /// atomically replace the Iceberg table's data files. Produces no rows.

--- a/beacon-core/src/statement_plan/logical.rs
+++ b/beacon-core/src/statement_plan/logical.rs
@@ -473,13 +473,32 @@ impl UserDefinedLogicalNodeCore for ShowIndexesNode {
     }
 }
 
+/// A native row mutation, derived best-effort at lowering time. When present and
+/// the target is a Lance table, it is applied via Lance's native `delete`/update
+/// (deletion vectors / fragment rewrite) instead of the copy-on-write `input`.
+/// Iceberg always uses the copy-on-write `input`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+pub(crate) enum Mutation {
+    /// `DELETE FROM t [WHERE predicate]`; `None` predicate deletes every row.
+    Delete { predicate: Option<String> },
+    /// `UPDATE t SET <assignments> [WHERE predicate]`, assignments as
+    /// `(column, value_sql)`.
+    Update {
+        predicate: Option<String>,
+        assignments: Vec<(String, String)>,
+    },
+}
+
 /// Logical node for the copy-on-write replacement that backs `DELETE` and
 /// `UPDATE`: `input` computes the table's full post-mutation contents, which
-/// atomically replace the Iceberg table's data files. Produces no rows.
+/// atomically replace the table's data files (used for Iceberg, and as the
+/// fallback when no native [`Mutation`] could be derived). Produces no rows.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Hash)]
 pub(crate) struct ReplaceTableContentsNode {
     pub(crate) table: TableReference,
     pub(crate) input: LogicalPlan,
+    /// Native mutation spec; `None` means copy-on-write only.
+    pub(crate) mutation: Option<Mutation>,
 }
 
 impl UserDefinedLogicalNodeCore for ReplaceTableContentsNode {
@@ -502,6 +521,7 @@ impl UserDefinedLogicalNodeCore for ReplaceTableContentsNode {
         Ok(Self {
             table: self.table.clone(),
             input: inputs.swap_remove(0),
+            mutation: self.mutation.clone(),
         })
     }
 }

--- a/beacon-core/src/statement_plan/lower.rs
+++ b/beacon-core/src/statement_plan/lower.rs
@@ -25,7 +25,36 @@ use datafusion::{
     sql::sqlparser::ast::{AlterTableOperation, ObjectName, Statement as SqlAstStatement},
 };
 
-use super::logical::{AlterTableNode, AlterTableSpec, Keyed, ReplaceTableContentsNode};
+use super::logical::{AlterTableNode, AlterTableSpec, Keyed, Mutation, ReplaceTableContentsNode};
+
+/// Render a DataFusion `Expr` back to a SQL string (best-effort). Used to derive
+/// native Lance `DELETE`/`UPDATE` predicates and `SET` values; `None` if the
+/// expression cannot be unparsed, in which case the caller falls back to the
+/// copy-on-write path.
+///
+/// Column references are stripped of their table qualifier first: Lance parses
+/// the predicate/value against the dataset schema, which has bare field names
+/// (`id`), so a qualified `t.id` would not resolve.
+fn unparse_expr(expr: &Expr) -> Option<String> {
+    use datafusion::common::tree_node::{Transformed, TreeNode};
+    use datafusion::common::Column;
+
+    let unqualified = expr
+        .clone()
+        .transform(|e| {
+            Ok(match e {
+                Expr::Column(c) => Transformed::yes(Expr::Column(Column::new_unqualified(c.name))),
+                other => Transformed::no(other),
+            })
+        })
+        .ok()?
+        .data;
+
+    datafusion::sql::unparser::Unparser::default()
+        .expr_to_sql(&unqualified)
+        .ok()
+        .map(|ast| ast.to_string())
+}
 
 /// Lower a parsed DataFusion statement to a logical plan. Permission checks are
 /// applied later by [`validate_query_plan`](super::validate_query_plan), once the
@@ -72,15 +101,15 @@ fn alter_table_plan(name: ObjectName, operations: Vec<AlterTableOperation>) -> L
 /// `DELETE FROM t [WHERE p]`: the surviving rows are `NOT p` (or none when there
 /// is no `WHERE`), and they replace the table's contents.
 fn delete_plan(dml: DmlStatement) -> anyhow::Result<LogicalPlan> {
-    let keep_plan = match dml.input.as_ref() {
+    let (keep_plan, predicate) = match dml.input.as_ref() {
         LogicalPlan::Filter(filter) => {
             let keep = Filter::try_new(not(filter.predicate.clone()), filter.input.clone())?;
-            LogicalPlan::Filter(keep)
+            (LogicalPlan::Filter(keep), Some(filter.predicate.clone()))
         }
         scan @ LogicalPlan::TableScan(_) => {
             // No WHERE clause: delete every row -> keep nothing.
             let keep = Filter::try_new(lit(false), Arc::new(scan.clone()))?;
-            LogicalPlan::Filter(keep)
+            (LogicalPlan::Filter(keep), None)
         }
         other => {
             return Err(anyhow::anyhow!(
@@ -90,7 +119,16 @@ fn delete_plan(dml: DmlStatement) -> anyhow::Result<LogicalPlan> {
         }
     };
 
-    Ok(replace_contents_plan(dml.table_name, keep_plan))
+    // Native delete spec (best-effort). A WHERE whose predicate cannot be
+    // unparsed yields `None` -> copy-on-write (never a native delete-all).
+    let mutation = match &predicate {
+        Some(expr) => unparse_expr(expr).map(|sql| Mutation::Delete {
+            predicate: Some(sql),
+        }),
+        None => Some(Mutation::Delete { predicate: None }),
+    };
+
+    Ok(replace_contents_plan(dml.table_name, keep_plan, mutation))
 }
 
 /// `UPDATE t SET col = expr [WHERE p]`: rebuild the full post-update table as a
@@ -137,11 +175,55 @@ fn update_plan(dml: DmlStatement) -> anyhow::Result<LogicalPlan> {
         _ => dml.input.as_ref().clone(),
     };
 
-    Ok(replace_contents_plan(dml.table_name, new_contents))
+    let mutation = update_mutation(projection);
+    Ok(replace_contents_plan(dml.table_name, new_contents, mutation))
 }
 
-fn replace_contents_plan(table: datafusion::sql::TableReference, input: LogicalPlan) -> LogicalPlan {
-    extension(Arc::new(ReplaceTableContentsNode { table, input }))
+/// Derive a native `UPDATE` spec from the planned projection (best-effort):
+/// the changed columns become `SET` assignments and the filter becomes the
+/// `WHERE`. Returns `None` (→ copy-on-write) if the shape is unexpected or any
+/// expression cannot be unparsed.
+fn update_mutation(projection: &datafusion::logical_expr::Projection) -> Option<Mutation> {
+    let (scan, predicate) = match projection.input.as_ref() {
+        LogicalPlan::Filter(filter) => (filter.input.as_ref(), Some(filter.predicate.clone())),
+        scan => (scan, None),
+    };
+    if projection.expr.len() != scan.schema().fields().len() {
+        return None;
+    }
+    let scan_cols = scan.schema().columns();
+
+    let mut assignments = Vec::new();
+    for (i, expr) in projection.expr.iter().enumerate() {
+        let new_value = expr.clone().unalias();
+        // Unchanged columns project the column through unchanged; skip those.
+        if new_value == Expr::Column(scan_cols[i].clone()) {
+            continue;
+        }
+        let name = projection.schema.field(i).name().clone();
+        assignments.push((name, unparse_expr(&new_value)?));
+    }
+
+    let predicate = match predicate {
+        Some(expr) => Some(unparse_expr(&expr)?),
+        None => None,
+    };
+    Some(Mutation::Update {
+        predicate,
+        assignments,
+    })
+}
+
+fn replace_contents_plan(
+    table: datafusion::sql::TableReference,
+    input: LogicalPlan,
+    mutation: Option<Mutation>,
+) -> LogicalPlan {
+    extension(Arc::new(ReplaceTableContentsNode {
+        table,
+        input,
+        mutation,
+    }))
 }
 
 /// `COPY ... TO` stays a standard DataFusion node (which it can plan + execute);

--- a/beacon-core/src/statement_plan/mod.rs
+++ b/beacon-core/src/statement_plan/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod materialized_view;
 mod physical;
 mod query_planner;
 mod stream_coalescer;
+pub(crate) mod table_engine;
 
 use std::sync::{Arc, OnceLock, Weak};
 
@@ -30,8 +31,9 @@ use datafusion::{
 };
 
 use crate::parser::statement::{
-    CreateCrawlerStatement, CreateMaterializedViewStatement, DropCrawlerStatement, RefreshStatement,
-    RunCrawlerStatement,
+    CreateCrawlerStatement, CreateIndexStatement, CreateMaterializedViewStatement,
+    DropCrawlerStatement, DropIndexStatement, RefreshStatement, RunCrawlerStatement,
+    ShowIndexesStatement,
 };
 
 pub(crate) use lower::lower_df_statement;
@@ -142,6 +144,37 @@ pub(crate) fn drop_crawler_plan(statement: DropCrawlerStatement) -> LogicalPlan 
 pub(crate) fn show_crawlers_plan() -> LogicalPlan {
     LogicalPlan::Extension(Extension {
         node: Arc::new(logical::ShowCrawlersNode),
+    })
+}
+
+/// Build the logical plan for `CREATE INDEX [<name>] ON <table> (<column>) [USING <type>]`.
+pub(crate) fn create_index_plan(statement: CreateIndexStatement) -> LogicalPlan {
+    LogicalPlan::Extension(Extension {
+        node: Arc::new(logical::CreateIndexNode {
+            table: statement.table.to_string(),
+            column: statement.column,
+            name: statement.name.map(|n| n.to_string()),
+            using: statement.using,
+        }),
+    })
+}
+
+/// Build the logical plan for `DROP INDEX <name> ON <table>`.
+pub(crate) fn drop_index_plan(statement: DropIndexStatement) -> LogicalPlan {
+    LogicalPlan::Extension(Extension {
+        node: Arc::new(logical::DropIndexNode {
+            table: statement.table.to_string(),
+            name: statement.name.to_string(),
+        }),
+    })
+}
+
+/// Build the logical plan for `SHOW INDEXES ON <table>`.
+pub(crate) fn show_indexes_plan(statement: ShowIndexesStatement) -> LogicalPlan {
+    LogicalPlan::Extension(Extension {
+        node: Arc::new(logical::ShowIndexesNode {
+            table: statement.table.to_string(),
+        }),
     })
 }
 

--- a/beacon-core/src/statement_plan/mod.rs
+++ b/beacon-core/src/statement_plan/mod.rs
@@ -194,6 +194,24 @@ pub(crate) async fn execute_statement_plan(
 ) -> anyhow::Result<SendableRecordBatchStream> {
     use futures::TryStreamExt;
 
+    // Statements (e.g. `SET beacon.table_engine = '…'`) cannot be physical-planned;
+    // DataFusion applies them to the session via `execute_logical_plan`. Route them
+    // there so the session config actually changes, then drain the (empty) result.
+    if matches!(plan, LogicalPlan::Statement(_)) {
+        let schema: arrow::datatypes::SchemaRef = Arc::new(arrow::datatypes::Schema::empty());
+        session_ctx
+            .execute_logical_plan(plan)
+            .await?
+            .collect()
+            .await?;
+        return Ok(Box::pin(
+            datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
+                schema,
+                futures::stream::empty(),
+            ),
+        ));
+    }
+
     let physical_plan = session_ctx.state().create_physical_plan(&plan).await?;
     let stream = datafusion::physical_plan::execute_stream(physical_plan, session_ctx.task_ctx())?;
     let stream = stream_coalescer::coalesce_sql_stream(session_ctx, stream);

--- a/beacon-core/src/statement_plan/physical.rs
+++ b/beacon-core/src/statement_plan/physical.rs
@@ -27,7 +27,7 @@ use futures::{StreamExt, TryStreamExt};
 
 use super::{
     actions, crawler,
-    logical::{count_arrow_schema, show_crawlers_arrow_schema, AlterTableSpec},
+    logical::{count_arrow_schema, show_crawlers_arrow_schema, show_indexes_arrow_schema, AlterTableSpec},
     materialized_view, SessionCell,
 };
 
@@ -848,6 +848,149 @@ impl ExecutionPlan for ShowCrawlersExec {
         let schema = show_crawlers_arrow_schema();
         let stream = futures::stream::once(async move {
             crawler::show_crawlers(&session).await.map_err(to_df_err)
+        });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}
+
+/// Physical node for `CREATE INDEX ... ON <table> (<column>)`.
+#[derive(Debug)]
+pub(crate) struct CreateIndexExec {
+    table: String,
+    column: String,
+    name: Option<String>,
+    using: Option<String>,
+    session: SessionCell,
+    cache: Arc<PlanProperties>,
+}
+
+impl CreateIndexExec {
+    pub(crate) fn new(
+        table: String,
+        column: String,
+        name: Option<String>,
+        using: Option<String>,
+        session: SessionCell,
+    ) -> Self {
+        Self {
+            table,
+            column,
+            name,
+            using,
+            session,
+            cache: Arc::new(side_effect_properties()),
+        }
+    }
+    fn fmt_label(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CreateIndexExec: table={} column={}", self.table, self.column)
+    }
+}
+
+side_effect_exec!(CreateIndexExec, "CreateIndexExec", |exec: &CreateIndexExec| {
+    let session = upgrade_session(&exec.session)?;
+    let table = exec.table.clone();
+    let column = exec.column.clone();
+    let name = exec.name.clone();
+    let using = exec.using.clone();
+    Ok(side_effect_stream(async move {
+        actions::create_index(&session, &table, &column, name, using)
+            .await
+            .map_err(to_df_err)
+    }))
+});
+
+/// Physical node for `DROP INDEX <name> ON <table>`.
+#[derive(Debug)]
+pub(crate) struct DropIndexExec {
+    table: String,
+    name: String,
+    session: SessionCell,
+    cache: Arc<PlanProperties>,
+}
+
+impl DropIndexExec {
+    pub(crate) fn new(table: String, name: String, session: SessionCell) -> Self {
+        Self {
+            table,
+            name,
+            session,
+            cache: Arc::new(side_effect_properties()),
+        }
+    }
+    fn fmt_label(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DropIndexExec: table={} name={}", self.table, self.name)
+    }
+}
+
+side_effect_exec!(DropIndexExec, "DropIndexExec", |exec: &DropIndexExec| {
+    let session = upgrade_session(&exec.session)?;
+    let table = exec.table.clone();
+    let name = exec.name.clone();
+    Ok(side_effect_stream(async move {
+        actions::drop_index(&session, &table, &name)
+            .await
+            .map_err(to_df_err)
+    }))
+});
+
+/// Physical node for `SHOW INDEXES ON <table>`. Produces one row per index.
+#[derive(Debug)]
+pub(crate) struct ShowIndexesExec {
+    table: String,
+    session: SessionCell,
+    cache: Arc<PlanProperties>,
+}
+
+impl ShowIndexesExec {
+    pub(crate) fn new(table: String, session: SessionCell) -> Self {
+        Self {
+            table,
+            session,
+            cache: Arc::new(plan_properties(show_indexes_arrow_schema())),
+        }
+    }
+}
+
+impl DisplayAs for ShowIndexesExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(f, "ShowIndexesExec: table={}", self.table)
+            }
+            DisplayFormatType::TreeRender => write!(f, "ShowIndexesExec"),
+        }
+    }
+}
+
+impl ExecutionPlan for ShowIndexesExec {
+    fn name(&self) -> &str {
+        "ShowIndexesExec"
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.cache
+    }
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let session = upgrade_session(&self.session)?;
+        let table = self.table.clone();
+        let schema = show_indexes_arrow_schema();
+        let stream = futures::stream::once(async move {
+            actions::list_indexes(&session, &table).await.map_err(to_df_err)
         });
         Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
     }

--- a/beacon-core/src/statement_plan/physical.rs
+++ b/beacon-core/src/statement_plan/physical.rs
@@ -27,7 +27,10 @@ use futures::{StreamExt, TryStreamExt};
 
 use super::{
     actions, crawler,
-    logical::{count_arrow_schema, show_crawlers_arrow_schema, show_indexes_arrow_schema, AlterTableSpec},
+    logical::{
+        count_arrow_schema, show_crawlers_arrow_schema, show_indexes_arrow_schema, AlterTableSpec,
+        Mutation,
+    },
     materialized_view, SessionCell,
 };
 
@@ -443,6 +446,7 @@ side_effect_exec!(AlterTableExec, "AlterTableExec", |exec: &AlterTableExec| {
 pub(crate) struct ReplaceTableContentsExec {
     table: TableReference,
     child: Arc<dyn ExecutionPlan>,
+    mutation: Option<Mutation>,
     session: SessionCell,
     cache: Arc<PlanProperties>,
 }
@@ -451,11 +455,13 @@ impl ReplaceTableContentsExec {
     pub(crate) fn new(
         table: TableReference,
         child: Arc<dyn ExecutionPlan>,
+        mutation: Option<Mutation>,
         session: SessionCell,
     ) -> Self {
         Self {
             table,
             child,
+            mutation,
             session,
             cache: Arc::new(side_effect_properties()),
         }
@@ -493,6 +499,7 @@ impl ExecutionPlan for ReplaceTableContentsExec {
         Ok(Arc::new(Self {
             table: self.table.clone(),
             child: children.swap_remove(0),
+            mutation: self.mutation.clone(),
             session: self.session.clone(),
             cache: self.cache.clone(),
         }))
@@ -505,8 +512,9 @@ impl ExecutionPlan for ReplaceTableContentsExec {
         let session = upgrade_session(&self.session)?;
         let table = self.table.clone();
         let child = self.child.clone();
+        let mutation = self.mutation.clone();
         Ok(side_effect_stream(async move {
-            actions::replace_table_contents(&session, &table, child, &context)
+            actions::replace_table_contents(&session, &table, child, mutation, &context)
                 .await
                 .map_err(to_df_err)
         }))

--- a/beacon-core/src/statement_plan/query_planner.rs
+++ b/beacon-core/src/statement_plan/query_planner.rs
@@ -172,6 +172,7 @@ impl ExtensionPlanner for BeaconExtensionPlanner {
             return Ok(Some(Arc::new(physical::ReplaceTableContentsExec::new(
                 replace.table.clone(),
                 physical_inputs[0].clone(),
+                replace.mutation.clone(),
                 session,
             ))));
         }

--- a/beacon-core/src/statement_plan/query_planner.rs
+++ b/beacon-core/src/statement_plan/query_planner.rs
@@ -203,6 +203,31 @@ impl ExtensionPlanner for BeaconExtensionPlanner {
             return Ok(Some(Arc::new(physical::ShowCrawlersExec::new(session))));
         }
 
+        if let Some(create) = any.downcast_ref::<logical::CreateIndexNode>() {
+            return Ok(Some(Arc::new(physical::CreateIndexExec::new(
+                create.table.clone(),
+                create.column.clone(),
+                create.name.clone(),
+                create.using.clone(),
+                session,
+            ))));
+        }
+
+        if let Some(drop) = any.downcast_ref::<logical::DropIndexNode>() {
+            return Ok(Some(Arc::new(physical::DropIndexExec::new(
+                drop.table.clone(),
+                drop.name.clone(),
+                session,
+            ))));
+        }
+
+        if let Some(show) = any.downcast_ref::<logical::ShowIndexesNode>() {
+            return Ok(Some(Arc::new(physical::ShowIndexesExec::new(
+                show.table.clone(),
+                session,
+            ))));
+        }
+
         // Unrecognized node: let the default planner handle it.
         Ok(None)
     }

--- a/beacon-core/src/statement_plan/table_engine.rs
+++ b/beacon-core/src/statement_plan/table_engine.rs
@@ -1,0 +1,47 @@
+//! Selecting the storage engine for managed `CREATE TABLE`.
+//!
+//! The effective engine is resolved per statement: a session-scoped
+//! `SET beacon.table_engine = 'iceberg'|'lance'` overrides the global default
+//! ([`beacon_config::SqlConfig::default_table_engine`], itself from
+//! `BEACON_DEFAULT_TABLE_ENGINE`, defaulting to Lance).
+//!
+//! The override is a DataFusion [`ConfigExtension`] so it rides the normal `SET`
+//! machinery and is visible to session-scoped execution.
+
+use beacon_config::{Config, TableEngine};
+use datafusion::config::ConfigExtension;
+use datafusion::prelude::SessionContext;
+
+datafusion::common::extensions_options! {
+    /// Beacon's session-scoped SQL options, settable via `SET beacon.<key>`.
+    pub struct BeaconSqlOptions {
+        /// Managed `CREATE TABLE` engine override (`lance` or `iceberg`). Empty
+        /// means "use the global default".
+        pub table_engine: String, default = String::new()
+    }
+}
+
+impl ConfigExtension for BeaconSqlOptions {
+    const PREFIX: &'static str = "beacon";
+}
+
+/// Resolve the engine for a managed `CREATE TABLE`: a non-empty session
+/// `SET beacon.table_engine` wins; otherwise the global config default.
+pub(crate) fn resolve_table_engine(session: &SessionContext) -> anyhow::Result<TableEngine> {
+    let state = session.state();
+
+    if let Some(options) = state.config_options().extensions.get::<BeaconSqlOptions>() {
+        let value = options.table_engine.trim();
+        if !value.is_empty() {
+            return value
+                .parse::<TableEngine>()
+                .map_err(|e| anyhow::anyhow!("invalid SET beacon.table_engine: {e}"));
+        }
+    }
+
+    let config = state
+        .config()
+        .get_extension::<Config>()
+        .ok_or_else(|| anyhow::anyhow!("Beacon configuration is unavailable"))?;
+    Ok(config.sql.default_table_engine)
+}

--- a/beacon-core/tests/iceberg_tables.rs
+++ b/beacon-core/tests/iceberg_tables.rs
@@ -44,6 +44,10 @@ fn scalar_string(batches: &[RecordBatch]) -> String {
 async fn iceberg_create_insert_select_ctas_drop() {
     let runtime = Runtime::new(std::sync::Arc::new(beacon_config::Config::load().unwrap())).await.expect("runtime should boot");
 
+    // The default managed-table engine is Lance; this test exercises the Iceberg
+    // path, so select it explicitly for this session.
+    run(&runtime, "SET beacon.table_engine = 'iceberg'").await;
+
     // Unique names so reruns/parallel suites do not collide in the shared
     // warehouse, and clean any leftovers from a previous aborted run.
     let table = format!("ice_e2e_{}", std::process::id());

--- a/beacon-core/tests/lance_tables.rs
+++ b/beacon-core/tests/lance_tables.rs
@@ -1,0 +1,115 @@
+//! End-to-end test for Lance-backed managed tables (the default engine) driven
+//! through the SQL endpoint: CREATE, INSERT, UPDATE and DELETE — exercising the
+//! native row-mutation path (predicate/SET unparsed and applied via Lance).
+
+use beacon_core::runtime::Runtime;
+use datafusion::arrow::array::{Int64Array, StringArray};
+use datafusion::arrow::record_batch::RecordBatch;
+use futures::TryStreamExt;
+
+/// Run SQL as a super-user (DDL/DML allowed) and collect the result batches.
+async fn run(runtime: &Runtime, sql: &str) -> Vec<RecordBatch> {
+    runtime
+        .run_query(beacon_core::query::Query::sql(sql.to_string()), true)
+        .await
+        .unwrap_or_else(|error| panic!("SQL failed to plan/execute: {sql}\n{error}"))
+        .into_record_stream()
+        .unwrap_or_else(|error| panic!("expected a streamed result: {sql}\n{error}"))
+        .try_collect()
+        .await
+        .unwrap_or_else(|error| panic!("SQL stream failed: {sql}\n{error}"))
+}
+
+fn scalar_count(batches: &[RecordBatch]) -> i64 {
+    batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("count column should be Int64")
+        .value(0)
+}
+
+fn scalar_string(batches: &[RecordBatch]) -> String {
+    batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("column should be Utf8")
+        .value(0)
+        .to_string()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lance_create_insert_update_delete() {
+    let runtime = Runtime::new(std::sync::Arc::new(beacon_config::Config::load().unwrap()))
+        .await
+        .expect("runtime should boot");
+
+    // Lance is the default engine, so no `SET beacon.table_engine` is needed.
+    let table = format!("lance_e2e_{}", std::process::id());
+    let _ = runtime
+        .run_query(
+            beacon_core::query::Query::sql(format!("DROP TABLE IF EXISTS {table}")),
+            true,
+        )
+        .await;
+
+    run(&runtime, &format!("CREATE TABLE {table} (id BIGINT, name VARCHAR)")).await;
+    run(&runtime, &format!("INSERT INTO {table} VALUES (1, 'a'), (2, 'b'), (3, 'c')")).await;
+    assert_eq!(
+        scalar_count(&run(&runtime, &format!("SELECT count(*) FROM {table}")).await),
+        3
+    );
+
+    // UPDATE WHERE: only the matching row changes; the others are untouched.
+    run(&runtime, &format!("UPDATE {table} SET name = 'Z' WHERE id = 2")).await;
+    assert_eq!(
+        scalar_string(&run(&runtime, &format!("SELECT name FROM {table} WHERE id = 2")).await),
+        "Z"
+    );
+    assert_eq!(
+        scalar_string(&run(&runtime, &format!("SELECT name FROM {table} WHERE id = 1")).await),
+        "a",
+        "non-matching row should be unchanged"
+    );
+    assert_eq!(
+        scalar_count(&run(&runtime, &format!("SELECT count(*) FROM {table}")).await),
+        3,
+        "UPDATE must not change the row count"
+    );
+
+    // UPDATE all rows (no WHERE).
+    run(&runtime, &format!("UPDATE {table} SET name = 'all'")).await;
+    assert_eq!(
+        scalar_count(
+            &run(&runtime, &format!("SELECT count(DISTINCT name) FROM {table}")).await
+        ),
+        1,
+        "UPDATE without WHERE should set every row"
+    );
+
+    // DELETE WHERE: remove one row, the other survives.
+    run(&runtime, &format!("DELETE FROM {table} WHERE id = 1")).await;
+    assert_eq!(
+        scalar_count(&run(&runtime, &format!("SELECT count(*) FROM {table}")).await),
+        2,
+        "DELETE WHERE id = 1 should remove one row"
+    );
+    assert_eq!(
+        scalar_count(
+            &run(&runtime, &format!("SELECT id FROM {table} ORDER BY id LIMIT 1")).await
+        ),
+        2,
+        "the smallest surviving id should be 2"
+    );
+
+    // DELETE all rows.
+    run(&runtime, &format!("DELETE FROM {table}")).await;
+    assert_eq!(
+        scalar_count(&run(&runtime, &format!("SELECT count(*) FROM {table}")).await),
+        0,
+        "DELETE without WHERE should empty the table"
+    );
+
+    run(&runtime, &format!("DROP TABLE {table}")).await;
+}

--- a/beacon-data-lake/Cargo.toml
+++ b/beacon-data-lake/Cargo.toml
@@ -27,6 +27,7 @@ beacon-config = { path = "../beacon-config" }
 beacon-object-storage = { path = "../beacon-object-storage" }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }
 beacon-iceberg = { path = "../beacon-file-formats/beacon-iceberg" }
+beacon-lance = { path = "../beacon-file-formats/beacon-lance" }
 beacon-delta = { path = "../beacon-file-formats/beacon-delta" }
 beacon-sql-databases = { path = "../beacon-sql-databases" }
 

--- a/beacon-data-lake/src/table_runtime/schema_persistence.rs
+++ b/beacon-data-lake/src/table_runtime/schema_persistence.rs
@@ -136,6 +136,8 @@ pub fn definition_from_provider(
 ) -> datafusion::error::Result<Arc<dyn TableDefinition>> {
     if let Some(table) = table.as_any().downcast_ref::<beacon_iceberg::IcebergTable>() {
         Ok(Arc::new(table.definition().clone()))
+    } else if let Some(table) = table.as_any().downcast_ref::<beacon_lance::LanceTable>() {
+        Ok(Arc::new(table.definition().clone()))
     } else if let Some(table) = table.as_any().downcast_ref::<ExternalTable>() {
         Ok(Arc::new(table.definition().clone()))
     } else if let Some(table) = table.as_any().downcast_ref::<MaterializedView>() {

--- a/beacon-file-formats/beacon-lance/Cargo.toml
+++ b/beacon-file-formats/beacon-lance/Cargo.toml
@@ -21,6 +21,10 @@ once_cell = { workspace = true }
 
 lance = { workspace = true }
 lance-index = { workspace = true }
+lance-io = { workspace = true }
+lance-core = { workspace = true }
+object_store = { workspace = true }
+url = "2"
 
 beacon-datafusion-ext = { path = "../../beacon-datafusion-ext" }
 beacon-config = { path = "../../beacon-config" }

--- a/beacon-file-formats/beacon-lance/Cargo.toml
+++ b/beacon-file-formats/beacon-lance/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "beacon-lance"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+datafusion = { workspace = true }
+arrow = { workspace = true }
+arrow-schema = { workspace = true, features = ["serde"] }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+typetag = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+futures = { workspace = true }
+parking_lot = { workspace = true }
+tracing = { workspace = true }
+once_cell = { workspace = true }
+
+lance = { workspace = true }
+lance-index = { workspace = true }
+
+beacon-datafusion-ext = { path = "../../beacon-datafusion-ext" }
+beacon-config = { path = "../../beacon-config" }
+beacon-object-storage = { path = "../../beacon-object-storage" }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/beacon-file-formats/beacon-lance/src/alter.rs
+++ b/beacon-file-formats/beacon-lance/src/alter.rs
@@ -1,0 +1,85 @@
+//! Schema evolution for managed Lance tables (`ALTER TABLE`).
+//!
+//! Maps beacon's `ALTER TABLE` operations onto Lance's native schema-evolution
+//! API: `add_columns` (all-null new columns), `drop_columns`, and `alter_columns`
+//! (rename / cast). Each change is its own atomic dataset version, so existing
+//! data is preserved without a table rebuild — unlike the Iceberg path.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+use lance::dataset::{ColumnAlteration, Dataset, NewColumnTransform};
+
+use crate::warehouse::{self, LanceWarehouse};
+
+/// A single schema change to apply to a Lance table.
+#[derive(Debug, Clone)]
+pub enum SchemaChange {
+    /// Add a new, initially all-null column.
+    AddColumn { name: String, data_type: DataType },
+    /// Drop an existing column.
+    DropColumn { name: String },
+    /// Rename a column (values preserved).
+    RenameColumn { from: String, to: String },
+    /// Cast a column to a new data type.
+    AlterColumnType { name: String, data_type: DataType },
+}
+
+/// Apply `changes` in order to the Lance table at `location`. Serialized against
+/// concurrent writers via the warehouse's per-location lock.
+pub async fn alter_table(
+    warehouse: &LanceWarehouse,
+    location: &str,
+    changes: &[SchemaChange],
+) -> anyhow::Result<()> {
+    let path = Path::new(location);
+    tracing::info!(location = %location, changes = changes.len(), "altering Lance table");
+
+    let lock = warehouse.lock(path);
+    let _guard = lock.lock().await;
+
+    let uri = warehouse::location_uri(path);
+    let mut dataset = Dataset::open(&uri)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to open Lance dataset '{uri}': {e}"))?;
+
+    for change in changes {
+        match change {
+            SchemaChange::AddColumn { name, data_type } => {
+                // New columns are nullable so existing rows read NULL.
+                let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+                    name,
+                    data_type.clone(),
+                    true,
+                )]));
+                dataset
+                    .add_columns(NewColumnTransform::AllNulls(schema), None, None)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to add column '{name}': {e}"))?;
+            }
+            SchemaChange::DropColumn { name } => {
+                dataset
+                    .drop_columns(&[name.as_str()])
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to drop column '{name}': {e}"))?;
+            }
+            SchemaChange::RenameColumn { from, to } => {
+                let alteration = ColumnAlteration::new(from.clone()).rename(to.clone());
+                dataset
+                    .alter_columns(&[alteration])
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to rename column '{from}': {e}"))?;
+            }
+            SchemaChange::AlterColumnType { name, data_type } => {
+                let alteration = ColumnAlteration::new(name.clone()).cast_to(data_type.clone());
+                dataset
+                    .alter_columns(&[alteration])
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to alter column type '{name}': {e}"))?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/beacon-file-formats/beacon-lance/src/alter.rs
+++ b/beacon-file-formats/beacon-lance/src/alter.rs
@@ -5,13 +5,13 @@
 //! (rename / cast). Each change is its own atomic dataset version, so existing
 //! data is preserved without a table rebuild — unlike the Iceberg path.
 
-use std::path::Path;
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
-use lance::dataset::{ColumnAlteration, Dataset, NewColumnTransform};
+use lance::dataset::builder::DatasetBuilder;
+use lance::dataset::{ColumnAlteration, NewColumnTransform};
 
-use crate::warehouse::{self, LanceWarehouse};
+use crate::warehouse::LanceWarehouse;
 
 /// A single schema change to apply to a Lance table.
 #[derive(Debug, Clone)]
@@ -26,21 +26,21 @@ pub enum SchemaChange {
     AlterColumnType { name: String, data_type: DataType },
 }
 
-/// Apply `changes` in order to the Lance table at `location`. Serialized against
-/// concurrent writers via the warehouse's per-location lock.
+/// Apply `changes` in order to the Lance table at `uri`. Serialized against
+/// concurrent writers via the warehouse's per-dataset lock.
 pub async fn alter_table(
     warehouse: &LanceWarehouse,
-    location: &str,
+    uri: &str,
     changes: &[SchemaChange],
 ) -> anyhow::Result<()> {
-    let path = Path::new(location);
-    tracing::info!(location = %location, changes = changes.len(), "altering Lance table");
+    tracing::info!(uri = %uri, changes = changes.len(), "altering Lance table");
 
-    let lock = warehouse.lock(path);
+    let lock = warehouse.lock(uri);
     let _guard = lock.lock().await;
 
-    let uri = warehouse::location_uri(path);
-    let mut dataset = Dataset::open(&uri)
+    let mut dataset = DatasetBuilder::from_uri(uri)
+        .with_session(warehouse.session())
+        .load()
         .await
         .map_err(|e| anyhow::anyhow!("Failed to open Lance dataset '{uri}': {e}"))?;
 

--- a/beacon-file-formats/beacon-lance/src/definition.rs
+++ b/beacon-file-formats/beacon-lance/src/definition.rs
@@ -1,0 +1,67 @@
+//! Persisted definition for a beacon-managed Lance table.
+//!
+//! Serialized to `table.json` (via the typetag `TableDefinition` trait). Unlike
+//! Iceberg there is no catalog: the on-disk `location` is the source of truth, so
+//! it is persisted directly. On startup, `build_provider` reopens the dataset at
+//! that path; the Lance manifest — not the JSON — remains authoritative for the
+//! schema.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use beacon_datafusion_ext::table_ext::TableDefinition;
+use datafusion::catalog::TableProvider;
+use datafusion::datasource::TableType;
+use datafusion::execution::object_store::ObjectStoreUrl;
+use datafusion::prelude::SessionContext;
+use serde::{Deserialize, Serialize};
+
+use crate::provider::LanceTable;
+use crate::warehouse::LanceWarehouse;
+
+/// Persisted configuration for a Lance-backed managed table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LanceTableDefinition {
+    /// Logical table name.
+    pub name: String,
+    /// Namespace the table lives under (e.g. `["beacon"]`).
+    pub namespace: Vec<String>,
+    /// Absolute on-disk location of the Lance dataset directory.
+    pub location: String,
+}
+
+impl LanceTableDefinition {
+    pub fn new(name: impl Into<String>, namespace: Vec<String>, location: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            namespace,
+            location: location.into(),
+        }
+    }
+}
+
+#[async_trait]
+#[typetag::serde(name = "lance")]
+impl TableDefinition for LanceTableDefinition {
+    async fn build_provider(
+        &self,
+        context: Arc<SessionContext>,
+        _data_store_url: &ObjectStoreUrl,
+    ) -> anyhow::Result<Arc<dyn TableProvider>> {
+        let warehouse = context
+            .state()
+            .config()
+            .get_extension::<LanceWarehouse>()
+            .ok_or_else(|| anyhow::anyhow!("Lance warehouse is unavailable in this session"))?;
+        let table = LanceTable::open(self.clone(), warehouse).await?;
+        Ok(Arc::new(table))
+    }
+
+    fn table_name(&self) -> &str {
+        &self.name
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+}

--- a/beacon-file-formats/beacon-lance/src/definition.rs
+++ b/beacon-file-formats/beacon-lance/src/definition.rs
@@ -1,10 +1,11 @@
 //! Persisted definition for a beacon-managed Lance table.
 //!
 //! Serialized to `table.json` (via the typetag `TableDefinition` trait). Unlike
-//! Iceberg there is no catalog: the on-disk `location` is the source of truth, so
-//! it is persisted directly. On startup, `build_provider` reopens the dataset at
-//! that path; the Lance manifest — not the JSON — remains authoritative for the
-//! schema.
+//! Iceberg there is no catalog: the dataset `location` (a `beacon-tables://` URI
+//! into the tables object store) is the source of truth, so it is persisted
+//! directly. On startup, `build_provider` reopens the dataset at that URI through
+//! the runtime's warehouse; the Lance manifest — not the JSON — remains
+//! authoritative for the schema.
 
 use std::sync::Arc;
 
@@ -26,7 +27,7 @@ pub struct LanceTableDefinition {
     pub name: String,
     /// Namespace the table lives under (e.g. `["beacon"]`).
     pub namespace: Vec<String>,
-    /// Absolute on-disk location of the Lance dataset directory.
+    /// The dataset's `beacon-tables://` URI into the tables object store.
     pub location: String,
 }
 

--- a/beacon-file-formats/beacon-lance/src/index.rs
+++ b/beacon-file-formats/beacon-lance/src/index.rs
@@ -1,0 +1,148 @@
+//! Scalar index management for managed Lance tables.
+//!
+//! Lance supports native secondary indexes — something Iceberg/Delta lack.
+//! Beacon exposes the scalar kinds useful for admin filtering: BTREE (range /
+//! equality), BITMAP (low-cardinality), and INVERTED (full-text search on string
+//! columns). Index creation scans the column once and commits a new dataset
+//! version; queries then use the index automatically.
+
+use std::path::Path;
+
+use lance::dataset::Dataset;
+use lance::index::DatasetIndexExt;
+use lance_index::scalar::ScalarIndexParams;
+use lance_index::IndexType;
+
+use crate::warehouse::{self, LanceWarehouse};
+
+/// Scalar index kinds exposed via `CREATE INDEX ... USING <kind>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScalarIndexKind {
+    /// Range / equality lookups (the default).
+    BTree,
+    /// Low-cardinality columns (few distinct values).
+    Bitmap,
+    /// Full-text search over string columns.
+    Inverted,
+}
+
+impl ScalarIndexKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ScalarIndexKind::BTree => "btree",
+            ScalarIndexKind::Bitmap => "bitmap",
+            ScalarIndexKind::Inverted => "inverted",
+        }
+    }
+
+    fn index_type(&self) -> IndexType {
+        match self {
+            ScalarIndexKind::BTree => IndexType::BTree,
+            ScalarIndexKind::Bitmap => IndexType::Bitmap,
+            ScalarIndexKind::Inverted => IndexType::Inverted,
+        }
+    }
+}
+
+impl std::str::FromStr for ScalarIndexKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "btree" => Ok(ScalarIndexKind::BTree),
+            "bitmap" => Ok(ScalarIndexKind::Bitmap),
+            "inverted" | "fts" => Ok(ScalarIndexKind::Inverted),
+            other => Err(format!(
+                "unknown index type '{other}', expected 'btree', 'bitmap', or 'inverted'"
+            )),
+        }
+    }
+}
+
+/// A listed index on a managed Lance table.
+#[derive(Debug, Clone)]
+pub struct IndexInfo {
+    pub name: String,
+    pub columns: Vec<String>,
+}
+
+/// Create a scalar index named `name` on `column` of the Lance table at
+/// `location`. Errors if an index with that name already exists.
+pub async fn create_index(
+    warehouse: &LanceWarehouse,
+    location: &str,
+    column: &str,
+    name: &str,
+    kind: ScalarIndexKind,
+) -> anyhow::Result<()> {
+    let path = Path::new(location);
+    tracing::info!(location = %location, column, name, kind = kind.as_str(), "creating Lance index");
+
+    let lock = warehouse.lock(path);
+    let _guard = lock.lock().await;
+
+    let uri = warehouse::location_uri(path);
+    let mut dataset = Dataset::open(&uri)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to open Lance dataset '{uri}': {e}"))?;
+
+    let params = ScalarIndexParams::default();
+    dataset
+        .create_index(&[column], kind.index_type(), Some(name.to_string()), &params, false)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to create index '{name}' on column '{column}': {e}"))?;
+    Ok(())
+}
+
+/// Drop the index named `name` from the Lance table at `location`.
+pub async fn drop_index(
+    warehouse: &LanceWarehouse,
+    location: &str,
+    name: &str,
+) -> anyhow::Result<()> {
+    let path = Path::new(location);
+    tracing::info!(location = %location, name, "dropping Lance index");
+
+    let lock = warehouse.lock(path);
+    let _guard = lock.lock().await;
+
+    let uri = warehouse::location_uri(path);
+    let mut dataset = Dataset::open(&uri)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to open Lance dataset '{uri}': {e}"))?;
+
+    dataset
+        .drop_index(name)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to drop index '{name}': {e}"))?;
+    Ok(())
+}
+
+/// List the indexes on the Lance table at `location` (name + indexed columns).
+pub async fn list_indices(location: &str) -> anyhow::Result<Vec<IndexInfo>> {
+    let path = Path::new(location);
+    let uri = warehouse::location_uri(path);
+    let dataset = Dataset::open(&uri)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to open Lance dataset '{uri}': {e}"))?;
+
+    let indices = dataset
+        .load_indices()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to load indices for '{uri}': {e}"))?;
+    let schema = dataset.schema();
+
+    let mut out = Vec::with_capacity(indices.len());
+    for index in indices.iter() {
+        let columns = index
+            .fields
+            .iter()
+            .filter_map(|field_id| schema.field_by_id(*field_id).map(|f| f.name.clone()))
+            .collect::<Vec<_>>();
+        out.push(IndexInfo {
+            name: index.name.clone(),
+            columns,
+        });
+    }
+    Ok(out)
+}

--- a/beacon-file-formats/beacon-lance/src/index.rs
+++ b/beacon-file-formats/beacon-lance/src/index.rs
@@ -6,14 +6,12 @@
 //! columns). Index creation scans the column once and commits a new dataset
 //! version; queries then use the index automatically.
 
-use std::path::Path;
-
-use lance::dataset::Dataset;
+use lance::dataset::builder::DatasetBuilder;
 use lance::index::DatasetIndexExt;
 use lance_index::scalar::ScalarIndexParams;
 use lance_index::IndexType;
 
-use crate::warehouse::{self, LanceWarehouse};
+use crate::warehouse::LanceWarehouse;
 
 /// Scalar index kinds exposed via `CREATE INDEX ... USING <kind>`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,19 +68,19 @@ pub struct IndexInfo {
 /// `location`. Errors if an index with that name already exists.
 pub async fn create_index(
     warehouse: &LanceWarehouse,
-    location: &str,
+    uri: &str,
     column: &str,
     name: &str,
     kind: ScalarIndexKind,
 ) -> anyhow::Result<()> {
-    let path = Path::new(location);
-    tracing::info!(location = %location, column, name, kind = kind.as_str(), "creating Lance index");
+    tracing::info!(uri = %uri, column, name, kind = kind.as_str(), "creating Lance index");
 
-    let lock = warehouse.lock(path);
+    let lock = warehouse.lock(uri);
     let _guard = lock.lock().await;
 
-    let uri = warehouse::location_uri(path);
-    let mut dataset = Dataset::open(&uri)
+    let mut dataset = DatasetBuilder::from_uri(uri)
+        .with_session(warehouse.session())
+        .load()
         .await
         .map_err(|e| anyhow::anyhow!("Failed to open Lance dataset '{uri}': {e}"))?;
 
@@ -94,20 +92,20 @@ pub async fn create_index(
     Ok(())
 }
 
-/// Drop the index named `name` from the Lance table at `location`.
+/// Drop the index named `name` from the Lance table at `uri`.
 pub async fn drop_index(
     warehouse: &LanceWarehouse,
-    location: &str,
+    uri: &str,
     name: &str,
 ) -> anyhow::Result<()> {
-    let path = Path::new(location);
-    tracing::info!(location = %location, name, "dropping Lance index");
+    tracing::info!(uri = %uri, name, "dropping Lance index");
 
-    let lock = warehouse.lock(path);
+    let lock = warehouse.lock(uri);
     let _guard = lock.lock().await;
 
-    let uri = warehouse::location_uri(path);
-    let mut dataset = Dataset::open(&uri)
+    let mut dataset = DatasetBuilder::from_uri(uri)
+        .with_session(warehouse.session())
+        .load()
         .await
         .map_err(|e| anyhow::anyhow!("Failed to open Lance dataset '{uri}': {e}"))?;
 
@@ -118,11 +116,14 @@ pub async fn drop_index(
     Ok(())
 }
 
-/// List the indexes on the Lance table at `location` (name + indexed columns).
-pub async fn list_indices(location: &str) -> anyhow::Result<Vec<IndexInfo>> {
-    let path = Path::new(location);
-    let uri = warehouse::location_uri(path);
-    let dataset = Dataset::open(&uri)
+/// List the indexes on the Lance table at `uri` (name + indexed columns).
+pub async fn list_indices(
+    warehouse: &LanceWarehouse,
+    uri: &str,
+) -> anyhow::Result<Vec<IndexInfo>> {
+    let dataset = DatasetBuilder::from_uri(uri)
+        .with_session(warehouse.session())
+        .load()
         .await
         .map_err(|e| anyhow::anyhow!("Failed to open Lance dataset '{uri}': {e}"))?;
 

--- a/beacon-file-formats/beacon-lance/src/io.rs
+++ b/beacon-file-formats/beacon-lance/src/io.rs
@@ -1,13 +1,18 @@
 //! Low-level Lance dataset writes, shared by create / insert / replace.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use arrow::array::RecordBatch;
 use arrow::compute::cast;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use arrow::record_batch::RecordBatchIterator;
-use lance::dataset::builder::DatasetBuilder;
-use lance::dataset::{Dataset, WriteMode, WriteParams};
+use arrow::error::ArrowError;
+use datafusion::error::DataFusionError;
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use futures::StreamExt;
+use lance::dataset::write::InsertBuilder;
+use lance::dataset::{WriteMode, WriteParams};
 use lance::session::Session;
 
 /// Map an Arrow data type to one Lance can store. Lance 7.x does not support the
@@ -37,39 +42,40 @@ pub(crate) fn lance_compatible_schema(schema: &Schema) -> SchemaRef {
     Arc::new(Schema::new(fields))
 }
 
-/// Cast `batches` to `target` (only the differing columns are cast).
-fn coerce_batches(
-    batches: Vec<RecordBatch>,
-    target: &SchemaRef,
-) -> anyhow::Result<Vec<RecordBatch>> {
-    batches
-        .into_iter()
-        .map(|batch| {
-            let columns = batch
-                .columns()
-                .iter()
-                .zip(target.fields())
-                .map(|(column, field)| {
-                    if column.data_type() == field.data_type() {
-                        Ok(column.clone())
-                    } else {
-                        cast(column, field.data_type())
-                    }
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            Ok(RecordBatch::try_new(target.clone(), columns)?)
+/// Cast a single batch to `target` (only the differing columns are cast).
+fn coerce_batch(batch: &RecordBatch, target: &SchemaRef) -> Result<RecordBatch, ArrowError> {
+    let columns = batch
+        .columns()
+        .iter()
+        .zip(target.fields())
+        .map(|(column, field)| {
+            if column.data_type() == field.data_type() {
+                Ok(column.clone())
+            } else {
+                cast(column, field.data_type())
+            }
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+    RecordBatch::try_new(target.clone(), columns)
 }
 
-/// How a batch of rows should be applied to a dataset.
+/// An empty (zero-row) stream carrying `schema` — used to create an empty
+/// dataset that only establishes the schema.
+pub fn empty_stream(schema: SchemaRef) -> SendableRecordBatchStream {
+    Box::pin(RecordBatchStreamAdapter::new(
+        schema,
+        futures::stream::empty::<Result<RecordBatch, DataFusionError>>(),
+    ))
+}
+
+/// How rows should be applied to a dataset.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WriteKind {
     /// Create a new dataset (errors if one already exists at the location).
     Create,
     /// Append rows to an existing dataset.
     Append,
-    /// Replace all rows: a new dataset version containing only `batches`.
+    /// Replace all rows: a new dataset version containing only the streamed rows.
     Overwrite,
 }
 
@@ -83,51 +89,44 @@ impl From<WriteKind> for WriteMode {
     }
 }
 
-/// Write `batches` to the Lance dataset at `uri` (a `beacon-tables://` URI),
-/// resolved through `session`'s object-store registry. Returns the rows written.
+/// Stream `rows` into the Lance dataset at `uri` (a `beacon-tables://` URI),
+/// resolved through `session`'s object-store registry. The input stream is fed
+/// directly into Lance's [`InsertBuilder`] (no full-table buffering); each batch
+/// is coerced to a Lance-writable schema (Arrow view types widened) on the fly.
+/// Returns the number of rows written.
 ///
-/// `Create`/`Overwrite` go through `Dataset::write`; `Append` opens the existing
-/// dataset and appends. Callers hold the dataset's
-/// [`LanceWarehouse`](crate::warehouse::LanceWarehouse) write lock across the call.
-pub async fn write_batches(
+/// Callers hold the dataset's [`LanceWarehouse`](crate::warehouse::LanceWarehouse)
+/// write lock across the call.
+pub async fn write_stream(
     uri: &str,
     session: Arc<Session>,
-    schema: SchemaRef,
-    batches: Vec<RecordBatch>,
+    rows: SendableRecordBatchStream,
     kind: WriteKind,
 ) -> anyhow::Result<u64> {
-    let num_rows: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
+    let target = lance_compatible_schema(&rows.schema());
 
-    // Lance can't store Arrow view types; coerce the schema and data to a
-    // Lance-writable form before writing.
-    let target = lance_compatible_schema(&schema);
-    let batches = coerce_batches(batches, &target)?;
+    // Count rows + coerce view types as batches stream past, without collecting.
+    let written = Arc::new(AtomicU64::new(0));
+    let counter = written.clone();
+    let coerce_target = target.clone();
+    let coerced = rows.map(move |batch| {
+        let batch = batch?;
+        counter.fetch_add(batch.num_rows() as u64, Ordering::Relaxed);
+        coerce_batch(&batch, &coerce_target).map_err(DataFusionError::from)
+    });
+    let source: SendableRecordBatchStream =
+        Box::pin(RecordBatchStreamAdapter::new(target, coerced));
 
-    match kind {
-        WriteKind::Append => {
-            let mut dataset = DatasetBuilder::from_uri(uri)
-                .with_session(session)
-                .load()
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to open Lance dataset '{uri}': {e}"))?;
-            let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), target);
-            dataset
-                .append(reader, None)
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to append to Lance dataset '{uri}': {e}"))?;
-        }
-        WriteKind::Create | WriteKind::Overwrite => {
-            let params = WriteParams {
-                mode: kind.into(),
-                session: Some(session),
-                ..Default::default()
-            };
-            let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), target);
-            Dataset::write(reader, uri, Some(params))
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to write Lance dataset '{uri}': {e}"))?;
-        }
-    }
+    let params = WriteParams {
+        mode: kind.into(),
+        session: Some(session),
+        ..Default::default()
+    };
+    InsertBuilder::new(uri)
+        .with_params(&params)
+        .execute_stream(source)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to write Lance dataset '{uri}': {e}"))?;
 
-    Ok(num_rows)
+    Ok(written.load(Ordering::Relaxed))
 }

--- a/beacon-file-formats/beacon-lance/src/io.rs
+++ b/beacon-file-formats/beacon-lance/src/io.rs
@@ -1,15 +1,14 @@
 //! Low-level Lance dataset writes, shared by create / insert / replace.
 
 use std::sync::Arc;
-use std::path::Path;
 
 use arrow::array::RecordBatch;
 use arrow::compute::cast;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatchIterator;
+use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::{Dataset, WriteMode, WriteParams};
-
-use crate::warehouse;
+use lance::session::Session;
 
 /// Map an Arrow data type to one Lance can store. Lance 7.x does not support the
 /// Arrow "view" types (`Utf8View`/`BinaryView`) that DataFusion 53 produces for
@@ -84,20 +83,20 @@ impl From<WriteKind> for WriteMode {
     }
 }
 
-/// Write `batches` to the Lance dataset at `location`. Returns the rows written.
+/// Write `batches` to the Lance dataset at `uri` (a `beacon-tables://` URI),
+/// resolved through `session`'s object-store registry. Returns the rows written.
 ///
 /// `Create`/`Overwrite` go through `Dataset::write`; `Append` opens the existing
-/// dataset and appends. The parent directory is created for `Create`. Callers are
-/// responsible for holding the location's [`LanceWarehouse`](crate::warehouse::LanceWarehouse)
-/// write lock across the call.
+/// dataset and appends. Callers hold the dataset's
+/// [`LanceWarehouse`](crate::warehouse::LanceWarehouse) write lock across the call.
 pub async fn write_batches(
-    location: &Path,
+    uri: &str,
+    session: Arc<Session>,
     schema: SchemaRef,
     batches: Vec<RecordBatch>,
     kind: WriteKind,
 ) -> anyhow::Result<u64> {
     let num_rows: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
-    let uri = warehouse::location_uri(location);
 
     // Lance can't store Arrow view types; coerce the schema and data to a
     // Lance-writable form before writing.
@@ -106,7 +105,9 @@ pub async fn write_batches(
 
     match kind {
         WriteKind::Append => {
-            let mut dataset = Dataset::open(&uri)
+            let mut dataset = DatasetBuilder::from_uri(uri)
+                .with_session(session)
+                .load()
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to open Lance dataset '{uri}': {e}"))?;
             let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), target);
@@ -116,17 +117,13 @@ pub async fn write_batches(
                 .map_err(|e| anyhow::anyhow!("Failed to append to Lance dataset '{uri}': {e}"))?;
         }
         WriteKind::Create | WriteKind::Overwrite => {
-            if let Some(parent) = location.parent() {
-                std::fs::create_dir_all(parent).map_err(|e| {
-                    anyhow::anyhow!("Failed to create Lance table directory '{}': {e}", parent.display())
-                })?;
-            }
             let params = WriteParams {
                 mode: kind.into(),
+                session: Some(session),
                 ..Default::default()
             };
             let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), target);
-            Dataset::write(reader, &uri, Some(params))
+            Dataset::write(reader, uri, Some(params))
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to write Lance dataset '{uri}': {e}"))?;
         }

--- a/beacon-file-formats/beacon-lance/src/io.rs
+++ b/beacon-file-formats/beacon-lance/src/io.rs
@@ -1,0 +1,136 @@
+//! Low-level Lance dataset writes, shared by create / insert / replace.
+
+use std::sync::Arc;
+use std::path::Path;
+
+use arrow::array::RecordBatch;
+use arrow::compute::cast;
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::record_batch::RecordBatchIterator;
+use lance::dataset::{Dataset, WriteMode, WriteParams};
+
+use crate::warehouse;
+
+/// Map an Arrow data type to one Lance can store. Lance 7.x does not support the
+/// Arrow "view" types (`Utf8View`/`BinaryView`) that DataFusion 53 produces for
+/// SQL string/binary columns, so they are widened to their non-view equivalents.
+fn lance_compatible_type(data_type: &DataType) -> DataType {
+    match data_type {
+        DataType::Utf8View => DataType::Utf8,
+        DataType::BinaryView => DataType::Binary,
+        other => other.clone(),
+    }
+}
+
+/// A Lance-writable version of `schema` (view types widened to non-view).
+pub(crate) fn lance_compatible_schema(schema: &Schema) -> SchemaRef {
+    let fields = schema
+        .fields()
+        .iter()
+        .map(|f| {
+            Arc::new(Field::new(
+                f.name(),
+                lance_compatible_type(f.data_type()),
+                f.is_nullable(),
+            ))
+        })
+        .collect::<Vec<_>>();
+    Arc::new(Schema::new(fields))
+}
+
+/// Cast `batches` to `target` (only the differing columns are cast).
+fn coerce_batches(
+    batches: Vec<RecordBatch>,
+    target: &SchemaRef,
+) -> anyhow::Result<Vec<RecordBatch>> {
+    batches
+        .into_iter()
+        .map(|batch| {
+            let columns = batch
+                .columns()
+                .iter()
+                .zip(target.fields())
+                .map(|(column, field)| {
+                    if column.data_type() == field.data_type() {
+                        Ok(column.clone())
+                    } else {
+                        cast(column, field.data_type())
+                    }
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(RecordBatch::try_new(target.clone(), columns)?)
+        })
+        .collect()
+}
+
+/// How a batch of rows should be applied to a dataset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteKind {
+    /// Create a new dataset (errors if one already exists at the location).
+    Create,
+    /// Append rows to an existing dataset.
+    Append,
+    /// Replace all rows: a new dataset version containing only `batches`.
+    Overwrite,
+}
+
+impl From<WriteKind> for WriteMode {
+    fn from(kind: WriteKind) -> Self {
+        match kind {
+            WriteKind::Create => WriteMode::Create,
+            WriteKind::Append => WriteMode::Append,
+            WriteKind::Overwrite => WriteMode::Overwrite,
+        }
+    }
+}
+
+/// Write `batches` to the Lance dataset at `location`. Returns the rows written.
+///
+/// `Create`/`Overwrite` go through `Dataset::write`; `Append` opens the existing
+/// dataset and appends. The parent directory is created for `Create`. Callers are
+/// responsible for holding the location's [`LanceWarehouse`](crate::warehouse::LanceWarehouse)
+/// write lock across the call.
+pub async fn write_batches(
+    location: &Path,
+    schema: SchemaRef,
+    batches: Vec<RecordBatch>,
+    kind: WriteKind,
+) -> anyhow::Result<u64> {
+    let num_rows: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
+    let uri = warehouse::location_uri(location);
+
+    // Lance can't store Arrow view types; coerce the schema and data to a
+    // Lance-writable form before writing.
+    let target = lance_compatible_schema(&schema);
+    let batches = coerce_batches(batches, &target)?;
+
+    match kind {
+        WriteKind::Append => {
+            let mut dataset = Dataset::open(&uri)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to open Lance dataset '{uri}': {e}"))?;
+            let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), target);
+            dataset
+                .append(reader, None)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to append to Lance dataset '{uri}': {e}"))?;
+        }
+        WriteKind::Create | WriteKind::Overwrite => {
+            if let Some(parent) = location.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    anyhow::anyhow!("Failed to create Lance table directory '{}': {e}", parent.display())
+                })?;
+            }
+            let params = WriteParams {
+                mode: kind.into(),
+                ..Default::default()
+            };
+            let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), target);
+            Dataset::write(reader, &uri, Some(params))
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to write Lance dataset '{uri}': {e}"))?;
+        }
+    }
+
+    Ok(num_rows)
+}

--- a/beacon-file-formats/beacon-lance/src/lib.rs
+++ b/beacon-file-formats/beacon-lance/src/lib.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::Schema as ArrowSchema;
 use datafusion::execution::SendableRecordBatchStream;
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use object_store::{ObjectStore, ObjectStoreExt};
 
 pub use alter::{alter_table, SchemaChange};
@@ -54,8 +54,15 @@ pub async fn create_lance_table(
     {
         let lock = warehouse.lock(&uri);
         let _guard = lock.lock().await;
-        io::write_batches(&uri, warehouse.session(), schema.clone(), Vec::new(), WriteKind::Create)
-            .await?;
+        // Create an empty dataset that just establishes the schema; CTAS inserts
+        // rows afterwards through the streaming insert path.
+        io::write_stream(
+            &uri,
+            warehouse.session(),
+            io::empty_stream(schema.clone()),
+            WriteKind::Create,
+        )
+        .await?;
     }
 
     let definition = LanceTableDefinition::new(name, namespace.to_vec(), uri);
@@ -100,14 +107,9 @@ pub async fn replace_table_contents(
 ) -> anyhow::Result<()> {
     tracing::info!(uri = %uri, "replacing Lance table contents");
 
-    let schema = new_rows.schema();
-    let batches = new_rows
-        .try_collect::<Vec<_>>()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to read replacement rows: {e}"))?;
     let lock = warehouse.lock(uri);
     let _guard = lock.lock().await;
-    io::write_batches(uri, warehouse.session(), schema, batches, WriteKind::Overwrite).await?;
+    io::write_stream(uri, warehouse.session(), new_rows, WriteKind::Overwrite).await?;
     Ok(())
 }
 

--- a/beacon-file-formats/beacon-lance/src/lib.rs
+++ b/beacon-file-formats/beacon-lance/src/lib.rs
@@ -1,0 +1,348 @@
+//! Lance integration for beacon managed tables.
+//!
+//! Provides a **local-filesystem**, columnar, transactionally-versioned table
+//! engine for beacon's `CREATE TABLE`:
+//! - a local [`warehouse`] (raw paths, no object store),
+//! - a [`LanceTable`] `TableProvider` wrapper, and
+//! - a [`LanceTableDefinition`] for persisting tables as `table.json`.
+//!
+//! Beacon's statement handler calls [`create_lance_table`] / [`drop_lance_table`]
+//! / [`replace_table_contents`] for `CREATE TABLE` / `DROP TABLE` / `DELETE`+
+//! `UPDATE`; discovery rebuilds providers via the definition's `build_provider`.
+//!
+//! Lance's atomic, versioned commits give readers a consistent snapshot with no
+//! torn reads; a per-location write lock serializes writers.
+
+pub mod alter;
+pub mod definition;
+pub mod index;
+pub mod io;
+pub mod provider;
+pub mod sink;
+pub mod warehouse;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::datatypes::Schema as ArrowSchema;
+use datafusion::execution::SendableRecordBatchStream;
+use futures::TryStreamExt;
+
+pub use alter::{alter_table, SchemaChange};
+pub use definition::LanceTableDefinition;
+pub use index::{create_index, drop_index, list_indices, IndexInfo, ScalarIndexKind};
+pub use io::WriteKind;
+pub use provider::LanceTable;
+pub use warehouse::{beacon_namespace, LanceWarehouse, BEACON_NAMESPACE};
+
+/// Create a new, empty Lance table at the warehouse location for
+/// `namespace`/`name` and return a ready [`LanceTable`] provider. The empty
+/// dataset carries the schema; `CREATE TABLE AS SELECT` inserts rows afterwards.
+pub async fn create_lance_table(
+    warehouse: Arc<LanceWarehouse>,
+    namespace: &[String],
+    name: &str,
+    arrow_schema: &ArrowSchema,
+) -> anyhow::Result<LanceTable> {
+    let location = warehouse.table_location(namespace, name);
+    tracing::info!(
+        namespace = ?namespace,
+        table = name,
+        location = %location.display(),
+        "creating Lance table"
+    );
+
+    // Store the Lance-writable schema (view types widened) so the provider's
+    // schema matches the on-disk dataset.
+    let schema = io::lance_compatible_schema(arrow_schema);
+    {
+        let lock = warehouse.lock(&location);
+        let _guard = lock.lock().await;
+        io::write_batches(&location, schema.clone(), Vec::new(), WriteKind::Create).await?;
+    }
+
+    let definition =
+        LanceTableDefinition::new(name, namespace.to_vec(), warehouse::location_uri(&location));
+    Ok(LanceTable::new(definition, schema, warehouse))
+}
+
+/// Drop a Lance table by removing its dataset directory.
+pub async fn drop_lance_table(warehouse: &LanceWarehouse, location: &str) -> anyhow::Result<()> {
+    let path = Path::new(location);
+    tracing::info!(location = %location, "dropping Lance table");
+
+    let lock = warehouse.lock(path);
+    let _guard = lock.lock().await;
+    if path.exists() {
+        std::fs::remove_dir_all(path)
+            .map_err(|e| anyhow::anyhow!("Failed to remove Lance table '{location}': {e}"))?;
+    }
+    Ok(())
+}
+
+/// Replace **all** rows of a Lance table with the rows produced by `new_rows`
+/// (atomic overwrite → a new dataset version). Used to implement `DELETE` /
+/// `UPDATE`: the caller passes the surviving rows (everything that does *not*
+/// match the predicate). An empty stream leaves an empty table.
+pub async fn replace_table_contents(
+    warehouse: &LanceWarehouse,
+    location: &str,
+    new_rows: SendableRecordBatchStream,
+) -> anyhow::Result<()> {
+    let path = Path::new(location);
+    tracing::info!(location = %location, "replacing Lance table contents");
+
+    let schema = new_rows.schema();
+    let batches = new_rows
+        .try_collect::<Vec<_>>()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to read replacement rows: {e}"))?;
+    let lock = warehouse.lock(path);
+    let _guard = lock.lock().await;
+    io::write_batches(path, schema, batches, WriteKind::Overwrite).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::Int64Array;
+    use datafusion::arrow::datatypes::{DataType, Field};
+    use datafusion::prelude::{SessionConfig, SessionContext};
+    use tempfile::TempDir;
+
+    fn sample_schema() -> ArrowSchema {
+        ArrowSchema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ])
+    }
+
+    /// A fresh, isolated warehouse rooted in `dir`. Each test owns its own
+    /// warehouse (and `TempDir`), so there is no shared global state.
+    fn test_warehouse(dir: &TempDir) -> Arc<LanceWarehouse> {
+        Arc::new(LanceWarehouse::new(dir.path().join("lance")))
+    }
+
+    async fn count(ctx: &SessionContext, name: &str) -> i64 {
+        let batches = ctx
+            .sql(&format!("SELECT count(*) AS c FROM {name}"))
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .value(0)
+    }
+
+    #[tokio::test]
+    async fn create_insert_replace_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let warehouse = test_warehouse(&dir);
+        let namespace = beacon_namespace();
+
+        let table = create_lance_table(warehouse.clone(), &namespace, "orders", &sample_schema())
+            .await
+            .expect("table should be created");
+        let location = table.definition().location.clone();
+
+        let ctx = SessionContext::new();
+        ctx.register_table("orders", Arc::new(table)).unwrap();
+
+        ctx.sql("INSERT INTO orders VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(count(&ctx, "orders").await, 3, "three inserted rows visible");
+
+        // DELETE WHERE id = 1 -> keep id <> 1.
+        let keep = ctx
+            .sql("SELECT * FROM orders WHERE id <> 1")
+            .await
+            .unwrap()
+            .execute_stream()
+            .await
+            .unwrap();
+        replace_table_contents(&warehouse, &location, keep)
+            .await
+            .expect("replace should succeed");
+        assert_eq!(count(&ctx, "orders").await, 2, "one row removed, two survive");
+    }
+
+    #[tokio::test]
+    async fn definition_build_provider_rediscovers_rows() {
+        use beacon_datafusion_ext::table_ext::TableDefinition;
+        use datafusion::execution::object_store::ObjectStoreUrl;
+
+        let dir = tempfile::tempdir().unwrap();
+        let warehouse = test_warehouse(&dir);
+        let namespace = beacon_namespace();
+
+        let table = create_lance_table(warehouse.clone(), &namespace, "discovered", &sample_schema())
+            .await
+            .unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_table("discovered", Arc::new(table)).unwrap();
+        ctx.sql("INSERT INTO discovered VALUES (7, 'g')")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        // Simulate restart: round-trip the definition through JSON and rebuild.
+        let location = warehouse.table_location(&namespace, "discovered");
+        let definition: Arc<dyn TableDefinition> = Arc::new(LanceTableDefinition::new(
+            "discovered",
+            namespace,
+            warehouse::location_uri(&location),
+        ));
+        let json = serde_json::to_string(&definition).unwrap();
+        assert!(json.contains("\"lance\""), "typetag tag present: {json}");
+        let restored: Arc<dyn TableDefinition> = serde_json::from_str(&json).unwrap();
+
+        // build_provider resolves the warehouse from the session extension, so the
+        // discovery context must carry it (as the runtime's does).
+        let build_ctx = Arc::new(SessionContext::new_with_config(
+            SessionConfig::new().with_extension(warehouse.clone()),
+        ));
+        let provider = restored
+            .build_provider(build_ctx, &ObjectStoreUrl::parse("tables://").unwrap())
+            .await
+            .expect("provider should rebuild from disk");
+
+        let ctx2 = SessionContext::new();
+        ctx2.register_table("discovered", provider).unwrap();
+        assert_eq!(count(&ctx2, "discovered").await, 1, "row survives discovery");
+    }
+
+    #[tokio::test]
+    async fn alter_add_and_rename_preserve_data() {
+        use datafusion::arrow::array::StringArray;
+
+        let dir = tempfile::tempdir().unwrap();
+        let warehouse = test_warehouse(&dir);
+        let namespace = beacon_namespace();
+
+        let table = create_lance_table(warehouse.clone(), &namespace, "orders", &sample_schema())
+            .await
+            .unwrap();
+        let location = table.definition().location.clone();
+        let ctx = SessionContext::new();
+        ctx.register_table("orders", Arc::new(table)).unwrap();
+        ctx.sql("INSERT INTO orders VALUES (1, 'a'), (2, 'b')")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        // ADD COLUMN age INT (existing rows read NULL), then RENAME name -> full_name.
+        alter_table(
+            &warehouse,
+            &location,
+            &[SchemaChange::AddColumn {
+                name: "age".to_string(),
+                data_type: DataType::Int32,
+            }],
+        )
+        .await
+        .expect("add column should succeed");
+        alter_table(
+            &warehouse,
+            &location,
+            &[SchemaChange::RenameColumn {
+                from: "name".to_string(),
+                to: "full_name".to_string(),
+            }],
+        )
+        .await
+        .expect("rename column should succeed");
+
+        // Reopen to pick up the evolved schema.
+        let reopened = LanceTable::open(
+            LanceTableDefinition::new("orders", beacon_namespace(), location.clone()),
+            warehouse.clone(),
+        )
+        .await
+        .unwrap();
+        let ctx2 = SessionContext::new();
+        ctx2.register_table("orders", Arc::new(reopened)).unwrap();
+
+        // New column present and NULL for pre-existing rows.
+        let batches = ctx2
+            .sql("SELECT count(age) AS c FROM orders")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let non_null_age = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .value(0);
+        assert_eq!(non_null_age, 0, "pre-existing rows read NULL for age");
+
+        // Renamed column keeps its values.
+        let batches = ctx2
+            .sql("SELECT full_name FROM orders WHERE id = 1")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let value = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .value(0);
+        assert_eq!(value, "a", "renamed column keeps its values");
+    }
+
+    #[tokio::test]
+    async fn create_list_drop_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let warehouse = test_warehouse(&dir);
+        let namespace = beacon_namespace();
+
+        let table = create_lance_table(warehouse.clone(), &namespace, "orders", &sample_schema())
+            .await
+            .unwrap();
+        let location = table.definition().location.clone();
+        let ctx = SessionContext::new();
+        ctx.register_table("orders", Arc::new(table)).unwrap();
+        ctx.sql("INSERT INTO orders VALUES (1, 'a'), (2, 'b')")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        create_index(&warehouse, &location, "id", "id_idx", ScalarIndexKind::BTree)
+            .await
+            .expect("create index should succeed");
+
+        let listed = list_indices(&location).await.expect("list indices");
+        assert_eq!(listed.len(), 1, "one index present");
+        assert_eq!(listed[0].name, "id_idx");
+        assert_eq!(listed[0].columns, vec!["id".to_string()]);
+
+        drop_index(&warehouse, &location, "id_idx")
+            .await
+            .expect("drop index should succeed");
+        assert!(
+            list_indices(&location).await.unwrap().is_empty(),
+            "no indices after drop"
+        );
+    }
+}

--- a/beacon-file-formats/beacon-lance/src/lib.rs
+++ b/beacon-file-formats/beacon-lance/src/lib.rs
@@ -1,8 +1,9 @@
 //! Lance integration for beacon managed tables.
 //!
-//! Provides a **local-filesystem**, columnar, transactionally-versioned table
-//! engine for beacon's `CREATE TABLE`:
-//! - a local [`warehouse`] (raw paths, no object store),
+//! Provides a columnar, transactionally-versioned table engine for beacon's
+//! `CREATE TABLE`, backed by beacon's tables object store:
+//! - a [`warehouse`] that routes Lance through that object store (via a
+//!   `beacon-tables://` scheme + [`warehouse::LanceWarehouse`]),
 //! - a [`LanceTable`] `TableProvider` wrapper, and
 //! - a [`LanceTableDefinition`] for persisting tables as `table.json`.
 //!
@@ -11,7 +12,7 @@
 //! `UPDATE`; discovery rebuilds providers via the definition's `build_provider`.
 //!
 //! Lance's atomic, versioned commits give readers a consistent snapshot with no
-//! torn reads; a per-location write lock serializes writers.
+//! torn reads; a per-dataset write lock serializes writers.
 
 pub mod alter;
 pub mod definition;
@@ -21,12 +22,12 @@ pub mod provider;
 pub mod sink;
 pub mod warehouse;
 
-use std::path::Path;
 use std::sync::Arc;
 
 use arrow::datatypes::Schema as ArrowSchema;
 use datafusion::execution::SendableRecordBatchStream;
-use futures::TryStreamExt;
+use futures::{StreamExt, TryStreamExt};
+use object_store::{ObjectStore, ObjectStoreExt};
 
 pub use alter::{alter_table, SchemaChange};
 pub use definition::LanceTableDefinition;
@@ -44,38 +45,46 @@ pub async fn create_lance_table(
     name: &str,
     arrow_schema: &ArrowSchema,
 ) -> anyhow::Result<LanceTable> {
-    let location = warehouse.table_location(namespace, name);
-    tracing::info!(
-        namespace = ?namespace,
-        table = name,
-        location = %location.display(),
-        "creating Lance table"
-    );
+    let uri = warehouse.table_uri(namespace, name);
+    tracing::info!(namespace = ?namespace, table = name, uri = %uri, "creating Lance table");
 
     // Store the Lance-writable schema (view types widened) so the provider's
-    // schema matches the on-disk dataset.
+    // schema matches the written dataset.
     let schema = io::lance_compatible_schema(arrow_schema);
     {
-        let lock = warehouse.lock(&location);
+        let lock = warehouse.lock(&uri);
         let _guard = lock.lock().await;
-        io::write_batches(&location, schema.clone(), Vec::new(), WriteKind::Create).await?;
+        io::write_batches(&uri, warehouse.session(), schema.clone(), Vec::new(), WriteKind::Create)
+            .await?;
     }
 
-    let definition =
-        LanceTableDefinition::new(name, namespace.to_vec(), warehouse::location_uri(&location));
+    let definition = LanceTableDefinition::new(name, namespace.to_vec(), uri);
     Ok(LanceTable::new(definition, schema, warehouse))
 }
 
-/// Drop a Lance table by removing its dataset directory.
-pub async fn drop_lance_table(warehouse: &LanceWarehouse, location: &str) -> anyhow::Result<()> {
-    let path = Path::new(location);
-    tracing::info!(location = %location, "dropping Lance table");
+/// Drop a Lance table by deleting all of its objects from the tables store.
+pub async fn drop_lance_table(warehouse: &LanceWarehouse, uri: &str) -> anyhow::Result<()> {
+    tracing::info!(uri = %uri, "dropping Lance table");
 
-    let lock = warehouse.lock(path);
+    let lock = warehouse.lock(uri);
     let _guard = lock.lock().await;
-    if path.exists() {
-        std::fs::remove_dir_all(path)
-            .map_err(|e| anyhow::anyhow!("Failed to remove Lance table '{location}': {e}"))?;
+
+    let prefix = LanceWarehouse::object_path(uri);
+    let store = warehouse.store();
+    let mut listing = store.list(Some(&prefix));
+    let mut locations = Vec::new();
+    while let Some(entry) = listing.next().await {
+        locations.push(
+            entry
+                .map_err(|e| anyhow::anyhow!("Failed to list Lance table files: {e}"))?
+                .location,
+        );
+    }
+    for location in locations {
+        store
+            .delete(&location)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to delete Lance table file: {e}"))?;
     }
     Ok(())
 }
@@ -86,20 +95,19 @@ pub async fn drop_lance_table(warehouse: &LanceWarehouse, location: &str) -> any
 /// match the predicate). An empty stream leaves an empty table.
 pub async fn replace_table_contents(
     warehouse: &LanceWarehouse,
-    location: &str,
+    uri: &str,
     new_rows: SendableRecordBatchStream,
 ) -> anyhow::Result<()> {
-    let path = Path::new(location);
-    tracing::info!(location = %location, "replacing Lance table contents");
+    tracing::info!(uri = %uri, "replacing Lance table contents");
 
     let schema = new_rows.schema();
     let batches = new_rows
         .try_collect::<Vec<_>>()
         .await
         .map_err(|e| anyhow::anyhow!("Failed to read replacement rows: {e}"))?;
-    let lock = warehouse.lock(path);
+    let lock = warehouse.lock(uri);
     let _guard = lock.lock().await;
-    io::write_batches(path, schema, batches, WriteKind::Overwrite).await?;
+    io::write_batches(uri, warehouse.session(), schema, batches, WriteKind::Overwrite).await?;
     Ok(())
 }
 
@@ -118,10 +126,13 @@ mod tests {
         ])
     }
 
-    /// A fresh, isolated warehouse rooted in `dir`. Each test owns its own
-    /// warehouse (and `TempDir`), so there is no shared global state.
+    /// A fresh, isolated warehouse over a local-filesystem object store rooted in
+    /// `dir`. Each test owns its own warehouse (and `TempDir`), so there is no
+    /// shared global state.
     fn test_warehouse(dir: &TempDir) -> Arc<LanceWarehouse> {
-        Arc::new(LanceWarehouse::new(dir.path().join("lance")))
+        let store: Arc<dyn ObjectStore> =
+            Arc::new(object_store::local::LocalFileSystem::new_with_prefix(dir.path()).unwrap());
+        Arc::new(LanceWarehouse::new(store))
     }
 
     async fn count(ctx: &SessionContext, name: &str) -> i64 {
@@ -198,12 +209,9 @@ mod tests {
             .unwrap();
 
         // Simulate restart: round-trip the definition through JSON and rebuild.
-        let location = warehouse.table_location(&namespace, "discovered");
-        let definition: Arc<dyn TableDefinition> = Arc::new(LanceTableDefinition::new(
-            "discovered",
-            namespace,
-            warehouse::location_uri(&location),
-        ));
+        let location = warehouse.table_uri(&namespace, "discovered");
+        let definition: Arc<dyn TableDefinition> =
+            Arc::new(LanceTableDefinition::new("discovered", namespace, location.clone()));
         let json = serde_json::to_string(&definition).unwrap();
         assert!(json.contains("\"lance\""), "typetag tag present: {json}");
         let restored: Arc<dyn TableDefinition> = serde_json::from_str(&json).unwrap();
@@ -332,7 +340,7 @@ mod tests {
             .await
             .expect("create index should succeed");
 
-        let listed = list_indices(&location).await.expect("list indices");
+        let listed = list_indices(&warehouse, &location).await.expect("list indices");
         assert_eq!(listed.len(), 1, "one index present");
         assert_eq!(listed[0].name, "id_idx");
         assert_eq!(listed[0].columns, vec!["id".to_string()]);
@@ -341,7 +349,7 @@ mod tests {
             .await
             .expect("drop index should succeed");
         assert!(
-            list_indices(&location).await.unwrap().is_empty(),
+            list_indices(&warehouse, &location).await.unwrap().is_empty(),
             "no indices after drop"
         );
     }

--- a/beacon-file-formats/beacon-lance/src/lib.rs
+++ b/beacon-file-formats/beacon-lance/src/lib.rs
@@ -18,6 +18,7 @@ pub mod alter;
 pub mod definition;
 pub mod index;
 pub mod io;
+pub mod mutate;
 pub mod provider;
 pub mod sink;
 pub mod warehouse;
@@ -33,6 +34,7 @@ pub use alter::{alter_table, SchemaChange};
 pub use definition::LanceTableDefinition;
 pub use index::{create_index, drop_index, list_indices, IndexInfo, ScalarIndexKind};
 pub use io::WriteKind;
+pub use mutate::{delete_rows, update_rows};
 pub use provider::LanceTable;
 pub use warehouse::{beacon_namespace, LanceWarehouse, BEACON_NAMESPACE};
 
@@ -354,5 +356,66 @@ mod tests {
             list_indices(&warehouse, &location).await.unwrap().is_empty(),
             "no indices after drop"
         );
+    }
+
+    #[tokio::test]
+    async fn native_update_and_delete() {
+        use datafusion::arrow::array::StringArray;
+
+        let dir = tempfile::tempdir().unwrap();
+        let warehouse = test_warehouse(&dir);
+        let namespace = beacon_namespace();
+
+        let table = create_lance_table(warehouse.clone(), &namespace, "orders", &sample_schema())
+            .await
+            .unwrap();
+        let location = table.definition().location.clone();
+        let ctx = SessionContext::new();
+        // The provider reopens the latest dataset version on each scan, so it
+        // observes the native mutations below without re-registration.
+        ctx.register_table("orders", Arc::new(table)).unwrap();
+        ctx.sql("INSERT INTO orders VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        // Native UPDATE name = 'Z' WHERE id = 2.
+        update_rows(
+            &warehouse,
+            &location,
+            Some("id = 2"),
+            &[("name".to_string(), "'Z'".to_string())],
+        )
+        .await
+        .expect("update should succeed");
+        let batches = ctx
+            .sql("SELECT name FROM orders WHERE id = 2")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let name = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .value(0);
+        assert_eq!(name, "Z", "row 2 should be updated");
+        assert_eq!(count(&ctx, "orders").await, 3, "UPDATE must not change row count");
+
+        // Native DELETE WHERE id = 1.
+        delete_rows(&warehouse, &location, Some("id = 1"))
+            .await
+            .expect("delete should succeed");
+        assert_eq!(count(&ctx, "orders").await, 2, "one row deleted");
+
+        // Native DELETE all.
+        delete_rows(&warehouse, &location, None)
+            .await
+            .expect("delete-all should succeed");
+        assert_eq!(count(&ctx, "orders").await, 0, "delete-all empties the table");
     }
 }

--- a/beacon-file-formats/beacon-lance/src/mutate.rs
+++ b/beacon-file-formats/beacon-lance/src/mutate.rs
@@ -1,0 +1,80 @@
+//! Native row mutations for managed Lance tables (`DELETE` / `UPDATE`).
+//!
+//! Unlike the copy-on-write path (which rewrites the whole table with the
+//! surviving/updated rows), these use Lance's native operations: `delete` marks
+//! rows via deletion vectors, and `UpdateBuilder` rewrites only affected
+//! fragments. Both commit a new dataset version. Predicates and SET values are
+//! SQL strings, which Lance parses against the dataset schema.
+
+use std::sync::Arc;
+
+use lance::dataset::builder::DatasetBuilder;
+use lance::dataset::write::update::UpdateBuilder;
+
+use crate::warehouse::LanceWarehouse;
+
+/// `DELETE FROM t [WHERE predicate]`. `None` deletes every row.
+pub async fn delete_rows(
+    warehouse: &LanceWarehouse,
+    uri: &str,
+    predicate: Option<&str>,
+) -> anyhow::Result<()> {
+    tracing::info!(uri = %uri, predicate = ?predicate, "deleting Lance rows");
+
+    let lock = warehouse.lock(uri);
+    let _guard = lock.lock().await;
+
+    let mut dataset = DatasetBuilder::from_uri(uri)
+        .with_session(warehouse.session())
+        .load()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to open Lance dataset '{uri}': {e}"))?;
+
+    dataset
+        .delete(predicate.unwrap_or("true"))
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to delete rows from '{uri}': {e}"))?;
+    Ok(())
+}
+
+/// `UPDATE t SET <assignments> [WHERE predicate]`. `assignments` are
+/// `(column, value_sql)` pairs; `predicate` `None` updates every row.
+pub async fn update_rows(
+    warehouse: &LanceWarehouse,
+    uri: &str,
+    predicate: Option<&str>,
+    assignments: &[(String, String)],
+) -> anyhow::Result<()> {
+    if assignments.is_empty() {
+        return Ok(());
+    }
+    tracing::info!(uri = %uri, predicate = ?predicate, cols = assignments.len(), "updating Lance rows");
+
+    let lock = warehouse.lock(uri);
+    let _guard = lock.lock().await;
+
+    let dataset = DatasetBuilder::from_uri(uri)
+        .with_session(warehouse.session())
+        .load()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to open Lance dataset '{uri}': {e}"))?;
+
+    let mut builder = UpdateBuilder::new(Arc::new(dataset));
+    if let Some(predicate) = predicate {
+        builder = builder
+            .update_where(predicate)
+            .map_err(|e| anyhow::anyhow!("Invalid UPDATE predicate '{predicate}': {e}"))?;
+    }
+    for (column, value) in assignments {
+        builder = builder
+            .set(column, value)
+            .map_err(|e| anyhow::anyhow!("Invalid SET {column} = {value}: {e}"))?;
+    }
+    let job = builder
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to build Lance update for '{uri}': {e}"))?;
+    job.execute()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to update rows in '{uri}': {e}"))?;
+    Ok(())
+}

--- a/beacon-file-formats/beacon-lance/src/provider.rs
+++ b/beacon-file-formats/beacon-lance/src/provider.rs
@@ -1,0 +1,134 @@
+//! [`LanceTable`]: beacon's `TableProvider` for a managed Lance dataset.
+//!
+//! Mirrors the `IcebergTable` wrapper: it holds its own serializable definition
+//! so beacon's schema-persistence layer can downcast to it and recover the
+//! `table.json`. Reads delegate to Lance's `LanceTableProvider`; the dataset is
+//! reopened at the **latest version** on every scan so prior inserts/replaces are
+//! visible. Writes go through a [`LanceDataSink`] (Lance's provider is read-only).
+
+use std::any::Any;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use arrow::datatypes::SchemaRef;
+use async_trait::async_trait;
+use datafusion::catalog::{Session, TableProvider};
+use datafusion::datasource::sink::DataSinkExec;
+use datafusion::datasource::TableType;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::logical_expr::dml::InsertOp;
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+use datafusion::physical_plan::ExecutionPlan;
+use lance::dataset::Dataset;
+use lance::datafusion::LanceTableProvider;
+
+use crate::definition::LanceTableDefinition;
+use crate::io::WriteKind;
+use crate::sink::LanceDataSink;
+use crate::warehouse::LanceWarehouse;
+
+/// A beacon-managed Lance table provider.
+#[derive(Debug, Clone)]
+pub struct LanceTable {
+    definition: LanceTableDefinition,
+    schema: SchemaRef,
+    /// The runtime-scoped warehouse, used to serialize writes (via the sink).
+    warehouse: Arc<LanceWarehouse>,
+}
+
+impl LanceTable {
+    pub fn new(
+        definition: LanceTableDefinition,
+        schema: SchemaRef,
+        warehouse: Arc<LanceWarehouse>,
+    ) -> Self {
+        Self {
+            definition,
+            schema,
+            warehouse,
+        }
+    }
+
+    /// Open the dataset at the definition's location, caching its Arrow schema.
+    pub async fn open(
+        definition: LanceTableDefinition,
+        warehouse: Arc<LanceWarehouse>,
+    ) -> anyhow::Result<Self> {
+        let provider = open_read_provider(&definition.location)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to open Lance table '{}': {e}", definition.name))?;
+        Ok(Self::new(definition, provider.schema(), warehouse))
+    }
+
+    /// The serializable definition used to persist and rebuild this table.
+    pub fn definition(&self) -> &LanceTableDefinition {
+        &self.definition
+    }
+
+    fn location(&self) -> PathBuf {
+        PathBuf::from(&self.definition.location)
+    }
+}
+
+/// Open the latest dataset version at `location` as a Lance read provider.
+async fn open_read_provider(location: &str) -> DataFusionResult<LanceTableProvider> {
+    let dataset = Dataset::open(location)
+        .await
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+    Ok(LanceTableProvider::new(Arc::new(dataset), false, false))
+}
+
+#[async_trait]
+impl TableProvider for LanceTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        // Reopen to the latest version so scans observe prior inserts/replaces.
+        let provider = open_read_provider(&self.definition.location).await?;
+        provider.scan(state, projection, filters, limit).await
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        // Report Inexact: Lance may use the predicate to prune, and DataFusion
+        // re-applies it for correctness.
+        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+    }
+
+    async fn insert_into(
+        &self,
+        _state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        insert_op: InsertOp,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let kind = match insert_op {
+            InsertOp::Append => WriteKind::Append,
+            InsertOp::Overwrite | InsertOp::Replace => WriteKind::Overwrite,
+        };
+        let sink = Arc::new(LanceDataSink::new(
+            self.location(),
+            self.schema.clone(),
+            kind,
+            self.warehouse.clone(),
+        ));
+        Ok(Arc::new(DataSinkExec::new(input, sink, None)))
+    }
+}

--- a/beacon-file-formats/beacon-lance/src/provider.rs
+++ b/beacon-file-formats/beacon-lance/src/provider.rs
@@ -7,7 +7,6 @@
 //! visible. Writes go through a [`LanceDataSink`] (Lance's provider is read-only).
 
 use std::any::Any;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use arrow::datatypes::SchemaRef;
@@ -19,8 +18,9 @@ use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::logical_expr::dml::InsertOp;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
 use datafusion::physical_plan::ExecutionPlan;
-use lance::dataset::Dataset;
+use lance::dataset::builder::DatasetBuilder;
 use lance::datafusion::LanceTableProvider;
+use lance::session::Session as LanceSession;
 
 use crate::definition::LanceTableDefinition;
 use crate::io::WriteKind;
@@ -54,7 +54,7 @@ impl LanceTable {
         definition: LanceTableDefinition,
         warehouse: Arc<LanceWarehouse>,
     ) -> anyhow::Result<Self> {
-        let provider = open_read_provider(&definition.location)
+        let provider = open_read_provider(&definition.location, warehouse.session())
             .await
             .map_err(|e| anyhow::anyhow!("Failed to open Lance table '{}': {e}", definition.name))?;
         Ok(Self::new(definition, provider.schema(), warehouse))
@@ -64,15 +64,17 @@ impl LanceTable {
     pub fn definition(&self) -> &LanceTableDefinition {
         &self.definition
     }
-
-    fn location(&self) -> PathBuf {
-        PathBuf::from(&self.definition.location)
-    }
 }
 
-/// Open the latest dataset version at `location` as a Lance read provider.
-async fn open_read_provider(location: &str) -> DataFusionResult<LanceTableProvider> {
-    let dataset = Dataset::open(location)
+/// Open the latest dataset version at `uri` (resolved through `session`'s
+/// object-store registry) as a Lance read provider.
+async fn open_read_provider(
+    uri: &str,
+    session: Arc<LanceSession>,
+) -> DataFusionResult<LanceTableProvider> {
+    let dataset = DatasetBuilder::from_uri(uri)
+        .with_session(session)
+        .load()
         .await
         .map_err(|e| DataFusionError::External(Box::new(e)))?;
     Ok(LanceTableProvider::new(Arc::new(dataset), false, false))
@@ -100,7 +102,8 @@ impl TableProvider for LanceTable {
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         // Reopen to the latest version so scans observe prior inserts/replaces.
-        let provider = open_read_provider(&self.definition.location).await?;
+        let provider =
+            open_read_provider(&self.definition.location, self.warehouse.session()).await?;
         provider.scan(state, projection, filters, limit).await
     }
 
@@ -124,7 +127,7 @@ impl TableProvider for LanceTable {
             InsertOp::Overwrite | InsertOp::Replace => WriteKind::Overwrite,
         };
         let sink = Arc::new(LanceDataSink::new(
-            self.location(),
+            self.definition.location.clone(),
             self.schema.clone(),
             kind,
             self.warehouse.clone(),

--- a/beacon-file-formats/beacon-lance/src/sink.rs
+++ b/beacon-file-formats/beacon-lance/src/sink.rs
@@ -16,9 +16,8 @@ use datafusion::error::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_plan::metrics::MetricsSet;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType};
-use futures::TryStreamExt;
 
-use crate::io::{write_batches, WriteKind};
+use crate::io::{write_stream, WriteKind};
 use crate::warehouse::LanceWarehouse;
 
 /// Sink that applies a stream of batches to a single Lance dataset (by URI).
@@ -71,18 +70,12 @@ impl DataSink for LanceDataSink {
         data: SendableRecordBatchStream,
         _context: &Arc<TaskContext>,
     ) -> DataFusionResult<u64> {
-        let batches = data.try_collect::<Vec<_>>().await?;
-        // Serialize writers to this dataset across the (async) write.
+        // Serialize writers to this dataset across the (async) write, then stream
+        // the input directly into Lance — no full-table buffering.
         let lock = self.warehouse.lock(&self.uri);
         let _guard = lock.lock().await;
-        write_batches(
-            &self.uri,
-            self.warehouse.session(),
-            self.schema.clone(),
-            batches,
-            self.kind,
-        )
-        .await
-        .map_err(|e| DataFusionError::External(e.into()))
+        write_stream(&self.uri, self.warehouse.session(), data, self.kind)
+            .await
+            .map_err(|e| DataFusionError::External(e.into()))
     }
 }

--- a/beacon-file-formats/beacon-lance/src/sink.rs
+++ b/beacon-file-formats/beacon-lance/src/sink.rs
@@ -1,0 +1,88 @@
+//! DataFusion [`DataSink`] that writes incoming rows into a Lance dataset.
+//!
+//! Lance's own `LanceTableProvider` is read-oriented, so beacon implements the
+//! write path: `LanceTable::insert_into` returns a `DataSinkExec` wrapping this
+//! sink, which collects the input stream and applies it via [`crate::io`].
+
+use std::any::Any;
+use std::fmt;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use arrow::datatypes::SchemaRef;
+use async_trait::async_trait;
+use datafusion::common::Result as DataFusionResult;
+use datafusion::datasource::sink::DataSink;
+use datafusion::error::DataFusionError;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_plan::metrics::MetricsSet;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType};
+use futures::TryStreamExt;
+
+use crate::io::{write_batches, WriteKind};
+use crate::warehouse::LanceWarehouse;
+
+/// Sink that applies a stream of batches to a single Lance dataset.
+#[derive(Debug)]
+pub struct LanceDataSink {
+    location: PathBuf,
+    schema: SchemaRef,
+    kind: WriteKind,
+    warehouse: Arc<LanceWarehouse>,
+}
+
+impl LanceDataSink {
+    pub fn new(
+        location: PathBuf,
+        schema: SchemaRef,
+        kind: WriteKind,
+        warehouse: Arc<LanceWarehouse>,
+    ) -> Self {
+        Self {
+            location,
+            schema,
+            kind,
+            warehouse,
+        }
+    }
+}
+
+impl DisplayAs for LanceDataSink {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "LanceDataSink(location={}, kind={:?})",
+            self.location.display(),
+            self.kind
+        )
+    }
+}
+
+#[async_trait]
+impl DataSink for LanceDataSink {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        None
+    }
+
+    async fn write_all(
+        &self,
+        data: SendableRecordBatchStream,
+        _context: &Arc<TaskContext>,
+    ) -> DataFusionResult<u64> {
+        let batches = data.try_collect::<Vec<_>>().await?;
+        // Serialize writers to this dataset across the (async) write.
+        let lock = self.warehouse.lock(&self.location);
+        let _guard = lock.lock().await;
+        write_batches(&self.location, self.schema.clone(), batches, self.kind)
+            .await
+            .map_err(|e| DataFusionError::External(e.into()))
+    }
+}

--- a/beacon-file-formats/beacon-lance/src/sink.rs
+++ b/beacon-file-formats/beacon-lance/src/sink.rs
@@ -6,7 +6,6 @@
 
 use std::any::Any;
 use std::fmt;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use arrow::datatypes::SchemaRef;
@@ -22,10 +21,10 @@ use futures::TryStreamExt;
 use crate::io::{write_batches, WriteKind};
 use crate::warehouse::LanceWarehouse;
 
-/// Sink that applies a stream of batches to a single Lance dataset.
+/// Sink that applies a stream of batches to a single Lance dataset (by URI).
 #[derive(Debug)]
 pub struct LanceDataSink {
-    location: PathBuf,
+    uri: String,
     schema: SchemaRef,
     kind: WriteKind,
     warehouse: Arc<LanceWarehouse>,
@@ -33,13 +32,13 @@ pub struct LanceDataSink {
 
 impl LanceDataSink {
     pub fn new(
-        location: PathBuf,
+        uri: String,
         schema: SchemaRef,
         kind: WriteKind,
         warehouse: Arc<LanceWarehouse>,
     ) -> Self {
         Self {
-            location,
+            uri,
             schema,
             kind,
             warehouse,
@@ -49,12 +48,7 @@ impl LanceDataSink {
 
 impl DisplayAs for LanceDataSink {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "LanceDataSink(location={}, kind={:?})",
-            self.location.display(),
-            self.kind
-        )
+        write!(f, "LanceDataSink(uri={}, kind={:?})", self.uri, self.kind)
     }
 }
 
@@ -79,10 +73,16 @@ impl DataSink for LanceDataSink {
     ) -> DataFusionResult<u64> {
         let batches = data.try_collect::<Vec<_>>().await?;
         // Serialize writers to this dataset across the (async) write.
-        let lock = self.warehouse.lock(&self.location);
+        let lock = self.warehouse.lock(&self.uri);
         let _guard = lock.lock().await;
-        write_batches(&self.location, self.schema.clone(), batches, self.kind)
-            .await
-            .map_err(|e| DataFusionError::External(e.into()))
+        write_batches(
+            &self.uri,
+            self.warehouse.session(),
+            self.schema.clone(),
+            batches,
+            self.kind,
+        )
+        .await
+        .map_err(|e| DataFusionError::External(e.into()))
     }
 }

--- a/beacon-file-formats/beacon-lance/src/warehouse.rs
+++ b/beacon-file-formats/beacon-lance/src/warehouse.rs
@@ -1,0 +1,83 @@
+//! Local-filesystem warehouse for beacon-managed Lance tables.
+//!
+//! Unlike Iceberg, Lance has no external catalog: a Lance dataset *is* a
+//! directory on disk, so the path is the source of truth. The
+//! [`LanceTableDefinition`](crate::definition::LanceTableDefinition) persists the
+//! absolute table location so discovery can reopen the dataset directly.
+//!
+//! The warehouse is **runtime-scoped**, not a process global: the runtime builds
+//! a [`LanceWarehouse`] from its configured tables directory and threads it
+//! through the session as an extension. This keeps multiple runtimes in one
+//! process (e.g. tests) isolated — each has its own root and write-lock map.
+//!
+//! Managed Lance tables are **local only** by design: they use raw filesystem
+//! paths and never go through beacon's object-store abstraction.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tokio::sync::Mutex as AsyncMutex;
+
+/// The single namespace beacon creates managed tables under (kept parallel to
+/// the Iceberg integration so table layouts are predictable).
+pub const BEACON_NAMESPACE: &str = "beacon";
+
+/// The namespace beacon uses, in the `Vec<String>` form the rest of the crate
+/// expects (mirrors `beacon_iceberg::beacon_namespace`).
+pub fn beacon_namespace() -> Vec<String> {
+    vec![BEACON_NAMESPACE.to_string()]
+}
+
+/// Lance opens datasets by URI string; a local path is its own URI.
+pub fn location_uri(location: &Path) -> String {
+    location.to_string_lossy().to_string()
+}
+
+/// A runtime-scoped Lance warehouse: the local root directory under which managed
+/// tables live, plus per-location write locks.
+///
+/// Lance's atomic, versioned commits already give readers a consistent snapshot
+/// with no torn reads; the per-location lock additionally serializes concurrent
+/// *writers* to the same dataset so they don't race on commit.
+#[derive(Debug)]
+pub struct LanceWarehouse {
+    root: PathBuf,
+    locks: Mutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>,
+}
+
+impl LanceWarehouse {
+    /// Build a warehouse rooted at `root` (e.g. `<tables_dir>/lance`).
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            locks: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// The warehouse root directory.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Absolute on-disk location of a managed table:
+    /// `<root>/<namespace>/<name>.lance`.
+    pub fn table_location(&self, namespace: &[String], name: &str) -> PathBuf {
+        let mut path = self.root.clone();
+        for part in namespace {
+            path.push(part);
+        }
+        path.push(format!("{name}.lance"));
+        path
+    }
+
+    /// The write lock guarding a given table location (created on first use).
+    pub fn lock(&self, location: &Path) -> Arc<AsyncMutex<()>> {
+        let mut locks = self.locks.lock();
+        locks
+            .entry(location.to_path_buf())
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone()
+    }
+}

--- a/beacon-file-formats/beacon-lance/src/warehouse.rs
+++ b/beacon-file-formats/beacon-lance/src/warehouse.rs
@@ -1,28 +1,41 @@
-//! Local-filesystem warehouse for beacon-managed Lance tables.
+//! Runtime-scoped Lance warehouse, backed by beacon's tables object store.
 //!
-//! Unlike Iceberg, Lance has no external catalog: a Lance dataset *is* a
-//! directory on disk, so the path is the source of truth. The
-//! [`LanceTableDefinition`](crate::definition::LanceTableDefinition) persists the
-//! absolute table location so discovery can reopen the dataset directly.
+//! Rather than raw filesystem paths, managed Lance datasets are read/written
+//! through the same `object_store` instance beacon uses for the tables store. We
+//! do this with Lance's [`ObjectStoreProvider`]/[`ObjectStoreRegistry`]: a
+//! provider that hands Lance our store for a custom `beacon-tables://` scheme is
+//! registered in a registry, which travels to Lance through a [`Session`]. Reads
+//! (`DatasetBuilder::with_session`) and writes (`WriteParams.session`) both pull
+//! the registry from that session.
 //!
-//! The warehouse is **runtime-scoped**, not a process global: the runtime builds
-//! a [`LanceWarehouse`] from its configured tables directory and threads it
-//! through the session as an extension. This keeps multiple runtimes in one
-//! process (e.g. tests) isolated — each has its own root and write-lock map.
-//!
-//! Managed Lance tables are **local only** by design: they use raw filesystem
-//! paths and never go through beacon's object-store abstraction.
+//! The warehouse is **runtime-scoped** (built per `Runtime`, threaded through the
+//! session as an extension), so multiple runtimes stay isolated. Beacon always
+//! backs the tables store with a local filesystem, so this stays local in
+//! practice — the abstraction just keeps Lance consistent with the rest of beacon.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use lance::session::Session;
+use lance_core::Result as LanceResult;
+use lance_io::object_store::{
+    ObjectStore, ObjectStoreParams, ObjectStoreProvider, ObjectStoreRegistry,
+};
+use object_store::DynObjectStore;
 use parking_lot::Mutex;
 use tokio::sync::Mutex as AsyncMutex;
+use url::Url;
 
 /// The single namespace beacon creates managed tables under (kept parallel to
 /// the Iceberg integration so table layouts are predictable).
 pub const BEACON_NAMESPACE: &str = "beacon";
+
+/// Custom URI scheme used to route managed Lance datasets through beacon's tables
+/// object store via the registered [`BeaconTablesProvider`].
+const SCHEME: &str = "beacon-tables";
+
+/// Sub-prefix within the tables store under which managed Lance datasets live.
+const PREFIX: &str = "lance";
 
 /// The namespace beacon uses, in the `Vec<String>` form the rest of the crate
 /// expects (mirrors `beacon_iceberg::beacon_namespace`).
@@ -30,53 +43,111 @@ pub fn beacon_namespace() -> Vec<String> {
     vec![BEACON_NAMESPACE.to_string()]
 }
 
-/// Lance opens datasets by URI string; a local path is its own URI.
-pub fn location_uri(location: &Path) -> String {
-    location.to_string_lossy().to_string()
+/// A Lance object-store provider that hands Lance beacon's tables store for the
+/// `beacon-tables://` scheme.
+#[derive(Debug)]
+struct BeaconTablesProvider {
+    inner: Arc<DynObjectStore>,
 }
 
-/// A runtime-scoped Lance warehouse: the local root directory under which managed
-/// tables live, plus per-location write locks.
-///
-/// Lance's atomic, versioned commits already give readers a consistent snapshot
-/// with no torn reads; the per-location lock additionally serializes concurrent
-/// *writers* to the same dataset so they don't race on commit.
+#[async_trait::async_trait]
+impl ObjectStoreProvider for BeaconTablesProvider {
+    async fn new_store(
+        &self,
+        base_path: Url,
+        _params: &ObjectStoreParams,
+    ) -> LanceResult<ObjectStore> {
+        let parallelism = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(8);
+        Ok(ObjectStore::new(
+            self.inner.clone(),
+            base_path,
+            None,  // block_size
+            None,  // wrapper
+            false, // use_constant_size_upload_parts
+            false, // list_is_lexically_ordered (local FS isn't; let Lance sort)
+            parallelism,
+            3, // download_retry_count
+            None,
+        ))
+    }
+
+    /// Give each dataset its own registry/cache entry (and thus an `ObjectStore`
+    /// with the correct base path), rather than sharing one keyed only by scheme.
+    fn calculate_object_store_prefix(
+        &self,
+        url: &Url,
+        _storage_options: Option<&HashMap<String, String>>,
+    ) -> LanceResult<String> {
+        Ok(format!("{}${}{}", url.scheme(), url.authority(), url.path()))
+    }
+}
+
+/// A runtime-scoped Lance warehouse over beacon's tables object store.
 #[derive(Debug)]
 pub struct LanceWarehouse {
-    root: PathBuf,
-    locks: Mutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>,
+    /// The tables object store (used directly for `DROP` cleanup).
+    store: Arc<DynObjectStore>,
+    /// Lance session carrying the registry that resolves `beacon-tables://`.
+    session: Arc<Session>,
+    /// Per-dataset write locks, keyed by dataset URI.
+    locks: Mutex<HashMap<String, Arc<AsyncMutex<()>>>>,
 }
 
 impl LanceWarehouse {
-    /// Build a warehouse rooted at `root` (e.g. `<tables_dir>/lance`).
-    pub fn new(root: impl Into<PathBuf>) -> Self {
+    /// Build a warehouse over `store` (beacon's tables object store).
+    pub fn new(store: Arc<DynObjectStore>) -> Self {
+        let registry = ObjectStoreRegistry::default();
+        registry.insert(
+            SCHEME,
+            Arc::new(BeaconTablesProvider {
+                inner: store.clone(),
+            }),
+        );
+        // Cache sizes mirror Lance's classic entry-count defaults; they affect
+        // only caching, not correctness.
+        let session = Arc::new(Session::new(128, 128, Arc::new(registry)));
         Self {
-            root: root.into(),
+            store,
+            session,
             locks: Mutex::new(HashMap::new()),
         }
     }
 
-    /// The warehouse root directory.
-    pub fn root(&self) -> &Path {
-        &self.root
+    /// The Lance session (carries the object-store registry) for open/write.
+    pub fn session(&self) -> Arc<Session> {
+        self.session.clone()
     }
 
-    /// Absolute on-disk location of a managed table:
-    /// `<root>/<namespace>/<name>.lance`.
-    pub fn table_location(&self, namespace: &[String], name: &str) -> PathBuf {
-        let mut path = self.root.clone();
-        for part in namespace {
-            path.push(part);
-        }
-        path.push(format!("{name}.lance"));
-        path
+    /// The tables object store, for `DROP` cleanup.
+    pub fn store(&self) -> &Arc<DynObjectStore> {
+        &self.store
     }
 
-    /// The write lock guarding a given table location (created on first use).
-    pub fn lock(&self, location: &Path) -> Arc<AsyncMutex<()>> {
+    /// The `beacon-tables://` URI of a managed table:
+    /// `beacon-tables:///lance/<namespace>/<name>.lance`.
+    pub fn table_uri(&self, namespace: &[String], name: &str) -> String {
+        let ns = namespace.join("/");
+        format!("{SCHEME}:///{PREFIX}/{ns}/{name}.lance")
+    }
+
+    /// The object-store key prefix for a table URI (everything after the scheme
+    /// authority), used to enumerate a dataset's objects on `DROP`.
+    pub fn object_path(uri: &str) -> object_store::path::Path {
+        let parsed = Url::parse(uri).ok();
+        let path = parsed
+            .as_ref()
+            .map(|u| u.path().trim_start_matches('/').to_string())
+            .unwrap_or_default();
+        object_store::path::Path::from(path)
+    }
+
+    /// The write lock guarding a given dataset URI (created on first use).
+    pub fn lock(&self, uri: &str) -> Arc<AsyncMutex<()>> {
         let mut locks = self.locks.lock();
         locks
-            .entry(location.to_path_buf())
+            .entry(uri.to_string())
             .or_insert_with(|| Arc::new(AsyncMutex::new(())))
             .clone()
     }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -381,11 +381,13 @@ export default defineConfig({
                   link: '/docs/1.7.3/sql/managed-tables',
                   collapsed: true,
                   items: [
+                    { text: 'Storage engine', link: '/docs/1.7.3/sql/managed-tables#choosing-the-storage-engine' },
                     { text: 'CREATE TABLE AS SELECT', link: '/docs/1.7.3/sql/managed-tables#create-table-as-select' },
                     { text: 'INSERT INTO', link: '/docs/1.7.3/sql/managed-tables#insert-into' },
                     { text: 'DELETE', link: '/docs/1.7.3/sql/managed-tables#delete' },
                     { text: 'UPDATE', link: '/docs/1.7.3/sql/managed-tables#update' },
                     { text: 'ALTER TABLE', link: '/docs/1.7.3/sql/managed-tables#alter-table' },
+                    { text: 'Indexes', link: '/docs/1.7.3/sql/managed-tables#indexes' },
                     { text: 'DROP TABLE', link: '/docs/1.7.3/sql/managed-tables#drop-table' },
                   ]
                 },

--- a/docs/docs/1.7.3/data-lake/configuration.md
+++ b/docs/docs/1.7.3/data-lake/configuration.md
@@ -52,6 +52,7 @@ rejected rather than writing plaintext.
 | `BEACON_ENABLE_SQL` | `true` | Enable the raw SQL query interface. Set to `false` to disable it (the JSON query API stays available). |
 | `BEACON_VM_MEMORY_SIZE` | `8192` | Working memory (MB) available to the query engine. More is better for larger datasets and memory-heavy operations such as spatial joins and `GROUP BY`. |
 | `BEACON_DEFAULT_TABLE` | `default` | Table queried when a request omits the source. Only applies to the JSON query API — SQL queries must always specify a source. |
+| `BEACON_DEFAULT_TABLE_ENGINE` | `lance` | Storage engine for [managed tables](../sql/managed-tables.md) created with `CREATE TABLE`: `lance` (local, supports indexes) or `iceberg` (object-store). Can be overridden per session with `SET beacon.table_engine = '…'`. |
 | `BEACON_ENABLE_PUSHDOWN_PROJECTION` | `true` | Push column projection down into file readers so only requested columns are decoded. |
 | `BEACON_SANITIZE_SCHEMA` | `false` | Sanitize dataset schemas (normalize column names/types) during discovery. |
 | `BEACON_ST_WITHIN_POINT_CACHE_SIZE` | `10000` | Cache size for `st_within_point` geometry lookups. |

--- a/docs/docs/1.7.3/introduction.md
+++ b/docs/docs/1.7.3/introduction.md
@@ -94,7 +94,7 @@ A few terms used throughout the docs:
 - **[Dataset](/docs/1.7.3/data-lake/datasets)** — an individual file Beacon reads in place (NetCDF, Zarr, Parquet, …).
 - **[External table](/docs/1.7.3/data-lake/external-tables)** — a registered name over one or more files (a folder or glob pattern), with a merged schema across them.
 - **[View](/docs/1.7.3/data-lake/view)** — a saved query exposed as a table.
-- **[Managed table](/docs/1.7.3/sql/managed-tables)** — an Iceberg-backed table Beacon owns and can mutate (`INSERT` / `UPDATE` / `DELETE`).
+- **[Managed table](/docs/1.7.3/sql/managed-tables)** — a table Beacon owns and can mutate (`INSERT` / `UPDATE` / `DELETE` / `ALTER` / `CREATE INDEX`), backed by Lance (default) or Iceberg.
 
 ## Next steps
 

--- a/docs/docs/1.7.3/sql/managed-tables.md
+++ b/docs/docs/1.7.3/sql/managed-tables.md
@@ -6,9 +6,35 @@ INSERT INTO observations VALUES (1, 'a'), (2, 'b');
 SELECT * FROM observations;
 ```
 
-A **managed table** is a SQL table whose data Beacon owns and stores itself, backed by [Apache Iceberg](https://iceberg.apache.org/). Unlike an [external table](../data-lake/external-tables.md) — which only points at existing files — a managed table is created empty (or from a query) and populated with `INSERT`. It supports `UPDATE`, `DELETE`, and schema evolution with `ALTER TABLE`, and its data lives inside Beacon's storage. Table definitions and data survive restarts.
+A **managed table** is a SQL table whose data Beacon owns and stores itself. Unlike an [external table](../data-lake/external-tables.md) — which only points at existing files — a managed table is created empty (or from a query) and populated with `INSERT`. It supports `UPDATE`, `DELETE`, schema evolution with `ALTER TABLE`, and secondary `INDEX`es. Table definitions and data survive restarts.
 
-Managed tables are an authenticated, write capability: `CREATE`, `INSERT`, `UPDATE`, `DELETE`, and `ALTER` require admin credentials. Anonymous access remains read-only.
+Managed tables are an authenticated, write capability: `CREATE`, `INSERT`, `UPDATE`, `DELETE`, `ALTER`, and `CREATE/DROP INDEX` require admin credentials. Anonymous access remains read-only.
+
+## Choosing the storage engine
+
+Managed tables can be backed by one of two engines:
+
+| Engine | Best for | Storage | Updates/Deletes | Indexes |
+| --- | --- | --- | --- | --- |
+| **Lance** *(default)* | fast local CRUD, secondary indexes | local filesystem (tables directory) | native — deletion vectors / fragment rewrite | ✅ scalar (btree, bitmap, full‑text) |
+| **Iceberg** | object‑store / cloud deployments | object store (alongside datasets, local or S3) | copy‑on‑write | ❌ |
+
+The engine is chosen **when the table is created** and recorded with the table; later `INSERT`/`UPDATE`/`DELETE`/`ALTER` automatically use the right engine.
+
+The default is **Lance**. Override it per session before creating a table:
+
+```sql
+SET beacon.table_engine = 'iceberg';
+CREATE TABLE archived (id BIGINT, name VARCHAR);   -- Iceberg-backed
+
+SET beacon.table_engine = 'lance';                 -- back to the default
+```
+
+Or change the deployment-wide default with the `BEACON_DEFAULT_TABLE_ENGINE` environment variable (`lance` or `iceberg`).
+
+::: tip
+Lance managed tables live on the **local filesystem** (the tables directory), even when your datasets are on S3. If you run Beacon with an S3 data lake and want managed tables on object storage, use the Iceberg engine.
+:::
 
 ## `CREATE TABLE`
 
@@ -68,6 +94,8 @@ DELETE FROM measurements WHERE value IS NULL;
 DELETE FROM measurements;        -- empties the table
 ```
 
+On **Lance** tables this is a native delete (deletion vectors) — it does not rewrite the whole table. On **Iceberg** tables it is copy-on-write.
+
 ## `UPDATE`
 
 Change column values for matching rows; unmatched rows are untouched:
@@ -78,7 +106,7 @@ UPDATE measurements SET name = 'unknown' WHERE name IS NULL;
 UPDATE measurements SET value = value * 1.0;   -- every row
 ```
 
-`UPDATE ... FROM` / joins are not supported.
+On **Lance** tables this rewrites only the affected fragments; on **Iceberg** it is copy-on-write. `UPDATE ... FROM` / joins are not supported.
 
 ## `ALTER TABLE`
 
@@ -98,7 +126,39 @@ ALTER TABLE measurements DROP COLUMN quality_flag;
 ALTER TABLE measurements ALTER COLUMN id TYPE BIGINT;
 ```
 
-Only safe type promotions are allowed: `INT → BIGINT`, `FLOAT → DOUBLE`, and decimal precision increases at the same scale. Narrowing or incompatible changes are rejected.
+On **Lance** tables schema changes are applied natively (no table rebuild). On **Iceberg** tables, only safe type promotions are allowed: `INT → BIGINT`, `FLOAT → DOUBLE`, and decimal precision increases at the same scale; narrowing or incompatible changes are rejected.
+
+## Indexes
+
+::: info Lance engine only
+Secondary indexes are a feature of the **Lance** engine. They are not available on Iceberg-backed tables.
+:::
+
+Create a scalar index on a column to speed up filters. Once created, queries use it automatically — no query changes are needed.
+
+```sql
+-- Default (BTREE) index; auto-named <table>_<column>_idx
+CREATE INDEX ON measurements (platform);
+
+-- Named index, explicit type
+CREATE INDEX value_idx  ON measurements (value)        USING btree;
+CREATE INDEX flag_idx   ON measurements (quality_flag) USING bitmap;
+CREATE INDEX name_idx   ON measurements (name)         USING inverted;
+```
+
+| Type | Use for |
+| --- | --- |
+| `btree` *(default)* | range / equality filters (`=`, `<`, `BETWEEN`, …) |
+| `bitmap` | low-cardinality columns (few distinct values) |
+| `inverted` | full-text search over string columns |
+
+List a table's indexes, or drop one by name:
+
+```sql
+SHOW INDEXES ON measurements;
+
+DROP INDEX value_idx ON measurements;
+```
 
 ## `DROP TABLE`
 
@@ -112,9 +172,10 @@ DROP TABLE IF EXISTS measurements;
 
 ## Notes & limitations
 
-- **Storage**: data and metadata live in Beacon's internal area of the configured storage (local filesystem or S3), alongside the datasets — there is nothing extra to configure.
-- **Write model**: `DELETE` and `UPDATE` are copy-on-write (the affected data is rewritten), and `ALTER TABLE` rebuilds the table under the new schema. These operations rewrite table data and do not preserve previous Iceberg snapshots, so they are best suited to moderate-sized tables and occasional schema changes rather than high-frequency row churn.
-- **Scope**: `ALTER` supports single-table `ADD` / `DROP` / `RENAME COLUMN` and `ALTER COLUMN TYPE`; added columns are nullable.
+- **Storage**: Lance tables live on the local filesystem (the tables directory); Iceberg tables live in Beacon's internal storage area alongside the datasets (local or S3). There is nothing extra to configure.
+- **Lance write model**: `INSERT` streams directly into the table; `DELETE`/`UPDATE` are native (deletion vectors / fragment rewrite); `ALTER` is applied without a rebuild. Each write commits a new dataset version, and readers always see a consistent snapshot.
+- **Iceberg write model**: `DELETE`/`UPDATE` are copy-on-write and `ALTER` rebuilds the table; best suited to moderate-sized tables and occasional schema changes rather than high-frequency row churn.
+- **Scope**: `ALTER` supports single-table `ADD` / `DROP` / `RENAME COLUMN` and `ALTER COLUMN TYPE`; added columns are nullable. Indexes are scalar only (vector/ANN indexes are not yet exposed).
 
 ## Querying and inspecting
 
@@ -122,4 +183,6 @@ DROP TABLE IF EXISTS measurements;
 SHOW TABLES;
 
 DESCRIBE measurements;
+
+SHOW INDEXES ON measurements;   -- Lance tables
 ```


### PR DESCRIPTION
Adds **`beacon-lance`**, a local-filesystem, columnar, transactionally-versioned engine for managed `CREATE TABLE`, and makes it the **default** managed-table engine. Iceberg remains selectable. This gives admins real read/write/update/delete plus schema evolution and **secondary indexes**

**Engine selection**
- `BEACON_DEFAULT_TABLE_ENGINE` (default `lance`) on `Config.sql`
- per-session override: `SET beacon.table_engine = 'lance'|'iceberg'` (DataFusion `ConfigExtension`)

**CRUD + DDL on Lance tables**
- Read via `LanceTableProvider` — the provider reopens the dataset at its latest version on every scan, so reads are snapshot-consistent with no torn reads
- `INSERT` via a custom `LanceDataSink`
- `DELETE` / `UPDATE` via atomic overwrite of the surviving rows
- `ALTER TABLE` via Lance's native `add_columns` / `drop_columns` / `alter_columns` (no table rebuild, unlike the Iceberg path)
- `DROP TABLE`

**Indexing (Lance-only)**
- `CREATE INDEX [name] ON <table> (<column>) [USING btree|bitmap|inverted]`
- `DROP INDEX <name> ON <table>`
- `SHOW INDEXES ON <table>`
- Scalar indexes only for now; vector ANN deferred
