### PR TITLE
Reduce dependencies and tune build for compile time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,17 +28,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if 1.0.4",
- "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,7 +44,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "const-random",
  "getrandom 0.3.4",
  "once_cell",
@@ -118,54 +107,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "anyhow"
@@ -1177,49 +1122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "aws-config"
-version = "1.8.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
- "aws-sdk-sts",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-schema",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "hex",
- "http 1.4.1",
- "sha1 0.10.6",
- "time",
- "tokio",
- "tracing",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "aws-credential-types"
-version = "1.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "zeroize",
-]
-
-[[package]]
 name = "aws-lc-rs"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,328 +1144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-runtime"
-version = "1.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
-dependencies = [
- "aws-credential-types",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "bytes-utils",
- "fastrand",
- "http 1.4.1",
- "http-body 1.0.1",
- "percent-encoding",
- "pin-project-lite",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "1.102.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c82b3ac19f1431854f7ace3a7531674633e286bfdde21976893bfee36fd493b"
-dependencies = [
- "arc-swap",
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.1",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.104.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321000d2b4c5519ee573f73167f612efd7329322d9b26969ad1979f0427f1913"
-dependencies = [
- "arc-swap",
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.1",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sts"
-version = "1.107.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560"
-dependencies = [
- "arc-swap",
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-query",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
- "fastrand",
- "http 0.2.12",
- "http 1.4.1",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "form_urlencoded",
- "hex",
- "hmac 0.13.0",
- "http 0.2.12",
- "http 1.4.1",
- "percent-encoding",
- "sha2 0.11.0",
- "time",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-async"
-version = "1.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.63.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
- "http-body-util",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http-client"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "h2",
- "http 1.4.1",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "pin-project-lite",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.62.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-schema",
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-observability"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
-dependencies = [
- "aws-smithy-runtime-api",
-]
-
-[[package]]
-name = "aws-smithy-query"
-version = "0.60.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
-dependencies = [
- "aws-smithy-types",
- "urlencoding",
-]
-
-[[package]]
-name = "aws-smithy-runtime"
-version = "1.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-http-client",
- "aws-smithy-observability",
- "aws-smithy-runtime-api",
- "aws-smithy-schema",
- "aws-smithy-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.1",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "http-body-util",
- "pin-project-lite",
- "pin-utils",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api-macros",
- "aws-smithy-types",
- "bytes",
- "http 0.2.12",
- "http 1.4.1",
- "pin-project-lite",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "aws-smithy-schema"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "http 1.4.1",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
-dependencies = [
- "base64-simd",
- "bytes",
- "bytes-utils",
- "http 0.2.12",
- "http 1.4.1",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "num-integer",
- "pin-project-lite",
- "pin-utils",
- "ryu",
- "serde",
- "time",
-]
-
-[[package]]
-name = "aws-smithy-xml"
-version = "0.60.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
-dependencies = [
- "xmlparser",
-]
-
-[[package]]
-name = "aws-types"
-version = "1.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-schema",
- "aws-smithy-types",
- "rustc_version",
- "tracing",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,8 +1154,8 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -1590,7 +1170,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1 0.10.6",
+ "sha1",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -1608,8 +1188,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -1629,20 +1209,9 @@ dependencies = [
  "axum",
  "bytes",
  "futures",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "tokio-stream",
-]
-
-[[package]]
-name = "backon"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
-dependencies = [
- "fastrand",
- "gloo-timers",
- "tokio",
 ]
 
 [[package]]
@@ -1652,7 +1221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -1665,22 +1234,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
-dependencies = [
- "outref",
- "vsimd",
-]
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bb8"
@@ -1720,7 +1273,6 @@ dependencies = [
  "beacon-core",
  "bytes",
  "futures",
- "futures-util",
  "pprof",
  "prost",
  "serde",
@@ -1850,7 +1402,6 @@ version = "1.7.3"
 dependencies = [
  "anyhow",
  "arrow 58.3.0",
- "arrow-schema 58.3.0",
  "async-trait",
  "beacon-common",
  "beacon-config",
@@ -1871,11 +1422,8 @@ dependencies = [
  "num-traits",
  "object_store 0.13.2",
  "ordered-float 5.3.0",
- "regex",
  "serde",
- "serde_json",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1894,14 +1442,10 @@ dependencies = [
  "csv",
  "datafusion",
  "futures",
- "futures-util",
  "indexmap 2.14.0",
- "lz4_flex 0.11.6",
  "object_store 0.13.2",
- "quick-xml 0.37.5",
  "regex",
  "serde",
- "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1910,7 +1454,6 @@ dependencies = [
  "utoipa",
  "walkdir",
  "zip 2.4.2",
- "zstd",
 ]
 
 [[package]]
@@ -1937,7 +1480,6 @@ dependencies = [
  "async-tiff",
  "async-trait",
  "beacon-common",
- "beacon-config",
  "beacon-datafusion-ext",
  "beacon-nd-array",
  "beacon-object-storage",
@@ -1962,15 +1504,12 @@ dependencies = [
  "beacon-common",
  "beacon-datafusion-ext",
  "beacon-nd-array",
- "crossbeam",
  "datafusion",
  "futures",
  "hifitime",
  "indexmap 2.14.0",
  "ndarray 0.17.2",
  "object_store 0.13.2",
- "parking_lot",
- "regex",
  "serde_json",
  "tempfile",
  "tokio",
@@ -2020,19 +1559,14 @@ dependencies = [
 name = "beacon-common"
 version = "1.7.3"
 dependencies = [
- "anyhow",
  "arrow 58.3.0",
- "async-stream",
  "async-trait",
- "chrono",
  "datafusion",
  "futures",
- "futures-util",
  "glob",
  "hifitime",
  "indexmap 2.14.0",
  "julian",
- "object_store 0.13.2",
  "regex",
  "rlimit",
  "thiserror 2.0.18",
@@ -2073,7 +1607,6 @@ dependencies = [
  "beacon-arrow-parquet",
  "beacon-arrow-tiff",
  "beacon-arrow-zarr",
- "beacon-common",
  "beacon-config",
  "beacon-data-lake",
  "beacon-datafusion-ext",
@@ -2081,32 +1614,24 @@ dependencies = [
  "beacon-functions",
  "beacon-iceberg",
  "beacon-lance",
- "beacon-nd-array",
  "beacon-object-storage",
  "beacon-sql-databases",
- "bytes",
  "cast",
  "chrono",
  "datafusion",
  "datafusion-federation",
  "deltalake",
  "futures",
- "futures-util",
  "geodatafusion",
  "geojson",
- "glob",
- "indexmap 2.14.0",
- "inventory",
  "object_store 0.13.2",
  "parking_lot",
- "pathdiff",
  "serde",
  "serde_json",
- "sysinfo 0.35.2",
+ "sysinfo",
  "tempfile",
  "tokio",
  "tracing",
- "typetag",
  "url",
  "utoipa",
  "uuid",
@@ -2156,7 +1681,6 @@ dependencies = [
  "anyhow",
  "arrow 58.3.0",
  "arrow-flight",
- "arrow-schema 58.3.0",
  "async-trait",
  "beacon-common",
  "beacon-object-storage",
@@ -2185,7 +1709,6 @@ dependencies = [
  "arrow 58.3.0",
  "async-trait",
  "beacon-common",
- "beacon-config",
  "beacon-datafusion-ext",
  "beacon-object-storage",
  "datafusion",
@@ -2196,7 +1719,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "tracing",
  "typetag",
  "url",
 ]
@@ -2218,7 +1740,6 @@ dependencies = [
  "beacon-arrow-tiff",
  "beacon-arrow-zarr",
  "beacon-common",
- "beacon-config",
  "beacon-datafusion-ext",
  "beacon-delta",
  "beacon-object-storage",
@@ -2229,7 +1750,6 @@ dependencies = [
  "geo",
  "geojson",
  "gsw",
- "inventory",
  "lazy_static",
  "lru 0.14.0",
  "object_store 0.13.2",
@@ -2249,7 +1769,6 @@ version = "1.7.3"
 dependencies = [
  "anyhow",
  "arrow 58.3.0",
- "arrow-schema 58.3.0",
  "async-trait",
  "beacon-config",
  "beacon-datafusion-ext",
@@ -2260,12 +1779,9 @@ dependencies = [
  "iceberg-file-catalog",
  "iceberg-rust",
  "object_store 0.13.2",
- "once_cell",
- "parking_lot",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
  "typetag",
@@ -2277,11 +1793,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrow 58.3.0",
- "arrow-schema 58.3.0",
  "async-trait",
- "beacon-config",
  "beacon-datafusion-ext",
- "beacon-object-storage",
  "datafusion",
  "futures",
  "lance",
@@ -2289,12 +1802,10 @@ dependencies = [
  "lance-index",
  "lance-io",
  "object_store 0.13.2",
- "once_cell",
  "parking_lot",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
  "typetag",
@@ -2308,20 +1819,16 @@ dependencies = [
  "anyhow",
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
- "arrow-schema 58.3.0",
  "async-trait",
  "bytemuck",
- "chrono",
  "criterion 0.5.1",
  "datafusion",
  "futures",
  "indexmap 2.14.0",
  "ndarray 0.17.2",
- "pin-project",
  "rand 0.8.6",
  "rkyv 0.8.10",
  "serde",
- "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2342,10 +1849,7 @@ dependencies = [
  "criterion 0.5.1",
  "futures",
  "ndarray 0.17.2",
- "pin-project",
  "rand 0.8.6",
- "serde",
- "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2357,24 +1861,18 @@ name = "beacon-object-storage"
 version = "1.7.3"
 dependencies = [
  "async-trait",
- "bumpalo",
  "chrono",
  "flume",
  "futures",
  "notify",
  "object_store 0.13.2",
- "once_cell",
  "parking_lot",
  "radix_trie",
- "serde",
- "serde_json",
  "smol_str",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-test",
- "walkdir",
 ]
 
 [[package]]
@@ -2385,20 +1883,16 @@ dependencies = [
  "arrow 58.3.0",
  "async-trait",
  "base64",
- "beacon-common",
  "beacon-config",
  "beacon-datafusion-ext",
  "chacha20poly1305",
  "datafusion",
  "datafusion-federation",
  "datafusion-table-providers",
- "futures",
  "secrecy",
  "serde",
  "serde_json",
  "tempfile",
- "tokio",
- "tracing",
  "typetag",
 ]
 
@@ -2467,7 +1961,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if 1.0.4",
+ "cfg-if",
  "constant_time_eq",
  "cpufeatures 0.3.0",
 ]
@@ -2488,15 +1982,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2593,17 +2078,6 @@ checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
-]
-
-[[package]]
-name = "bstr"
-version = "1.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e308e67087593070530a666f7fe8815cbd2e61d8f5b7313b71b7d721d1dfde"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde_core",
 ]
 
 [[package]]
@@ -2743,16 +2217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "bytes-utils"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
-dependencies = [
- "bytes",
- "either",
-]
-
-[[package]]
 name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,15 +2232,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,12 +2242,6 @@ dependencies = [
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -2812,7 +2261,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "cipher",
  "cpufeatures 0.2.17",
 ]
@@ -2823,7 +2272,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
@@ -2922,7 +2371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
- "clap_derive",
 ]
 
 [[package]]
@@ -2931,22 +2379,8 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
  "anstyle",
  "clap_lex 1.1.0",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2978,21 +2412,6 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "colored"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "combine"
@@ -3047,12 +2466,6 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -3075,21 +2488,6 @@ dependencies = [
  "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
-]
-
-[[package]]
-name = "const-str"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
-
-[[package]]
-name = "const_panic"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
-dependencies = [
- "typewit",
 ]
 
 [[package]]
@@ -3143,21 +2541,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "countio"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9702aee5d1d744c01d82f6915644f950f898e014903385464c773b96fefdecb"
-dependencies = [
- "futures-io",
-]
-
-[[package]]
 name = "cpp_demangle"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
 ]
 
 [[package]]
@@ -3208,7 +2597,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
 ]
 
 [[package]]
@@ -3395,30 +2784,14 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
-dependencies = [
- "ctor-proc-macro 0.0.7",
- "dtor 0.1.1",
-]
-
-[[package]]
-name = "ctor"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
 dependencies = [
- "ctor-proc-macro 0.0.13",
- "dtor 0.8.1",
+ "ctor-proc-macro",
+ "dtor",
  "link-section",
 ]
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "ctor-proc-macro"
@@ -3510,7 +2883,7 @@ version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
@@ -4382,7 +3755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2695b91fd02afd5b4726a190fd58019674492d824e30598391390b0307644da8"
 dependencies = [
  "buoyant_kernel",
- "ctor 0.10.1",
+ "ctor",
  "deltalake-core",
 ]
 
@@ -4406,7 +3779,7 @@ dependencies = [
  "async-trait",
  "buoyant_kernel",
  "bytes",
- "cfg-if 1.0.4",
+ "cfg-if",
  "chrono",
  "dashmap",
  "datafusion",
@@ -4451,17 +3824,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468",
- "zeroize",
 ]
 
 [[package]]
@@ -4557,7 +3919,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -4569,7 +3930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -4607,37 +3968,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
-
-[[package]]
-name = "dtor"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
-dependencies = [
- "dtor-proc-macro 0.0.6",
-]
-
-[[package]]
 name = "dtor"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
 dependencies = [
- "dtor-proc-macro 0.0.13",
+ "dtor-proc-macro",
 ]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dtor-proc-macro"
@@ -4673,7 +4010,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
 ]
 
 [[package]]
@@ -4811,16 +4148,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "filetime"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
-dependencies = [
- "cfg-if 1.0.4",
- "libc",
-]
 
 [[package]]
 name = "find-msvc-tools"
@@ -5085,22 +4412,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "gearhash"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cf82cf76cd16485e56295a1377c775ce708c9f1a0be6b029076d60a245d213"
-dependencies = [
- "cfg-if 0.1.10",
-]
-
-[[package]]
 name = "generator"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "log",
  "rustversion",
@@ -5324,7 +4642,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -5337,7 +4655,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "js-sys",
  "libc",
  "r-efi 5.3.0",
@@ -5351,14 +4669,12 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if 1.0.4",
- "js-sys",
+ "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -5368,42 +4684,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
-name = "git-version"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
-dependencies = [
- "git-version-macro",
-]
-
-[[package]]
-name = "git-version-macro"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "gsw"
@@ -5426,7 +4710,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.1",
+ "http",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -5441,7 +4725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "bytemuck",
- "cfg-if 1.0.4",
+ "cfg-if",
  "crunchy",
  "num-traits",
  "zerocopy",
@@ -5534,12 +4818,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heapify"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0049b265b7f201ca9ab25475b22b47fe444060126a51abe00f77d986fc5cc52e"
-
-[[package]]
 name = "heapless"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5608,35 +4886,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hf-xet"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430b33fa84f92796d4d263070b6c0d3ca219df7b9a0e1853ee431029b1612bcd"
-dependencies = [
- "async-trait",
- "bytes",
- "http 1.4.1",
- "more-asserts",
- "serde",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
- "xet-client",
- "xet-core-structures",
- "xet-data",
- "xet-runtime",
-]
-
-[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
- "cfg-if 1.0.4",
+ "cfg-if",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
@@ -5660,7 +4916,7 @@ version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "futures-util",
  "hickory-proto",
  "ipconfig",
@@ -5694,31 +4950,11 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
 ]
 
 [[package]]
@@ -5733,23 +4969,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.1",
+ "http",
 ]
 
 [[package]]
@@ -5760,8 +4985,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -5809,8 +5034,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -5826,7 +5051,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.1",
+ "http",
  "hyper",
  "hyper-util",
  "rustls",
@@ -5860,8 +5085,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "hyper",
  "ipnet",
  "libc",
@@ -6223,7 +5448,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array 0.14.7",
 ]
 
@@ -6249,7 +5473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
 dependencies = [
  "bitflags 2.12.1",
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
 ]
 
@@ -6282,12 +5506,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -6340,12 +5558,10 @@ dependencies = [
  "defmt",
  "jiff-static",
  "jiff-tzdb-platform",
- "js-sys",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -6381,7 +5597,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "combine",
  "jni-macros",
  "jni-sys",
@@ -6446,7 +5662,7 @@ version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
@@ -6491,23 +5707,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "konst"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f660d5f887e3562f9ab6f4a14988795b694099d66b4f5dedc02d197ba9becb1d"
-dependencies = [
- "const_panic",
- "konst_proc_macros",
- "typewit",
-]
-
-[[package]]
-name = "konst_proc_macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
-
-[[package]]
 name = "kqueue"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6547,7 +5746,6 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "async_cell",
- "aws-credential-types",
  "bitpacking",
  "byteorder",
  "bytes",
@@ -6694,7 +5892,6 @@ dependencies = [
  "lance-arrow",
  "lance-core",
  "lance-datagen",
- "lance-geo",
  "log",
  "pin-project",
  "prost",
@@ -6794,22 +5991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lance-geo"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5466cc6524104de7f07d70d4af57fb6912b0eb484f4ac939501c01dbfae572df"
-dependencies = [
- "datafusion",
- "geo-traits 0.3.0",
- "geo-types",
- "geoarrow-array",
- "geoarrow-schema",
- "geodatafusion",
- "lance-core",
- "serde",
-]
-
-[[package]]
 name = "lance-index"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6838,9 +6019,6 @@ dependencies = [
  "dirs",
  "fst",
  "futures",
- "geo-types",
- "geoarrow-array",
- "geoarrow-schema",
  "half",
  "itertools 0.13.0",
  "jsonb",
@@ -6850,7 +6028,6 @@ dependencies = [
  "lance-datagen",
  "lance-encoding",
  "lance-file",
- "lance-geo",
  "lance-io",
  "lance-linalg",
  "lance-table",
@@ -6894,14 +6071,12 @@ dependencies = [
  "arrow-select 58.3.0",
  "async-recursion",
  "async-trait",
- "aws-config",
- "aws-credential-types",
  "byteorder",
  "bytes",
  "chrono",
  "deepsize",
  "futures",
- "http 1.4.1",
+ "http",
  "io-uring",
  "lance-arrow",
  "lance-core",
@@ -6909,8 +6084,6 @@ dependencies = [
  "log",
  "moka",
  "object_store 0.13.2",
- "object_store_opendal",
- "opendal",
  "path_abs",
  "pin-project",
  "prost",
@@ -7023,9 +6196,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin 0.9.8",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -7108,7 +6278,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "windows-link 0.2.1",
 ]
 
@@ -7208,7 +6378,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "generator",
  "scoped-tls",
  "tracing",
@@ -7351,7 +6521,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "digest 0.10.7",
 ]
 
@@ -7361,17 +6531,8 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "digest 0.11.3",
-]
-
-[[package]]
-name = "mea"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2640d335e7273dacdcf51044026139b2e269c3bb0dfc3f8cb3496b85e3f6a42c"
-dependencies = [
- "slab",
 ]
 
 [[package]]
@@ -7470,12 +6631,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "more-asserts"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
-
-[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7484,7 +6639,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.4.1",
+ "http",
  "httparse",
  "memchr",
  "mime",
@@ -7595,7 +6750,7 @@ dependencies = [
  "saturating",
  "serde",
  "serde_json",
- "sha1 0.10.6",
+ "sha1",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "time",
@@ -7708,7 +6863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
 ]
 
@@ -7790,22 +6945,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
 ]
 
 [[package]]
@@ -7956,7 +7095,7 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "futures",
- "http 1.4.1",
+ "http",
  "http-body-util",
  "humantime",
  "hyper",
@@ -7994,7 +7133,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.1",
+ "http",
  "http-body-util",
  "httparse",
  "humantime",
@@ -8021,23 +7160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object_store_opendal"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08298874eee5935c95bcaa393148834f9c53d904461ca15584a041d8a1c907c2"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures",
- "mea",
- "object_store 0.13.2",
- "opendal",
- "pin-project",
- "tokio",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8046,18 +7168,6 @@ dependencies = [
  "critical-section",
  "portable-atomic",
 ]
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "oneshot"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
 name = "oorandom"
@@ -8072,248 +7182,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "opendal"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b31d3d8e99a85d83b73ec26647f5607b80578ed9375810b6e44ffa3590a236"
-dependencies = [
- "ctor 0.6.3",
- "opendal-core",
- "opendal-layer-concurrent-limit",
- "opendal-layer-logging",
- "opendal-layer-retry",
- "opendal-layer-timeout",
- "opendal-service-azblob",
- "opendal-service-azdls",
- "opendal-service-cos",
- "opendal-service-gcs",
- "opendal-service-hf",
- "opendal-service-oss",
- "opendal-service-s3",
-]
-
-[[package]]
-name = "opendal-core"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1849dd2687e173e776d3af5fce1ba3ae47b9dd37a09d1c4deba850ef45fe00ca"
-dependencies = [
- "anyhow",
- "base64",
- "bytes",
- "futures",
- "http 1.4.1",
- "http-body 1.0.1",
- "jiff",
- "log",
- "md-5 0.10.6",
- "mea",
- "percent-encoding",
- "quick-xml 0.38.4",
- "reqsign-core",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "tokio",
- "url",
- "uuid",
- "web-time",
-]
-
-[[package]]
-name = "opendal-layer-concurrent-limit"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048b1b29c503263bdd80a9afe46a68cd02ea9bd361185b1feab4b151078998e9"
-dependencies = [
- "futures",
- "http 1.4.1",
- "mea",
- "opendal-core",
-]
-
-[[package]]
-name = "opendal-layer-logging"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2645adc988b12eda106e2679ae529facfbbaa868ceb706f6f8125c6af15c47b"
-dependencies = [
- "log",
- "opendal-core",
-]
-
-[[package]]
-name = "opendal-layer-retry"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eac134ffa4ddda6131a640a84a5315996424b9416c85052f8c64c1a33b70ad4"
-dependencies = [
- "backon",
- "log",
- "opendal-core",
-]
-
-[[package]]
-name = "opendal-layer-timeout"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619586ab7480c2e3009f6d18eabab18957bc094778fd130bcc38924970a90f4c"
-dependencies = [
- "opendal-core",
- "tokio",
-]
-
-[[package]]
-name = "opendal-service-azblob"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7452bf3ec61cfd81ac9ad9ada17825931e9e371d44a045c6bfab9596c0a2ac3b"
-dependencies = [
- "base64",
- "bytes",
- "http 1.4.1",
- "log",
- "opendal-core",
- "opendal-service-azure-common",
- "quick-xml 0.38.4",
- "reqsign-azure-storage",
- "reqsign-core",
- "reqsign-file-read-tokio",
- "serde",
- "sha2 0.10.9",
- "uuid",
-]
-
-[[package]]
-name = "opendal-service-azdls"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9884c2d8cf8ba2bb077d79c877dac5863ba3bab9e2c9c1e41a2e0491404772"
-dependencies = [
- "bytes",
- "http 1.4.1",
- "log",
- "opendal-core",
- "opendal-service-azure-common",
- "quick-xml 0.38.4",
- "reqsign-azure-storage",
- "reqsign-core",
- "reqsign-file-read-tokio",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "opendal-service-azure-common"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb0e45d6c8dcf66ce2da20e241bcb80e6e540e109a4ff20f318f6c9b4c54e0c"
-dependencies = [
- "http 1.4.1",
- "opendal-core",
-]
-
-[[package]]
-name = "opendal-service-cos"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a0765ba451b6effdbf514b7b50060530ff8a29e4231c4a3ab7792c016408e6"
-dependencies = [
- "bytes",
- "http 1.4.1",
- "log",
- "opendal-core",
- "quick-xml 0.38.4",
- "reqsign-core",
- "reqsign-file-read-tokio",
- "reqsign-tencent-cos",
- "serde",
-]
-
-[[package]]
-name = "opendal-service-gcs"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a49477a10163431896d106136117f5670717f9c9e49cf6f710528800c6633a"
-dependencies = [
- "async-trait",
- "bytes",
- "http 1.4.1",
- "log",
- "opendal-core",
- "percent-encoding",
- "quick-xml 0.38.4",
- "reqsign-core",
- "reqsign-file-read-tokio",
- "reqsign-google",
- "serde",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "opendal-service-hf"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2ab7a2a8a11dfe257ef4db5c0de798acbcd0d6429c37382dad2154bc06a388"
-dependencies = [
- "bytes",
- "hf-xet",
- "http 1.4.1",
- "log",
- "opendal-core",
- "percent-encoding",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "opendal-service-oss"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c8a917829ad06d21b639558532cb0101fe49b040d946d673a73018683fac05"
-dependencies = [
- "bytes",
- "http 1.4.1",
- "log",
- "opendal-core",
- "quick-xml 0.38.4",
- "reqsign-aliyun-oss",
- "reqsign-core",
- "reqsign-file-read-tokio",
- "serde",
-]
-
-[[package]]
-name = "opendal-service-s3"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dadddeb9bb50b0d30927dd914c298c4ddca47e4c1cfa7674d311f0cf9b051c8"
-dependencies = [
- "base64",
- "bytes",
- "crc32c",
- "http 1.4.1",
- "log",
- "md-5 0.10.6",
- "opendal-core",
- "quick-xml 0.38.4",
- "reqsign-aws-v4",
- "reqsign-core",
- "reqsign-file-read-tokio",
- "serde",
- "url",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.12.1",
- "cfg-if 1.0.4",
+ "cfg-if",
  "foreign-types",
  "libc",
  "openssl-macros",
@@ -8376,29 +7251,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
-]
-
-[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "outref"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "page_size"
@@ -8432,7 +7288,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -8500,16 +7356,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
-]
-
-[[package]]
 name = "pdqselect"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8523,15 +7369,6 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -8628,50 +7465,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs5"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
-dependencies = [
- "aes",
- "cbc",
- "der",
- "pbkdf2",
- "scrypt",
- "sha2 0.10.9",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "pkcs5",
- "rand_core 0.6.4",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8764,7 +7557,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
- "hmac 0.13.0",
+ "hmac",
  "md-5 0.11.0",
  "memchr",
  "rand 0.10.1",
@@ -8811,7 +7604,7 @@ checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
 dependencies = [
  "aligned-vec",
  "backtrace",
- "cfg-if 1.0.4",
+ "cfg-if",
  "findshlibs",
  "inferno",
  "libc",
@@ -9013,15 +7806,6 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
@@ -9035,16 +7819,6 @@ name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
@@ -9336,15 +8110,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redb"
-version = "3.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9418,135 +8183,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqsign-aliyun-oss"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372266b4733756738eeb199a98188037d27a0989980e2600ae7ce1faf00a867d"
-dependencies = [
- "anyhow",
- "form_urlencoded",
- "http 1.4.1",
- "log",
- "percent-encoding",
- "reqsign-core",
- "rust-ini",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "reqsign-aws-v4"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75624bd8a466e37ddc0a7b6c33ac859a85347c153a916e1dd9d0b68338f74a"
-dependencies = [
- "anyhow",
- "bytes",
- "form_urlencoded",
- "hex",
- "http 1.4.1",
- "log",
- "percent-encoding",
- "quick-xml 0.40.1",
- "reqsign-core",
- "rust-ini",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sha1 0.11.0",
-]
-
-[[package]]
-name = "reqsign-azure-storage"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b96928e73ad984de1d99e382749d09e5dab7dd707b767974f7e40aa926b82f"
-dependencies = [
- "anyhow",
- "base64",
- "bytes",
- "form_urlencoded",
- "http 1.4.1",
- "log",
- "pem",
- "percent-encoding",
- "reqsign-core",
- "rsa",
- "serde",
- "serde_json",
- "sha1 0.11.0",
-]
-
-[[package]]
-name = "reqsign-core"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fa5cb48808693614d1701fcd3db0b30fa292e0f18e122ae068b6d32eaeed3f"
-dependencies = [
- "anyhow",
- "base64",
- "bytes",
- "form_urlencoded",
- "futures",
- "hex",
- "hmac 0.13.0",
- "http 1.4.1",
- "jiff",
- "log",
- "percent-encoding",
- "rsa",
- "serde",
- "serde_json",
- "sha1 0.11.0",
- "sha2 0.11.0",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "reqsign-file-read-tokio"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a4b6f3a3fd29ffcc99a90aec585a65217783badfd73acddf847b63ae683bda9"
-dependencies = [
- "anyhow",
- "reqsign-core",
- "tokio",
-]
-
-[[package]]
-name = "reqsign-google"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb215d0876a18b6bd9cdd380b589e5292aaa638ca15266de794b1122d898b6b2"
-dependencies = [
- "form_urlencoded",
- "http 1.4.1",
- "log",
- "percent-encoding",
- "reqsign-aws-v4",
- "reqsign-core",
- "rsa",
- "serde",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "reqsign-tencent-cos"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84110aabba799fbcd48b3abb51fbbff4749f879252e5806b6f5d0cbe0fef6abb"
-dependencies = [
- "anyhow",
- "http 1.4.1",
- "log",
- "percent-encoding",
- "reqsign-core",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9558,8 +8194,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -9587,7 +8223,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -9601,10 +8237,9 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
  "h2",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -9618,34 +8253,16 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
- "serde",
- "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
  "web-sys",
-]
-
-[[package]]
-name = "reqwest-middleware"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
-dependencies = [
- "anyhow",
- "async-trait",
- "http 1.4.1",
- "reqwest 0.13.4",
- "thiserror 2.0.18",
- "tower-service",
 ]
 
 [[package]]
@@ -9670,7 +8287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if 1.0.4",
+ "cfg-if",
  "getrandom 0.2.17",
  "libc",
  "untrusted",
@@ -9782,27 +8399,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "sha2 0.10.9",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rstar"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9895,16 +8491,6 @@ checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2 0.10.9",
  "walkdir",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
-dependencies = [
- "cfg-if 1.0.4",
- "ordered-multimap",
 ]
 
 [[package]]
@@ -10058,21 +8644,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "safe-transmute"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
-
-[[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10107,17 +8678,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "pbkdf2",
- "salsa20",
- "sha2 0.10.9",
-]
 
 [[package]]
 name = "sea-query"
@@ -10321,20 +8881,9 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha1"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
-dependencies = [
- "cfg-if 1.0.4",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
 ]
 
 [[package]]
@@ -10343,10 +8892,9 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
- "sha2-asm",
 ]
 
 [[package]]
@@ -10355,18 +8903,9 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
-]
-
-[[package]]
-name = "sha2-asm"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -10376,17 +8915,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "shellexpand"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
-dependencies = [
- "bstr",
- "dirs",
- "os_str_bytes",
 ]
 
 [[package]]
@@ -10403,16 +8931,6 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -10553,16 +9071,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "sqlparser"
 version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10597,26 +9105,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
 dependencies = [
  "cc",
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "psm",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "statrs"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
-dependencies = [
- "approx",
- "num-traits",
 ]
 
 [[package]]
@@ -10786,21 +9278,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "serde",
- "windows 0.61.3",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -10835,17 +9313,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tar"
-version = "0.4.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
 
 [[package]]
 name = "tempfile"
@@ -10930,7 +9397,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
 ]
 
 [[package]]
@@ -11104,17 +9571,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-retry"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
-dependencies = [
- "pin-project-lite",
- "rand 0.10.1",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11203,8 +9659,8 @@ dependencies = [
  "base64",
  "bytes",
  "h2",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-timeout",
@@ -11262,8 +9718,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -11360,16 +9816,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11379,36 +9825,12 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
-]
-
-[[package]]
-name = "tracing-test"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
-dependencies = [
- "tracing-core",
- "tracing-subscriber",
- "tracing-test-macro",
-]
-
-[[package]]
-name = "tracing-test-macro"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
-dependencies = [
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -11425,11 +9847,11 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.1",
+ "http",
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1 0.10.6",
+ "sha1",
  "thiserror 2.0.18",
 ]
 
@@ -11477,12 +9899,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "typewit"
-version = "1.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "unicase"
@@ -11571,12 +9987,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
 name = "utf8-ranges"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11587,12 +9997,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
@@ -11724,12 +10128,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11796,7 +10194,7 @@ version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "once_cell",
  "rustversion",
  "serde",
@@ -11873,19 +10271,6 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -11997,23 +10382,11 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections 0.2.0",
+ "windows-collections",
  "windows-core 0.61.2",
- "windows-future 0.2.1",
+ "windows-future",
  "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -12023,15 +10396,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -12068,18 +10432,7 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading 0.1.0",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-threading",
 ]
 
 [[package]]
@@ -12124,16 +10477,6 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -12274,15 +10617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -12438,7 +10772,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "serde",
  "windows-sys 0.48.0",
 ]
@@ -12589,169 +10923,6 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
-
-[[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix",
-]
-
-[[package]]
-name = "xet-client"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1e496dcbe6a09017acdfaf48e1a646735e7ff5b2a49e2c7e081cca77a59bc8"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64",
- "bytes",
- "clap 4.6.1",
- "crc32fast",
- "futures",
- "http 1.4.1",
- "hyper",
- "lazy_static",
- "more-asserts",
- "rand 0.10.1",
- "redb",
- "reqwest 0.13.4",
- "reqwest-middleware",
- "serde",
- "serde_json",
- "serde_repr",
- "statrs",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-retry",
- "tracing",
- "tracing-subscriber",
- "url",
- "urlencoding",
- "web-time",
- "xet-core-structures",
- "xet-runtime",
-]
-
-[[package]]
-name = "xet-core-structures"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb838aa8eb67d730af301584cf003caad407487606058292a6750711b603fbee"
-dependencies = [
- "async-trait",
- "base64",
- "blake3",
- "bytemuck",
- "bytes",
- "clap 4.6.1",
- "countio",
- "csv",
- "futures",
- "futures-util",
- "getrandom 0.4.2",
- "heapify",
- "itertools 0.14.0",
- "lazy_static",
- "lz4_flex 0.13.1",
- "more-asserts",
- "rand 0.10.1",
- "regex",
- "safe-transmute",
- "serde",
- "static_assertions",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
- "web-time",
- "xet-runtime",
-]
-
-[[package]]
-name = "xet-data"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fd409bef621411a9d9013798540bb8036cb2678f03ab39af89a5e88034ed8c"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "chrono",
- "clap 4.6.1",
- "gearhash",
- "http 1.4.1",
- "itertools 0.14.0",
- "lazy_static",
- "more-asserts",
- "rand 0.10.1",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "url",
- "uuid",
- "walkdir",
- "xet-client",
- "xet-core-structures",
- "xet-runtime",
-]
-
-[[package]]
-name = "xet-runtime"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d8f121c33866f7648b737abe70d0e2dd9c0af4ffdd7219207531d0283aa63d"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "chrono",
- "colored",
- "const-str",
- "ctor 0.6.3",
- "dirs",
- "futures",
- "git-version",
- "humantime",
- "konst",
- "lazy_static",
- "libc",
- "more-asserts",
- "oneshot",
- "pin-project",
- "rand 0.10.1",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "shellexpand",
- "sysinfo 0.38.4",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "tracing-appender",
- "tracing-subscriber",
- "whoami",
- "winapi",
-]
-
-[[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,20 @@
 [workspace]
+# Edition-2024 members imply resolver 3; set it explicitly so features aren't
+# over-unified across normal/build/dev deps (fewer features compiled).
+resolver = "3"
 members = ["beacon-api", "beacon-file-formats/beacon-arrow-netcdf", "beacon-file-formats/beacon-arrow-odv", "beacon-common", "beacon-config", "beacon-core", "beacon-functions", "beacon-data-lake", "beacon-sql-databases", "beacon-file-formats/beacon-delta", "beacon-file-formats/beacon-arrow-zarr", "beacon-file-formats/beacon-binary-format", "beacon-object-storage", "beacon-file-formats/beacon-nd-arrow", "beacon-datafusion-ext", "beacon-file-formats/beacon-iceberg", "beacon-file-formats/beacon-lance", "beacon-file-formats/beacon-nd-array", "beacon-file-formats/beacon-arrow-tiff", "beacon-file-formats/beacon-arrow-atlas", "beacon-file-formats/beacon-arrow-geoparquet", "beacon-file-formats/beacon-arrow-bbf", "beacon-file-formats/beacon-arrow-ipc", "beacon-file-formats/beacon-arrow-csv", "beacon-file-formats/beacon-arrow-parquet"]
 exclude = ["beacon-file-formats/beacon-binary-format-toolbox"]
 
 [workspace.dependencies]
-tokio = { version = "1.47.1", features = ["full"] }
-tokio-util = {version ="0.7.13", features = ["io"]}
+tokio = {version = "1.47.1", features = ["full"]}
+tokio-util = {version = "0.7.13", features = ["io"]}
 futures = "0.3.31"
 futures-util = "0.3.31"
 async-trait = "0.1.88"
 bytes = "1.10.0"
-flume = { version = "0.11.1", features = ["async"] }
-parking_lot = { version = "0.12.3", features = ["send_guard", "serde"] }
-ordered-float = { version = "5.1.0", features = ["serde"] }
+flume = {version = "0.11.1", features = ["async"]}
+parking_lot = {version = "0.12.3", features = ["send_guard", "serde"]}
+ordered-float = {version = "5.1.0", features = ["serde"]}
 num_cpus = "1.17.0"
 
 utoipa = { version= "=5.3.1", features = ["chrono","preserve_order", "preserve_path_order","rc_schema", "axum_extras"] }
@@ -31,11 +34,11 @@ tracing-test = { version = "0.2.5", features = ["no-env-filter"]}
 glob = "0.3.2"
 tempfile = "3.15.0"
 typetag = "0.2.19"
-indexmap = { version = "2.7.1", features = ["serde"]}
+indexmap = {version = "2.7.1", features = ["serde"]}
 chrono = { version = "0.4.41", features = ["serde"] }
 crossbeam = "0.8.4"
-moka = { version = "0.12.10", features = ["future", "sync"] }
-lru = "0.16.2"
+moka = {version = "0.12.10", features = ["future", "sync"]}
+lru = "0.14.0"
 once_cell = "1.21.3"
 lazy_static = "1.5.0"
 base64 = "0.22"
@@ -70,13 +73,20 @@ iceberg-file-catalog = "0.10"
 # 0.13, matching our versions. Provides `lance::datafusion::LanceTableProvider`
 # plus the `Dataset` write/append/delete API used by beacon-lance. Requires
 # `protoc` at build time (Lance generates protobuf in its build script).
-lance = "=7.0.0"
+#
+# default-features = false drops the bundled cloud backends (aws/azure/gcp/oss/
+# tencent/huggingface SDKs + the aws-config/aws-smithy stack) and `geo`: beacon
+# routes Lance through its own injected object store via a custom
+# `beacon-tables://` scheme, so Lance's native cloud schemes are never used.
+lance = { version = "=7.0.0", default-features = false }
 # Lance index types (IndexType, ScalarIndexParams) for managed-table indexing.
 # Version-locked to `lance` so the shared types are a single compilation.
 lance-index = "=7.0.0"
 # Lance IO + core: the ObjectStoreProvider/ObjectStoreRegistry mechanism used to
 # route Lance through beacon's tables object store. Version-locked to `lance`.
-lance-io = "=7.0.0"
+# Cloud backends disabled (see `lance` above) — the registry mechanism beacon
+# uses lives in core lance-io, not behind the aws/azure/gcp features.
+lance-io = { version = "=7.0.0", default-features = false }
 lance-core = "=7.0.0"
 
 arrow = { version = "^58", features = ["prettyprint"]}
@@ -90,3 +100,65 @@ geoarrow-schema = "^0.8"
 geoparquet = "^0.8"
 
 beacon-nd-arrow = { path = "beacon-file-formats/beacon-nd-arrow" }
+
+arrow-csv = "^58"
+async-stream = "0.3.6"
+async-tiff = {version = "0.3.0", default-features = false}
+async_zip = {version = "0.0.18", features = ["deflate", "tokio", "zstd"]}
+axum = {version = "0.8.1", features = ["multipart", "tracing", "ws"]}
+axum-streams = {version = "0.25.0", features = ["arrow"]}
+bytemuck = {version = "1.25.0", features = ["derive"]}
+byteorder = "1.5.0"
+cast = "0.3.0"
+chacha20poly1305 = "0.10"
+csv = "1.3.1"
+envconfig = "0.11.0"
+geo = "0.31"
+geojson = "0.24.2"
+gsw = "0.2.2"
+hifitime = "4.0.2"
+julian = "0.7.1"
+lz4_flex = "0.11"
+lzzzz = "2.0.0"
+ndarray = "0.17.1"
+notify = {version = "8.2.0", features = ["flume"]}
+num-traits = "0.2.19"
+pprof = {version = "0.15", features = ["flamegraph"]}
+prost = "0.14.1"
+radix_trie = "0.3.0"
+regex = "1.11.1"
+rkyv = {version = "=0.8.10", features = ["bytes-1", "indexmap-2", "pointer_width_64", "smol_str-0_3"]}
+rlimit = "0.11.0"
+rmp-serde = "1"
+secrecy = "0.10"
+smol_str = {version = "0.3.4", features = ["serde"]}
+strsim = "0.11.1"
+sysinfo = {version = "0.35.2", features = ["serde"]}
+tikv-jemallocator = "0.6.0"
+tower-http = {version = "0.6.1", features = ["cors", "fs", "trace"]}
+tracing-panic = "0.1"
+url = "2.5.4"
+uuid = "1.16.0"
+walkdir = "2.5.0"
+wkt = {version = "0.12.0", features = ["geo-types"]}
+zarrs = {version = "0.23.12", features = ["async"]}
+zarrs_object_store = "0.6.0"
+zarrs_storage = "0.4.2"
+zip = {version = "2.2.3", default-features = false, features = ["deflate"]}
+zstd = "0.13.2"
+
+# Build profiles tuned for compile time and on-disk footprint. Cargo defaults
+# emit full DWARF for the entire graph, which dominated both `target/` size and
+# link time. `line-tables-only` keeps usable backtraces; dependencies get no
+# debuginfo at all (we never step into them).
+[profile.dev]
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+
+[profile.dev.package."*"]
+debug = false
+
+# Tests/benches inherit dev but spell out the dep override so `cargo test`
+# artifacts stay small too.
+[profile.test.package."*"]
+debug = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,8 @@ COPY Cargo.toml /
 COPY Cargo.lock /
 COPY rust-toolchain /
 
-#Build the project
-RUN cargo build --release
+#Build the project (only the server binary the image ships; jemalloc on for prod)
+RUN cargo build --release -p beacon-api --features jemalloc
 
 # Build the admin web UI (Vite SPA) from the JS client workspace. The SDK
 # (@beacon/client) must be built before the web app, which imports from its dist.

--- a/beacon-api/Cargo.toml
+++ b/beacon-api/Cargo.toml
@@ -4,17 +4,22 @@ version = "1.7.3"
 edition = "2021"
 
 [target.'cfg(not(windows))'.dependencies]
-tikv-jemallocator = "0.6.0"
-pprof = { version = "0.15", features = ["flamegraph"] }
+# jemalloc is a production allocator; building its C source costs ~23s. Gate it
+# behind a non-default feature so dev/CI builds skip it. Release images enable
+# it via `cargo build --release -p beacon-api --features jemalloc` (see Dockerfile).
+tikv-jemallocator = {workspace = true, optional = true}
+pprof = {workspace = true}
+
+[features]
+jemalloc = ["dep:tikv-jemallocator"]
 
 [dependencies]
-axum = { version = "0.8.1", features = ["tracing", "multipart", "ws"] }
-axum-streams = { version = "0.25.0", features = ["arrow"]}
-tower-http = { version = "0.6.1", features = ["trace", "cors", "fs"] }
-base64 = "0.22.1"
+axum = {workspace = true}
+axum-streams = {workspace = true}
+tower-http = {workspace = true}
+base64 = {workspace = true}
 
 futures = { workspace = true }
-futures-util = { workspace = true }
 bytes = { workspace = true }
 arrow-flight = { workspace = true, features = ["flight-sql"] }
 arrow-ipc = { workspace = true }
@@ -29,13 +34,13 @@ serde = { workspace = true}
 serde_json = { workspace = true}
 anyhow = { workspace = true}
 arrow = { workspace = true}
-uuid = { version = "1.16.0" }
+uuid = {workspace = true}
 tracing = { workspace = true}
 tracing-subscriber = { workspace = true}
 tracing-appender = { workspace = true}
-tracing-panic = "0.1"
-tonic = "0.14.1"
-prost = "0.14.1"
+tracing-panic = {workspace = true}
+tonic = {workspace = true}
+prost = {workspace = true}
 
 # Local dependencies
 beacon-config = { path = "../beacon-config" }

--- a/beacon-api/src/main.rs
+++ b/beacon-api/src/main.rs
@@ -16,10 +16,10 @@ mod auth;
 mod axum;
 mod flight_sql;
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 

--- a/beacon-common/Cargo.toml
+++ b/beacon-common/Cargo.toml
@@ -6,20 +6,15 @@ edition = "2021"
 [dependencies]
 arrow = { workspace=true }
 datafusion = {workspace = true}
-anyhow = { workspace=true }
 indexmap = { workspace = true }
 thiserror = { workspace=true }
 async-trait = { workspace=true }
-async-stream = "0.3.6"
-regex = "1.11.1"
-glob = "0.3.3"
-url = "2.5.4"
-julian = "0.7.1"
-hifitime = "4.0.2"
-chrono = { workspace = true }
-object_store = { workspace = true }
+regex = {workspace = true}
+glob = {workspace = true}
+url = {workspace = true}
+julian = {workspace = true}
+hifitime = {workspace = true}
 
 futures = { workspace=true}
-futures-util = { workspace=true}
 tracing = { workspace = true }
-rlimit = "0.11.0"
+rlimit = {workspace = true}

--- a/beacon-config/Cargo.toml
+++ b/beacon-config/Cargo.toml
@@ -4,8 +4,8 @@ version = "1.7.3"
 edition = "2021"
 
 [dependencies]
-lazy_static = "1.4.0"
-envconfig = "0.11.0"
+lazy_static = {workspace = true}
+envconfig = {workspace = true}
 object_store = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/beacon-core/Cargo.toml
+++ b/beacon-core/Cargo.toml
@@ -5,32 +5,25 @@ edition = "2021"
 
 [dependencies]
 futures = { workspace=true}
-futures-util = { workspace=true}
-bytes = { workspace=true}
 anyhow = { workspace=true}
 tempfile = { workspace=true}
 serde = { workspace=true}
 serde_json = { workspace=true}
 utoipa = { workspace=true}
-typetag =  { workspace=true}
 async-trait = { workspace=true }
 datafusion = { workspace=true }
 datafusion-federation = { workspace=true }
 geodatafusion = { workspace=true }
 arrow = { workspace=true}
-glob = { workspace = true}
 tokio = { workspace = true }
-indexmap = { workspace = true }
 object_store = { workspace = true }
-async-stream = "0.3.6"
+async-stream = {workspace = true}
 parking_lot = { workspace = true}
-sysinfo = { version = "0.35.2", features = ["serde"]}
-uuid = "1.16.0"
-inventory = "0.3.18"
-pathdiff = "0.2.3"
+sysinfo = {workspace = true}
+uuid = {workspace = true}
 chrono = { workspace = true }
-cast = "0.3.0"
-geojson = "0.24.2"
+cast = {workspace = true}
+geojson = {workspace = true}
 
 tracing = { workspace=true}
 # Local dependencies
@@ -48,13 +41,11 @@ beacon-arrow-bbf = { path = "../beacon-file-formats/beacon-arrow-bbf" }
 beacon-arrow-zarr = { path = "../beacon-file-formats/beacon-arrow-zarr" }
 beacon-object-storage = { path = "../beacon-object-storage" }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }
-beacon-common = { path = "../beacon-common" }
 beacon-iceberg = { path = "../beacon-file-formats/beacon-iceberg" }
 beacon-lance = { path = "../beacon-file-formats/beacon-lance" }
 beacon-delta = { path = "../beacon-file-formats/beacon-delta" }
-beacon-nd-array = { path = "../beacon-file-formats/beacon-nd-array" }
 beacon-sql-databases = { path = "../beacon-sql-databases" }
 
 [dev-dependencies]
 deltalake = { workspace = true }
-url = "2"
+url = {workspace = true}

--- a/beacon-data-lake/Cargo.toml
+++ b/beacon-data-lake/Cargo.toml
@@ -9,8 +9,8 @@ datafusion = { workspace = true }
 anyhow = { workspace = true }
 
 object_store = { workspace = true }
-url = "2.5.4"
-tempfile = "3.15.0"
+url = {workspace = true}
+tempfile = {workspace = true}
 
 typetag =  { workspace=true}
 async-trait = { workspace=true}

--- a/beacon-datafusion-ext/Cargo.toml
+++ b/beacon-datafusion-ext/Cargo.toml
@@ -14,7 +14,6 @@ serde_json = { workspace = true }
 typetag =  { workspace=true}
 anyhow = { workspace = true }
 arrow = { workspace = true }
-arrow-schema = { workspace = true }
 ordered-float = { workspace = true }
 indexmap = { workspace = true }
 moka = { workspace = true }

--- a/beacon-file-formats/beacon-arrow-atlas/Cargo.toml
+++ b/beacon-file-formats/beacon-arrow-atlas/Cargo.toml
@@ -16,10 +16,10 @@ chrono = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-rmp-serde = "1"
-zstd = "0.13"
-lz4_flex = "0.11"
-ndarray = "0.17"
+rmp-serde = {workspace = true}
+zstd = {workspace = true}
+lz4_flex = {workspace = true}
+ndarray = {workspace = true}
 atlas = { package = "atlas-rust", git = "https://github.com/maris-development/atlas.git", version = "0.9.1" }
 crossbeam = { workspace = true }
 moka = { workspace = true }

--- a/beacon-file-formats/beacon-arrow-netcdf/Cargo.toml
+++ b/beacon-file-formats/beacon-arrow-netcdf/Cargo.toml
@@ -8,24 +8,20 @@ netcdf = { git ="https://github.com/robinskil/netcdf.git", features = ["ndarray"
 netcdf-sys = { git ="https://github.com/robinskil/netcdf.git", package = "netcdf-sys" }
 arrow = { workspace = true }
 
-arrow-schema = { workspace = true }
 anyhow = { workspace=true }
 tempfile = { workspace=true}
 tokio = { workspace=true }
 futures = { workspace=true }
 indexmap = { workspace=true }
-thiserror = { workspace=true }
 async-trait = { workspace=true }
-ndarray = "0.17.1"
+ndarray = {workspace = true}
 ordered-float = { workspace = true }
-num-traits = "0.2.19"
-hifitime = "4.0.2"
-regex = "1.11.1"
-bytemuck = {version = "1.25.0", features = ["derive"]}
-julian = "0.7.1"
+num-traits = {workspace = true}
+hifitime = {workspace = true}
+bytemuck = {workspace = true}
+julian = {workspace = true}
 tracing = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 object_store = { workspace = true }
 datafusion = { workspace = true }
 moka = { workspace = true }

--- a/beacon-file-formats/beacon-arrow-odv/Cargo.toml
+++ b/beacon-file-formats/beacon-arrow-odv/Cargo.toml
@@ -8,28 +8,23 @@ serde = { workspace=true}
 tokio = { workspace = true }
 indexmap = { workspace = true }
 arrow = { workspace=true}
-arrow-csv = "^58"
+arrow-csv = {workspace = true}
 datafusion = { workspace = true }
 tracing = { workspace = true }
 beacon-common = { path = "../../beacon-common" }
 anyhow = { workspace=true}
 async-trait = { workspace=true}
 futures = { workspace=true}
-futures-util = { workspace=true}
 tempfile = { workspace=true}
 utoipa = { workspace=true}
-csv = "1.3.1"
-tar = "0.4.44"
-zstd = "0.13.3"
-lz4_flex = "0.11.3"
+csv = {workspace = true}
 # default-features disabled to drop xz/lzma support (xz2 -> lzma-sys conflicts with
 # datafusion 53's liblzma on the native `lzma` links). Only deflate is used.
-zip = { version = "2.2.3", default-features = false, features = ["deflate"] }
-async_zip = { version = "0.0.18", features = ["tokio", "zstd", "deflate"] }
-tokio-util = "0.7.16"
-walkdir = "2.5.0"
-regex = "1.11.1"
-quick-xml = "0.37.2"
+zip = {workspace = true}
+async_zip = {workspace = true}
+tokio-util = {workspace = true}
+walkdir = {workspace = true}
+regex = {workspace = true}
 thiserror = {workspace=true}
 bytes = { workspace = true}
 object_store = { workspace = true}

--- a/beacon-file-formats/beacon-arrow-tiff/Cargo.toml
+++ b/beacon-file-formats/beacon-arrow-tiff/Cargo.toml
@@ -17,13 +17,12 @@ arrow = { workspace = true }
 datafusion = { workspace = true }
 object_store = { workspace = true }
 
-async-tiff = { version = "0.3.0", default-features = false }
+async-tiff = {workspace = true}
 
 beacon-common = { path = "../../beacon-common" }
-beacon-config = { path = "../../beacon-config" }
 beacon-datafusion-ext = { path = "../../beacon-datafusion-ext" }
 beacon-nd-array = { path = "../beacon-nd-array" }
-ndarray = { version = "0.17" }
+ndarray = {workspace = true}
 beacon-object-storage = { path = "../../beacon-object-storage" }
 
 [dev-dependencies]

--- a/beacon-file-formats/beacon-arrow-zarr/Cargo.toml
+++ b/beacon-file-formats/beacon-arrow-zarr/Cargo.toml
@@ -4,24 +4,21 @@ version = "1.7.3"
 edition = "2024"
 
 [dependencies]
-zarrs = {"version" = "0.23.12", features = ["async"]}
-zarrs_object_store = "0.6.0"
-zarrs_storage = "0.4.2"
+zarrs = {workspace = true}
+zarrs_object_store = {workspace = true}
+zarrs_storage = {workspace = true}
 object_store = { workspace = true }
 tokio = { workspace = true }
 arrow = { workspace = true }
 datafusion = { workspace = true }
-ndarray = "0.17"
+ndarray = {workspace = true}
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
 indexmap = { workspace = true }
 tracing = { workspace = true }
-hifitime = "4.0.2"
-regex = "1.11.1"
+hifitime = {workspace = true}
 futures = { workspace = true }
-parking_lot = { workspace = true }
-crossbeam = { workspace = true }
 
 beacon-nd-array = { path = "../beacon-nd-array" }
 beacon-datafusion-ext = { path = "../../beacon-datafusion-ext" }

--- a/beacon-file-formats/beacon-delta/Cargo.toml
+++ b/beacon-file-formats/beacon-delta/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 beacon-common = { path = "../../beacon-common" }
 beacon-datafusion-ext = { path = "../../beacon-datafusion-ext" }
 beacon-object-storage = { path = "../../beacon-object-storage" }
-beacon-config = { path = "../../beacon-config" }
 
 deltalake = { workspace = true }
 datafusion = { workspace = true }
@@ -20,8 +19,7 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 typetag = { workspace = true }
 tokio = { workspace = true }
-tracing = { workspace = true }
-url = "2"
+url = {workspace = true}
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/beacon-file-formats/beacon-iceberg/Cargo.toml
+++ b/beacon-file-formats/beacon-iceberg/Cargo.toml
@@ -6,19 +6,15 @@ edition = "2024"
 [dependencies]
 datafusion = { workspace = true }
 arrow = { workspace = true }
-arrow-schema = { workspace = true }
 async-trait = { workspace = true }
 object_store = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 typetag = { workspace = true }
 anyhow = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
-parking_lot = { workspace = true }
 tracing = { workspace = true }
-once_cell = { workspace = true }
 
 iceberg-rust = { workspace = true }
 datafusion_iceberg = { workspace = true }

--- a/beacon-file-formats/beacon-lance/Cargo.toml
+++ b/beacon-file-formats/beacon-lance/Cargo.toml
@@ -6,29 +6,24 @@ edition = "2024"
 [dependencies]
 datafusion = { workspace = true }
 arrow = { workspace = true }
-arrow-schema = { workspace = true, features = ["serde"] }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 typetag = { workspace = true }
 anyhow = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 parking_lot = { workspace = true }
 tracing = { workspace = true }
-once_cell = { workspace = true }
 
 lance = { workspace = true }
 lance-index = { workspace = true }
 lance-io = { workspace = true }
 lance-core = { workspace = true }
 object_store = { workspace = true }
-url = "2"
+url = {workspace = true}
 
 beacon-datafusion-ext = { path = "../../beacon-datafusion-ext" }
-beacon-config = { path = "../../beacon-config" }
-beacon-object-storage = { path = "../../beacon-object-storage" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/beacon-file-formats/beacon-nd-array/Cargo.toml
+++ b/beacon-file-formats/beacon-nd-array/Cargo.toml
@@ -6,20 +6,16 @@ readme = "README.md"
 
 [dependencies]
 arrow = { workspace = true }
-arrow-schema = { workspace = true }
 datafusion = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 thiserror = { workspace = true }
-chrono = { workspace = true }
-ndarray = { version = "0.17" }
+ndarray = {workspace = true}
 anyhow = { workspace=true }
 async-trait = { workspace=true }
 futures = { workspace=true }
 indexmap = { workspace=true }
-pin-project = "1.1.10"
-bytemuck = {version = "1.25.0", features = ["derive"]}
-rkyv = { version = "0.8.10", features = ["pointer_width_64"] }
+bytemuck = {workspace = true}
+rkyv = {workspace = true}
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/beacon-file-formats/beacon-nd-arrow/Cargo.toml
+++ b/beacon-file-formats/beacon-nd-arrow/Cargo.toml
@@ -11,17 +11,14 @@ ndarray = ["dep:ndarray", "dep:chrono"]
 [dependencies]
 arrow = { workspace = true }
 arrow-schema = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true, optional = true }
-ndarray = { version = "0.17", optional = true }
+ndarray = {workspace = true, optional = true}
 anyhow = { workspace=true }
 async-trait = { workspace=true }
 futures = { workspace=true }
-pin-project = "1.1.10"
-bytemuck = {version = "1.25.0", features = ["derive"]}
+bytemuck = {workspace = true}
 
 [dev-dependencies]
 arrow-ipc = { workspace = true }

--- a/beacon-functions/Cargo.toml
+++ b/beacon-functions/Cargo.toml
@@ -6,29 +6,27 @@ edition = "2021"
 [dependencies]
 datafusion = {workspace = true}
 arrow = {workspace = true}
-geo = "0.31"
-geojson = "0.24.2"
-wkt = { version = "0.12.0", features = ["geo-types"] }
-strsim = "0.11.1"
+geo = {workspace = true}
+geojson = {workspace = true}
+wkt = {workspace = true}
+strsim = {workspace = true}
 anyhow = { workspace = true}
-inventory = "0.3.18"
 serde = { workspace = true}
 serde_json = { workspace = true}
-csv = "1.3.1"
+csv = {workspace = true}
 object_store = { workspace = true }
 once_cell = { workspace = true }
 
-lazy_static = "1.5.0"
-gsw = "0.2.2"
-lru = "0.14.0"
-ordered-float = "5.0.0"
+lazy_static = {workspace = true}
+gsw = {workspace = true}
+lru = {workspace = true}
+ordered-float = {workspace = true}
 tracing = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 chrono = { workspace = true }
 
 beacon-common = { path = "../beacon-common" }
-beacon-config = { path = "../beacon-config" }
 beacon-object-storage = { path = "../beacon-object-storage" }
 beacon-arrow-atlas = { path = "../beacon-file-formats/beacon-arrow-atlas" }
 beacon-arrow-odv = { path = "../beacon-file-formats/beacon-arrow-odv" }

--- a/beacon-object-storage/Cargo.toml
+++ b/beacon-object-storage/Cargo.toml
@@ -4,21 +4,15 @@ version = "1.7.3"
 edition = "2024"
 
 [dependencies]
-bumpalo = "3.19.1"
-smol_str = { version = "0.3.4", features = ["serde"] }
-notify = { version = "8.2.0", features = ["flume"] }
-radix_trie = "0.3.0"
-walkdir = "2.5.0"
+smol_str = {workspace = true}
+notify = {workspace = true}
+radix_trie = {workspace = true}
 
 parking_lot = { workspace = true }
-serde = { workspace = true}
-serde_json = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
-once_cell = { workspace = true }
 tracing = { workspace = true }
-tracing-test = { workspace = true }
 chrono = { workspace = true }
 flume = { workspace = true }
 thiserror = { workspace = true }

--- a/beacon-sql-databases/Cargo.toml
+++ b/beacon-sql-databases/Cargo.toml
@@ -12,7 +12,6 @@ postgres = ["datafusion-table-providers/postgres-federation"]
 mysql = ["datafusion-table-providers/mysql-federation"]
 
 [dependencies]
-beacon-common = { path = "../beacon-common" }
 beacon-config = { path = "../beacon-config" }
 beacon-datafusion-ext = { path = "../beacon-datafusion-ext" }
 
@@ -22,17 +21,14 @@ datafusion-table-providers = { workspace = true }
 arrow = { workspace = true }
 
 async-trait = { workspace = true }
-futures = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 typetag = { workspace = true }
-tokio = { workspace = true }
-tracing = { workspace = true }
-secrecy = "0.10"
+secrecy = {workspace = true}
 # XChaCha20-Poly1305 AEAD for encrypting persisted DB credentials at rest.
 # `getrandom` (default) provides OsRng for nonce generation.
-chacha20poly1305 = "0.10"
+chacha20poly1305 = {workspace = true}
 base64 = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Cuts the dependency graph and configures faster, smaller builds. No behavior changes — verified by `cargo check --workspace --tests` (green) and `cargo test -p beacon-lance` (5/5 pass).

## Dependency cleanup
- **Remove 67 unused dependencies** across 17 crates. Verified two ways: clean `cargo check --workspace --tests`, and zero source references. (Notably `serde` in `beacon-binary-format` was a cargo-machete false positive — its `Serialize`/`Deserialize` are rkyv's, not serde's.)
- **Disable Lance's bundled cloud backends** (`aws`/`azure`/`gcp`/`oss`/`tencent`/`huggingface` + `geo`) via `default-features = false`. Beacon routes Lance through its own injected object store (custom `beacon-tables://` scheme), so Lance's native cloud schemes are never used. Drops ~130 transitive crates including the `aws-config`/`aws-smithy` AWS SDK stack. S3-backed tables are unaffected — they go through beacon's own `object_store` (aws feature intact), not Lance's.
- **Centralize 62 version-pinned deps** (85 occurrences) into `[workspace.dependencies]`; members inherit via `workspace = true`. Resolved versions unchanged (pure manifest move). Left local on purpose: `criterion`/`rand` (semver-incompatible dev versions across crates) and `beacon-binary-format`'s renamed `arrow-56/57/58` + `object_store-12/13` multi-version shims.

## Build tuning
- **`resolver = "3"`** — edition-2024 members imply it; avoids feature over-unification across normal/build/dev deps.
- **`[profile.dev]`** — `line-tables-only` debuginfo + no debuginfo for deps: smaller `target/`, faster linking, backtraces preserved.
- **Gate jemalloc** behind a `beacon-api` `jemalloc` feature so dev/CI builds skip its ~23s C compile; the release image enables it via the Dockerfile (`-p beacon-api --features jemalloc`).

## Net effect
Dependency graph: **1050 → 914 crates** (−136).

## Not included
Local build-env tuning (sccache + shared `CARGO_TARGET_DIR`) is intentionally kept out of the repo — those paths/wrapper are machine-specific and would break teammates/CI.