### PR TITLE
Return a clear error for an output format on a non-SELECT statement

### DIFF
--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -285,7 +285,19 @@ impl Runtime {
         crate::statement_plan::validate_query_plan(&plan, is_super_user)?;
 
         match output {
-            Some(output) => self.run_query_to_file(plan, output, query_id, query_json).await,
+            Some(output) => {
+                // An output format wraps the plan in a `COPY TO`, which only
+                // accepts a row-producing input. Reject side-effecting statements
+                // (DDL/DML, `SET`, ...) here with a clear message instead of
+                // letting the `COPY TO` builder fail with a cryptic planner error.
+                if !crate::statement_plan::plan_produces_result_set(&plan) {
+                    anyhow::bail!(
+                        "an output format can only be applied to queries that return rows \
+                         (e.g. SELECT); this statement produces no result set to export"
+                    );
+                }
+                self.run_query_to_file(plan, output, query_id, query_json).await
+            }
             None => self.run_query_to_stream(plan, query_id, query_json).await,
         }
     }

--- a/beacon-core/src/statement_plan/mod.rs
+++ b/beacon-core/src/statement_plan/mod.rs
@@ -63,6 +63,33 @@ pub(crate) fn validate_query_plan(plan: &LogicalPlan, is_super_user: bool) -> an
     Ok(())
 }
 
