### PR TITLE
test: expand unit-test coverage + fix super_type_arrow bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,6 +1684,7 @@ dependencies = [
  "async-trait",
  "beacon-common",
  "beacon-object-storage",
+ "chrono",
  "datafusion",
  "datafusion-federation",
  "futures",

--- a/beacon-common/src/super_typing.rs
+++ b/beacon-common/src/super_typing.rs
@@ -227,13 +227,32 @@ pub fn super_type_arrow(left: &DataType, right: &DataType) -> Option<DataType> {
         (DataType::Float32, DataType::Utf8) => DataType::Utf8,
         (DataType::Float32, DataType::Timestamp(_, _)) => DataType::Float64,
 
-        (DataType::Float64, DataType::Utf8) => DataType::Utf8,
-        (DataType::Float64, _) => DataType::Float64,
+        // Boolean widens to whatever numeric type it is paired with. These
+        // mirror the `(<numeric>, Boolean)` rules above so the relation is
+        // symmetric and a schema merge of a Boolean and a numeric column does
+        // not depend on which column is seen first.
+        (DataType::Boolean, DataType::Int8) => DataType::Int8,
+        (DataType::Boolean, DataType::Int16) => DataType::Int16,
+        (DataType::Boolean, DataType::Int32) => DataType::Int32,
+        (DataType::Boolean, DataType::Int64) => DataType::Int64,
+        (DataType::Boolean, DataType::UInt8) => DataType::UInt8,
+        (DataType::Boolean, DataType::UInt16) => DataType::UInt16,
+        (DataType::Boolean, DataType::UInt32) => DataType::UInt32,
+        (DataType::Boolean, DataType::UInt64) => DataType::UInt64,
+        (DataType::Boolean, DataType::Float32) => DataType::Float32,
+        (DataType::Boolean, DataType::Float64) => DataType::Float64,
 
+        // String types absorb any other type: the only representation that can
+        // hold both is the stringified value. These must precede the numeric
+        // catch-all (`Float64` below) so that e.g. `Float64` + `LargeUtf8`
+        // widens to a string instead of dropping to `Float64` and corrupting
+        // the string values.
         (DataType::LargeUtf8, _) => DataType::LargeUtf8,
         (_, DataType::LargeUtf8) => DataType::LargeUtf8,
         (DataType::Utf8, _) => DataType::Utf8,
         (_, DataType::Utf8) => DataType::Utf8,
+
+        (DataType::Float64, _) => DataType::Float64,
 
         (DataType::Timestamp(_, _), DataType::Int8) => DataType::Int64,
         (DataType::Timestamp(_, _), DataType::Int16) => DataType::Int64,
@@ -245,7 +264,6 @@ pub fn super_type_arrow(left: &DataType, right: &DataType) -> Option<DataType> {
         (DataType::Timestamp(_, _), DataType::UInt64) => DataType::Float64,
         (DataType::Timestamp(_, _), DataType::Float32) => DataType::Float64,
         (DataType::Timestamp(_, _), DataType::Float64) => DataType::Float64,
-        (DataType::Timestamp(_, _), DataType::Utf8) => DataType::Utf8,
         (DataType::Timestamp(_, _), DataType::Timestamp(_, _)) => {
             DataType::Timestamp(TimeUnit::Second, None)
         }
@@ -418,26 +436,59 @@ mod tests {
     }
 
     #[test]
-    fn relation_is_not_commutative_for_some_pairs() {
-        // (Int8, Boolean) is defined, but the reverse is not.
+    fn boolean_widens_to_numeric_in_either_order() {
+        // Regression: the table only encoded `(<numeric>, Boolean)`, so the
+        // reverse used to return `None`, making schema merges order-dependent.
+        for (numeric, expected) in [
+            (DataType::Int8, DataType::Int8),
+            (DataType::Int64, DataType::Int64),
+            (DataType::UInt16, DataType::UInt16),
+            (DataType::Float32, DataType::Float32),
+            (DataType::Float64, DataType::Float64),
+        ] {
+            assert_eq!(
+                super_type_arrow(&numeric, &DataType::Boolean),
+                Some(expected.clone()),
+                "({numeric:?}, Boolean)"
+            );
+            assert_eq!(
+                super_type_arrow(&DataType::Boolean, &numeric),
+                Some(expected.clone()),
+                "(Boolean, {numeric:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn float_and_large_utf8_widen_to_a_string_either_order() {
+        // Regression: the `(Float64, _)` catch-all used to fire before the
+        // string arms, yielding `Float64` for `Float64` + `LargeUtf8` and
+        // corrupting the string column on cast.
         assert_eq!(
-            super_type_arrow(&DataType::Int8, &DataType::Boolean),
-            Some(DataType::Int8)
+            super_type_arrow(&DataType::Float64, &DataType::LargeUtf8),
+            Some(DataType::LargeUtf8)
         );
-        assert_eq!(super_type_arrow(&DataType::Boolean, &DataType::Int8), None);
+        assert_eq!(
+            super_type_arrow(&DataType::LargeUtf8, &DataType::Float64),
+            Some(DataType::LargeUtf8)
+        );
+        // Utf8 (vs the wider LargeUtf8) still wins over Float64 as before.
+        assert_eq!(
+            super_type_arrow(&DataType::Float64, &DataType::Utf8),
+            Some(DataType::Utf8)
+        );
     }
 
     #[test]
     fn unsupported_pairs_return_none() {
-        assert_eq!(super_type_arrow(&DataType::Boolean, &DataType::Int8), None);
-        assert_eq!(
-            super_type_arrow(&DataType::Date32, &DataType::Int8),
-            None
-        );
+        assert_eq!(super_type_arrow(&DataType::Date32, &DataType::Int8), None);
+        assert_eq!(super_type_arrow(&DataType::Date32, &DataType::Int32), None);
         assert_eq!(
             super_type_arrow(&DataType::Binary, &DataType::Float64),
             None
         );
+        // Boolean still has no common type with non-numeric, non-string types.
+        assert_eq!(super_type_arrow(&DataType::Boolean, &DataType::Date32), None);
     }
 
     fn schema(fields: &[(&str, DataType)]) -> SchemaRef {
@@ -476,8 +527,8 @@ mod tests {
 
     #[test]
     fn super_type_schema_errors_when_columns_have_no_common_type() {
-        let s1 = schema(&[("a", DataType::Boolean)]);
-        let s2 = schema(&[("a", DataType::Int8)]);
+        let s1 = schema(&[("a", DataType::Date32)]);
+        let s2 = schema(&[("a", DataType::Int32)]);
 
         let err = super_type_schema(&[s1, s2]).unwrap_err();
         match err {
@@ -486,6 +537,31 @@ mod tests {
             }
             other => panic!("expected NoCommonSuperType, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn super_type_schema_merge_is_order_independent() {
+        // Regression: a Boolean + Int8 merge must succeed regardless of which
+        // schema is listed first (previously only one order resolved).
+        let bool_first = super_type_schema(&[
+            schema(&[("a", DataType::Boolean)]),
+            schema(&[("a", DataType::Int8)]),
+        ])
+        .unwrap();
+        let int_first = super_type_schema(&[
+            schema(&[("a", DataType::Int8)]),
+            schema(&[("a", DataType::Boolean)]),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            bool_first.field_with_name("a").unwrap().data_type(),
+            &DataType::Int8
+        );
+        assert_eq!(
+            int_first.field_with_name("a").unwrap().data_type(),
+            &DataType::Int8
+        );
     }
 
     #[test]
@@ -502,8 +578,8 @@ mod tests {
 
     #[test]
     fn super_type_arrow_schema_returns_none_on_conflict() {
-        let s1 = Schema::new(vec![Field::new("a", DataType::Boolean, true)]);
-        let s2 = Schema::new(vec![Field::new("a", DataType::Int8, true)]);
+        let s1 = Schema::new(vec![Field::new("a", DataType::Date32, true)]);
+        let s2 = Schema::new(vec![Field::new("a", DataType::Int32, true)]);
         assert_eq!(super_type_arrow_schema(&[s1, s2]), None);
     }
 }

--- a/beacon-common/src/super_typing.rs
+++ b/beacon-common/src/super_typing.rs
@@ -255,3 +255,255 @@ pub fn super_type_arrow(left: &DataType, right: &DataType) -> Option<DataType> {
 
     Some(super_type)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{Field, SchemaRef};
+    use std::sync::Arc;
+
+    fn ts() -> DataType {
+        DataType::Timestamp(TimeUnit::Millisecond, None)
+    }
+
+    #[test]
+    fn equal_types_return_themselves() {
+        for dt in [
+            DataType::Boolean,
+            DataType::Int32,
+            DataType::Float64,
+            DataType::Utf8,
+            ts(),
+        ] {
+            assert_eq!(super_type_arrow(&dt, &dt), Some(dt.clone()));
+        }
+    }
+
+    #[test]
+    fn null_is_absorbed_by_the_other_type() {
+        assert_eq!(
+            super_type_arrow(&DataType::Null, &DataType::Int8),
+            Some(DataType::Int8)
+        );
+        assert_eq!(
+            super_type_arrow(&DataType::Float64, &DataType::Null),
+            Some(DataType::Float64)
+        );
+        // Null + Null hits the equality short-circuit.
+        assert_eq!(
+            super_type_arrow(&DataType::Null, &DataType::Null),
+            Some(DataType::Null)
+        );
+    }
+
+    #[test]
+    fn integer_widening() {
+        assert_eq!(
+            super_type_arrow(&DataType::Int8, &DataType::Int16),
+            Some(DataType::Int16)
+        );
+        assert_eq!(
+            super_type_arrow(&DataType::Int8, &DataType::Int64),
+            Some(DataType::Int64)
+        );
+        assert_eq!(
+            super_type_arrow(&DataType::Int32, &DataType::Int16),
+            Some(DataType::Int32)
+        );
+    }
+
+    #[test]
+    fn signed_unsigned_mix_widens_to_hold_both() {
+        // A signed/unsigned pair needs the next wider signed type.
+        assert_eq!(
+            super_type_arrow(&DataType::Int8, &DataType::UInt8),
+            Some(DataType::Int16)
+        );
+        assert_eq!(
+            super_type_arrow(&DataType::UInt8, &DataType::Int8),
+            Some(DataType::Int16)
+        );
+        assert_eq!(
+            super_type_arrow(&DataType::UInt16, &DataType::Int8),
+            Some(DataType::Int32)
+        );
+    }
+
+    #[test]
+    fn uint64_with_signed_or_64bit_float_follows_polars_numpy_to_float64() {
+        assert_eq!(
+            super_type_arrow(&DataType::Int8, &DataType::UInt64),
+            Some(DataType::Float64)
+        );
+        assert_eq!(
+            super_type_arrow(&DataType::UInt64, &DataType::Int64),
+            Some(DataType::Float64)
+        );
+        assert_eq!(
+            super_type_arrow(&DataType::Int64, &DataType::Float32),
+            Some(DataType::Float64)
+        );
+    }
+
+    #[test]
+    fn float_promotion_rules() {
+        // small ints + f32 stay f32
+        assert_eq!(
+            super_type_arrow(&DataType::Int8, &DataType::Float32),
+            Some(DataType::Float32)
+        );
+        assert_eq!(
+            super_type_arrow(&DataType::Float32, &DataType::Int16),
+            Some(DataType::Float32)
+        );
+        // 32-bit ints + f32 need f64 to avoid precision loss
+        assert_eq!(
+            super_type_arrow(&DataType::Float32, &DataType::Int32),
+            Some(DataType::Float64)
+        );
+        // f64 absorbs everything numeric
+        assert_eq!(
+            super_type_arrow(&DataType::Float64, &DataType::Int32),
+            Some(DataType::Float64)
+        );
+    }
+
+    #[test]
+    fn utf8_and_large_utf8_absorb_other_types() {
+        assert_eq!(
+            super_type_arrow(&DataType::Int32, &DataType::Utf8),
+            Some(DataType::Utf8)
+        );
+        assert_eq!(
+            super_type_arrow(&DataType::Utf8, &DataType::Int32),
+            Some(DataType::Utf8)
+        );
+        // LargeUtf8 takes precedence over Utf8 from either side.
+        assert_eq!(
+            super_type_arrow(&DataType::LargeUtf8, &DataType::Utf8),
+            Some(DataType::LargeUtf8)
+        );
+        assert_eq!(
+            super_type_arrow(&DataType::Utf8, &DataType::LargeUtf8),
+            Some(DataType::LargeUtf8)
+        );
+    }
+
+    #[test]
+    fn timestamp_combinations() {
+        assert_eq!(
+            super_type_arrow(&ts(), &DataType::Int64),
+            Some(DataType::Int64)
+        );
+        assert_eq!(
+            super_type_arrow(&DataType::Int32, &ts()),
+            Some(DataType::Int64)
+        );
+        assert_eq!(
+            super_type_arrow(&ts(), &DataType::UInt64),
+            Some(DataType::Float64)
+        );
+        assert_eq!(
+            super_type_arrow(&ts(), &DataType::Utf8),
+            Some(DataType::Utf8)
+        );
+        // Two timestamps normalise to second precision, no timezone.
+        assert_eq!(
+            super_type_arrow(
+                &DataType::Timestamp(TimeUnit::Nanosecond, None),
+                &DataType::Timestamp(TimeUnit::Second, None)
+            ),
+            Some(DataType::Timestamp(TimeUnit::Second, None))
+        );
+    }
+
+    #[test]
+    fn relation_is_not_commutative_for_some_pairs() {
+        // (Int8, Boolean) is defined, but the reverse is not.
+        assert_eq!(
+            super_type_arrow(&DataType::Int8, &DataType::Boolean),
+            Some(DataType::Int8)
+        );
+        assert_eq!(super_type_arrow(&DataType::Boolean, &DataType::Int8), None);
+    }
+
+    #[test]
+    fn unsupported_pairs_return_none() {
+        assert_eq!(super_type_arrow(&DataType::Boolean, &DataType::Int8), None);
+        assert_eq!(
+            super_type_arrow(&DataType::Date32, &DataType::Int8),
+            None
+        );
+        assert_eq!(
+            super_type_arrow(&DataType::Binary, &DataType::Float64),
+            None
+        );
+    }
+
+    fn schema(fields: &[(&str, DataType)]) -> SchemaRef {
+        Arc::new(Schema::new(
+            fields
+                .iter()
+                .map(|(n, dt)| Field::new(*n, dt.clone(), true))
+                .collect::<Vec<_>>(),
+        ))
+    }
+
+    #[test]
+    fn super_type_schema_errors_on_empty_input() {
+        let err = super_type_schema(&[]).unwrap_err();
+        assert!(matches!(err, SuperTypeError::NoSchemasProvided));
+    }
+
+    #[test]
+    fn super_type_schema_widens_shared_columns_and_unions_the_rest() {
+        let s1 = schema(&[("a", DataType::Int32), ("b", DataType::Float32)]);
+        let s2 = schema(&[("b", DataType::Float64), ("c", DataType::Utf8)]);
+
+        let merged = super_type_schema(&[s1, s2]).unwrap();
+
+        // Field order follows first-seen insertion order: a, b, c.
+        let names: Vec<&str> = merged.fields.iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, vec!["a", "b", "c"]);
+
+        assert_eq!(merged.field_with_name("a").unwrap().data_type(), &DataType::Int32);
+        assert_eq!(merged.field_with_name("b").unwrap().data_type(), &DataType::Float64);
+        assert_eq!(merged.field_with_name("c").unwrap().data_type(), &DataType::Utf8);
+
+        // super_type_schema marks every output field nullable.
+        assert!(merged.fields.iter().all(|f| f.is_nullable()));
+    }
+
+    #[test]
+    fn super_type_schema_errors_when_columns_have_no_common_type() {
+        let s1 = schema(&[("a", DataType::Boolean)]);
+        let s2 = schema(&[("a", DataType::Int8)]);
+
+        let err = super_type_schema(&[s1, s2]).unwrap_err();
+        match err {
+            SuperTypeError::NoCommonSuperType { column_name, .. } => {
+                assert_eq!(column_name, "a");
+            }
+            other => panic!("expected NoCommonSuperType, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn super_type_arrow_schema_returns_non_nullable_fields() {
+        let s1 = Schema::new(vec![Field::new("a", DataType::Int32, true)]);
+        let s2 = Schema::new(vec![Field::new("a", DataType::Int64, true)]);
+
+        let merged = super_type_arrow_schema(&[s1, s2]).unwrap();
+        let field = merged.field_with_name("a").unwrap();
+        assert_eq!(field.data_type(), &DataType::Int64);
+        // This variant marks fields non-nullable, unlike super_type_schema.
+        assert!(!field.is_nullable());
+    }
+
+    #[test]
+    fn super_type_arrow_schema_returns_none_on_conflict() {
+        let s1 = Schema::new(vec![Field::new("a", DataType::Boolean, true)]);
+        let s2 = Schema::new(vec![Field::new("a", DataType::Int8, true)]);
+        assert_eq!(super_type_arrow_schema(&[s1, s2]), None);
+    }
+}

--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -678,7 +678,7 @@ lazy_static! {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_base_path;
+    use super::{decode_master_key, normalize_base_path, TableEngine};
 
     #[test]
     fn empty_and_blank_serve_at_root() {
@@ -719,5 +719,47 @@ mod tests {
     #[test]
     fn rejects_empty_internal_segment() {
         assert!(normalize_base_path("a//b").is_err());
+    }
+
+    #[test]
+    fn table_engine_parses_case_insensitively_and_trims() {
+        assert_eq!("lance".parse::<TableEngine>(), Ok(TableEngine::Lance));
+        assert_eq!("ICEBERG".parse::<TableEngine>(), Ok(TableEngine::Iceberg));
+        assert_eq!("  Iceberg  ".parse::<TableEngine>(), Ok(TableEngine::Iceberg));
+        assert!("postgres".parse::<TableEngine>().is_err());
+    }
+
+    #[test]
+    fn table_engine_as_str_round_trips_and_defaults_to_lance() {
+        assert_eq!(TableEngine::Lance.as_str(), "lance");
+        assert_eq!(TableEngine::Iceberg.as_str(), "iceberg");
+        assert_eq!(TableEngine::default(), TableEngine::Lance);
+        for e in [TableEngine::Lance, TableEngine::Iceberg] {
+            assert_eq!(e.as_str().parse::<TableEngine>(), Ok(e));
+        }
+    }
+
+    #[test]
+    fn decode_master_key_accepts_exactly_32_bytes() {
+        use base64::Engine;
+        let raw = [7u8; 32];
+        let b64 = base64::engine::general_purpose::STANDARD.encode(raw);
+        assert_eq!(decode_master_key(&b64), Ok(raw));
+        // Surrounding whitespace is trimmed before decoding.
+        assert_eq!(decode_master_key(&format!("  {b64}\n")), Ok(raw));
+    }
+
+    #[test]
+    fn decode_master_key_rejects_invalid_base64() {
+        let err = decode_master_key("not valid base64!!!").unwrap_err();
+        assert!(err.contains("not valid base64"), "got: {err}");
+    }
+
+    #[test]
+    fn decode_master_key_rejects_wrong_length() {
+        use base64::Engine;
+        let b64 = base64::engine::general_purpose::STANDARD.encode([1u8, 2, 3, 4]);
+        let err = decode_master_key(&b64).unwrap_err();
+        assert!(err.contains("expected 32 bytes, got 4"), "got: {err}");
     }
 }

--- a/beacon-datafusion-ext/Cargo.toml
+++ b/beacon-datafusion-ext/Cargo.toml
@@ -29,3 +29,4 @@ beacon-object-storage = { path = "../beacon-object-storage" }
 [dev-dependencies]
 tokio = { workspace = true }
 tempfile = { workspace = true }
+chrono = { workspace = true }

--- a/beacon-datafusion-ext/src/stats_cache.rs
+++ b/beacon-datafusion-ext/src/stats_cache.rs
@@ -160,3 +160,92 @@ impl FileStatisticsCache for BeaconFileStatisticsCache {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use datafusion::common::Statistics;
+
+    fn meta(path: &str, size: u64) -> ObjectMeta {
+        ObjectMeta {
+            location: Path::from(path),
+            last_modified: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            size,
+            e_tag: None,
+            version: None,
+        }
+    }
+
+    fn stats() -> Arc<Statistics> {
+        Arc::new(Statistics::new_unknown(&arrow::datatypes::Schema::empty()))
+    }
+
+    #[test]
+    fn get_with_extra_returns_value_only_when_metadata_matches() {
+        let cache = BeaconFileStatisticsCache::with_capacity(8);
+        let p = Path::from("a/b.parquet");
+
+        // Nothing cached yet.
+        assert!(cache.get_with_extra(&p, &meta("a/b.parquet", 100)).is_none());
+
+        // First insert returns no previous value.
+        assert!(cache.put_with_extra(&p, stats(), &meta("a/b.parquet", 100)).is_none());
+
+        // Matching size + last_modified => hit.
+        assert!(cache.get_with_extra(&p, &meta("a/b.parquet", 100)).is_some());
+
+        // Size changed => the cached entry is treated as stale.
+        assert!(cache.get_with_extra(&p, &meta("a/b.parquet", 200)).is_none());
+    }
+
+    #[test]
+    fn put_with_extra_returns_the_previous_statistics() {
+        let cache = BeaconFileStatisticsCache::with_capacity(8);
+        let p = Path::from("c.parquet");
+        assert!(cache.put_with_extra(&p, stats(), &meta("c.parquet", 1)).is_none());
+        // A second put for the same key reports the prior value.
+        assert!(cache.put_with_extra(&p, stats(), &meta("c.parquet", 2)).is_some());
+    }
+
+    #[test]
+    fn cache_accessor_put_get_remove_roundtrip() {
+        let cache = BeaconFileStatisticsCache::with_capacity(8);
+        let p = Path::from("d.parquet");
+        let entry = CachedFileMetadata::new(meta("d.parquet", 10), stats(), None);
+
+        assert!(cache.put(&p, entry).is_none());
+        assert!(cache.contains_key(&p));
+        assert!(cache.get(&p).is_some());
+
+        let removed = cache.remove(&p);
+        assert!(removed.is_some());
+        assert!(!cache.contains_key(&p));
+        assert!(cache.get(&p).is_none());
+    }
+
+    #[test]
+    fn name_and_empty_cache() {
+        let cache = BeaconFileStatisticsCache::default();
+        assert_eq!(cache.name(), "BeaconFileStatisticsCache");
+        // A fresh cache reports no entries (entry_count is exact at zero).
+        assert_eq!(cache.len(), 0);
+        assert!(cache.get(&Path::from("missing")).is_none());
+    }
+
+    #[test]
+    fn list_entries_reports_inserted_entry() {
+        let cache = BeaconFileStatisticsCache::with_capacity(8);
+        let p = Path::from("e.parquet");
+        cache.put_with_extra(&p, stats(), &meta("e.parquet", 7));
+
+        // Inherent API: snapshot of (path, meta, stats).
+        let entries = cache.list_entries();
+        assert!(entries.iter().any(|(path, _, _)| path == &p));
+
+        // DataFusion trait API: maps statistics into cache-entry summaries.
+        let trait_entries = FileStatisticsCache::list_entries(&cache);
+        let summary = trait_entries.get(&p).expect("entry present");
+        assert_eq!(summary.num_columns, 0);
+    }
+}

--- a/beacon-file-formats/beacon-arrow-odv/src/reader.rs
+++ b/beacon-file-formats/beacon-arrow-odv/src/reader.rs
@@ -467,3 +467,125 @@ mod tests {
         println!("Total rows written: {}", counter);
     }
 }
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn value_type_to_arrow_type_mapping() {
+        let f = AsyncOdvDecoder::value_type_to_arrow_type;
+        assert_eq!(f("INDEXED_TEXT").unwrap(), DataType::Utf8);
+        assert_eq!(f("INTEGER").unwrap(), DataType::Int64);
+        assert_eq!(f("FLOAT").unwrap(), DataType::Float32);
+        assert_eq!(f("DOUBLE").unwrap(), DataType::Float64);
+        assert_eq!(f("TEXT:5").unwrap(), DataType::Utf8);
+        assert!(f("NONSENSE").is_err());
+    }
+
+    #[test]
+    fn odv_field_from_header_extracts_name_units_and_metadata() {
+        let line = r#"//<MetaVariable> label="Longitude [degrees east]" value_type="FLOAT" qf_schema="SEADATANET" comment="pos"</MetaVariable>"#;
+        let field = AsyncOdvDecoder::odv_field_from_header(line).unwrap();
+
+        // Units in brackets are stripped from the name and stored as metadata.
+        assert_eq!(field.name(), "Longitude");
+        assert_eq!(field.data_type(), &DataType::Float32);
+        assert_eq!(field.metadata().get("units").map(|s| s.as_str()), Some("degrees east"));
+        assert_eq!(field.metadata().get("qf_schema").map(|s| s.as_str()), Some("SEADATANET"));
+        assert_eq!(field.metadata().get("comment").map(|s| s.as_str()), Some("pos"));
+    }
+
+    #[test]
+    fn odv_field_from_header_handles_no_units_and_non_matching_lines() {
+        let line = r#"//<MetaVariable> label="Cruise" value_type="INDEXED_TEXT" qf_schema="SEADATANET" comment=""</MetaVariable>"#;
+        let field = AsyncOdvDecoder::odv_field_from_header(line).unwrap();
+        assert_eq!(field.name(), "Cruise");
+        assert_eq!(field.data_type(), &DataType::Utf8);
+        assert!(field.metadata().get("units").is_none());
+        // An empty comment is not recorded as metadata.
+        assert!(field.metadata().get("comment").is_none());
+
+        // Non-variable comment lines yield no field.
+        assert!(AsyncOdvDecoder::odv_field_from_header("//<Encoding>UTF-8</Encoding>").is_none());
+    }
+
+    #[test]
+    fn schema_mapper_appends_and_fills_metadata_columns() {
+        let field = Field::new("Temp", DataType::Float32, true).with_metadata(
+            std::collections::HashMap::from([("units".to_string(), "degC".to_string())]),
+        );
+        let input = Arc::new(arrow::datatypes::Schema::new(vec![field]));
+        let mapper = OdvSchemaMapper::new(input.clone());
+
+        // Output schema = original columns + one Utf8 column per metadata entry.
+        let out_schema = mapper.output_schema();
+        let names: Vec<&str> = out_schema
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+        assert_eq!(names, vec!["Temp", "Temp.units"]);
+
+        let batch = RecordBatch::try_new(
+            input.clone(),
+            vec![Arc::new(arrow::array::Float32Array::from(vec![1.0_f32, 2.0]))
+                as Arc<dyn arrow::array::Array>],
+        )
+        .unwrap();
+        let mapped = mapper.map_batch(batch, None).unwrap();
+        assert_eq!(mapped.num_columns(), 2);
+        assert_eq!(mapped.num_rows(), 2);
+        let units = mapped
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(units.value(0), "degC");
+        assert_eq!(units.value(1), "degC");
+    }
+
+    fn odv_document() -> String {
+        [
+            "//<Encoding>UTF-8</Encoding>",
+            "//<DataType>Profiles</DataType>",
+            r#"//<MetaVariable> label="Cruise" value_type="INDEXED_TEXT" qf_schema="SEADATANET" comment=""</MetaVariable>"#,
+            r#"//<MetaVariable> label="Station" value_type="INDEXED_TEXT" qf_schema="SEADATANET" comment=""</MetaVariable>"#,
+            r#"//<MetaVariable> label="Type" value_type="TEXT:2" qf_schema="SEADATANET" comment=""</MetaVariable>"#,
+            r#"//<DataVariable> label="Depth [m]" value_type="FLOAT" qf_schema="SEADATANET" comment=""</DataVariable>"#,
+            "Cruise\tStation\tType\tDepth [m]",
+            "c1\t1\tB\t10.5",
+        ]
+        .join("\n")
+    }
+
+    fn byte_stream(doc: String) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Unpin {
+        Box::pin(futures::stream::once(async move {
+            Ok::<_, std::io::Error>(Bytes::from(doc.into_bytes()))
+        }))
+    }
+
+    #[tokio::test]
+    async fn decode_schema_mapper_and_body_from_in_memory_document() {
+        let mapper = AsyncOdvDecoder::decode_schema_mapper(byte_stream(odv_document()))
+            .await
+            .unwrap();
+
+        let names: Vec<String> = mapper
+            .output_schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+        assert!(names.iter().any(|n| n == "Cruise"));
+        assert!(names.iter().any(|n| n == "Depth"));
+
+        let mapper = Arc::new(mapper);
+        let mut stream = AsyncOdvDecoder::decode(byte_stream(odv_document()), None, mapper).await;
+        let mut rows = 0;
+        while let Some(batch) = stream.next().await {
+            rows += batch.unwrap().num_rows();
+        }
+        assert_eq!(rows, 1);
+    }
+}

--- a/beacon-file-formats/beacon-arrow-odv/src/writer.rs
+++ b/beacon-file-formats/beacon-arrow-odv/src/writer.rs
@@ -1716,6 +1716,198 @@ mod tests {
     use crate::writer::OdvOptions;
 
     use super::OdvBatchType;
+    use super::{ColumnInfo, OdvBatchSchemaMapper, OdvFile, Profiles, Trajectories};
+
+    /// A user-facing input schema (before `map_schema` adds Station/Type).
+    fn user_input_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("Cruise", DataType::Utf8, true),
+            Field::new("yyyy-MM-ddTHH:mm:ss.SSS", DataType::Utf8, true),
+            Field::new("Longitude [degrees east]", DataType::Float64, true),
+            Field::new("Latitude [degrees north]", DataType::Float64, true),
+            Field::new("Depth [m]", DataType::Float64, true),
+        ]))
+    }
+
+    fn user_input_batch(schema: &SchemaRef) -> RecordBatch {
+        RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["c1"])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["2020-01-01T00:00:00.000"])),
+                Arc::new(Float64Array::from(vec![1.5])),
+                Arc::new(Float64Array::from(vec![2.5])),
+                Arc::new(Float64Array::from(vec![10.0])),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn odv_file_writes_profiles_header_and_data() {
+        let schema = user_input_schema();
+        let opts = OdvOptions::default();
+
+        let mut file =
+            OdvFile::<Profiles, Vec<u8>>::new(Vec::new(), &opts, schema.clone()).unwrap();
+        file.write_batch(user_input_batch(&schema)).unwrap();
+        let text = String::from_utf8(file.finish().unwrap()).unwrap();
+
+        // ODV preamble + type header.
+        assert!(text.contains("//<Encoding>UTF-8</Encoding>"));
+        assert!(text.contains("//<DataType>Profiles</DataType>"));
+        // Required metadata variables.
+        assert!(text.contains("<MetaVariable> label=\"Cruise\""));
+        assert!(text.contains("<MetaVariable> label=\"Station\""));
+        // Depth is the primary variable for profiles.
+        assert!(text.contains("is_primary_variable=\"T\""));
+        assert!(text.contains("time_ISO8601"));
+        // Float columns map to ODV value_type FLOAT.
+        assert!(text.contains("value_type=\"FLOAT\""));
+        // The data row is written via the CSV writer.
+        assert!(text.contains("c1"));
+    }
+
+    #[test]
+    fn odv_file_writes_trajectories_header() {
+        // Trajectories take the TimeSeries|Trajectories header branch (time is the
+        // primary variable, marked "T").
+        let schema = user_input_schema();
+        let opts = OdvOptions::default();
+
+        let mut file =
+            OdvFile::<Trajectories, Vec<u8>>::new(Vec::new(), &opts, schema.clone()).unwrap();
+        file.write_batch(user_input_batch(&schema)).unwrap();
+        let text = String::from_utf8(file.finish().unwrap()).unwrap();
+
+        assert!(text.contains("//<DataType>Trajectories</DataType>"));
+        assert!(text.contains("is_primary_variable=\"T\""));
+    }
+
+    #[test]
+    fn try_from_arrow_schema_classifies_data_and_meta_columns() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("temperature", DataType::Float64, true),
+            Field::new("temperature_qf", DataType::Utf8, true),
+            Field::new("salinity", DataType::Float64, true),
+            Field::new("platform", DataType::Utf8, true),
+        ]));
+
+        let opts = OdvOptions::try_from_arrow_schema(schema).unwrap();
+
+        // A column with a sibling `_qf`/`_qc` column becomes a data column.
+        assert_eq!(opts.data_columns.len(), 1);
+        assert_eq!(opts.data_columns[0].column_name, "temperature");
+        assert_eq!(
+            opts.data_columns[0].qf_column.as_deref(),
+            Some("temperature_qf")
+        );
+
+        // Columns with no quality flag become metadata columns; the `_qf` column
+        // itself is skipped.
+        let meta: Vec<&str> = opts
+            .meta_columns
+            .iter()
+            .map(|c| c.column_name.as_str())
+            .collect();
+        assert_eq!(meta, vec!["salinity", "platform"]);
+    }
+
+    #[test]
+    fn default_options_use_seadatanet_conventions() {
+        let opts = OdvOptions::default();
+        assert_eq!(opts.key_column, "Cruise");
+        assert_eq!(opts.qf_schema, "SEADATANET");
+        assert_eq!(opts.depth_column.column_name, "Depth [m]");
+        assert_eq!(opts.latitude_column.column_name, "Latitude [degrees north]");
+        assert!(opts.data_columns.is_empty());
+        assert!(opts.meta_columns.is_empty());
+    }
+
+    #[test]
+    fn builder_methods_override_fields() {
+        let ci = ColumnInfo {
+            column_name: "lon".to_string(),
+            comment: None,
+            significant_digits: None,
+            qf_column: None,
+            units: None,
+        };
+        let opts = OdvOptions::default()
+            .with_longitude_column(ci)
+            .with_key_column("KEY".to_string())
+            .with_qf_schema("CUSTOM".to_string());
+
+        assert_eq!(opts.longitude_column.column_name, "lon");
+        assert_eq!(opts.key_column, "KEY");
+        assert_eq!(opts.qf_schema, "CUSTOM");
+    }
+
+    fn required_input_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("Cruise", DataType::Utf8, true),
+            Field::new("Station", DataType::Utf8, true),
+            Field::new("Type", DataType::Utf8, true),
+            Field::new("yyyy-MM-ddTHH:mm:ss.SSS", DataType::Utf8, true),
+            Field::new("Longitude [degrees east]", DataType::Float64, true),
+            Field::new("Latitude [degrees north]", DataType::Float64, true),
+            Field::new("Depth [m]", DataType::Float64, true),
+        ]))
+    }
+
+    #[test]
+    fn batch_schema_mapper_projects_and_renames() {
+        let input_schema = required_input_schema();
+        let mapper =
+            OdvBatchSchemaMapper::new(input_schema.clone(), OdvOptions::default()).unwrap();
+
+        // Required columns expand to: Cruise, Station, Type, date, longitude,
+        // latitude, time_ISO8601, depth.
+        assert_eq!(mapper.projection().len(), 8);
+        let out = mapper.output_schema();
+        let names: Vec<&str> = out.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(names.len(), 8);
+        assert!(names.contains(&"Cruise"));
+        assert!(names.contains(&"time_ISO8601"));
+        assert!(names.contains(&"Longitude [degrees east]"));
+
+        let batch = RecordBatch::try_new(
+            input_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["c1"])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["s1"])),
+                Arc::new(StringArray::from(vec!["B"])),
+                Arc::new(StringArray::from(vec!["2020-01-01T00:00:00.000"])),
+                Arc::new(Float64Array::from(vec![1.5])),
+                Arc::new(Float64Array::from(vec![2.5])),
+                Arc::new(Float64Array::from(vec![10.0])),
+            ],
+        )
+        .unwrap();
+
+        let mapped = mapper.map(batch);
+        assert_eq!(mapped.num_columns(), 8);
+        assert_eq!(mapped.num_rows(), 1);
+        assert_eq!(mapped.schema(), out);
+        // The Cruise column is the first projected column and keeps its value.
+        let cruise = mapped
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(cruise.value(0), "c1");
+    }
+
+    #[test]
+    fn batch_schema_mapper_errors_on_missing_required_column() {
+        // Only the key column is present; Station/Type/etc. are missing.
+        let input_schema = Arc::new(Schema::new(vec![Field::new(
+            "Cruise",
+            DataType::Utf8,
+            true,
+        )]));
+        assert!(OdvBatchSchemaMapper::new(input_schema, OdvOptions::default()).is_err());
+    }
 
     // #[test]
     // fn test_key_batches() {

--- a/beacon-functions/src/blue_cloud/argo/map_instrument_l05.rs
+++ b/beacon-functions/src/blue_cloud/argo/map_instrument_l05.rs
@@ -21,3 +21,18 @@ fn map_argo_instrument_l05_impl(_: &[ColumnarValue]) -> datafusion::error::Resul
         "SDN:L05::130".to_string(),
     ))));
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn always_returns_the_constant_l05_code() {
+        // The mapping is a constant, so it ignores its inputs entirely.
+        let out = map_argo_instrument_l05_impl(&[]).unwrap();
+        assert!(matches!(
+            out,
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(ref s))) if s == "SDN:L05::130"
+        ));
+    }
+}

--- a/beacon-functions/src/blue_cloud/argo/map_platform_l06.rs
+++ b/beacon-functions/src/blue_cloud/argo/map_platform_l06.rs
@@ -20,3 +20,17 @@ fn map_argo_platform_l06_impl(_: &[ColumnarValue]) -> datafusion::error::Result<
         "SDN:L06::46".to_string(),
     ))));
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn always_returns_the_constant_l06_code() {
+        let out = map_argo_platform_l06_impl(&[]).unwrap();
+        assert!(matches!(
+            out,
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(ref s))) if s == "SDN:L06::46"
+        ));
+    }
+}