+/// Whether `plan` produces a result set that can be exported in an output format.
+///
+/// A requested output format wraps the plan in a `COPY TO` (see
+/// [`Output::parse`](crate::query::output::Output::parse)), which only accepts a
+/// row-producing input. Side-effecting / administrative statements return no rows,
+/// so they cannot be exported: standard DDL, DML (`INSERT`/`UPDATE`/`DELETE`),
+/// `COPY`, and `SET`, plus beacon's side-effecting extension nodes (materialized
+/// views, `REFRESH`, `ALTER TABLE`, copy-on-write `DELETE`/`UPDATE`, crawler/index
+/// DDL), which all expose an empty schema. Row-producing statements (`SELECT`,
+/// `SHOW CRAWLERS`, `SHOW INDEXES`, ...) do produce an exportable result set.
+pub(crate) fn plan_produces_result_set(plan: &LogicalPlan) -> bool {
+    match plan {
+        LogicalPlan::Ddl(_)
+        | LogicalPlan::Dml(_)
+        | LogicalPlan::Copy(_)
+        | LogicalPlan::Statement(_) => false,
+        // Beacon's extension nodes carry their own output schema: the
+        // side-effecting ones (materialized views, `REFRESH`, `ALTER TABLE`,
+        // copy-on-write `DELETE`/`UPDATE`, crawler/index DDL) report an empty
+        // schema, while the row-producing ones (`SHOW CRAWLERS`, `SHOW INDEXES`)
+        // report real columns — so the schema decides whether they can be exported.
+        LogicalPlan::Extension(ext) => !ext.node.schema().fields().is_empty(),
+        // Everything else is a row-producing query (`SELECT`, `VALUES`, ...).
+        other => !other.schema().fields().is_empty(),
+    }
+}
+
 /// Whether `plan` contains any [`LogicalPlan::Extension`] node (all of beacon's
 /// extension nodes are super-user-only operations).
 fn plan_contains_extension(plan: &LogicalPlan) -> anyhow::Result<bool> {

--- a/beacon-core/tests/output_on_non_select.rs
+++ b/beacon-core/tests/output_on_non_select.rs
@@ -1,0 +1,89 @@
+//! `Runtime::run_query` rejects an output format on a statement that produces no
+//! result set (DDL/DML/`SET`) with a clear error, instead of letting the
+//! `COPY TO` wrapping fail with a cryptic planner error — while still honoring an
+//! output format on a row-producing `SELECT`.
+
+use beacon_core::query::output::{Output, OutputFormat};
+use beacon_core::query::{InnerQuery, Query};
+use beacon_core::query_result::QueryOutput;
+use beacon_core::runtime::Runtime;
+
+async fn boot() -> Runtime {
+    Runtime::new(std::sync::Arc::new(beacon_config::Config::load().unwrap()))
+        .await
+        .expect("runtime should boot")
+}
+
+fn csv_query(sql: &str) -> Query {
+    Query {
+        inner: InnerQuery::Sql(sql.to_string()),
+        output: Some(Output {
+            format: OutputFormat::Csv,
+        }),
+    }
+}
+
+/// Run a CSV-output query expecting it to fail, returning the error message.
+/// (`QueryResult` is not `Debug`, so `Result::expect_err` is unavailable.)
+async fn expect_output_error(runtime: &Runtime, sql: &str) -> String {
+    match runtime.run_query(csv_query(sql), true).await {
+        Ok(_) => panic!("expected an error for: {sql}"),
+        Err(error) => error.to_string(),
+    }
+}
+
+/// A DDL/DML/administrative statement with an output format fails with the clear,
+/// actionable message rather than a `COPY TO` planner error.
+#[tokio::test(flavor = "multi_thread")]
+async fn output_on_non_row_producing_statement_is_a_clear_error() {
+    let runtime = boot().await;
+    let table = format!("output_guard_{}", std::process::id());
+    let _ = runtime
+        .run_query(Query::sql(format!("DROP TABLE IF EXISTS {table}")), true)
+        .await;
+
+    // CREATE TABLE (DDL) and SET (statement) both return no rows.
+    let cases = [
+        format!("CREATE TABLE {table} (id BIGINT)"),
+        "SET beacon.table_engine = 'lance'".to_string(),
+    ];
+    for sql in cases {
+        let message = expect_output_error(&runtime, &sql).await;
+        assert!(
+            message.contains("output format can only be applied to queries that return rows"),
+            "unexpected error for `{sql}`: {message}"
+        );
+    }
+
+    // INSERT, after the table exists, is also rejected (DML produces only a count).
+    runtime
+        .run_query(
+            Query::sql(format!("CREATE TABLE {table} (id BIGINT)")),
+            true,
+        )
+        .await
+        .expect("create table should succeed without output");
+    let message = expect_output_error(&runtime, &format!("INSERT INTO {table} VALUES (1)")).await;
+    assert!(
+        message.contains("output format can only be applied to queries that return rows"),
+        "unexpected error for INSERT: {message}"
+    );
+
+    let _ = runtime
+        .run_query(Query::sql(format!("DROP TABLE IF EXISTS {table}")), true)
+        .await;
+}
+
+/// A row-producing `SELECT` with an output format still succeeds and yields a file.
+#[tokio::test(flavor = "multi_thread")]
+async fn output_on_select_still_succeeds() {
+    let runtime = boot().await;
+    let result = runtime
+        .run_query(csv_query("SELECT 1 AS a"), true)
+        .await
+        .expect("SELECT with output should succeed");
+    assert!(
+        matches!(result.query_output, QueryOutput::File(_)),
+        "expected a file output for a SELECT with an output format"
+    );
+}


### PR DESCRIPTION
## Problem

A query (JSON DSL or SQL) can carry an `output` format (e.g. `{"format": "csv"}`). When the statement was DDL/DML — `CREATE`, `ALTER`, `INSERT`, `UPDATE`, `DELETE`, `SET`, … — rather than a row-producing `SELECT`, `run_query` unconditionally wrapped the plan in a `COPY TO` via `Output::parse`. DataFusion's `LogicalPlanBuilder::copy_to` only accepts a row-producing input, so it failed deep in the planner with a cryptic error instead of telling the caller their request doesn't make sense.

JSON-DSL queries can only express `SELECT`, so the JSON path never triggered it on its own — but any query (JSON or SQL) pairing an output with a non-row-producing statement hit it.

## Fix

Guard the output path in `run_query`, *before* the `COPY TO` wrapping: if an `output` is present but the plan produces no result set, bail with an actionable message:

> an output format can only be applied to queries that return rows (e.g. SELECT); this statement produces no result set to export

A new `plan_produces_result_set` helper (next to `validate_query_plan`) classifies plans:
- `Ddl` / `Dml` / `Copy` / `Statement` → not exportable.
- Beacon **extension** nodes → decided by their output schema. Side-effecting nodes (materialized views, `REFRESH`, `ALTER TABLE`, copy-on-write `DELETE`/`UPDATE`, crawler/index DDL) report an empty schema; the row-producing `SHOW CRAWLERS` / `SHOW INDEXES` report real columns and stay exportable.
- Everything else (`SELECT`, `VALUES`, …) → exportable.

## Tests

New integration test `output_on_non_select.rs`:
- `CREATE TABLE`, `SET`, and `INSERT` with an output each return the clear error.
- `SELECT` with an output still succeeds and yields a file.

Both pass; `beacon-core` builds cleanly.