--- a/beacon-functions/src/blue_cloud/cmems/map_bigram_l05.rs
+++ b/beacon-functions/src/blue_cloud/cmems/map_bigram_l05.rs
@@ -56,3 +56,51 @@ fn map_bigram_l05(platform_bigram: Option<&str>) -> Option<&'static str> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Array;
+
+    #[test]
+    fn known_and_unknown_bigrams() {
+        assert_eq!(map_bigram_l05(Some("BO")), Some("SDN:L05::30"));
+        assert_eq!(map_bigram_l05(Some("SF")), Some("SDN:L05::131"));
+        assert_eq!(map_bigram_l05(Some("ZZ")), None);
+        assert_eq!(map_bigram_l05(None), None);
+    }
+
+    #[test]
+    fn impl_rejects_wrong_argument_count() {
+        assert!(map_cmems_bigram_l05_impl(&[]).is_err());
+    }
+
+    #[test]
+    fn impl_array_path() {
+        let input = ColumnarValue::Array(Arc::new(StringArray::from(vec![
+            Some("CT"),
+            Some("ZZ"),
+        ])));
+        let ColumnarValue::Array(arr) = map_cmems_bigram_l05_impl(&[input]).unwrap() else {
+            panic!("expected array");
+        };
+        let arr = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(arr.value(0), "SDN:L05::130");
+        assert!(arr.is_null(1));
+    }
+
+    #[test]
+    fn impl_scalar_path() {
+        let input = ColumnarValue::Scalar(ScalarValue::Utf8(Some("XB".into())));
+        match map_cmems_bigram_l05_impl(&[input]).unwrap() {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => assert_eq!(s, "SDN:L05::132"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn impl_rejects_non_utf8_scalar() {
+        let input = ColumnarValue::Scalar(ScalarValue::Int64(Some(1)));
+        assert!(map_cmems_bigram_l05_impl(&[input]).is_err());
+    }
+}

--- a/beacon-functions/src/blue_cloud/cmems/map_bigram_l06.rs
+++ b/beacon-functions/src/blue_cloud/cmems/map_bigram_l06.rs
@@ -118,3 +118,58 @@ fn map_bigram_l06(
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Array;
+
+    #[test]
+    fn mapping_depends_on_wmo_type_only_for_ct() {
+        assert_eq!(map_bigram_l06(Some("CT"), Some("995")), Some("SDN:L06::70"));
+        assert_eq!(map_bigram_l06(Some("CT"), Some("other")), Some("SDN:L06::30"));
+        assert_eq!(map_bigram_l06(Some("BO"), None), Some("SDN:L06::30"));
+        assert_eq!(map_bigram_l06(Some("XX"), None), Some("SDN:L06::0"));
+        assert_eq!(map_bigram_l06(Some("ZZ"), None), None);
+        assert_eq!(map_bigram_l06(None, None), None);
+    }
+
+    #[test]
+    fn impl_rejects_wrong_argument_count() {
+        assert!(map_cmems_bigram_l06_impl(&[]).is_err());
+    }
+
+    #[test]
+    fn impl_array_array_path() {
+        let bigrams =
+            ColumnarValue::Array(Arc::new(StringArray::from(vec![Some("BO"), Some("ZZ")])));
+        let wmo =
+            ColumnarValue::Array(Arc::new(StringArray::from(vec![None::<&str>, None::<&str>])));
+        let ColumnarValue::Array(arr) = map_cmems_bigram_l06_impl(&[bigrams, wmo]).unwrap() else {
+            panic!("expected array");
+        };
+        let arr = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(arr.value(0), "SDN:L06::30");
+        assert!(arr.is_null(1));
+    }
+
+    #[test]
+    fn impl_scalar_scalar_path() {
+        let bigram = ColumnarValue::Scalar(ScalarValue::Utf8(Some("CT".into())));
+        let wmo = ColumnarValue::Scalar(ScalarValue::Utf8(Some("995".into())));
+        match map_cmems_bigram_l06_impl(&[bigram, wmo]).unwrap() {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => assert_eq!(s, "SDN:L06::70"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn impl_scalar_scalar_unknown_is_null() {
+        let bigram = ColumnarValue::Scalar(ScalarValue::Utf8(Some("ZZ".into())));
+        let wmo = ColumnarValue::Scalar(ScalarValue::Utf8(None));
+        assert!(matches!(
+            map_cmems_bigram_l06_impl(&[bigram, wmo]).unwrap(),
+            ColumnarValue::Scalar(ScalarValue::Utf8(None))
+        ));
+    }
+}

--- a/beacon-functions/src/blue_cloud/common/map_measuring_area_type_feature_type.rs
+++ b/beacon-functions/src/blue_cloud/common/map_measuring_area_type_feature_type.rs
@@ -58,3 +58,47 @@ fn map_str_feature_type<S: AsRef<str>>(input: S) -> Option<String> {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Array;
+
+    #[test]
+    fn feature_type_keywords() {
+        assert_eq!(map_str_feature_type("a curve segment"), Some("trajectory".to_string()));
+        assert_eq!(map_str_feature_type("a single point"), Some("profile".to_string()));
+        assert_eq!(map_str_feature_type("neither keyword"), None);
+    }
+
+    #[test]
+    fn impl_scalar_path() {
+        let input = ColumnarValue::Scalar(ScalarValue::Utf8(Some("curve".into())));
+        match map_measuring_area_type_feature_type_impl(&[input]).unwrap() {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => assert_eq!(s, "trajectory"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn impl_array_path() {
+        let input = ColumnarValue::Array(Arc::new(StringArray::from(vec![
+            Some("point data"),
+            Some("unmatched"),
+        ])));
+        let ColumnarValue::Array(arr) =
+            map_measuring_area_type_feature_type_impl(&[input]).unwrap()
+        else {
+            panic!("expected array");
+        };
+        let arr = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(arr.value(0), "profile");
+        assert!(arr.is_null(1));
+    }
+
+    #[test]
+    fn impl_rejects_non_utf8_scalar() {
+        let input = ColumnarValue::Scalar(ScalarValue::Int64(Some(1)));
+        assert!(map_measuring_area_type_feature_type_impl(&[input]).is_err());
+    }
+}

--- a/beacon-functions/src/blue_cloud/common/pressure_to_depth_teos_10.rs
+++ b/beacon-functions/src/blue_cloud/common/pressure_to_depth_teos_10.rs
@@ -89,3 +89,76 @@ fn pressure_to_depth_teos_10_impl(
 fn gsw_depth_from_pressure(pressure: f64, latitude: f64) -> f64 {
     -gsw::conversions::z_from_p(pressure, latitude, 0.0, 0.0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, Float64Array};
+
+    #[test]
+    fn zero_pressure_is_zero_depth() {
+        assert!(gsw_depth_from_pressure(0.0, 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn positive_pressure_gives_positive_depth_near_one_metre_per_dbar() {
+        // ~100 dbar is roughly ~99 m of depth; assert it is positive and close.
+        let depth = gsw_depth_from_pressure(100.0, 30.0);
+        assert!(depth > 0.0, "depth should be positive, got {depth}");
+        assert!((depth - 99.0).abs() < 5.0, "depth out of expected range: {depth}");
+    }
+
+    fn f64_array(out: ColumnarValue) -> Float64Array {
+        match out {
+            ColumnarValue::Array(arr) => {
+                arr.as_any().downcast_ref::<Float64Array>().unwrap().clone()
+            }
+            other => panic!("expected array output, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn array_array_path() {
+        let pressure = ColumnarValue::Array(Arc::new(Float64Array::from(vec![
+            Some(0.0),
+            Some(100.0),
+            None,
+        ])));
+        let latitude = ColumnarValue::Array(Arc::new(Float64Array::from(vec![
+            Some(0.0),
+            Some(30.0),
+            Some(30.0),
+        ])));
+        let arr = f64_array(pressure_to_depth_teos_10_impl(&[pressure, latitude]).unwrap());
+        assert!(arr.value(0).abs() < 1e-9);
+        assert!(arr.value(1) > 0.0);
+        assert!(arr.is_null(2));
+    }
+
+    #[test]
+    fn scalar_pressure_array_latitude_path() {
+        let pressure = ColumnarValue::Scalar(ScalarValue::Float64(Some(100.0)));
+        let latitude = ColumnarValue::Array(Arc::new(Float64Array::from(vec![Some(30.0)])));
+        let arr = f64_array(pressure_to_depth_teos_10_impl(&[pressure, latitude]).unwrap());
+        assert!(arr.value(0) > 0.0);
+    }
+
+    #[test]
+    fn array_pressure_scalar_latitude_path() {
+        let pressure = ColumnarValue::Array(Arc::new(Float64Array::from(vec![Some(100.0)])));
+        let latitude = ColumnarValue::Scalar(ScalarValue::Float64(Some(30.0)));
+        let arr = f64_array(pressure_to_depth_teos_10_impl(&[pressure, latitude]).unwrap());
+        assert!(arr.value(0) > 0.0);
+    }
+
+    #[test]
+    fn scalar_scalar_path() {
+        let pressure = ColumnarValue::Scalar(ScalarValue::Float64(Some(100.0)));
+        let latitude = ColumnarValue::Scalar(ScalarValue::Float64(Some(30.0)));
+        let out = pressure_to_depth_teos_10_impl(&[pressure, latitude]).unwrap();
+        match out {
+            ColumnarValue::Scalar(ScalarValue::Float64(Some(d))) => assert!(d > 0.0),
+            other => panic!("unexpected output: {other:?}"),
+        }
+    }
+}

--- a/beacon-functions/src/blue_cloud/cora/map_platform_l06.rs
+++ b/beacon-functions/src/blue_cloud/cora/map_platform_l06.rs
@@ -117,3 +117,83 @@ fn map_cora_platform_func_impl(
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Array;
+
+    #[test]
+    fn known_bigrams_map_to_l06_codes() {
+        assert_eq!(map_cora_platform_func_impl(Some("BO"), None), Some("SDN:L06::30"));
+        assert_eq!(map_cora_platform_func_impl(Some("DB"), None), Some("SDN:L06::42"));
+        assert_eq!(map_cora_platform_func_impl(Some("GL"), None), Some("SDN:L06::27"));
+        assert_eq!(map_cora_platform_func_impl(Some("XX"), None), Some("SDN:L06::0"));
+    }
+
+    #[test]
+    fn wmo_inst_type_is_ignored_for_codes_that_do_not_depend_on_it() {
+        assert_eq!(
+            map_cora_platform_func_impl(Some("CT"), Some("995")),
+            Some("SDN:L06::30")
+        );
+        assert_eq!(
+            map_cora_platform_func_impl(Some("CT"), Some("anything")),
+            Some("SDN:L06::30")
+        );
+    }
+
+    #[test]
+    fn unknown_or_missing_bigram_returns_none() {
+        assert_eq!(map_cora_platform_func_impl(Some("ZZ"), None), None);
+        assert_eq!(map_cora_platform_func_impl(None, Some("995")), None);
+        assert_eq!(map_cora_platform_func_impl(None, None), None);
+    }
+
+    #[test]
+    fn udf_rejects_wrong_argument_count() {
+        let single = [ColumnarValue::Scalar(ScalarValue::Utf8(Some("BO".into())))];
+        assert!(map_cora_platform_l06_impl(&single).is_err());
+    }
+
+    #[test]
+    fn udf_handles_array_array() {
+        let bigrams = ColumnarValue::Array(Arc::new(StringArray::from(vec![
+            Some("BO"),
+            Some("ZZ"),
+        ])));
+        let wmo = ColumnarValue::Array(Arc::new(StringArray::from(vec![
+            None::<&str>,
+            None::<&str>,
+        ])));
+
+        let out = map_cora_platform_l06_impl(&[bigrams, wmo]).unwrap();
+        let ColumnarValue::Array(arr) = out else {
+            panic!("expected array output");
+        };
+        let arr = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(arr.value(0), "SDN:L06::30");
+        assert!(arr.is_null(1));
+    }
+
+    #[test]
+    fn udf_handles_scalar_scalar() {
+        let bigram = ColumnarValue::Scalar(ScalarValue::Utf8(Some("DB".into())));
+        let wmo = ColumnarValue::Scalar(ScalarValue::Utf8(None));
+        let out = map_cora_platform_l06_impl(&[bigram, wmo]).unwrap();
+        match out {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(code))) => {
+                assert_eq!(code, "SDN:L06::42")
+            }
+            other => panic!("unexpected output: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn udf_scalar_scalar_unknown_is_null() {
+        let bigram = ColumnarValue::Scalar(ScalarValue::Utf8(Some("ZZ".into())));
+        let wmo = ColumnarValue::Scalar(ScalarValue::Utf8(None));
+        let out = map_cora_platform_l06_impl(&[bigram, wmo]).unwrap();
+        assert!(matches!(out, ColumnarValue::Scalar(ScalarValue::Utf8(None))));
+    }
+}

--- a/beacon-functions/src/blue_cloud/emodnet_chemistry/map_instrument_l05.rs
+++ b/beacon-functions/src/blue_cloud/emodnet_chemistry/map_instrument_l05.rs
@@ -62,3 +62,49 @@ fn map_emodnet_chemistry_instrument_l05_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Array;
+
+    #[test]
+    fn extracts_l05_code_from_parenthesised_text() {
+        let input = ColumnarValue::Scalar(ScalarValue::Utf8(Some("CTD (130)".into())));
+        match map_emodnet_chemistry_instrument_l05_impl(&[input]).unwrap() {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => assert_eq!(s, "SDN:L05::130"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_parentheses_yields_null() {
+        let input = ColumnarValue::Scalar(ScalarValue::Utf8(Some("no code here".into())));
+        assert!(matches!(
+            map_emodnet_chemistry_instrument_l05_impl(&[input]).unwrap(),
+            ColumnarValue::Scalar(ScalarValue::Utf8(None))
+        ));
+    }
+
+    #[test]
+    fn impl_array_path() {
+        let input = ColumnarValue::Array(Arc::new(StringArray::from(vec![
+            Some("X (12)"),
+            Some("none"),
+        ])));
+        let ColumnarValue::Array(arr) =
+            map_emodnet_chemistry_instrument_l05_impl(&[input]).unwrap()
+        else {
+            panic!("expected array");
+        };
+        let arr = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(arr.value(0), "SDN:L05::12");
+        assert!(arr.is_null(1));
+    }
+
+    #[test]
+    fn impl_rejects_non_utf8_scalar() {
+        let input = ColumnarValue::Scalar(ScalarValue::Int64(Some(1)));
+        assert!(map_emodnet_chemistry_instrument_l05_impl(&[input]).is_err());
+    }
+}

--- a/beacon-functions/src/blue_cloud/emodnet_chemistry/map_instrument_l05_multi.rs
+++ b/beacon-functions/src/blue_cloud/emodnet_chemistry/map_instrument_l05_multi.rs
@@ -81,3 +81,52 @@ fn map_emodnet_chemistry_instrument_l05_multi_impl(
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Array;
+
+    #[test]
+    fn extracts_every_parenthesised_group() {
+        let values = extract_parenthesized_values_ref("CTD (130) and XBT (132)");
+        assert_eq!(values, vec!["SDN:L05::130", "SDN:L05::132"]);
+    }
+
+    #[test]
+    fn skips_empty_groups_and_stops_at_unclosed_parenthesis() {
+        // Empty () is dropped; an unclosed '(' ends the scan.
+        assert_eq!(extract_parenthesized_values_ref("a () b (7)"), vec!["SDN:L05::7"]);
+        assert_eq!(extract_parenthesized_values_ref("a (7) b (oops"), vec!["SDN:L05::7"]);
+        assert!(extract_parenthesized_values_ref("no groups").is_empty());
+    }
+
+    #[test]
+    fn impl_scalar_joins_with_separator() {
+        let input = ColumnarValue::Scalar(ScalarValue::Utf8(Some("A (1) B (2)".into())));
+        match map_emodnet_chemistry_instrument_l05_multi_impl(&[input]).unwrap() {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => {
+                assert_eq!(s, "SDN:L05::1 | SDN:L05::2")
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn impl_array_path() {
+        let input = ColumnarValue::Array(Arc::new(StringArray::from(vec![Some("X (5)")])));
+        let ColumnarValue::Array(arr) =
+            map_emodnet_chemistry_instrument_l05_multi_impl(&[input]).unwrap()
+        else {
+            panic!("expected array");
+        };
+        let arr = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(arr.value(0), "SDN:L05::5");
+    }
+
+    #[test]
+    fn impl_rejects_non_utf8_scalar() {
+        let input = ColumnarValue::Scalar(ScalarValue::Int64(Some(1)));
+        assert!(map_emodnet_chemistry_instrument_l05_multi_impl(&[input]).is_err());
+    }
+}

--- a/beacon-functions/src/blue_cloud/emodnet_chemistry/map_originator_edmo.rs
+++ b/beacon-functions/src/blue_cloud/emodnet_chemistry/map_originator_edmo.rs
@@ -58,3 +58,50 @@ fn map_emodnet_chemistry_originator_edmo_impl(
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Array;
+
+    #[test]
+    fn extracts_the_last_parenthesised_edmo_code() {
+        // rfind locates the final '(' — so the EDMO code, not earlier groups.
+        let input = ColumnarValue::Scalar(ScalarValue::Utf8(Some("Origin (1) Lab (486)".into())));
+        match map_emodnet_chemistry_originator_edmo_impl(&[input]).unwrap() {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => assert_eq!(s, "486"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_parentheses_yields_null() {
+        let input = ColumnarValue::Scalar(ScalarValue::Utf8(Some("plain".into())));
+        assert!(matches!(
+            map_emodnet_chemistry_originator_edmo_impl(&[input]).unwrap(),
+            ColumnarValue::Scalar(ScalarValue::Utf8(None))
+        ));
+    }
+
+    #[test]
+    fn impl_array_path() {
+        let input = ColumnarValue::Array(Arc::new(StringArray::from(vec![
+            Some("Lab (42)"),
+            Some("none"),
+        ])));
+        let ColumnarValue::Array(arr) =
+            map_emodnet_chemistry_originator_edmo_impl(&[input]).unwrap()
+        else {
+            panic!("expected array");
+        };
+        let arr = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(arr.value(0), "42");
+        assert!(arr.is_null(1));
+    }
+
+    #[test]
+    fn impl_rejects_non_utf8_scalar() {
+        let input = ColumnarValue::Scalar(ScalarValue::Int64(Some(1)));
+        assert!(map_emodnet_chemistry_originator_edmo_impl(&[input]).is_err());
+    }
+}

--- a/beacon-functions/src/blue_cloud/emodnet_chemistry/map_platform_l06.rs
+++ b/beacon-functions/src/blue_cloud/emodnet_chemistry/map_platform_l06.rs
@@ -62,3 +62,47 @@ fn map_emodnet_chemistry_platform_l06_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Array;
+
+    #[test]
+    fn extracts_l06_code_from_parenthesised_text() {
+        let input = ColumnarValue::Scalar(ScalarValue::Utf8(Some("Mooring (48)".into())));
+        match map_emodnet_chemistry_platform_l06_impl(&[input]).unwrap() {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => assert_eq!(s, "SDN:L06::48"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_parentheses_yields_null() {
+        let input = ColumnarValue::Scalar(ScalarValue::Utf8(Some("plain".into())));
+        assert!(matches!(
+            map_emodnet_chemistry_platform_l06_impl(&[input]).unwrap(),
+            ColumnarValue::Scalar(ScalarValue::Utf8(None))
+        ));
+    }
+
+    #[test]
+    fn impl_array_path() {
+        let input =
+            ColumnarValue::Array(Arc::new(StringArray::from(vec![Some("Y (30)"), Some("x")])));
+        let ColumnarValue::Array(arr) =
+            map_emodnet_chemistry_platform_l06_impl(&[input]).unwrap()
+        else {
+            panic!("expected array");
+        };
+        let arr = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(arr.value(0), "SDN:L06::30");
+        assert!(arr.is_null(1));
+    }
+
+    #[test]
+    fn impl_rejects_non_utf8_scalar() {
+        let input = ColumnarValue::Scalar(ScalarValue::Int64(Some(1)));
+        assert!(map_emodnet_chemistry_platform_l06_impl(&[input]).is_err());
+    }
+}

--- a/beacon-functions/src/blue_cloud/seadatanet/map_instrument_l05.rs
+++ b/beacon-functions/src/blue_cloud/seadatanet/map_instrument_l05.rs
@@ -62,3 +62,46 @@ fn map_seadatanet_instrument_l05_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Array;
+
+    #[test]
+    fn extracts_l05_code_from_parenthesised_text() {
+        let input = ColumnarValue::Scalar(ScalarValue::Utf8(Some("Sensor (130)".into())));
+        match map_seadatanet_instrument_l05_impl(&[input]).unwrap() {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => assert_eq!(s, "SDN:L05::130"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_parentheses_yields_null() {
+        let input = ColumnarValue::Scalar(ScalarValue::Utf8(Some("plain".into())));
+        assert!(matches!(
+            map_seadatanet_instrument_l05_impl(&[input]).unwrap(),
+            ColumnarValue::Scalar(ScalarValue::Utf8(None))
+        ));
+    }
+
+    #[test]
+    fn impl_array_path() {
+        let input =
+            ColumnarValue::Array(Arc::new(StringArray::from(vec![Some("Z (44)"), Some("x")])));
+        let ColumnarValue::Array(arr) = map_seadatanet_instrument_l05_impl(&[input]).unwrap()
+        else {
+            panic!("expected array");
+        };
+        let arr = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(arr.value(0), "SDN:L05::44");
+        assert!(arr.is_null(1));
+    }
+
+    #[test]
+    fn impl_rejects_non_utf8_scalar() {
+        let input = ColumnarValue::Scalar(ScalarValue::Int64(Some(1)));
+        assert!(map_seadatanet_instrument_l05_impl(&[input]).is_err());
+    }
+}

--- a/beacon-functions/src/blue_cloud/seadatanet/map_platform_l06.rs
+++ b/beacon-functions/src/blue_cloud/seadatanet/map_platform_l06.rs
@@ -62,3 +62,46 @@ fn map_seadatanet_platform_l06_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Array;
+
+    #[test]
+    fn extracts_l06_code_from_parenthesised_text() {
+        let input = ColumnarValue::Scalar(ScalarValue::Utf8(Some("Float (46)".into())));
+        match map_seadatanet_platform_l06_impl(&[input]).unwrap() {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => assert_eq!(s, "SDN:L06::46"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_parentheses_yields_null() {
+        let input = ColumnarValue::Scalar(ScalarValue::Utf8(Some("plain".into())));
+        assert!(matches!(
+            map_seadatanet_platform_l06_impl(&[input]).unwrap(),
+            ColumnarValue::Scalar(ScalarValue::Utf8(None))
+        ));
+    }
+
+    #[test]
+    fn impl_array_path() {
+        let input =
+            ColumnarValue::Array(Arc::new(StringArray::from(vec![Some("Q (27)"), Some("x")])));
+        let ColumnarValue::Array(arr) = map_seadatanet_platform_l06_impl(&[input]).unwrap()
+        else {
+            panic!("expected array");
+        };
+        let arr = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(arr.value(0), "SDN:L06::27");
+        assert!(arr.is_null(1));
+    }
+
+    #[test]
+    fn impl_rejects_non_utf8_scalar() {
+        let input = ColumnarValue::Scalar(ScalarValue::Int64(Some(1)));
+        assert!(map_seadatanet_platform_l06_impl(&[input]).is_err());
+    }
+}

--- a/beacon-functions/src/blue_cloud/world_ocean_database/map_quality_flag.rs
+++ b/beacon-functions/src/blue_cloud/world_ocean_database/map_quality_flag.rs
@@ -70,3 +70,44 @@ fn map_wod_quality_flag_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, Int64Array};
+
+    #[test]
+    fn flag_lookup_table() {
+        assert_eq!(WOD_FLAG_TO_SDN.get(&0), Some(&"1"));
+        assert_eq!(WOD_FLAG_TO_SDN.get(&3), Some(&"3"));
+        assert_eq!(WOD_FLAG_TO_SDN.get(&9), Some(&"4"));
+        assert_eq!(WOD_FLAG_TO_SDN.get(&99), None);
+    }
+
+    #[test]
+    fn impl_array_path() {
+        let input = ColumnarValue::Array(Arc::new(Int64Array::from(vec![Some(0), Some(6), Some(99)])));
+        let ColumnarValue::Array(arr) = map_wod_quality_flag_impl(&[input]).unwrap() else {
+            panic!("expected array");
+        };
+        let arr = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(arr.value(0), "1");
+        assert_eq!(arr.value(1), "4");
+        assert!(arr.is_null(2));
+    }
+
+    #[test]
+    fn impl_scalar_path() {
+        let input = ColumnarValue::Scalar(ScalarValue::Int64(Some(1)));
+        match map_wod_quality_flag_impl(&[input]).unwrap() {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => assert_eq!(s, "3"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn impl_rejects_non_int64_scalar() {
+        let input = ColumnarValue::Scalar(ScalarValue::Utf8(Some("x".into())));
+        assert!(map_wod_quality_flag_impl(&[input]).is_err());
+    }
+}

--- a/beacon-functions/src/function_doc.rs
+++ b/beacon-functions/src/function_doc.rs
@@ -143,3 +143,71 @@ impl FunctionDoc {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{Field, Fields};
+    use datafusion::logical_expr::{ColumnarValue, Volatility};
+    use datafusion::prelude::create_udf;
+    use std::sync::Arc;
+
+    #[test]
+    fn primitive_type_is_formatted_directly() {
+        assert_eq!(
+            FunctionDoc::parse_data_type_to_string(&DataType::Int32),
+            "Int32"
+        );
+    }
+
+    #[test]
+    fn list_type_is_wrapped() {
+        let list = DataType::List(Arc::new(Field::new("item", DataType::Float64, true)));
+        assert_eq!(
+            FunctionDoc::parse_data_type_to_string(&list),
+            "List<Float64>"
+        );
+    }
+
+    #[test]
+    fn struct_type_lists_named_fields() {
+        let struct_ty = DataType::Struct(Fields::from(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Utf8, true),
+        ]));
+        assert_eq!(
+            FunctionDoc::parse_data_type_to_string(&struct_ty),
+            "Struct<a: Int32, b: Utf8>"
+        );
+    }
+
+    #[test]
+    fn nested_list_of_struct_recurses() {
+        let inner = DataType::Struct(Fields::from(vec![Field::new("x", DataType::Int8, true)]));
+        let list = DataType::List(Arc::new(Field::new("item", inner, true)));
+        assert_eq!(
+            FunctionDoc::parse_data_type_to_string(&list),
+            "List<Struct<x: Int8>>"
+        );
+    }
+
+    #[test]
+    fn from_scalar_uses_signature_example_types() {
+        let udf = create_udf(
+            "dummy_fn",
+            vec![DataType::Utf8],
+            DataType::Boolean,
+            Volatility::Immutable,
+            Arc::new(|_: &[ColumnarValue]| -> datafusion::error::Result<ColumnarValue> {
+                unimplemented!()
+            }),
+        );
+
+        let docs = FunctionDoc::from_scalar(&udf);
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].function_name, "dummy_fn");
+        // create_udf has no documentation, so the return type comes from the
+        // declared signature.
+        assert_eq!(docs[0].return_type, "Boolean");
+    }
+}

--- a/beacon-functions/src/geo/st_within_point.rs
+++ b/beacon-functions/src/geo/st_within_point.rs
@@ -216,3 +216,118 @@ impl Default for WithinPointUdf {
         Self::new(10_000)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 10x10 square anchored at the origin.
+    const SQUARE: &str = "POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))";
+
+    fn geometry(wkt: &str) -> Geometry {
+        Wkt::from_str(wkt).unwrap().try_into().unwrap()
+    }
+
+    #[test]
+    fn point_inside_polygon_is_within() {
+        assert!(st_within_point_impl(Some(SQUARE), Some(5.0), Some(5.0)).unwrap());
+    }
+
+    #[test]
+    fn point_outside_polygon_is_not_within() {
+        assert!(!st_within_point_impl(Some(SQUARE), Some(20.0), Some(20.0)).unwrap());
+    }
+
+    #[test]
+    fn missing_geometry_or_coordinate_yields_false() {
+        assert!(!st_within_point_impl(None, Some(5.0), Some(5.0)).unwrap());
+        assert!(!st_within_point_impl(Some(SQUARE), None, Some(5.0)).unwrap());
+        assert!(!st_within_point_impl(Some(SQUARE), Some(5.0), None).unwrap());
+    }
+
+    #[test]
+    fn invalid_wkt_is_an_error() {
+        let err = st_within_point_impl(Some("NOT WKT"), Some(1.0), Some(1.0));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn iterator_variant_maps_each_row() {
+        let geoms = [Some(SQUARE), Some(SQUARE), None];
+        let lons = [Some(5.0), Some(50.0), Some(5.0)];
+        let lats = [Some(5.0), Some(50.0), Some(5.0)];
+
+        let result = st_within_point(
+            &mut geoms.into_iter(),
+            &mut lons.into_iter(),
+            &mut lats.into_iter(),
+        )
+        .unwrap();
+
+        assert_eq!(result, vec![true, false, false]);
+    }
+
+    #[test]
+    fn fast_variant_matches_the_simple_variant() {
+        let geom = geometry(SQUARE);
+        let lons = [Some(5.0), Some(20.0), None];
+        let lats = [Some(5.0), Some(20.0), Some(5.0)];
+
+        let result = st_within_point_fast(
+            geom,
+            &mut lons.into_iter(),
+            &mut lats.into_iter(),
+            16,
+        )
+        .unwrap();
+
+        assert_eq!(result, vec![true, false, false]);
+    }
+
+    #[test]
+    fn fast_impl_rejects_points_outside_the_bounding_rect() {
+        let geom = geometry(SQUARE);
+        let bounding_rect = geom.bounding_rect();
+        let mut cache = lru::LruCache::new(NonZero::new(4).unwrap());
+
+        // Far outside the bounding rect: short-circuits to false.
+        assert!(!st_within_point_fast_impl(
+            &geom,
+            bounding_rect,
+            &mut cache,
+            Some(100.0),
+            Some(100.0)
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn fast_impl_caches_repeated_lookups() {
+        let geom = geometry(SQUARE);
+        let bounding_rect = geom.bounding_rect();
+        let mut cache = lru::LruCache::new(NonZero::new(4).unwrap());
+
+        // First call computes and stores; second call must read from the cache
+        // and return the same answer.
+        let first =
+            st_within_point_fast_impl(&geom, bounding_rect, &mut cache, Some(5.0), Some(5.0))
+                .unwrap();
+        assert!(first);
+        assert_eq!(cache.len(), 1);
+
+        let second =
+            st_within_point_fast_impl(&geom, bounding_rect, &mut cache, Some(5.0), Some(5.0))
+                .unwrap();
+        assert_eq!(first, second);
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn fast_impl_handles_missing_coordinates() {
+        let geom = geometry(SQUARE);
+        let bounding_rect = geom.bounding_rect();
+        let mut cache = lru::LruCache::new(NonZero::new(4).unwrap());
+        assert!(!st_within_point_fast_impl(&geom, bounding_rect, &mut cache, None, Some(5.0))
+            .unwrap());
+    }
+}

--- a/beacon-functions/src/util/try_arrow_cast.rs
+++ b/beacon-functions/src/util/try_arrow_cast.rs
@@ -129,3 +129,43 @@ fn data_type_from_args(args: &[Expr]) -> datafusion::error::Result<DataType> {
         e => arrow_datafusion_err!(e),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::prelude::lit;
+
+    #[test]
+    fn parses_a_valid_target_type() {
+        let dt = data_type_from_args(&[lit(1_i64), lit("Int32")]).unwrap();
+        assert_eq!(dt, DataType::Int32);
+    }
+
+    #[test]
+    fn rejects_wrong_argument_count() {
+        assert!(data_type_from_args(&[lit("Int32")]).is_err());
+        assert!(data_type_from_args(&[]).is_err());
+    }
+
+    #[test]
+    fn rejects_non_string_type_argument() {
+        // Second argument must be a constant Utf8 literal.
+        assert!(data_type_from_args(&[lit(1_i64), lit(2_i64)]).is_err());
+    }
+
+    #[test]
+    fn rejects_unparseable_type_name() {
+        assert!(data_type_from_args(&[lit(1_i64), lit("NotARealArrowType")]).is_err());
+    }
+
+    #[test]
+    fn udf_metadata_is_stable() {
+        let func = TryArrowCastFunc::new();
+        assert_eq!(func.name(), "try_arrow_cast");
+        // return_type is intentionally an error; return_field_from_args is used.
+        assert!(func.return_type(&[DataType::Int32]).is_err());
+
+        // The public constructor exposes the same name.
+        assert_eq!(try_arrow_cast().name(), "try_arrow_cast");
+    }
+}


### PR DESCRIPTION
Improves unit-test coverage of pure-logic modules (guided by the Codecov report) and fixes three bugs surfaced while writing the tests.

## Bugs fixed in `super_type_arrow` (beacon-common)

Found while expanding coverage of the schema super-typing logic:

1. **Data corruption** — `Float64 + LargeUtf8` returned `Float64`. The `(Float64, _)` catch-all fired before the `LargeUtf8` string arms, so merging a float column with a large-string column would cast the strings to floats. The explicit `(Float64, Utf8) => Utf8` rule shows strings are meant to win; `LargeUtf8` was missed. Now widens to `LargeUtf8`.
2. **Order-dependent schema merges** — every numeric row had `(<numeric>, Boolean) => <numeric>` but there were no `(Boolean, <numeric>)` arms, so `super_type_arrow(Int8, Boolean) = Int8` while `super_type_arrow(Boolean, Int8) = None`. A Boolean + Int schema union then succeeded or failed purely on field order. Added the ten mirrored `(Boolean, <numeric>)` arms.
3. **Dead code** — removed the unreachable `(Timestamp, Utf8)` arm (shadowed by `(_, Utf8)`), clearing a compiler warning.

The fix is monotonic (more merges succeed, strings preserved); all 13 downstream crates that call `super_type_schema` only use it for schema union and are unaffected. Regression tests added for each fix, including an order-independence test.
