### PR TITLE
docs: prepare 1.8.0 release

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -62,5 +62,5 @@ Interactive API docs are at <http://localhost:5001/swagger/>.
 
 - [README](README.md) — features, configuration, and query examples.
 - [Documentation](https://maris-development.github.io/beacon/) — full data model and API reference.
-- [Configuration reference](https://maris-development.github.io/beacon/docs/1.7.3/data-lake/configuration.html) — all `BEACON_*` settings.
+- [Configuration reference](https://maris-development.github.io/beacon/docs/1.8.0/data-lake/configuration.html) — all `BEACON_*` settings.
 - Community [Slack](https://beacontechnic-wwa5548.slack.com/join/shared_invite/zt-2dp1vv56r-tj_KFac0sAKNuAgUKPPDRg).

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Start it with `docker compose up -d`, then open the interactive API docs at <htt
 
 Add data by placing files (e.g. `.nc`, `.zarr`, `.parquet`, `.csv`) into `./datasets` — the container discovers them through the mounted volume.
 
-> See the [installation guide](https://maris-development.github.io/beacon/docs/1.7.3/getting-started.html#local).
+> See the [installation guide](https://maris-development.github.io/beacon/docs/1.8.0/getting-started.html#local).
 
 ## Query examples
 
@@ -147,7 +147,7 @@ Content-Type: application/json
 }
 ```
 
-The response is a streamed file in the chosen `output.format` (here, CSV). See the [query reference](https://maris-development.github.io/beacon/docs/1.7.3/api/querying/) for the full schema, all source types, and every output format.
+The response is a streamed file in the chosen `output.format` (here, CSV). See the [query reference](https://maris-development.github.io/beacon/docs/1.8.0/api/querying/) for the full schema, all source types, and every output format.
 
 ## Configuration
 
@@ -167,13 +167,13 @@ Beacon is configured entirely through `BEACON_*` environment variables. The most
 | `BEACON_FLIGHT_SQL_ENABLE` | `true` | Enable the Arrow Flight SQL endpoint. |
 | `BEACON_FLIGHT_SQL_PORT` | `32011` | Arrow Flight SQL port. |
 
-S3-compatible storage, CORS, NetCDF caching, the crawler, and Flight SQL authentication have their own `BEACON_*` settings — see the [configuration reference](https://maris-development.github.io/beacon/docs/1.7.3/data-lake/configuration.html) for the complete list.
+S3-compatible storage, CORS, NetCDF caching, the crawler, and Flight SQL authentication have their own `BEACON_*` settings — see the [configuration reference](https://maris-development.github.io/beacon/docs/1.8.0/data-lake/configuration.html) for the complete list.
 
 ## Documentation
 
 - Docs home: <https://maris-development.github.io/beacon/>
-- Getting started: <https://maris-development.github.io/beacon/docs/1.7.3/getting-started.html#local>
-- Query reference: <https://maris-development.github.io/beacon/docs/1.7.3/api/querying/>
+- Getting started: <https://maris-development.github.io/beacon/docs/1.8.0/getting-started.html#local>
+- Query reference: <https://maris-development.github.io/beacon/docs/1.8.0/api/querying/>
 - Community Slack: [join here](https://beacontechnic-wwa5548.slack.com/join/shared_invite/zt-2dp1vv56r-tj_KFac0sAKNuAgUKPPDRg)
 
 ## Contributing

--- a/beacon-api/Cargo.toml
+++ b/beacon-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon-api"
-version = "1.7.3"
+version = "1.8.0"
 edition = "2021"
 
 [target.'cfg(not(windows))'.dependencies]

--- a/beacon-common/Cargo.toml
+++ b/beacon-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon-common"
-version = "1.7.3"
+version = "1.8.0"
 edition = "2021"
 
 [dependencies]

--- a/beacon-core/Cargo.toml
+++ b/beacon-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon-core"
-version = "1.7.3"
+version = "1.8.0"
 edition = "2021"
 
 [dependencies]

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -125,6 +125,10 @@ export default defineConfig({
           collapsed: false,
           items: [
             {
+              text: 'Quick Start',
+              link: '/docs/1.8.0/getting-started#quick-start',
+            },
+            {
               text: 'Local',
               link: '/docs/1.8.0/getting-started#local',
             },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -268,6 +268,17 @@ export default defineConfig({
               link: '/docs/1.8.0/data-lake/configuration',
             },
             {
+              text: 'Access Control',
+              link: '/docs/1.8.0/security/access-control',
+              collapsed: true,
+              items: [
+                { text: 'Enforcement', link: '/docs/1.8.0/security/access-control#enforcement' },
+                { text: 'Roles & privileges', link: '/docs/1.8.0/security/access-control#roles-privileges-and-targets' },
+                { text: 'OIDC (SSO)', link: '/docs/1.8.0/security/access-control#oidc-single-sign-on' },
+                { text: 'Configuration', link: '/docs/1.8.0/security/access-control#configuration-reference' },
+              ]
+            },
+            {
               text: 'Performance Tuning',
               link: '/docs/1.8.0/data-lake/performance-tuning',
               collapsed: true,
@@ -421,6 +432,17 @@ export default defineConfig({
                     { text: 'DROP CRAWLER', link: '/docs/1.8.0/data-lake/crawlers#drop-crawler' },
                   ]
                 },
+                {
+                  text: 'Users, Roles & Grants',
+                  link: '/docs/1.8.0/security/access-control#managing-users-and-roles-sql',
+                  collapsed: true,
+                  items: [
+                    { text: 'CREATE USER', link: '/docs/1.8.0/security/access-control#users' },
+                    { text: 'CREATE ROLE', link: '/docs/1.8.0/security/access-control#roles' },
+                    { text: 'GRANT / DENY', link: '/docs/1.8.0/security/access-control#grants-and-denies' },
+                    { text: 'Anonymous access', link: '/docs/1.8.0/security/access-control#anonymous-access' },
+                  ]
+                },
               ]
             },
             {
@@ -571,16 +593,6 @@ export default defineConfig({
               text: 'Python ADBC Driver',
               link: '/docs/1.8.0/connect/python-adbc',
             }
-          ]
-        },
-        {
-          text: 'Security',
-          collapsed: true,
-          items: [
-            {
-              text: 'Authentication & Access Control',
-              link: '/docs/1.8.0/security/access-control',
-            },
           ]
         }
       ],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -85,7 +85,12 @@ export default defineConfig({
       {
         text: 'Docs', items: [
           {
-            text: '1.7.3 (latest)',
+            text: '1.8.0 (latest)',
+            link: '/docs/1.8.0/introduction',
+            activeMatch: '/docs/1.8.0/introduction'
+          },
+          {
+            text: '1.7.3',
             link: '/docs/1.7.3/introduction',
             activeMatch: '/docs/1.7.3/introduction'
           },
@@ -109,6 +114,466 @@ export default defineConfig({
     ],
 
     sidebar: {
+      '/docs/1.8.0/': [
+        {
+          text: 'Introduction',
+          link: '/docs/1.8.0/introduction',
+        },
+        {
+          text: 'Getting Started',
+          link: '/docs/1.8.0/getting-started',
+          collapsed: false,
+          items: [
+            {
+              text: 'Local',
+              link: '/docs/1.8.0/getting-started#local',
+            },
+            {
+              text: 'S3 / Object Storage',
+              link: '/docs/1.8.0/getting-started#s3-compatible-object-storage',
+            }
+          ]
+        },
+        {
+          text: 'Data Lakehouse Setup',
+          link: '/docs/1.8.0/data-lake',
+          collapsed: false,
+          items: [
+            {
+              text: 'Supported Formats',
+              link: '/docs/1.8.0/data-lake/datasets',
+              collapsed: true,
+              items: [
+                {
+                  text: 'Parquet',
+                  link: '/docs/1.8.0/data-lake/datasets#parquet'
+                },
+                {
+                  text: 'GeoParquet',
+                  link: '/docs/1.8.0/data-lake/geoparquet'
+                },
+                {
+                  text: 'NetCDF',
+                  link: '/docs/1.8.0/data-lake/datasets#netcdf'
+                },
+                {
+                  text: 'Zarr',
+                  link: '/docs/1.8.0/data-lake/datasets#zarr'
+                },
+                {
+                  text: 'Arrow IPC',
+                  link: '/docs/1.8.0/data-lake/datasets#arrow-ipc'
+                },
+                {
+                  text: 'ODV ASCII',
+                  link: '/docs/1.8.0/data-lake/datasets#odv-ascii'
+                },
+                {
+                  text: 'CSV',
+                  link: '/docs/1.8.0/data-lake/datasets#csv'
+                },
+                {
+                  text: 'GeoTIFF',
+                  link: '/docs/1.8.0/data-lake/datasets#geotiff--cloud-optimized-geotiff'
+                },
+                {
+                  text: 'Atlas',
+                  link: '/docs/1.8.0/data-lake/datasets#atlas'
+                },
+                {
+                  text: 'Beacon Binary Format',
+                  link: '/docs/1.8.0/data-lake/datasets#beacon-binary-format-bbf'
+                },
+              ]
+            },
+            {
+              text: 'SQL Tables & Views',
+              collapsed: false,
+              items: [
+                {
+                  text: 'External Tables',
+                  link: '/docs/1.8.0/data-lake/external-tables',
+                  collapsed: true,
+                  items: [
+                    { text: 'Parquet', link: '/docs/1.8.0/data-lake/external-tables#parquet' },
+                    { text: 'GeoParquet', link: '/docs/1.8.0/data-lake/external-tables#geoparquet' },
+                    { text: 'NetCDF', link: '/docs/1.8.0/data-lake/external-tables#netcdf' },
+                    { text: 'Zarr', link: '/docs/1.8.0/data-lake/external-tables#zarr' },
+                    { text: 'Atlas', link: '/docs/1.8.0/data-lake/external-tables#atlas' },
+                    { text: 'CSV', link: '/docs/1.8.0/data-lake/external-tables#csv' },
+                    { text: 'Arrow IPC', link: '/docs/1.8.0/data-lake/external-tables#arrow-ipc' },
+                    { text: 'ODV ASCII', link: '/docs/1.8.0/data-lake/external-tables#odv-ascii' },
+                    { text: 'GeoTIFF / COG', link: '/docs/1.8.0/data-lake/external-tables#geotiff-cog' },
+                    { text: 'Delta Lake', link: '/docs/1.8.0/data-lake/external-tables#delta-lake' },
+                  ]
+                },
+                {
+                  text: 'Crawlers',
+                  link: '/docs/1.8.0/data-lake/crawlers',
+                  collapsed: true,
+                  items: [
+                    { text: 'CREATE CRAWLER', link: '/docs/1.8.0/data-lake/crawlers#create-crawler' },
+                    { text: 'RUN / SHOW / DROP', link: '/docs/1.8.0/data-lake/crawlers#run-crawler' },
+                    { text: 'Partition detection', link: '/docs/1.8.0/data-lake/crawlers#partition-detection' },
+                    { text: 'Triggers', link: '/docs/1.8.0/data-lake/crawlers#triggers' },
+                    { text: 'Configuration', link: '/docs/1.8.0/data-lake/crawlers#configuration' },
+                    { text: 'Limitations', link: '/docs/1.8.0/data-lake/crawlers#supported-formats-and-limitations' },
+                  ]
+                },
+                {
+                  text: 'Managed Tables',
+                  link: '/docs/1.8.0/sql/managed-tables',
+                },
+                {
+                  text: 'Views',
+                  link: '/docs/1.8.0/data-lake/view',
+                },
+                {
+                  text: 'Delta Lake',
+                  link: '/docs/1.8.0/data-lake/delta-lake',
+                  collapsed: true,
+                  items: [
+                    { text: 'Defining a Delta table', link: '/docs/1.8.0/data-lake/delta-lake#defining-a-delta-external-table' },
+                    { text: 'Time travel', link: '/docs/1.8.0/data-lake/delta-lake#options-time-travel' },
+                    { text: 'Writing (INSERT INTO)', link: '/docs/1.8.0/data-lake/delta-lake#writing-insert-into' },
+                    { text: 'Limitations', link: '/docs/1.8.0/data-lake/delta-lake#limitations' },
+                  ]
+                },
+                {
+                  text: 'Remote Tables (Federation)',
+                  link: '/docs/1.8.0/data-lake/remote-tables',
+                  collapsed: true,
+                  items: [
+                    { text: 'Defining a remote table', link: '/docs/1.8.0/data-lake/remote-tables#defining-a-remote-table' },
+                    { text: 'How pushdown works', link: '/docs/1.8.0/data-lake/remote-tables#how-pushdown-works' },
+                    { text: 'Schema handling', link: '/docs/1.8.0/data-lake/remote-tables#schema-handling' },
+                    { text: 'Limitations', link: '/docs/1.8.0/data-lake/remote-tables#limitations' },
+                  ]
+                },
+                {
+                  text: 'SQL Databases (Postgres / MySQL)',
+                  link: '/docs/1.8.0/data-lake/sql-databases',
+                  collapsed: true,
+                  items: [
+                    { text: 'Credentials', link: '/docs/1.8.0/data-lake/sql-databases#credentials' },
+                    { text: 'Defining a database table', link: '/docs/1.8.0/data-lake/sql-databases#defining-a-sql-database-table' },
+                    { text: 'How pushdown works', link: '/docs/1.8.0/data-lake/sql-databases#how-pushdown-works' },
+                    { text: 'Limitations', link: '/docs/1.8.0/data-lake/sql-databases#limitations' },
+                  ]
+                }
+              ]
+            },
+            {
+              text: 'Configuration',
+              link: '/docs/1.8.0/data-lake/configuration',
+            },
+            {
+              text: 'Performance Tuning',
+              link: '/docs/1.8.0/data-lake/performance-tuning',
+              collapsed: true,
+              items: [
+                {
+                  text: 'Settings',
+                  link: '/docs/1.8.0/data-lake/performance-tuning#beacon-query-engine-settings'
+                },
+                {
+                  text: 'NetCDF',
+                  link: '/docs/1.8.0/data-lake/performance-tuning#netcdf-tuning'
+                },
+                {
+                  text: 'Zarr',
+                  link: '/docs/1.8.0/data-lake/performance-tuning#zarr-predicate-pushdown'
+                },
+                {
+                  text: 'Atlas',
+                  link: '/docs/1.8.0/data-lake/performance-tuning#atlas-tuning'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          text: 'SQL Guide',
+          link: '/docs/1.8.0/sql/',
+          collapsed: true,
+          items: [
+            {
+              text: 'Introduction',
+              link: '/docs/1.8.0/sql/',
+            },
+            {
+              text: 'Querying',
+              collapsed: true,
+              items: [
+                {
+                  text: 'SELECT',
+                  link: '/docs/1.8.0/sql/select',
+                },
+                {
+                  text: 'WHERE',
+                  link: '/docs/1.8.0/sql/where',
+                  collapsed: true,
+                  items: [
+                    { text: 'Comparison', link: '/docs/1.8.0/sql/where#comparison-operators' },
+                    { text: 'BETWEEN', link: '/docs/1.8.0/sql/where#between' },
+                    { text: 'IN', link: '/docs/1.8.0/sql/where#in' },
+                    { text: 'LIKE', link: '/docs/1.8.0/sql/where#like' },
+                    { text: 'IS NULL', link: '/docs/1.8.0/sql/where#is-null--is-not-null' },
+                    { text: 'AND / OR / NOT', link: '/docs/1.8.0/sql/where#and--or--not' },
+                    { text: 'Date & time', link: '/docs/1.8.0/sql/where#date-and-time-filtering' },
+                  ]
+                },
+                {
+                  text: 'GROUP BY',
+                  link: '/docs/1.8.0/sql/group-by',
+                },
+                {
+                  text: 'JOIN',
+                  link: '/docs/1.8.0/sql/join',
+                  collapsed: true,
+                  items: [
+                    { text: 'INNER JOIN', link: '/docs/1.8.0/sql/join#inner-join' },
+                    { text: 'LEFT JOIN', link: '/docs/1.8.0/sql/join#left-join' },
+                  ]
+                },
+                {
+                  text: 'Reading Files',
+                  link: '/docs/1.8.0/sql/table-functions',
+                  collapsed: true,
+                  items: [
+                    { text: 'read_netcdf', link: '/docs/1.8.0/sql/table-functions#read_netcdf' },
+                    { text: 'read_zarr', link: '/docs/1.8.0/sql/table-functions#read_zarr' },
+                    { text: 'read_atlas', link: '/docs/1.8.0/sql/table-functions#read_atlas' },
+                    { text: 'read_parquet', link: '/docs/1.8.0/sql/table-functions#read_parquet' },
+                    { text: 'read_arrow', link: '/docs/1.8.0/sql/table-functions#read_arrow' },
+                    { text: 'read_csv', link: '/docs/1.8.0/sql/table-functions#read_csv' },
+                    { text: 'read_odv_ascii', link: '/docs/1.8.0/sql/table-functions#read_odv_ascii' },
+                    { text: 'read_bbf', link: '/docs/1.8.0/sql/table-functions#read_bbf' },
+                    { text: 'read_tiff', link: '/docs/1.8.0/sql/table-functions#read_tiff' },
+                    { text: 'read_delta', link: '/docs/1.8.0/sql/table-functions#read_delta' },
+                  ]
+                },
+                {
+                  text: 'UNION ALL BY NAME',
+                  link: '/docs/1.8.0/sql/union-by-name',
+                },
+                {
+                  text: 'GeoParquet',
+                  link: '/docs/1.8.0/sql/geoparquet',
+                },
+                {
+                  text: 'Remote Tables',
+                  link: '/docs/1.8.0/sql/remote-tables',
+                },
+              ]
+            },
+            {
+              text: 'DDL',
+              items: [
+                {
+                  text: 'CREATE EXTERNAL TABLE',
+                  link: '/docs/1.8.0/sql/create-table',
+                  collapsed: true,
+                  items: [
+                    { text: 'IF NOT EXISTS', link: '/docs/1.8.0/sql/create-table#if-not-exists' },
+                    { text: 'OR REPLACE', link: '/docs/1.8.0/sql/create-table#or-replace' },
+                    { text: 'PARTITIONED BY', link: '/docs/1.8.0/sql/create-table#partitioned-by' },
+                    { text: 'DROP TABLE', link: '/docs/1.8.0/sql/create-table#drop-table' },
+                  ]
+                },
+                {
+                  text: 'CREATE TABLE (Managed)',
+                  link: '/docs/1.8.0/sql/managed-tables',
+                  collapsed: true,
+                  items: [
+                    { text: 'Storage engine', link: '/docs/1.8.0/sql/managed-tables#choosing-the-storage-engine' },
+                    { text: 'CREATE TABLE AS SELECT', link: '/docs/1.8.0/sql/managed-tables#create-table-as-select' },
+                    { text: 'INSERT INTO', link: '/docs/1.8.0/sql/managed-tables#insert-into' },
+                    { text: 'DELETE', link: '/docs/1.8.0/sql/managed-tables#delete' },
+                    { text: 'UPDATE', link: '/docs/1.8.0/sql/managed-tables#update' },
+                    { text: 'ALTER TABLE', link: '/docs/1.8.0/sql/managed-tables#alter-table' },
+                    { text: 'Indexes', link: '/docs/1.8.0/sql/managed-tables#indexes' },
+                    { text: 'DROP TABLE', link: '/docs/1.8.0/sql/managed-tables#drop-table' },
+                  ]
+                },
+                {
+                  text: 'CREATE VIEW',
+                  link: '/docs/1.8.0/sql/create-view',
+                },
+                {
+                  text: 'CREATE MATERIALIZED VIEW',
+                  link: '/docs/1.8.0/sql/create-materialized-view',
+                  collapsed: true,
+                  items: [
+                    { text: 'Querying', link: '/docs/1.8.0/sql/create-materialized-view#querying' },
+                    { text: 'REFRESH', link: '/docs/1.8.0/sql/create-materialized-view#refresh' },
+                    { text: 'DROP', link: '/docs/1.8.0/sql/create-materialized-view#drop' },
+                  ]
+                },
+                {
+                  text: 'CREATE CRAWLER',
+                  link: '/docs/1.8.0/data-lake/crawlers',
+                  collapsed: true,
+                  items: [
+                    { text: 'Options', link: '/docs/1.8.0/data-lake/crawlers#options' },
+                    { text: 'RUN CRAWLER', link: '/docs/1.8.0/data-lake/crawlers#run-crawler' },
+                    { text: 'SHOW CRAWLERS', link: '/docs/1.8.0/data-lake/crawlers#show-crawlers' },
+                    { text: 'DROP CRAWLER', link: '/docs/1.8.0/data-lake/crawlers#drop-crawler' },
+                  ]
+                },
+              ]
+            },
+            {
+              text: 'Introspection',
+              link: '/docs/1.8.0/sql/table-functions-utility',
+              collapsed: true,
+              items: [
+                { text: 'read_schema', link: '/docs/1.8.0/sql/table-functions-utility#read_schema' },
+                { text: 'list_datasets', link: '/docs/1.8.0/sql/table-functions-utility#list_datasets' },
+                { text: 'view_dataset_statistics', link: '/docs/1.8.0/sql/table-functions-utility#view_dataset_statistics' },
+                { text: 'view_external_table_statistics', link: '/docs/1.8.0/sql/table-functions-utility#view_external_table_statistics' },
+                { text: 'view_statistics_cache', link: '/docs/1.8.0/sql/table-functions-utility#view_statistics_cache' },
+              ]
+            },
+            {
+              text: 'Function Reference',
+              link: '/docs/1.8.0/sql/function-reference',
+              collapsed: true,
+              items: [
+                { text: 'Aggregate', link: '/docs/1.8.0/sql/function-reference#aggregate-functions' },
+                { text: 'Math', link: '/docs/1.8.0/sql/function-reference#math-functions' },
+                { text: 'String', link: '/docs/1.8.0/sql/function-reference#string-functions' },
+                { text: 'Regular Expressions', link: '/docs/1.8.0/sql/function-reference#regular-expression-functions' },
+                { text: 'Binary String', link: '/docs/1.8.0/sql/function-reference#binary-string-functions' },
+                { text: 'Date & Time', link: '/docs/1.8.0/sql/function-reference#date-and-time-functions' },
+                { text: 'Conditional', link: '/docs/1.8.0/sql/function-reference#conditional-expressions' },
+                { text: 'Casting', link: '/docs/1.8.0/sql/function-reference#casting' },
+                {
+                  text: 'Beacon-specific',
+                  link: '/docs/1.8.0/sql/function-reference#beacon-specific-functions',
+                  collapsed: true,
+                  items: [
+                    { text: 'beacon_version', link: '/docs/1.8.0/sql/function-reference#beacon_version' },
+                    { text: 'coalesce_label', link: '/docs/1.8.0/sql/function-reference#coalesce_label' },
+                    { text: 'cast_int8_as_char', link: '/docs/1.8.0/sql/function-reference#cast_int8_as_charn' },
+                    { text: 'try_arrow_cast', link: '/docs/1.8.0/sql/function-reference#try_arrow_castexpr-type_str' },
+                  ]
+                },
+                {
+                  text: 'Geospatial',
+                  link: '/docs/1.8.0/sql/function-reference#geospatial-functions',
+                  collapsed: true,
+                  items: [
+                    { text: 'st_within_point', link: '/docs/1.8.0/sql/function-reference#st_within_point' },
+                    { text: 'st_geojson_as_wkt', link: '/docs/1.8.0/sql/function-reference#st_geojson_as_wkt' },
+                  ]
+                },
+                {
+                  text: 'Domain Mapping',
+                  link: '/docs/1.8.0/sql/function-reference#domain-mapping-functions',
+                  collapsed: true,
+                  items: [
+                    { text: 'pressure_to_depth_teos_10', link: '/docs/1.8.0/sql/function-reference#pressure_to_depth_teos_10' },
+                    { text: 'map_units', link: '/docs/1.8.0/sql/function-reference#map_units' },
+                    { text: 'Common', link: '/docs/1.8.0/sql/function-reference#common' },
+                    { text: 'CMEMS', link: '/docs/1.8.0/sql/function-reference#cmems' },
+                    { text: 'CORA', link: '/docs/1.8.0/sql/function-reference#cora' },
+                    { text: 'EMODnet Chemistry', link: '/docs/1.8.0/sql/function-reference#emodnet-chemistry' },
+                    { text: 'SeaDataNet', link: '/docs/1.8.0/sql/function-reference#seadatanet' },
+                    { text: 'Argo', link: '/docs/1.8.0/sql/function-reference#argo' },
+                    { text: 'World Ocean Database', link: '/docs/1.8.0/sql/function-reference#world-ocean-database-wod' },
+                  ]
+                },
+              ]
+            },
+          ]
+        },
+        {
+          text: 'REST API',
+          link: '/docs/1.8.0/api/',
+          collapsed: true,
+          items: [
+            {
+              text: 'Introduction',
+              link: '/docs/1.8.0/api/',
+            },
+            {
+              text: 'Exploring the Data Lake',
+              link: '/docs/1.8.0/api/exploring-data-lake',
+              collapsed: true,
+              items: [
+                { text: 'Datasets', link: '/docs/1.8.0/api/exploring-data-lake#datasets' },
+                { text: 'Tables', link: '/docs/1.8.0/api/exploring-data-lake#tables' },
+                { text: 'Functions', link: '/docs/1.8.0/api/exploring-data-lake#functions' },
+                { text: 'Admin', link: '/docs/1.8.0/api/exploring-data-lake#admin' },
+              ]
+            },
+            {
+              text: 'Querying',
+              link: '/docs/1.8.0/api/querying',
+              collapsed: false,
+              items: [
+                {
+                  text: 'JSON Query DSL',
+                  link: '/docs/1.8.0/api/querying/json',
+                  collapsed: true,
+                  items: [
+                    { text: 'Selecting Columns', link: '/docs/1.8.0/api/querying/json#selecting-columns' },
+                    { text: 'Data Source', link: '/docs/1.8.0/api/querying/json#choosing-the-data-source-from' },
+                    { text: 'Filters', link: '/docs/1.8.0/api/querying/json#filters' },
+                    { text: 'Sorting & Pagination', link: '/docs/1.8.0/api/querying/json#sorting-and-pagination' },
+                    { text: 'Output Formats', link: '/docs/1.8.0/api/querying/json#output-formats' },
+                  ]
+                },
+                {
+                  text: 'SQL',
+                  link: '/docs/1.8.0/api/querying/sql',
+                  collapsed: true,
+                  items: [
+                    { text: 'Query a Table', link: '/docs/1.8.0/api/querying/sql#query-a-registered-table' },
+                    { text: 'Table Functions', link: '/docs/1.8.0/api/querying/sql#query-files-directly' },
+                    { text: 'Output Formats', link: '/docs/1.8.0/api/querying/sql#output-formats' },
+                  ]
+                },
+                {
+                  text: 'Examples',
+                  link: '/docs/1.8.0/api/querying/examples',
+                },
+              ]
+            },
+          ]
+        },
+        {
+          text: 'Connect',
+          collapsed: true,
+          items: [
+            {
+              text: 'JetBrains DataGrip',
+              link: '/docs/1.8.0/connect/jetbrains-datagrip',
+            },
+            {
+              text: 'Beacon CLI',
+              link: '/docs/1.8.0/connect/beacon-cli',
+            },
+            {
+              text: 'Beacon TypeScript SDK',
+              link: '/docs/1.8.0/connect/beacon-typescript-sdk',
+            },
+            {
+              text: 'Admin Web UI',
+              link: '/docs/1.8.0/connect/web-admin-ui',
+            },
+            {
+              text: 'Beacon Python SDK',
+              link: '/docs/1.8.0/connect/beacon-python-sdk',
+            },
+            {
+              text: 'Python ADBC Driver',
+              link: '/docs/1.8.0/connect/python-adbc',
+            }
+          ]
+        }
+      ],
       '/docs/1.7.3/': [
         {
           text: 'Introduction',
@@ -915,6 +1380,10 @@ export default defineConfig({
           text: 'Release Posts',
           items: [
             {
+              text: 'What\'s new in 1.8.0',
+              link: '/docs/changelog/release-1.8.0'
+            },
+            {
               text: 'What\'s new in 1.7.0',
               link: '/docs/changelog/release-1.7.0'
             },
@@ -927,6 +1396,10 @@ export default defineConfig({
         {
           text: 'Changelog',
           items: [
+            {
+              text: '1.8.0',
+              link: '/docs/changelog'
+            },
             {
               text: '1.7.3',
               link: '/docs/changelog'

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -572,6 +572,16 @@ export default defineConfig({
               link: '/docs/1.8.0/connect/python-adbc',
             }
           ]
+        },
+        {
+          text: 'Security',
+          collapsed: true,
+          items: [
+            {
+              text: 'Authentication & Access Control',
+              link: '/docs/1.8.0/security/access-control',
+            },
+          ]
         }
       ],
       '/docs/1.7.3/': [

--- a/docs/docs/1.8.0/api/exploring-data-lake.md
+++ b/docs/docs/1.8.0/api/exploring-data-lake.md
@@ -1,0 +1,251 @@
+# Exploring the Data Lake (REST API)
+
+Use these endpoints to discover what data is available on a running Beacon instance — without running a full query.
+
+**Concepts:**
+
+- **Datasets** — individual files (a single `.nc` file, a `.parquet` file, a Zarr group, etc.)
+- **Tables** — named logical tables registered in Beacon, often spanning many datasets
+- **Schemas** — Arrow field lists (name + type) describing the columns available for `select` and `filter`
+
+## System info
+
+```http
+GET /api/info
+```
+
+Returns Beacon version, configuration summary, and registered table count.
+
+## Datasets
+
+### List datasets
+
+```http
+GET /api/list-datasets
+```
+
+::: info Deprecated alias
+`GET /api/datasets` is a deprecated alias of `/api/list-datasets`. Use
+`/api/list-datasets` in new code.
+:::
+
+Optional query parameters:
+
+| Parameter | Description |
+| --------- | ----------- |
+| `pattern` | Glob to filter paths (e.g. `*.nc`, `**/*.parquet`) |
+| `offset` | Pagination offset |
+| `limit` | Pagination limit |
+
+```http
+GET /api/list-datasets?pattern=argo/**/*.nc&limit=50&offset=0
+```
+
+### Dataset count
+
+```http
+GET /api/total-datasets
+```
+
+### Dataset schema
+
+Returns the Arrow schema (fields + types) for a single path:
+
+```http
+GET /api/dataset-schema?file=argo/profile_001.nc
+```
+
+To infer a merged schema across multiple files using a glob:
+
+```http
+GET /api/dataset-schema?file=argo/**/*.nc
+```
+
+The response contains an Arrow schema JSON. Column names are under `.fields[].name`.
+
+## Tables
+
+### List tables
+
+```http
+GET /api/tables
+```
+
+### Default table
+
+Beacon uses this table when a query omits `from`:
+
+```http
+GET /api/default-table
+```
+
+### Table schema
+
+```http
+GET /api/table-schema?table_name=default
+```
+
+### Default table schema
+
+The Arrow schema of the default table (the one queried when a request omits
+`from`):
+
+```http
+GET /api/default-table-schema
+```
+
+::: info Deprecated alias
+`GET /api/query/available-columns` is a deprecated endpoint that returns only the
+column names of the default table schema. Use `/api/default-table-schema` in new
+code.
+:::
+
+### All tables with schemas
+
+Convenient for UI discovery, but can be slow on large installations:
+
+```http
+GET /api/tables-with-schema
+```
+
+### Table configuration
+
+Shows how a table was constructed — paths, file format, statistics settings, etc.
+This endpoint is **admin-only** (see [Admin](#admin)) and requires HTTP Basic
+auth; unauthenticated requests get `401`. Sensitive options such as SQL-database
+passwords are redacted (the `secret` field is returned as `***`).
+
+```http
+GET /api/admin/table-config?table_name=default
+Authorization: Basic <base64(username:password)>
+```
+
+## Functions
+
+List all registered DataFusion scalar functions:
+
+```http
+GET /api/functions
+```
+
+List all registered Beacon table functions (e.g. `read_netcdf`, `read_zarr`):
+
+```http
+GET /api/table-functions
+```
+
+See the [Function Reference](../sql/function-reference.md) for descriptions and signatures.
+
+## Table lifecycle
+
+**Table lifecycle is SQL-only.** Create, replace, or remove tables by sending SQL DDL to the query endpoint:
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{ "sql": "CREATE EXTERNAL TABLE argo STORED AS PARQUET LOCATION 'argo/'" }
+```
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{ "sql": "DROP TABLE argo" }
+```
+
+Write operations require the admin credentials (`BEACON_ADMIN_USERNAME` /
+`BEACON_ADMIN_PASSWORD`) via HTTP basic auth; anonymous requests are read-only.
+
+## Admin
+
+All `/api/admin/*` endpoints require the admin credentials
+(`BEACON_ADMIN_USERNAME` / `BEACON_ADMIN_PASSWORD`) via HTTP basic auth;
+unauthenticated requests get `401`.
+
+Creating, replacing, and removing tables can still be done through authenticated
+SQL DDL on `/api/query` (see [Table lifecycle](#table-lifecycle) above). In
+addition, these dedicated, JSON-typed admin endpoints are available:
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| `GET` | `/api/admin/check` | Connectivity check; returns `{ "is_admin": true }` |
+| `GET` | `/api/admin/table-config` | Inspect a table's storage format and configuration |
+| `POST` | `/api/admin/crawlers` | Define (or replace) a crawler |
+| `GET` | `/api/admin/crawlers` | List defined crawlers |
+| `GET` | `/api/admin/crawlers/{name}` | Get one crawler (or `404`) |
+| `POST` | `/api/admin/crawlers/{name}/run` | Run a crawler once; returns its crawl report |
+| `DELETE` | `/api/admin/crawlers/{name}` | Drop a crawler (crawled tables are left in place) |
+| `POST` | `/api/admin/external-tables` | Create an external table from structured fields |
+
+Every example below sends the credentials via HTTP Basic auth
+(`Authorization: Basic <base64(username:password)>`); the header is omitted from
+the snippets after the first for brevity.
+
+Check that your credentials are accepted:
+
+```http
+GET /api/admin/check
+Authorization: Basic <base64(username:password)>
+```
+
+Inspect a table's storage format and configuration (sensitive options such as
+SQL-database passwords are returned as `***`):
+
+```http
+GET /api/admin/table-config?table_name=default
+```
+
+Create a crawler (the structured equivalent of [`CREATE CRAWLER`](../data-lake/crawlers.md)):
+
+```http
+POST /api/admin/crawlers
+Authorization: Basic <base64(username:password)>
+Content-Type: application/json
+
+{ "name": "argo", "target_prefix": "argo/", "format_filter": ["parquet"],
+  "schedule_secs": 900, "table_naming": "crawler_prefixed" }
+```
+
+Create an external table (the structured equivalent of
+[`CREATE EXTERNAL TABLE`](../sql/create-table.md)):
+
+```http
+POST /api/admin/external-tables
+Authorization: Basic <base64(username:password)>
+Content-Type: application/json
+
+{ "name": "observations", "file_type": "PARQUET", "location": "obs/",
+  "partition_cols": ["year", "month"] }
+```
+
+List the defined crawlers, or fetch a single one by name:
+
+```http
+GET /api/admin/crawlers
+```
+
+```http
+GET /api/admin/crawlers/argo
+```
+
+Run a crawler once on demand (returns its crawl report):
+
+```http
+POST /api/admin/crawlers/argo/run
+```
+
+Drop a crawler (its already-crawled tables are left in place):
+
+```http
+DELETE /api/admin/crawlers/argo
+```
+
+## OpenAPI
+
+This page is a curated subset. The complete, always-current request and response
+shapes are generated from the server itself:
+
+- Swagger UI: `/swagger`
+- Scalar UI: `/scalar/`
+- OpenAPI document: `/openapi.json`

--- a/docs/docs/1.8.0/api/index.md
+++ b/docs/docs/1.8.0/api/index.md
@@ -1,0 +1,35 @@
+# REST API
+
+Beacon exposes an HTTP API for querying datasets, inspecting schemas, and managing the data lake. All surfaces speak JSON over HTTP.
+
+## OpenAPI reference
+
+Beacon generates an OpenAPI spec at runtime. When the server is running, open one of these URLs:
+
+| UI | URL |
+| -- | --- |
+| Swagger UI | `/swagger` |
+| Scalar UI | `/scalar/` |
+| Raw spec (JSON) | `/openapi.json` |
+
+## Base URL
+
+All endpoints in these docs are shown as relative paths (e.g. `GET /api/health`). Send requests to your Beacon base URL — by default `http://localhost:5001`. If you run behind a reverse proxy, use that URL instead.
+
+## Health check
+
+```http
+GET /api/health
+```
+
+Returns `200 OK` when Beacon is up and ready.
+
+## What's in the API
+
+| Section | Description |
+| ------- | ----------- |
+| [Exploring the Data Lake](./exploring-data-lake.md) | Discover datasets, tables, and schemas |
+| [Querying](./querying/index.md) | Run queries (JSON DSL or SQL) and receive results |
+| [JSON Query DSL](./querying/json.md) | Structured query format for programmatic clients |
+| [SQL](./querying/sql.md) | Full SQL via DataFusion |
+| [Examples](./querying/examples.md) | Copy-paste query patterns |

--- a/docs/docs/1.8.0/api/querying/examples.md
+++ b/docs/docs/1.8.0/api/querying/examples.md
@@ -1,0 +1,252 @@
+# Query Examples
+
+Copy-paste examples for both query styles. All examples use `"output": { "format": "csv" }` — omit `output` to receive a streaming Arrow IPC response instead.
+
+## JSON DSL
+
+### Select with computed column
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "from": "default",
+  "select": [
+    "time",
+    "latitude",
+    "longitude",
+    { "function": "round", "args": ["temperature", { "value": 2 }], "alias": "temperature_rounded" }
+  ],
+  "limit": 100,
+  "output": { "format": "csv" }
+}
+```
+
+### Range filter on multiple columns
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "from": "default",
+  "select": ["time", "latitude", "longitude", "temperature"],
+  "filters": [
+    { "column": "temperature", "min": 2, "max": 10 },
+    { "column": "latitude", "min": -10, "max": 10 }
+  ],
+  "limit": 1000,
+  "output": { "format": "csv" }
+}
+```
+
+### OR filter
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "from": "default",
+  "select": ["time", "platform", "temperature"],
+  "filters": [
+    {
+      "or": [
+        { "column": "platform", "eq": "SHIP" },
+        { "column": "platform", "eq": "BUOY" }
+      ]
+    }
+  ],
+  "limit": 1000,
+  "output": { "format": "csv" }
+}
+```
+
+### Sort, offset, and limit
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "from": "default",
+  "select": ["time", "temperature"],
+  "sort_by": [{ "Desc": "time" }],
+  "offset": 100,
+  "limit": 50,
+  "output": { "format": "csv" }
+}
+```
+
+### DISTINCT ON
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "from": "default",
+  "distinct": {
+    "on": ["platform"],
+    "select": ["platform", "time", "temperature"]
+  },
+  "sort_by": [{ "Desc": "time" }],
+  "limit": 100,
+  "output": { "format": "csv" }
+}
+```
+
+### GeoJSON spatial filter
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "from": "default",
+  "select": ["time", "longitude", "latitude", "temperature"],
+  "filters": [
+    {
+      "longitude_column": "longitude",
+      "latitude_column": "latitude",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[4.0, 52.0], [6.0, 52.0], [6.0, 54.0], [4.0, 54.0], [4.0, 52.0]]]
+      }
+    }
+  ],
+  "limit": 10000,
+  "output": { "format": "csv" }
+}
+```
+
+### Query a NetCDF file directly
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "from": { "netcdf": { "paths": ["argo/**/*.nc"] } },
+  "select": ["time", "latitude", "longitude", "temperature"],
+  "limit": 100,
+  "output": { "format": "csv" }
+}
+```
+
+### Query Zarr with a coordinate range
+
+Predicate pushdown is automatic — Beacon prunes chunks and slices coordinate dimensions from your `filters`:
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "from": {
+    "zarr": {
+      "paths": ["sst/*/zarr.json"]
+    }
+  },
+  "select": ["time", "latitude", "longitude", "sst"],
+  "filters": [
+    { "column": "time", "min": "2025-01-01" },
+    { "column": "latitude", "min": -10, "max": 10 }
+  ],
+  "limit": 1000,
+  "output": { "format": "csv" }
+}
+```
+
+---
+
+## SQL
+
+:::warning
+SQL requires `BEACON_ENABLE_SQL=true`.
+:::
+
+### Select with a computed column
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT time, latitude, longitude, round(temperature, 2) AS temperature_rounded FROM default LIMIT 100",
+  "output": { "format": "csv" }
+}
+```
+
+### WHERE with multiple conditions
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT time, latitude, longitude, temperature FROM default WHERE temperature BETWEEN 2 AND 10 AND latitude BETWEEN -10 AND 10 LIMIT 1000",
+  "output": { "format": "csv" }
+}
+```
+
+### GROUP BY aggregation
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT platform, avg(temperature) AS avg_temp, count(*) AS n FROM default GROUP BY platform ORDER BY n DESC LIMIT 100",
+  "output": { "format": "csv" }
+}
+```
+
+### Read Zarr directly with 1D pushdown
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT time, latitude, longitude, sst FROM read_zarr(['sst/*/zarr.json'], ['time', 'latitude', 'longitude']) WHERE time >= '2025-01-01' LIMIT 1000",
+  "output": { "format": "csv" }
+}
+```
+
+### Export as GeoParquet
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT longitude, latitude, time, temperature FROM default LIMIT 100000",
+  "output": {
+    "format": {
+      "geoparquet": { "longitude_column": "longitude", "latitude_column": "latitude" }
+    }
+  }
+}
+```
+
+---
+
+## Validate and explain
+
+Both styles support validate and explain. The request body is identical to a normal query body.
+
+```http
+POST /api/parse-query
+Content-Type: application/json
+
+{ "select": ["time", "temperature"], "limit": 1 }
+```
+
+```http
+POST /api/explain-query
+Content-Type: application/json
+
+{ "sql": "SELECT * FROM default LIMIT 10" }
+```

--- a/docs/docs/1.8.0/api/querying/index.md
+++ b/docs/docs/1.8.0/api/querying/index.md
@@ -1,0 +1,177 @@
+# Querying
+
+All queries go through a single endpoint:
+
+```http
+POST /api/query
+Content-Type: application/json
+```
+
+The request body selects between two query styles:
+
+| Style | When to use | Body key |
+| ----- | ----------- | -------- |
+| [JSON DSL](./json.md) | Programmatic clients, query builders | `select`, `from`, `filters`, … |
+| [SQL](./sql.md) | Power users, ad-hoc analysis | `sql` |
+
+Both styles share the same `output` field and the same supporting endpoints.
+
+## Supporting endpoints
+
+### Validate
+
+Check that a query body is well-formed (it deserializes into a valid query) without executing it. This is a structural check, not column-level type-checking:
+
+```http
+POST /api/parse-query
+Content-Type: application/json
+
+{ "select": ["time", "temperature"], "limit": 1 }
+```
+
+### Explain
+
+Return the query plan without executing it — useful for debugging and performance work:
+
+```http
+POST /api/explain-query
+Content-Type: application/json
+
+{ "select": ["time", "temperature"], "limit": 1 }
+```
+
+### Explain Analyze
+
+**Run** the query and return the physical plan annotated with per-operator
+runtime metrics (rows, bytes, and time per node) — the analog of SQL `EXPLAIN
+ANALYZE`. Because it executes the query, it is subject to the same SQL gating as
+`/api/query` (disabled when `BEACON_ENABLE_SQL=false` for `sql` bodies):
+
+```http
+POST /api/explain-analyze-query
+Content-Type: application/json
+
+{ "select": ["time", "temperature"], "limit": 1 }
+```
+
+### Query metrics
+
+Beacon returns a query ID via the `x-beacon-query-id` response header. Use it to fetch timing and row-count metrics after the query completes:
+
+```http
+GET /api/query/metrics/{query_id}
+```
+
+## Default response: Arrow IPC stream
+
+When `output` is omitted, `/api/query` returns an [Apache Arrow IPC stream](https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format) (`application/vnd.apache.arrow.stream`). This is the most efficient format for downstream processing.
+
+Client libraries:
+
+- Python: [PyArrow `open_stream` / `RecordBatchStreamReader`](https://arrow.apache.org/docs/python/ipc.html)
+- Rust: [`arrow-ipc` `StreamReader`](https://docs.rs/arrow-ipc/latest/arrow_ipc/reader/struct.StreamReader.html)
+- C++: [`RecordBatchStreamReader`](https://arrow.apache.org/docs/cpp/ipc.html)
+
+## Output formats
+
+Add an `output` field to download a single file instead of streaming Arrow IPC.
+
+### Simple formats
+
+Set `output.format` to one of: `csv`, `parquet`, `netcdf`, `ipc` (alias: `arrow`).
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "select": ["time", "temperature"],
+  "output": { "format": "csv" }
+}
+```
+
+### GeoParquet
+
+Requires longitude and latitude columns:
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "select": ["longitude", "latitude", "time", "temperature"],
+  "output": {
+    "format": {
+      "geoparquet": {
+        "longitude_column": "longitude",
+        "latitude_column": "latitude"
+      }
+    }
+  }
+}
+```
+
+### N-dimensional NetCDF
+
+Reconstructs a multi-dimensional NetCDF file from the result, using the specified columns as dimension axes:
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "select": ["time", "depth", "temperature"],
+  "output": {
+    "format": {
+      "nd_netcdf": {
+        "dimension_columns": ["time", "depth"]
+      }
+    }
+  }
+}
+```
+
+### ODV (Ocean Data View)
+
+Exports the result as an Ocean Data View collection, returned as a **ZIP
+archive**. ODV needs to know which columns carry the station coordinates and
+which are data vs. metadata, so the format is configured with an options object:
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "select": ["cruise", "longitude", "latitude", "depth", "time", "temperature"],
+  "output": {
+    "format": {
+      "odv": {
+        "longitude_column": { "column_name": "longitude" },
+        "latitude_column": { "column_name": "latitude" },
+        "depth_column": { "column_name": "depth" },
+        "time_column": { "column_name": "time" },
+        "key_column": "cruise",
+        "qf_schema": "SEADATANET",
+        "data_columns": [{ "column_name": "temperature" }],
+        "meta_columns": []
+      }
+    }
+  }
+}
+```
+
+Each `*_column` / `data_columns` / `meta_columns` entry identifies a result
+column (and may carry ODV-specific attributes such as units and quality-flag
+column). `key_column` groups rows into ODV stations and `qf_schema` selects the
+quality-flag scheme. Compression and archiving behavior are configurable; the
+response is always a ZIP.
+
+## Data sources
+
+Most queries target a **registered table** by name:
+
+```json
+{ "from": "default", "select": ["time"] }
+```
+
+Both styles also support querying files directly without a registered table — see the [JSON DSL `from` reference](./json.md#choosing-the-data-source-from) and the [SQL table functions](./sql.md#query-files-directly).

--- a/docs/docs/1.8.0/api/querying/json.md
+++ b/docs/docs/1.8.0/api/querying/json.md
@@ -1,0 +1,297 @@
+# JSON Query DSL
+
+The JSON DSL lets you express queries as a typed object — no SQL string building required. It is the preferred interface for programmatic clients and query builders.
+
+```http
+POST /api/query
+Content-Type: application/json
+```
+
+:::tip
+Discover available columns before querying:
+
+- Default table: `GET /api/table-schema?table_name=default`
+- From a file glob: `GET /api/dataset-schema?file=argo/**/*.nc`
+
+:::
+
+## Request shape
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
+| `select` | Yes | Columns (and expressions) to return |
+| `from` | No | Data source — table name or inline file source |
+| `filters` | No | Row filters, combined with AND by default |
+| `sort_by` | No | Sort expressions |
+| `limit` | No | Maximum rows to return |
+| `offset` | No | Rows to skip |
+| `distinct` | No | DISTINCT ON expression |
+| `output` | No | Output format (default: Arrow IPC stream) |
+
+## Selecting columns
+
+### Plain column
+
+```json
+{ "select": ["time", "latitude", "longitude"] }
+```
+
+### Column with alias
+
+```json
+{
+  "select": [
+    { "column": "sea_surface_temperature", "alias": "sst" }
+  ]
+}
+```
+
+### Function call
+
+```json
+{
+  "select": [
+    { "function": "round", "args": ["temperature", { "value": 2 }], "alias": "temperature_rounded" }
+  ]
+}
+```
+
+`args` entries are either a column name string or a literal `{ "value": … }` object.
+
+## Choosing the data source (`from`)
+
+### Query a registered table
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "from": "default",
+  "select": ["time", "temperature"],
+  "limit": 100,
+  "output": { "format": "csv" }
+}
+```
+
+Use `GET /api/tables` to list available table names. When `from` is omitted, Beacon uses the configured default table.
+
+### Query files directly
+
+Pass a format key with a `paths` array. Paths are resolved relative to Beacon's dataset root and support glob patterns.
+
+**NetCDF:**
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "from": { "netcdf": { "paths": ["argo/**/*.nc"] } },
+  "select": ["time", "latitude", "longitude", "temperature"],
+  "limit": 100,
+  "output": { "format": "csv" }
+}
+```
+
+**Zarr:**
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "from": { "zarr": { "paths": ["sst/*/zarr.json"] } },
+  "select": ["time", "sst"],
+  "limit": 100,
+  "output": { "format": "csv" }
+}
+```
+
+Predicate pushdown is automatic for large Zarr stores — Beacon prunes chunks and slices coordinate dimensions from your `filters`, with no extra options to configure:
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "from": {
+    "zarr": {
+      "paths": ["sst/*/zarr.json"]
+    }
+  },
+  "select": ["time", "latitude", "longitude", "sst"],
+  "filters": [{ "column": "time", "min": "2025-01-01" }],
+  "limit": 1000,
+  "output": { "format": "csv" }
+}
+```
+
+**Parquet:**
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "from": { "parquet": { "paths": ["obs/**/*.parquet"] } },
+  "select": ["time", "latitude", "longitude"],
+  "limit": 100,
+  "output": { "format": "csv" }
+}
+```
+
+Other supported format keys: `csv`, `arrow`, `odv`, `tiff`, `bbf`.
+
+## Filters
+
+`filters` is an array of filter objects. Multiple entries are combined with AND. A filter can be placed on any column in the schema.
+
+### Range (min / max)
+
+```json
+{ "filters": [{ "column": "temperature", "min": 2, "max": 10 }] }
+```
+
+Either `min` or `max` can be omitted for an open-ended range.
+
+### Equality
+
+```json
+{ "filters": [{ "column": "platform", "eq": "SHIP" }] }
+```
+
+### AND (multiple filters)
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "select": ["time", "latitude", "longitude", "temperature"],
+  "filters": [
+    { "column": "temperature", "min": 2, "max": 10 },
+    { "column": "latitude", "min": -10, "max": 10 }
+  ],
+  "limit": 10000,
+  "output": { "format": "csv" }
+}
+```
+
+### OR
+
+Wrap OR branches in a single `or` filter object:
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "select": ["time", "platform", "temperature"],
+  "filters": [
+    {
+      "or": [
+        { "column": "platform", "eq": "SHIP" },
+        { "column": "platform", "eq": "BUOY" }
+      ]
+    }
+  ],
+  "limit": 1000,
+  "output": { "format": "csv" }
+}
+```
+
+### GeoJSON spatial filter
+
+Tests whether a point (lon/lat columns) falls within a GeoJSON geometry:
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "select": ["time", "longitude", "latitude", "temperature"],
+  "filters": [
+    {
+      "longitude_column": "longitude",
+      "latitude_column": "latitude",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[4.0, 52.0], [6.0, 52.0], [6.0, 54.0], [4.0, 54.0], [4.0, 52.0]]]
+      }
+    }
+  ],
+  "limit": 10000,
+  "output": { "format": "csv" }
+}
+```
+
+### Filter operator reference
+
+Every leaf filter names a column with `column` (alias `for_query_parameter`) plus
+one operator key. The full set:
+
+| Operator | Key(s) | Example |
+| --- | --- | --- |
+| Equal | `eq` | `{ "column": "platform", "eq": "SHIP" }` |
+| Not equal | `neq` (aliases `not_eq`, `not_equal`) | `{ "column": "platform", "neq": "BUOY" }` |
+| Greater than | `gt` | `{ "column": "depth", "gt": 0 }` |
+| Greater or equal | `gt_eq` (alias `min`) | `{ "column": "depth", "gt_eq": 0 }` |
+| Less than | `lt` | `{ "column": "depth", "lt": 100 }` |
+| Less or equal | `lt_eq` (alias `max`) | `{ "column": "depth", "lt_eq": 100 }` |
+| Range (between) | `gt_eq` + `lt_eq` (aliases `min`/`low` and `max`/`high`) | `{ "column": "temp", "min": 2, "max": 10 }` |
+| Is null | `is_null` | `{ "is_null": { "column": "qc_flag" } }` |
+| Is not null | `is_not_null` (aliases `skip_fill_values`, `skip_missing`) | `{ "is_not_null": { "column": "qc_flag" } }` |
+| All of | `and` | `{ "and": [ … ] }` |
+| Any of | `or` | `{ "or": [ … ] }` |
+| Point-in-geometry | `longitude_column` + `latitude_column` + `geometry` | see [GeoJSON spatial filter](#geojson-spatial-filter) |
+
+The `min` / `max` keys used elsewhere on this page are aliases of `gt_eq` / `lt_eq`.
+
+## Sorting and pagination
+
+| Field | Description |
+| ----- | ----------- |
+| `sort_by` | Array of `{"Asc": "col"}` or `{"Desc": "col"}` objects |
+| `limit` | Maximum number of rows |
+| `offset` | Number of rows to skip |
+
+:::warning
+`sort_by` enum keys are case-sensitive: `"Asc"` and `"Desc"`, not `"asc"` / `"desc"`.
+:::
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "select": ["time", "temperature"],
+  "sort_by": [{ "Desc": "time" }],
+  "offset": 100,
+  "limit": 50,
+  "output": { "format": "csv" }
+}
+```
+
+## DISTINCT ON
+
+Return one row per unique combination of the `on` columns:
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "distinct": {
+    "on": ["platform"],
+    "select": ["platform", "time", "temperature"]
+  },
+  "sort_by": [{ "Desc": "time" }],
+  "limit": 100,
+  "output": { "format": "csv" }
+}
+```
+
+## Output formats
+
+See [Querying — Output formats](./index.md#output-formats) for the full list. The `output` field is identical for JSON DSL and SQL queries.

--- a/docs/docs/1.8.0/api/querying/sql.md
+++ b/docs/docs/1.8.0/api/querying/sql.md
@@ -1,0 +1,135 @@
+# SQL
+
+Beacon can execute SQL through DataFusion. SQL queries are submitted to the same endpoint as JSON queries:
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{ "sql": "SELECT time, temperature FROM default LIMIT 10" }
+```
+
+:::warning
+SQL is disabled by default. Enable it by setting the environment variable `BEACON_ENABLE_SQL=true`. Requests with `"sql": "..."` return an error when SQL is disabled.
+:::
+
+## Query a registered table
+
+List available tables:
+
+```http
+GET /api/tables
+```
+
+Run a SQL query against a table:
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT time, latitude, longitude, temperature FROM default WHERE temperature > 5 LIMIT 1000",
+  "output": { "format": "csv" }
+}
+```
+
+Inspect the table schema:
+
+```http
+GET /api/table-schema?table_name=default
+```
+
+## Query files directly
+
+Table functions let you query files without registering a table first. Paths are resolved relative to Beacon's dataset root and support glob patterns.
+
+List available table functions:
+
+```http
+GET /api/table-functions
+```
+
+### NetCDF
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT time, latitude, longitude FROM read_netcdf(['argo/**/*.nc']) LIMIT 100",
+  "output": { "format": "csv" }
+}
+```
+
+### Zarr
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT time, sst FROM read_zarr(['sst/*/zarr.json']) LIMIT 100",
+  "output": { "format": "csv" }
+}
+```
+
+Predicate pushdown is automatic — Beacon prunes chunks and slices coordinate dimensions based on your `WHERE` clause, with no extra arguments to configure:
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT time, latitude, longitude, sst FROM read_zarr(['sst/*/zarr.json']) WHERE time >= '2025-01-01' LIMIT 1000",
+  "output": { "format": "csv" }
+}
+```
+
+### Parquet
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT * FROM read_parquet(['obs/**/*.parquet']) LIMIT 100",
+  "output": { "format": "csv" }
+}
+```
+
+Other table functions: `read_arrow`, `read_csv`, `read_odv_ascii`, `read_bbf`, `read_tiff`. See [Reading Files](../../sql/table-functions.md) for full signatures.
+
+## Output formats
+
+See [Querying — Output formats](./index.md#output-formats) for the full list. Add `output` alongside `sql` in the same request body:
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT longitude, latitude, time, temperature FROM default LIMIT 100000",
+  "output": {
+    "format": {
+      "geoparquet": { "longitude_column": "longitude", "latitude_column": "latitude" }
+    }
+  }
+}
+```
+
+## Explain and metrics
+
+Explain the physical plan for a SQL query:
+
+```http
+POST /api/explain-query
+Content-Type: application/json
+
+{ "sql": "SELECT * FROM default LIMIT 10" }
+```
+
+Fetch metrics after execution (query ID comes from the `x-beacon-query-id` response header):
+
+```http
+GET /api/query/metrics/{query_id}
+```

--- a/docs/docs/1.8.0/connect/beacon-cli.md
+++ b/docs/docs/1.8.0/connect/beacon-cli.md
@@ -1,0 +1,109 @@
+---
+description: beacon-cli is a terminal client for Beacon — run SQL against a running server, explore tables/datasets/schemas, render results, and export to CSV, Parquet, Arrow IPC, or NetCDF.
+---
+
+# Beacon CLI
+
+`beacon-cli` is a terminal client for a running Beacon server. It runs SQL,
+explores tables / datasets / schemas, renders results as tables in your
+terminal, and exports to CSV, Parquet, Arrow IPC, or NetCDF — all without
+leaving the shell. It talks to the server's `/api/*` HTTP endpoints, decoding the
+zstd-compressed Arrow IPC result stream, and offers both one-shot subcommands and
+an interactive REPL.
+
+It ships in the Beacon repository under [`clients/beacon-cli`](https://github.com/maris-development/beacon/tree/main/clients/beacon-cli).
+
+## Install
+
+Requires Python 3.10+. Install it (editable) from a checkout of the repo:
+
+```bash
+pip install -e clients/beacon-cli
+# or, with uv:
+uv pip install -e clients/beacon-cli
+```
+
+This installs the `beacon-cli` console script.
+
+## Connecting
+
+Defaults match the Beacon server (`http://localhost:5001`). Override per
+invocation or via environment variables:
+
+| Option | Env var | Default |
+| --- | --- | --- |
+| `--url` | `BEACON_URL` | `http://localhost:5001` |
+| `--username` | `BEACON_ADMIN_USERNAME` | _(none)_ |
+| `--password` | `BEACON_ADMIN_PASSWORD` | _(none)_ |
+
+Credentials are sent as HTTP Basic auth and elevate the session to super-user,
+which is required for DDL/DML (e.g. `CREATE EXTERNAL TABLE`). Read-only queries
+need no credentials.
+
+## One-shot commands
+
+```bash
+# Run SQL and render a table
+beacon-cli query "SELECT * FROM default LIMIT 10"
+
+# From a file or stdin
+beacon-cli query -f query.sql
+echo "SELECT count(*) FROM default" | beacon-cli query
+
+# Export results to a file (format inferred from the extension)
+beacon-cli export "SELECT * FROM default" -o out.parquet
+
+# Explore
+beacon-cli tables                 # list table names
+beacon-cli tables --detail        # + kind / format / location / partitions
+beacon-cli tables --schema        # + each table's columns
+beacon-cli schema default         # one table's schema
+beacon-cli datasets               # list datasets
+beacon-cli dataset-schema path/to/file.parquet
+beacon-cli functions              # scalar/aggregate functions
+beacon-cli functions --table      # table functions
+beacon-cli info                   # server info
+beacon-cli metrics <query-id>     # metrics for a prior query
+```
+
+Useful `query` flags: `--max-rows N` (render limit, default 100; `-1` = all),
+`--all` (fetch the entire result), `--expand`/`-x` (render rows vertically for
+wide tables), and `--json` (emit rows as JSON on stdout).
+
+### DDL, admin & crawler statements
+
+`query` (and the REPL) send raw SQL straight through, so any statement the server
+accepts works — including Beacon's custom DDL. Read-only statements need no
+credentials; anything that mutates state requires admin basic auth.
+
+```bash
+# Read-only (no credentials)
+beacon-cli query "SHOW TABLES"
+beacon-cli query "SHOW CRAWLERS"
+
+# Admin — DDL/DML, crawlers, materialized views
+beacon-cli -u beacon-admin -p beacon-password \
+  query "CREATE EXTERNAL TABLE obs STORED AS DELTA LOCATION 'datasets://obs/'"
+beacon-cli -u beacon-admin -p beacon-password \
+  query "CREATE CRAWLER cr ON 'crawl_src/' WITH ('format' 'parquet', 'schedule' '15m')"
+```
+
+## Interactive shell
+
+Run `beacon-cli` with no subcommand to open the REPL:
+
+```
+beacon> SELECT * FROM default LIMIT 5;
+beacon> \dt                 -- list tables
+beacon> \dt+                -- tables with kind / format / location
+beacon> \d default          -- table schema
+beacon> \datasets           -- list datasets
+beacon> \crawlers           -- SHOW CRAWLERS
+beacon> \run-crawler cr     -- RUN CRAWLER cr      (admin)
+beacon> \refresh obs        -- REFRESH TABLE obs   (admin)
+beacon> \format parquet     -- set export format
+beacon> \x                  -- toggle expanded (vertical) rendering
+```
+
+See the [`clients/beacon-cli` README](https://github.com/maris-development/beacon/tree/main/clients/beacon-cli)
+for the full command list and export options.

--- a/docs/docs/1.8.0/connect/beacon-python-sdk.md
+++ b/docs/docs/1.8.0/connect/beacon-python-sdk.md
@@ -1,0 +1,215 @@
+# Beacon Python SDK
+
+Beacon has an official Python client library that makes it easy to explore a data lake and run queries without manually constructing HTTP requests.
+
+The SDK documentation lives here:
+
+- [Beacon Python SDK docs](https://maris-development.github.io/beacon-py/latest/)
+
+## Install
+
+```bash
+pip install beacon-api
+```
+
+Import the client:
+
+```python
+from beacon_api import Client
+```
+
+## Connect to a Beacon node
+
+Create a client using your Beacon base URL:
+
+```python
+from beacon_api import Client
+
+client = Client(
+    "https://beacon.example.com",
+    # jwt_token="<optional bearer token>",
+    # proxy_headers={"X-Forwarded-For": "<optional ip>"},
+    # basic_auth=("user", "pass"),
+)
+
+client.check_status()  # probes /api/health and prints the Beacon version
+info = client.get_server_info()  # metadata from /api/info
+print(info.get("beacon_version"))
+```
+
+## Explore tables
+
+`list_tables()` returns a mapping of table names to `DataTable` helpers.
+
+```python
+tables = client.list_tables()
+
+for name, table in tables.items():
+    print(name, table.get_table_type(), table.get_table_description())
+```
+
+Inspect the Arrow schema for a table:
+
+```python
+default_table = tables["default"]
+
+schema = default_table.get_table_schema_arrow()
+for field in schema:
+    print(f"{field.name}: {field.type}")
+```
+
+## Explore datasets (Beacon ≥ 1.4.0)
+
+If your node supports dataset listing, you can query files directly (without creating a table first).
+
+```python
+datasets = client.list_datasets(pattern="**/*.parquet", limit=10)
+first = next(iter(datasets.values()))
+
+print(first.get_file_path(), first.get_file_format())
+schema = first.get_schema()
+```
+
+## Query with the JSON builder (recommended)
+
+Start from a table (or dataset) and chain selects and filters.
+
+```python
+stations = client.list_tables()["default"]
+
+df = (
+    stations
+    .query()
+    .add_select_columns([
+        ("LONGITUDE", None),
+        ("LATITUDE", None),
+        ("JULD", None),
+        ("TEMP", "temperature_c"),
+    ])
+    .add_range_filter("JULD", "2024-01-01T00:00:00", "2024-06-30T23:59:59")
+    .to_pandas_dataframe()
+)
+
+print(df.head())
+```
+
+### Expressions and functions
+
+The SDK exposes helpers for building common server-side expressions:
+
+```python
+from beacon_api.query import Functions
+
+query = (
+    stations
+    .query()
+    .add_select_column("CRUISE")
+    .add_select_column("STATION")
+    .add_select(Functions.concat(["CRUISE", "STATION"], alias="cast_id"))
+    .add_select(Functions.try_cast_to_type("TEMP", to_type="float64", alias="temp_float"))
+)
+```
+
+### Multiple filters
+
+```python
+filtered = (
+    stations
+    .query()
+    .add_select_column("LONGITUDE")
+    .add_select_column("LATITUDE")
+    .add_select_column("JULD")
+    .add_select_column("TEMP")
+    .add_equals_filter("DATA_TYPE", "CTD")
+    .add_range_filter("PRES", 0, 10)
+    .add_bbox_filter("LONGITUDE", "LATITUDE", bbox=(-20, 40, -10, 55))
+)
+```
+
+For custom boolean logic, compose filter nodes and pass them to `add_filter()`:
+
+```python
+from beacon_api.query import AndFilter, RangeFilter
+
+filtered = filtered.add_filter(
+    AndFilter([
+        RangeFilter("TEMP", gt_eq=-2, lt_eq=35),
+        RangeFilter("PSAL", gt_eq=30, lt_eq=40),
+    ])
+)
+```
+
+### Distinct and sorting
+
+```python
+query = (
+    stations
+    .query()
+    .add_select_column("CRUISE")
+    .add_select_column("STATION")
+    .add_select_column("JULD")
+    .set_distinct(["CRUISE", "STATION"])
+    .add_sort("JULD", ascending=True)
+)
+```
+
+### Explain the plan
+
+`explain()` calls the Beacon `/api/explain-query` endpoint so you can inspect how the server plans to execute your request.
+
+```python
+plan = query.explain()
+print(plan)
+```
+
+## Export results (Pandas / GeoPandas / Parquet / NetCDF / ...)
+
+Every query can materialize into common Python data structures or write directly to disk.
+
+```python
+query = (
+    stations
+    .query()
+    .add_select_column("LONGITUDE")
+    .add_select_column("LATITUDE")
+    .add_select_column("JULD")
+    .add_select_column("TEMP")
+    .add_range_filter("JULD", "2024-01-01T00:00:00", "2024-01-31T23:59:59")
+)
+
+df = query.to_pandas_dataframe()
+gdf = query.to_geo_pandas_dataframe("LONGITUDE", "LATITUDE")
+
+query.to_parquet("subset.parquet")
+query.to_geoparquet("subset.geoparquet", "LONGITUDE", "LATITUDE")
+query.to_csv("subset.csv")
+```
+
+::: tip
+If your Beacon node supports server-side NdNetCDF (Beacon ≥ 1.5.0), you can export using `to_nd_netcdf(path, dimension_columns=[...])`.
+:::
+
+## Query with SQL
+
+If you already have SQL, build an `SQLQuery` and use the same output helpers:
+
+```python
+sql = client.sql_query(
+    """
+    SELECT LONGITUDE, LATITUDE, JULD, TEMP AS temperature_c
+    FROM default
+    WHERE JULD BETWEEN '2024-01-01 00:00:00' AND '2024-06-30 23:59:59'
+    ORDER BY JULD ASC
+    """
+)
+
+df = sql.to_pandas_dataframe()
+sql.to_parquet("slice.parquet")
+```
+
+## More SDK docs
+
+- [Getting started](https://maris-development.github.io/beacon-py/latest/getting_started/)
+- [Exploring](https://maris-development.github.io/beacon-py/latest/using/exploring/)
+- [Querying](https://maris-development.github.io/beacon-py/latest/using/querying/)
+- [API reference](https://maris-development.github.io/beacon-py/latest/reference/client/)

--- a/docs/docs/1.8.0/connect/beacon-typescript-sdk.md
+++ b/docs/docs/1.8.0/connect/beacon-typescript-sdk.md
@@ -1,0 +1,109 @@
+---
+description: "@beacon/client is an isomorphic TypeScript SDK for Beacon — run SQL or the JSON query DSL from Node.js or the browser, decode the Arrow result stream to plain JS objects, and build queries with an EF Core-style fluent builder."
+---
+
+# Beacon TypeScript SDK
+
+`@beacon/client` is an isomorphic TypeScript/JavaScript SDK for a running Beacon
+server. It runs in **Node.js (18+)** and the **browser**, built on the global
+`fetch`. It runs SQL or the [JSON query DSL](/docs/1.8.0/api/querying/json),
+decodes Beacon's zstd-compressed Arrow IPC results into plain JS row objects, and
+ships a fluent, EF Core / LINQ-style query builder.
+
+It lives in the Beacon repository under [`clients/beacon-ts`](https://github.com/maris-development/beacon/tree/main/clients/beacon-ts).
+
+## Install
+
+```bash
+npm install @beacon/client
+```
+
+`apache-arrow` (the result decoder) and `fzstd` (a tiny pure-JS zstd
+decompressor) are regular dependencies and install automatically — no extra
+setup. Beacon's results are zstd-compressed Arrow IPC; the SDK registers an
+fzstd-backed zstd codec with `apache-arrow` so they decode out of the box.
+
+## Quick start
+
+```ts
+import { BeaconClient } from "@beacon/client";
+
+const beacon = new BeaconClient({ url: "http://localhost:5001" });
+
+// Run SQL and get plain JS row objects (decoded from the Arrow stream).
+const { rows, queryId, table } = await beacon.query(
+  "SELECT TEMP, PSAL FROM read_netcdf(['file.nc']) LIMIT 5",
+);
+
+// Or use the structured JSON query DSL.
+const result = await beacon.query({
+  select: [{ column: "TEMP", alias: "temperature" }, "PSAL"],
+  filter: { column: "depth", gt_eq: 0, lt_eq: 100 },
+  limit: 100,
+});
+
+// Inspect the catalog.
+const tables = await beacon.tables();
+const info = await beacon.info();
+```
+
+Every query returns `{ rows, queryId, table }`: `rows` are decoded JS objects,
+`queryId` is the server's `x-beacon-query-id` (use it to fetch query metrics),
+and `table` is the underlying [Arrow](https://arrow.apache.org/) `Table` for
+zero-copy access.
+
+## Query builder (EF Core / LINQ-style)
+
+A fluent builder produces the JSON DSL for you. JavaScript can't overload
+operators, so predicates use methods (`col("d").gte(0)`) rather than `d >= 0`;
+otherwise it reads like EF Core's method syntax.
+
+```ts
+import { column, func, col } from "@beacon/client";
+
+const { rows } = await beacon
+  .from({ netcdf: { paths: ["argo.nc"] } })       // or .fromNetcdf("argo.nc"), .fromTable("t")
+  .select("TEMP", column("PSAL", "salinity"), func("avg", ["TEMP"], "mean"))
+  .where((x) => x.depth.gte(0).and(x.depth.lte(100)))  // x.<col> → comparison methods
+  .orderByDescending("TEMP")
+  .skip(0)
+  .take(100)
+  .execute();                                     // → { rows, queryId, table }
+
+// EF-style terminals:
+const list = await beacon.from("ctd").select("*").toArray();      // just rows
+const one = await beacon.select("TEMP").where(col("id").eq(7)).first();
+
+// Other outputs from the same builder:
+const arrow = await beacon.from("ctd").select("TEMP").toArrow();  // Arrow Table
+for await (const batch of beacon.from("ctd").select("TEMP").stream()) {
+  /* RecordBatch */
+}
+
+// Inspect or reuse the DSL without running it:
+const dsl = beacon.from("ctd").select("TEMP").where(col("d").gte(0)).build();
+```
+
+## Admin operations
+
+When constructed with admin Basic-auth credentials, the client can manage the
+data lake — register external tables, manage crawlers, and drop tables:
+
+```ts
+const beacon = new BeaconClient({
+  url: "http://localhost:5001",
+  username: "beacon-admin",
+  password: "beacon-password",
+});
+```
+
+The credentials are sent on every request and are verified server-side against
+`GET /api/admin/check`. See the [REST API reference](/docs/1.8.0/api/) for the
+full set of admin endpoints.
+
+## Browser usage
+
+The SDK is bundler-friendly and runs unmodified in the browser. Beacon's default
+CORS policy (`*`, with the `Authorization` header allowed) lets a browser app
+call the server directly. The bundled [Admin Web UI](/docs/1.8.0/connect/web-admin-ui)
+is built entirely on this SDK and is a good reference for browser usage.

--- a/docs/docs/1.8.0/connect/jetbrains-datagrip.md
+++ b/docs/docs/1.8.0/connect/jetbrains-datagrip.md
@@ -1,0 +1,96 @@
+# JetBrains DataGrip
+
+You can connect to a Beacon data lakehouse from [JetBrains DataGrip](https://www.jetbrains.com/datagrip/) using the **Arrow Flight SQL JDBC driver**. This gives you a full SQL interface — browse tables, run queries, and explore your data directly from the IDE.
+
+## Prerequisites
+
+- DataGrip installed
+- A running Beacon instance with Arrow Flight SQL enabled (enabled by default)
+- Port `32011` reachable from your machine (see [Docker note](#expose-the-flight-sql-port) below)
+
+## Step 1 — Download the Arrow Flight SQL JDBC driver
+
+Download the driver from:
+
+- [JetBrains JDBC Drivers page](https://www.jetbrains.com/datagrip/jdbc-drivers/) — search for "Apache Arrow Flight"
+    Click on the versions (18.3.0 or later) to download a zip file containing the JAR.
+    Unzip the downloaded file and locate the JAR (e.g. `flight-sql-jdbc-driver-18.3.0.jar`).
+
+## Step 2 — Add the driver to DataGrip
+
+1. Open **Database Explorer** → **New** → **Driver**.
+![DataGrip Driver Manager](/connect_datagrip/2.png)
+2. Click **+** to create a new driver. Give it a name (e.g. Beacon Driver). Add driver files (the JAR you downloaded in Step 1) and set the driver class to `org.apache.arrow.driver.jdbc.ArrowFlightJdbcDriver`. Save the driver.
+3. Under **Driver Files**, click **+** → **Custom JARs…** and select the JAR you downloaded (it is contained within the downloaded zip file).
+![DataGrip Driver Manager](/connect_datagrip/3.png)
+4. Set **Class** to `org.apache.arrow.driver.jdbc.ArrowFlightJdbcDriver`.
+![DataGrip Driver Manager](/connect_datagrip/4.png)
+5. Click **OK** to save the driver.
+
+## Step 3 — Create a data source
+
+1. Open **Database Explorer** → **New** → **Data Source** -> **YOUR_DRIVER_NAME**.
+2. Click **+** → select the **YOUR_DRIVER_NAME** driver.
+3. Fill in the connection details:
+
+| Field        | Value                                                          |
+| ------------ | -------------------------------------------------------------- |
+| **User**     | Your Beacon admin username (`BEACON_ADMIN_USERNAME`)           |
+| **Password** | Your Beacon admin password (`BEACON_ADMIN_PASSWORD`)           |
+| **URL**      | `jdbc:arrow-flight-sql://localhost:32011?useEncryption=false`  |
+
+![DataGrip Data Source Configuration](/connect_datagrip/6.png)
+
+:::info
+If your Beacon instance is served over TLS, change `useEncryption=false` to `useEncryption=true` in the JDBC URL.
+:::
+
+4. Click **Test Connection** to verify. You should see a *Successful* message.
+5. Click **OK** to save.
+
+## Expose the Flight SQL port
+
+By default, Arrow Flight SQL listens on port `32011`. When running Beacon via Docker Compose, make sure this port is published:
+
+```yaml
+services:
+    beacon:
+        image: ghcr.io/maris-development/beacon:latest
+        ports:
+            - "5001:5001"   # HTTP API
+            - "32011:32011" # Arrow Flight SQL  # [!code ++]
+```
+
+## Querying your data
+
+Once connected, DataGrip will introspect the available tables. You can then:
+
+- Browse the schema tree in the **Database** panel
+- Open a query console and run SQL against your datasets
+
+```sql
+-- List all available tables
+SHOW TABLES;
+
+-- Query a dataset
+SELECT 1;
+
+-- Query a dataset
+SELECT * FROM read_netcdf(['my_dataset.nc'], ['TIME', 'DEPTH']) LIMIT 100;
+```
+
+:::tip
+Beacon tables are named after your dataset files or registered external table names. If you don't see tables immediately, right-click the data source and choose **Refresh**.
+:::
+
+## Configuration reference
+
+The Arrow Flight SQL endpoint can be tuned with the following environment variables in your Beacon deployment:
+
+| Variable                              | Default   | Description                              |
+| ------------------------------------- | --------- | ---------------------------------------- |
+| `BEACON_FLIGHT_SQL_ENABLE`            | `true`    | Enable or disable the Flight SQL server  |
+| `BEACON_FLIGHT_SQL_HOST`              | `0.0.0.0` | IP address to listen on                  |
+| `BEACON_FLIGHT_SQL_PORT`              | `32011`   | Port for the Flight SQL gRPC server      |
+| `BEACON_FLIGHT_SQL_ALLOW_ANONYMOUS`   | `false`   | Allow unauthenticated connections        |
+| `BEACON_FLIGHT_SQL_TOKEN_TTL_SECS`    | `3600`    | Auth token lifetime in seconds           |

--- a/docs/docs/1.8.0/connect/python-adbc.md
+++ b/docs/docs/1.8.0/connect/python-adbc.md
@@ -1,0 +1,130 @@
+# Python — ADBC (Arrow Database Connectivity)
+
+[ADBC](https://arrow.apache.org/adbc/) is a database-connectivity standard built on Apache Arrow. The `adbc-driver-flightsql` package connects to any Arrow Flight SQL server — including Beacon — and returns results as zero-copy Arrow record batches, making it ideal for data science workloads.
+
+## Installation
+
+```bash
+pip install adbc-driver-flightsql adbc-driver-manager pyarrow
+```
+
+## Connecting
+
+Beacon's Arrow Flight SQL server listens on port `32011` by default (separate from the HTTP API on port `5001`). Make sure that port is reachable — see the [Docker Compose note](#expose-the-flight-sql-port) below.
+
+### DBAPI 2.0 interface (recommended)
+
+The `adbc_driver_flightsql.dbapi` module exposes a standard [PEP 249](https://peps.python.org/pep-0249/) interface, compatible with `pandas.read_sql` and similar helpers.
+
+```python
+import adbc_driver_flightsql.dbapi as flight_sql
+
+conn = flight_sql.connect(
+    "grpc://localhost:32011",
+    db_kwargs={
+        "username": "admin",        # BEACON_ADMIN_USERNAME
+        "password": "securepassword", # BEACON_ADMIN_PASSWORD
+    },
+)
+```
+
+### Low-level `AdbcDatabase` interface
+
+Use `adbc_driver_manager.AdbcDatabase` when you need direct control over the connection lifecycle or want to integrate with libraries that accept the ADBC database handle.
+
+```python
+import adbc_driver_manager as mgr
+import adbc_driver_flightsql as flightsql
+
+db = mgr.AdbcDatabase(
+    driver=flightsql.DRIVER_PATH,
+    uri="grpc://localhost:32011",
+    **{flightsql.DatabaseOptions.USERNAME.value: "admin"},
+    **{flightsql.DatabaseOptions.PASSWORD.value: "securepassword"},
+)
+conn = db.connect()
+```
+
+## Running queries
+
+### Fetch rows with a cursor
+
+```python
+with flight_sql.connect("grpc://localhost:32011", db_kwargs={...}) as conn:
+    with conn.cursor() as cur:
+        cur.execute("SELECT * FROM default LIMIT 10")
+        rows = cur.fetchall()
+        print(rows)
+```
+
+### Fetch as an Arrow table
+
+```python
+with flight_sql.connect("grpc://localhost:32011", db_kwargs={...}) as conn:
+    with conn.cursor() as cur:
+        cur.execute("SELECT time, latitude, longitude, temp FROM default LIMIT 10000")
+        arrow_table = cur.fetch_arrow_table()  # pyarrow.Table, zero-copy
+        print(arrow_table.schema)
+```
+
+### Read into a pandas DataFrame
+
+```python
+import pandas as pd
+
+with flight_sql.connect("grpc://localhost:32011", db_kwargs={...}) as conn:
+    df = pd.read_sql("SELECT * FROM default LIMIT 1000", conn)
+    print(df.head())
+```
+
+## Expose the Flight SQL port
+
+When running Beacon via Docker Compose, publish port `32011` alongside the HTTP API:
+
+```yaml
+services:
+    beacon:
+        image: ghcr.io/maris-development/beacon:latest
+        ports:
+            - "5001:5001"   # HTTP API
+            - "32011:32011" # Arrow Flight SQL  # [!code ++]
+```
+
+## TLS connections
+
+If your Beacon instance is behind TLS, use `grpc+tls://` as the URI scheme:
+
+```python
+conn = flight_sql.connect(
+    "grpc+tls://your-beacon-host:32011",
+    db_kwargs={
+        "username": "admin",
+        "password": "securepassword",
+    },
+)
+```
+
+For self-signed certificates, disable certificate verification:
+
+```python
+import adbc_driver_flightsql as flightsql
+
+conn = flight_sql.connect(
+    "grpc+tls://your-beacon-host:32011",
+    db_kwargs={
+        "username": "admin",
+        "password": "securepassword",
+        flightsql.DatabaseOptions.TLS_SKIP_VERIFY.value: "true",
+    },
+)
+```
+
+## Configuration reference
+
+| Variable                            | Default   | Description                             |
+| ----------------------------------- | --------- | --------------------------------------- |
+| `BEACON_FLIGHT_SQL_ENABLE`          | `true`    | Enable or disable the Flight SQL server |
+| `BEACON_FLIGHT_SQL_HOST`            | `0.0.0.0` | IP address to listen on                 |
+| `BEACON_FLIGHT_SQL_PORT`            | `32011`   | Port for the Flight SQL gRPC server     |
+| `BEACON_FLIGHT_SQL_ALLOW_ANONYMOUS` | `false`   | Allow unauthenticated connections       |
+| `BEACON_FLIGHT_SQL_TOKEN_TTL_SECS`  | `3600`    | Auth token lifetime in seconds          |

--- a/docs/docs/1.8.0/connect/web-admin-ui.md
+++ b/docs/docs/1.8.0/connect/web-admin-ui.md
@@ -1,0 +1,72 @@
+---
+description: Beacon ships a bundled admin web UI — an Athena-style query workbench plus pages to manage tables, datasets, crawlers and external tables, served at /admin straight from the Beacon server and Docker image.
+---
+
+# Admin Web UI
+
+Beacon ships with a bundled **admin web interface** — an Athena-style query
+workbench and data-lake admin console. It is built into the Beacon server and the
+official Docker image, so there is nothing extra to deploy: when a build is
+present, the server serves it at **`/admin`**.
+
+```
+http://localhost:5001/admin
+```
+
+The UI is a React single-page app (Vite, Tailwind CSS, shadcn/ui) that talks to
+Beacon exclusively through the [`@beacon/client`](/docs/1.8.0/connect/beacon-typescript-sdk)
+TypeScript SDK.
+
+## Logging in
+
+The UI is **admin-only**: a login screen gates the whole app. Sign in with the
+Beacon server URL and the admin Basic-auth credentials configured on the server:
+
+```bash
+BEACON_ADMIN_USERNAME=beacon-admin
+BEACON_ADMIN_PASSWORD=beacon-password
+```
+
+Credentials are verified against `GET /api/admin/check` and stored in the
+browser's `localStorage`, then sent on every request.
+
+:::warning
+This is browser-side gating over Beacon's HTTP Basic admin auth — it restricts
+who uses the UI, it is not a secret-keeping mechanism. Serve Beacon over HTTPS
+and expose `/admin` only to trusted operators.
+:::
+
+## Features
+
+- **Query editor** — an Athena-style workbench: a searchable table/column data
+  panel, a CodeMirror SQL editor (run with <kbd>⌘</kbd>/<kbd>Ctrl</kbd> +
+  <kbd>Enter</kbd>), a results grid, and CSV / Parquet download. **Explain**
+  renders the query's logical plan as a collapsible tree, and queries can be
+  **saved** to the browser and reloaded.
+- **Tables** — browse registered tables, their Arrow schemas and table
+  configuration, and drop a table (`DROP TABLE`, leaving the underlying files in
+  place).
+- **Datasets** — explore discovered dataset files and inspect each file's schema.
+- **Crawlers** — list, [create, run, and delete crawlers](/docs/1.8.0/data-lake/crawlers).
+- **External tables** — register an [external table](/docs/1.8.0/data-lake/external-tables)
+  over files in the datasets store.
+- **Server** — runtime info, health, and the available scalar / table functions.
+- **Light / dark / system theme** — switch from the top bar; the choice persists
+  in the browser.
+
+## Running it standalone
+
+The bundled copy is enough for most deployments. To run the UI from source (for
+development) it lives in the `clients/` npm workspace and depends on the SDK,
+which must be built first:
+
+```bash
+# from clients/
+npm install                       # installs the JS workspace (beacon-ts + beacon-web)
+npm run build -w @beacon/client   # build the SDK so beacon-web can import it
+npm run dev -w @beacon/web        # start the Vite dev server
+```
+
+Point it at any running Beacon server; the default CORS policy permits the dev
+server to call the API directly. The app source is in
+[`clients/beacon-web`](https://github.com/maris-development/beacon/tree/main/clients/beacon-web).

--- a/docs/docs/1.8.0/data-lake/configuration.md
+++ b/docs/docs/1.8.0/data-lake/configuration.md
@@ -32,8 +32,27 @@ over HTTP and the admin endpoints).
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `BEACON_ADMIN_USERNAME` | `beacon-admin` | Admin username for management endpoints. |
-| `BEACON_ADMIN_PASSWORD` | `beacon-password` | Admin password — **change this in production**. |
+| `BEACON_ADMIN_USERNAME` | `beacon-admin` | Super-user username for management endpoints. |
+| `BEACON_ADMIN_PASSWORD` | `beacon-password` | Super-user password — **change this in production**. |
+
+## Authentication & access control
+
+Beacon adds role-based access control on top of the super-user above: read-only
+SQL-managed users and roles, table/path grants and denies, anonymous access, and
+optional OIDC. See the [Access Control guide](/docs/1.8.0/security/access-control)
+for the full model and SQL reference. The variables that tune it:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_AUTH_ENFORCE` | `false` | Enforce read authorization (default-deny). When `false`, authorization is a no-op. |
+| `BEACON_AUTH_ANONYMOUS_ENABLED` | `true` | Allow unauthenticated requests as the built-in `anonymous` user. |
+| `BEACON_OIDC_ENABLED` | `false` | Accept OIDC bearer tokens in addition to local passwords. |
+| `BEACON_OIDC_ISSUER` | _(none)_ | Expected token issuer. |
+| `BEACON_OIDC_JWKS_URL` | _(none)_ | JWKS endpoint used to validate token signatures. |
+| `BEACON_OIDC_AUDIENCE` | _(none)_ | Expected audience; validated only when set. |
+| `BEACON_OIDC_ROLES_CLAIM` | `realm_access.roles` | Token claim (dot-path) holding role names. |
+| `BEACON_OIDC_USERNAME_CLAIM` | `preferred_username` | Token claim holding the username. |
+| `BEACON_OIDC_JWKS_CACHE_TTL_SECS` | `300` | How long to cache the issuer's JWKS. |
 
 ## Secrets
 

--- a/docs/docs/1.8.0/data-lake/configuration.md
+++ b/docs/docs/1.8.0/data-lake/configuration.md
@@ -1,0 +1,214 @@
+---
+description: Complete reference of Beacon's BEACON_* environment variables — server, query engine, storage, S3, Arrow Flight SQL, crawler, file formats, and API docs metadata — with their defaults.
+---
+
+# Configuration
+
+Beacon is configured entirely through **environment variables**. There is no
+configuration file: every option below is read from the environment at startup.
+Unset variables fall back to the defaults listed here.
+
+::: info
+All settings use `BEACON_*` names, except the S3 credential variables, which use
+the standard `AWS_*` names so they interoperate with existing AWS tooling (see
+[S3 object storage](#s3-object-storage)).
+:::
+
+## Server
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_HOST` | `0.0.0.0` | IP address the HTTP API listens on. |
+| `BEACON_PORT` | `5001` | Port the HTTP API listens on. |
+| `BEACON_WORKER_THREADS` | `8` | Number of worker threads for the async runtime. |
+| `BEACON_LOG_LEVEL` | `info` | Log level: `trace`, `debug`, `info`, `warn`, `error` (case-insensitive). |
+| `BEACON_BASE_PATH` | _(empty)_ | Optional URL path prefix for the HTTP API, OpenAPI document, and Swagger UI (e.g. `/beacon`). Useful behind a reverse proxy. Normalized to exactly one leading slash and no trailing slash, so `beacon`, `/beacon`, and `/beacon/` are equivalent. Only URL-safe characters are allowed (letters, digits, `-`, `_`, `.`, `~`, and `/` as a separator); any other character causes Beacon to exit at startup with a descriptive error. |
+| `BEACON_WEB_UI_DIR` | `web` | Directory holding the built admin web UI. Served at `{BEACON_BASE_PATH}/admin` when the directory exists, and skipped otherwise. Resolved relative to the working directory (`/beacon/web` in the Docker image). |
+
+## Admin
+
+The admin credentials gate the authenticated write/management surface (DDL/DML
+over HTTP and the admin endpoints).
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_ADMIN_USERNAME` | `beacon-admin` | Admin username for management endpoints. |
+| `BEACON_ADMIN_PASSWORD` | `beacon-password` | Admin password — **change this in production**. |
+
+## Secrets
+
+Master key used to encrypt persisted credentials at rest — currently the
+`password` of external [SQL database tables](./sql-databases.md). It is required
+to create a database table with a password; without it, such a `CREATE` is
+rejected rather than writing plaintext.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_SECRETS_KEY` | _(none)_ | Base64-encoded **32-byte** key (e.g. `openssl rand -base64 32`). If set, it must decode to exactly 32 bytes or Beacon exits at startup. Losing or changing it makes previously stored credentials undecryptable — recreate those tables with the new key. |
+
+## Query engine
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_ENABLE_SQL` | `true` | Enable the raw SQL query interface. Set to `false` to disable it (the JSON query API stays available). |
+| `BEACON_VM_MEMORY_SIZE` | `8192` | Working memory (MB) available to the query engine. More is better for larger datasets and memory-heavy operations such as spatial joins and `GROUP BY`. |
+| `BEACON_DEFAULT_TABLE` | `default` | Table queried when a request omits the source. Only applies to the JSON query API — SQL queries must always specify a source. |
+| `BEACON_DEFAULT_TABLE_ENGINE` | `lance` | Storage engine for [managed tables](../sql/managed-tables.md) created with `CREATE TABLE`: `lance` (local, supports indexes) or `iceberg` (object-store). Can be overridden per session with `SET beacon.table_engine = '…'`. |
+| `BEACON_ENABLE_PUSHDOWN_PROJECTION` | `true` | Push column projection down into file readers so only requested columns are decoded. |
+| `BEACON_SANITIZE_SCHEMA` | `false` | Sanitize dataset schemas (normalize column names/types) during discovery. |
+| `BEACON_ST_WITHIN_POINT_CACHE_SIZE` | `10000` | Cache size for `st_within_point` geometry lookups. |
+| `BEACON_BATCH_SIZE` | `64000` | Batch size, in rows, for NetCDF reads (local and MPIO). |
+| `BEACON_STATS_CACHE_CAPACITY` | `10000` | Maximum number of per-file statistics entries cached for query pruning. Read once at startup. |
+
+### SQL result-stream coalescing
+
+Small record batches produced by a query are merged into larger ones before being
+streamed to the client, which improves throughput for fine-grained results.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_SQL_STREAM_COALESCE_ENABLED` | `true` | Enable coalescing of the SQL result stream. |
+| `BEACON_SQL_STREAM_COALESCE_TARGET_ROWS` | `65536` | Target rows per coalesced batch. |
+| `BEACON_SQL_STREAM_COALESCE_FLUSH_TIMEOUT_MS` | `25` | Max time (ms) to wait while accumulating rows before flushing a partial batch. |
+| `BEACON_SQL_STREAM_COALESCE_MAX_ROWS` | `262144` | Hard upper bound on rows per coalesced batch. |
+
+## Arrow Flight SQL
+
+Beacon also exposes an [Arrow Flight SQL](https://arrow.apache.org/docs/format/FlightSql.html)
+endpoint on its own port, used by clients such as JetBrains DataGrip and the
+Python ADBC driver (see [Connect](../connect/jetbrains-datagrip.md)). Unlike the
+HTTP API, Flight SQL uses bearer-token authentication.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_FLIGHT_SQL_ENABLE` | `true` | Enable the Arrow Flight SQL server. |
+| `BEACON_FLIGHT_SQL_HOST` | `0.0.0.0` | Address the Flight SQL server binds to. |
+| `BEACON_FLIGHT_SQL_PORT` | `32011` | Port the Flight SQL server listens on. |
+| `BEACON_FLIGHT_SQL_ALLOW_ANONYMOUS` | `false` | Allow unauthenticated Flight SQL sessions. |
+| `BEACON_FLIGHT_SQL_TOKEN_TTL_SECS` | `3600` | Lifetime (seconds) of an issued session token. |
+| `BEACON_FLIGHT_SQL_STATEMENT_TTL_SECS` | `300` | Lifetime (seconds) of a server-side statement handle. |
+| `BEACON_FLIGHT_SQL_PREPARED_STATEMENT_TTL_SECS` | `900` | Lifetime (seconds) of a prepared-statement handle. |
+
+## Storage and data directories
+
+Beacon keeps all local state under a single root directory.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_DATA_DIR` | `./data` | Root directory for all local data. |
+| `BEACON_ENABLE_FS_EVENTS` | `true` | Watch the local datasets directory so new files are picked up automatically (uses inotify on Linux). Set to `false` to disable. Not used with the S3 data lake. Mounted Docker volumes can interfere with filesystem events — test this in your deployment environment. |
+
+The following sub-directories are created under `BEACON_DATA_DIR` and used by
+Beacon:
+
+| Sub-directory | Purpose |
+| --- | --- |
+| `datasets/` | Local datasets store (the files you query in place). |
+| `tables/` | Persisted external tables, views, and managed-table definitions. |
+| `tmp/` | Temporary files (e.g. materialized query output). |
+| `indexes/` | Dataset path/index data. |
+| `cache/` | Internal caches. |
+
+When mounting volumes with Docker, mount the sub-directories you want to persist
+(e.g. `-v ./datasets:/beacon/data/datasets`, `-v ./tables:/beacon/data/tables`).
+
+## S3 object storage
+
+Set `BEACON_S3_DATA_LAKE=true` to back the **datasets** store with S3-compatible
+object storage instead of the local filesystem. The `tables/`, `tmp/`, `indexes/`,
+and `cache/` directories remain on local disk.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_S3_DATA_LAKE` | `false` | Use S3-compatible object storage as the datasets store. When `false`, the local filesystem is used. |
+| `BEACON_S3_BUCKET` | _(none)_ | Bucket name. **Required** when `BEACON_S3_DATA_LAKE=true` — Beacon exits at startup if it is missing. Never inferred from the endpoint. |
+| `BEACON_S3_ENABLE_VIRTUAL_HOSTING` | `false` | Use virtual-hosted-style addressing (bucket in the host) instead of path-style (`{endpoint}/{bucket}/{key}`). |
+| `BEACON_S3_ALLOW_HTTP` | `true` | Allow plain `http://` endpoints (useful for local MinIO; disable for production). |
+| `BEACON_ENABLE_S3_EVENTS` | `false` | Reserved: wire S3 change notifications into the event listener. |
+
+### S3 credentials and endpoint (`AWS_*`)
+
+Credentials and the endpoint are resolved through the standard AWS environment
+chain (object-store's `from_env`), so the usual `AWS_*` variables apply. The
+endpoint and region Beacon captures here always override the corresponding
+environment values.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `AWS_ENDPOINT` | _(none)_ | S3-compatible endpoint URL, e.g. `https://s3.amazonaws.com` or `http://minio:9000`. The bucket is always taken from `BEACON_S3_BUCKET`, never parsed from this URL. |
+| `AWS_REGION` | _(none)_ | S3 region. (Note: `AWS_DEFAULT_REGION` is **not** used — set `AWS_REGION`.) |
+| `AWS_ACCESS_KEY_ID` | _(none)_ | Access key. Only required when the object store needs authentication. |
+| `AWS_SECRET_ACCESS_KEY` | _(none)_ | Secret key. Only required when the object store needs authentication. |
+| `AWS_SKIP_SIGNATURE` | _(none)_ | Set to `true` to send unsigned requests — useful for public/anonymous buckets. |
+
+## Crawler
+
+The [crawler](./crawlers.md) discovers files under a prefix and registers them as
+external tables.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_CRAWLER_ENABLE` | `true` | Master switch for crawler scheduling and event triggers. When `false`, crawlers can still be defined and run on demand, but no background tasks are spawned. |
+| `BEACON_CRAWLER_DEFAULT_INTERVAL_SECS` | `900` | Fallback poll interval (seconds) for an event-driven crawler on a deployment where storage events are unavailable. |
+
+## CORS
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_CORS_ALLOWED_METHODS` | `GET,POST,PUT,DELETE,OPTIONS` | Allowed HTTP methods. |
+| `BEACON_CORS_ALLOWED_ORIGINS` | `*` | Allowed origins. |
+| `BEACON_CORS_ALLOWED_HEADERS` | `Content-Type,Authorization` | Allowed request headers. |
+| `BEACON_CORS_EXPOSE_HEADERS` | `x-beacon-query-id` | Response headers exposed to browser JS on cross-origin requests. The default lets a cross-origin UI (e.g. the Vite dev server) read the `x-beacon-query-id` the SDK surfaces. |
+| `BEACON_CORS_ALLOWED_CREDENTIALS` | `false` | Allow credentials. |
+| `BEACON_CORS_MAX_AGE` | `3600` | Preflight cache duration (seconds). |
+
+## File formats
+
+Per-format tuning. See [Performance Tuning](./performance-tuning.md) for guidance
+on when to change these.
+
+### NetCDF
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_NETCDF_ENABLE_STATISTICS` | `true` | Compute and cache per-file statistics used for query pruning. |
+| `BEACON_NETCDF_USE_READER_CACHE` | `true` | Cache opened NetCDF readers in memory. |
+| `BEACON_NETCDF_READER_CACHE_SIZE` | `128` | Max NetCDF reader entries to keep cached. |
+
+### Atlas
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_ATLAS_USE_READER_CACHE` | `true` | Cache opened Atlas store readers in memory, avoiding re-opening the same `atlas.json` across queries. |
+| `BEACON_ATLAS_READER_CACHE_SIZE` | `32` | Max Atlas reader entries to keep cached. |
+
+### Beacon Binary Format (BBF)
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_ENABLE_BBF_SPLIT_STREAMS_SLICE` | `false` | Split large batches into smaller slices for better memory use and parallelism on BBF queries. |
+
+## API documentation metadata
+
+These customize the top-level metadata of the generated OpenAPI document and the
+Swagger / Scalar UIs, so a deployment can brand its own API docs without
+recompiling. All are optional except the title and description, which have
+defaults.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_API_TITLE` | `Beacon Rest API` | API document title. |
+| `BEACON_API_DESCRIPTION` | _(built-in summary)_ | API document description. |
+| `BEACON_API_TERMS_OF_SERVICE` | _(none)_ | Terms-of-service URL. |
+| `BEACON_API_CONTACT_NAME` | _(none)_ | Contact name. |
+| `BEACON_API_CONTACT_URL` | _(none)_ | Contact URL. |
+| `BEACON_API_CONTACT_EMAIL` | _(none)_ | Contact email. |
+| `BEACON_API_LICENSE_NAME` | _(none)_ | License name. |
+| `BEACON_API_LICENSE_URL` | _(none)_ | License URL. |
+| `BEACON_API_LICENSE_IDENTIFIER` | _(none)_ | SPDX license identifier. |
+
+## Miscellaneous
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_ENABLE_SYS_INFO` | `false` | Expose host system information (CPU, memory) via the API. |

--- a/docs/docs/1.8.0/data-lake/crawlers.md
+++ b/docs/docs/1.8.0/data-lake/crawlers.md
@@ -1,0 +1,172 @@
+# Crawlers
+
+```sql
+CREATE CRAWLER argo
+ON 'argo/'
+WITH ('format' 'parquet', 'schedule' '15m');
+
+RUN CRAWLER argo;
+```
+
+A **crawler** automatically discovers datasets in Beacon's storage and registers them as [external tables](./external-tables.md) — so you don't have to write one `CREATE EXTERNAL TABLE` per dataset. It scans a prefix, groups files by format, detects Hive-style partitions, infers each table's schema, and registers a table for every dataset it finds. As new files land, a crawler keeps the catalog up to date on a schedule or in response to storage events.
+
+This is Beacon's equivalent of an AWS Glue crawler. The tables it produces are ordinary external tables: they persist across restarts, and you `SELECT`, `JOIN`, and `DROP` them like any other table.
+
+:::tip When to use a crawler
+Reach for a crawler when you have **many** datasets under a prefix (often partitioned by date/region) and want them registered — and kept current — without maintaining DDL by hand. For a one-off table, a plain [`CREATE EXTERNAL TABLE`](../sql/create-table.md) is simpler.
+:::
+
+Crawler DDL can be submitted through any of Beacon's SQL surfaces:
+
+- **HTTP** — `POST /api/query` with `{ "sql": "CREATE CRAWLER ..." }`
+- **Arrow Flight SQL** — any Flight SQL client (DataGrip, ADBC, DBeaver, …)
+
+:::info
+SQL must be enabled (`BEACON_ENABLE_SQL=true`) to run DDL over the HTTP API. Arrow Flight SQL does not require this flag.
+:::
+
+## CREATE CRAWLER
+
+```sql
+CREATE CRAWLER <name>
+[ ON '<prefix>' ]
+[ WITH ( '<key>' '<value>' [, ...] ) ]
+```
+
+- **`<name>`** — a unique crawler name.
+- **`ON '<prefix>'`** — the storage prefix to scan, relative to the datasets root (e.g. `argo/`). Equivalent to the `target_prefix` option.
+- **`WITH (...)`** — key/value options, using the same shape as `CREATE EXTERNAL TABLE … OPTIONS (…)`.
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `format` | all formats | Comma-separated list restricting which formats to discover, e.g. `'parquet,nc'`. |
+| `detect_partitions` | `true` | Detect Hive-style `key=value/` partitions and map them to partition columns. |
+| `schedule` | _none_ | Periodic re-crawl interval: `30s`, `15m`, `2h`, `1d`, or a bare number of seconds. Omit for no timer. |
+| `event_driven` | `false` | Re-crawl when storage events fire under the prefix (see [Triggers](#triggers)). |
+| `table_naming` | `leaf_prefix` | `leaf_prefix` (use the prefix leaf) or `crawler_prefixed` (`<crawler>_<leaf>`). |
+
+Any **other** key in `WITH (...)` is forwarded verbatim into every discovered table's format `OPTIONS` — for example `'read_dimensions' 'lat,lon'` for NetCDF.
+
+```sql
+CREATE CRAWLER profiles
+ON 'argo/'
+WITH (
+  'format'            'parquet,nc',
+  'detect_partitions' 'true',
+  'schedule'          '15m',
+  'event_driven'      'true',
+  'read_dimensions'   'lat,lon'
+);
+```
+
+Defining a crawler **persists** it (it reloads on restart) and starts its triggers, but does not crawl immediately — issue `RUN CRAWLER` for the first pass, or wait for the first scheduled tick.
+
+## RUN CRAWLER
+
+```sql
+RUN CRAWLER <name>
+```
+
+Runs a crawl once, on demand. Each run scans the prefix and creates or updates the tables it owns. Runs are idempotent — re-running registers no duplicates.
+
+## SHOW CRAWLERS
+
+```sql
+SHOW CRAWLERS
+```
+
+Lists every defined crawler with its prefix, format filter, schedule, partition and event settings, and naming policy.
+
+## DROP CRAWLER
+
+```sql
+DROP CRAWLER <name>
+```
+
+Removes the crawler definition and stops its triggers. **The tables it created are left in place** — dropping a crawler never deletes data or tables. Drop the tables separately with `DROP TABLE` if you want them gone.
+
+## Partition detection
+
+With `detect_partitions` enabled (the default), the crawler recognises Hive-style directory partitioning:
+
+```
+argo/year=2024/month=01/part-0.parquet
+argo/year=2024/month=02/part-1.parquet
+argo/year=2025/month=01/part-2.parquet
+```
+
+becomes a single table partitioned by `year` and `month`. The partition columns are added to the table schema and support partition pruning:
+
+```sql
+SELECT count(*) FROM argo WHERE year = '2024' AND month = '01';
+```
+
+Files that share a format and a base prefix are grouped into one table; the partition columns are read from the `key=value` path segments.
+
+## Table naming
+
+A discovered group is named after the **leaf** of its base prefix. For example, files under `data/argo_floats/…` produce a table named `argo_floats`. Use `table_naming` `crawler_prefixed` to prefix the crawler name (`<crawler>_argo_floats`). Names are slugified to valid SQL identifiers, and collisions are disambiguated deterministically.
+
+## Ownership
+
+Crawled tables are tagged internally as owned by the crawler that created them. This guarantees two things:
+
+- A crawl **never overwrites a hand-created table** (or one owned by a different crawler) — such tables are skipped.
+- Re-running a crawler **updates its own tables** (new files, new partitions, schema changes) rather than creating duplicates.
+
+The ownership marker is internal and is hidden from the table config API.
+
+## Triggers
+
+Crawlers can keep the catalog current automatically through two mechanisms:
+
+### Scheduled
+
+When `schedule` is set, Beacon runs the crawl on that interval. Scheduling re-lists the prefix every tick and reconciles new files, new partitions, and schema changes. This is the baseline mechanism and works on every storage backend, including S3.
+
+### Event-driven
+
+When `event_driven` is `true` **and** storage events are available, Beacon subscribes to change events under the prefix and runs an incremental crawl shortly after new or changed files appear (debounced to coalesce bursts). This gives lower latency than polling.
+
+:::warning Event availability
+Filesystem events require `BEACON_ENABLE_FS_EVENTS=true` (the default for the local backend). On S3, change events are not yet wired up. If a crawler requests `event_driven` where events cannot fire **and** it has no `schedule`, Beacon falls back to a default poll interval so the crawler still makes progress rather than sitting idle — see [Configuration](#configuration).
+:::
+
+## Configuration
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `BEACON_CRAWLER_ENABLE` | `true` | Master switch for crawler background triggers. When `false`, crawlers can still be defined and run on demand, but no scheduled/event tasks are spawned. |
+| `BEACON_CRAWLER_DEFAULT_INTERVAL_SECS` | `900` | Fallback poll interval applied to an `event_driven` crawler when storage events are unavailable and no explicit schedule is set. |
+
+## Admin REST API
+
+Besides the SQL DDL above, crawlers can be managed over HTTP. All of these
+endpoints require admin basic auth (the same credentials used for other write
+operations) and back the admin web UI:
+
+| Method & path | Purpose |
+| --- | --- |
+| `POST /api/admin/crawlers` | Define (or replace) a crawler and start its triggers. |
+| `GET /api/admin/crawlers` | List all defined crawlers. |
+| `GET /api/admin/crawlers/{name}` | Fetch one crawler's definition (404 if unknown). |
+| `POST /api/admin/crawlers/{name}/run` | Run a crawler once on demand and return its report. |
+| `DELETE /api/admin/crawlers/{name}` | Remove a crawler and stop its triggers (crawled tables are left in place). |
+
+## Supported formats and limitations
+
+The crawler discovers **file-per-dataset** formats whose files are matched by extension: `parquet`, `csv` / `tsv`, `nc` (NetCDF), `bbf`, `arrow`, and `tiff`.
+
+Directory/marker-based stores — **Zarr** (`*.zarr/zarr.json`) and **Atlas** (`atlas.json`) — are **skipped** by the crawler. They are not registered as external tables through the listing-table path (Zarr is read via [`read_zarr`](../sql/table-functions.md#read_zarr)); a crawl that encounters them ignores them and continues with the other datasets. Register these with an explicit table function or `CREATE EXTERNAL TABLE` instead.
+
+GeoParquet files (`*.parquet`) are claimed by the Parquet crawler; create a GeoParquet external table explicitly if you need GeoArrow geometry decoding.
+
+**Delta Lake** tables — directories containing a `_delta_log/` — are also **not** auto-crawled. Register them explicitly with [`CREATE EXTERNAL TABLE ... STORED AS DELTA`](./delta-lake.md).
+
+## See also
+
+- [External Tables](./external-tables.md) — the tables a crawler produces
+- [`CREATE EXTERNAL TABLE`](../sql/create-table.md) — the manual equivalent, including `PARTITIONED BY`
+- [Configuration](./configuration.md) — all Beacon settings

--- a/docs/docs/1.8.0/data-lake/datasets.md
+++ b/docs/docs/1.8.0/data-lake/datasets.md
@@ -1,0 +1,230 @@
+# Supported Formats
+
+Beacon discovers datasets from its configured storage root automatically — no registration step is required. Place files in the datasets folder (or S3 prefix) and they become immediately queryable via table functions or [External Tables](./external-tables.md).
+
+Default local path inside the Docker container: `/beacon/data/datasets/`
+
+## Format support matrix
+
+| Format | Recognized files | `STORED AS` | `read_*` function | Output format |
+| --- | --- | --- | --- | --- |
+| Parquet | `.parquet` | `PARQUET` | `read_parquet` | ✅ |
+| GeoParquet | `.geoparquet` | `GEOPARQUET` | `read_geoparquet` | ✅ |
+| CSV / TSV | `.csv`, `.tsv` | `CSV` | `read_csv` | ✅ |
+| Arrow IPC | `.arrow`, `.feather` | `ARROW` | `read_arrow` | ✅ (`ipc`) |
+| NetCDF | `.nc` | `NC` | `read_netcdf` | ✅ (+ ND-NetCDF) |
+| Zarr | `zarr.json` marker | `ZARR` | `read_zarr` | — |
+| Atlas | `atlas.json` marker | `ATLAS` | `read_atlas` | — |
+| GeoTIFF / COG | `.tiff`, `.tif` | `TIFF` | `read_tiff` | — |
+| BBF | `.bbf` | `BBF` | `read_bbf` | — |
+| Delta Lake | `_delta_log/` directory | `DELTA` | `read_delta` | — |
+| ODV ASCII | `.txt` | — | `read_odv_ascii` | ✅ |
+
+Every format above is **auto-discovered** from the datasets store except **Delta
+Lake** and **ODV ASCII** — point a [`read_*` function](../sql/table-functions.md)
+(or, for Delta, `CREATE EXTERNAL TABLE … STORED AS DELTA LOCATION …`) at those
+directly. "Output format" marks formats a query result can be exported to via
+[`output.format`](../api/querying/index.md#output-formats).
+
+## Parquet
+
+Native support via DataFusion. Recommended for analytical workloads due to columnar storage and built-in predicate pushdown.
+
+- Column pruning and predicate pushdown are fully supported.
+- Hive-style directory partitioning is supported via `PARTITIONED BY` on [External Tables](./external-tables.md).
+- Compatible with files produced by DuckDB, Spark, pandas, and similar tools.
+
+## GeoParquet
+
+[GeoParquet](https://geoparquet.org/) files (`.geoparquet`) are Parquet files that carry geospatial geometry columns and a `geo` metadata key. Beacon reads them in addition to writing them. See the dedicated [GeoParquet chapter](./geoparquet.md) for setup details and the [GeoParquet SQL chapter](../sql/geoparquet.md) for querying geometry.
+
+- Geometry columns described in the file's `geo` metadata are decoded to their native [GeoArrow](https://geoarrow.org/) representation on read (a non-geospatial Parquet file is read like ordinary Parquet).
+- Column projection is applied — only the columns a query selects are materialized.
+- Works over local disk and S3-compatible object stores.
+
+Query a GeoParquet file with the [`read_geoparquet()`](../sql/table-functions.md#read_geoparquet) table function:
+
+```sql
+SELECT * FROM read_geoparquet(['spatial/**/*.geoparquet']) LIMIT 100
+```
+
+Or register a stable table name with an [External Table](./external-tables.md):
+
+```sql
+CREATE EXTERNAL TABLE stations
+STORED AS GEOPARQUET
+LOCATION 'spatial/stations/*.geoparquet';
+
+SELECT * FROM stations LIMIT 10;
+```
+
+:::tip
+Beacon can also *write* GeoParquet: a query result with longitude/latitude columns is mapped into a geometry column on output. See [querying output formats](../api/querying/index.md).
+:::
+
+:::warning
+Spatial bounding-box pruning (row-group skipping via the GeoParquet `bbox` covering) is not yet applied on read — queries perform a full scan with column projection. Geometry-aware predicate pushdown is planned.
+:::
+
+## NetCDF
+
+Streaming reads with chunk-level access — large files are read incrementally rather than loaded entirely into memory.
+
+Supported dialects:
+
+- **NetCDF4** (recommended)
+- **NetCDF3** — `char*` arrays with a string-like dimension (e.g. `STRLEN`) are inferred as fixed-length strings
+
+### Variable attributes
+
+NetCDF variables carry metadata attributes (e.g. `units`, `long_name`, `valid_min`). Beacon exposes these as extra columns using dot notation: `<variable>.<attribute>`. For example, a variable `temperature` with a `units` attribute is accessible as the column `temperature.units`.
+
+Attribute columns preserve the original type (string, integer, float, …) as stored in the file. They are available alongside the variable columns in every query.
+
+File-level global attributes are exposed with a leading dot and no variable prefix: `.<attribute>`. For example, a global attribute `source` is accessible as the column `.source`.
+
+```sql
+SELECT temperature, "temperature.units", "temperature.long_name", ".source"
+FROM read_netcdf(['argo/**/*.nc'])
+LIMIT 1
+```
+
+Limitations:
+
+- User-defined types are not supported.
+- S3 / object-store backends only support anonymous access. Authenticated S3 reads are not yet supported.
+
+:::tip
+For best performance with large NetCDF collections, convert the files into a single [Atlas](#atlas) collection. Atlas consolidates many NetCDF files into one statistics-aware array store, so Beacon can prune whole datasets and read only the projected arrays — typically much faster than scanning the original NetCDF files.
+:::
+
+## Zarr
+
+Zarr datasets are queried using chunk-level predicate pushdown — Beacon reads only the chunks that can satisfy the query predicates, which makes spatial and temporal range queries fast even over large multi-dimensional stores.
+
+- Zarr v3 stores are supported, identified by their `zarr.json` entry file. (v2 stores, which use `.zarray`/`.zgroup`/`.zattrs` instead, are not discovered.)
+- Compressed chunks (zstd, gzip, blosc, …) are decompressed transparently.
+- Multiple Zarr stores can be combined in a single external table using glob patterns (e.g. `sst/*/zarr.json`).
+- S3 and other object-store backends are fully supported.
+
+### Array attributes
+
+Zarr arrays store per-array attributes in the `attributes` section of their `zarr.json`. Beacon exposes these as extra columns using dot notation: `<array>.<attribute>`. For example, an array `sst` with a `units` attribute is accessible as the column `sst.units`.
+
+Attribute columns preserve the original type (string, integer, float, …) as stored in the file.
+
+Root-level store attributes (not tied to a specific array) are exposed with a leading dot and no array prefix: `.<attribute>`. For example, a root attribute `Conventions` is accessible as the column `.Conventions`.
+
+```sql
+SELECT sst, "sst.units", "sst.long_name", ".Conventions"
+FROM read_zarr(['sst/*/zarr.json'])
+LIMIT 1
+```
+
+Limitations:
+
+- User-defined data types are not supported.
+
+:::tip
+Predicate pushdown is automatic — Beacon prunes chunks and slices coordinate dimensions like `time`, `latitude`, and `longitude` based on your query's filters, with nothing to configure.
+
+For collections that are queried repeatedly, convert the Zarr stores into a single [Atlas](#atlas) collection — a statistics-aware array store that lets Beacon prune whole datasets before any chunk is read.
+:::
+
+## Arrow IPC
+
+Fully supported. Arrow IPC stream files (`.arrow`, `.feather`) are read natively with zero-copy column access.
+
+## ODV ASCII
+
+Supported via the [`read_odv_ascii()`](../sql/table-functions.md#read_odv_ascii)
+table function (and the `odv` source in the JSON query API). Unlike the formats
+above, ODV is **not** auto-discovered as a dataset and has no `CREATE EXTERNAL
+TABLE ... STORED AS ODV` form — point `read_odv_ascii()` at the files directly:
+
+```sql
+SELECT * FROM read_odv_ascii('odv/*.txt') LIMIT 100;
+```
+
+Storing ODV ASCII files with zstd compression is recommended to reduce storage and I/O:
+
+```bash
+zstd -9 < input.txt > output.txt.zst
+```
+
+Beacon detects compression automatically and decompresses on the fly. zstd-compressed ODV files work with S3-backed storage.
+
+## CSV
+
+- The first row must be a header row containing column names.
+- Files must be UTF-8 encoded.
+- Schema is inferred from the file contents.
+
+## GeoTIFF / Cloud-Optimized GeoTIFF
+
+Raster data in GeoTIFF and Cloud-Optimized GeoTIFF (COG) formats is supported. COG files are particularly efficient over S3 because Beacon can issue range requests to read only the required tiles.
+
+### Tag attributes
+
+GeoTIFF files carry TIFF tags and GeoTIFF metadata (e.g. `nodata`, `crs`, `scale`). Beacon exposes these per-band as extra columns using dot notation: `<band>.<attribute>`. For example, a band column `band_1` with a `nodata` tag is accessible as `band_1.nodata`.
+
+Attribute columns preserve the original type (string, integer, float, …) as stored in the file.
+
+File-level tags that are not tied to a specific band are exposed with a leading dot and no band prefix: `.<attribute>`. For example, a file-level `crs` tag is accessible as the column `.crs`.
+
+```sql
+SELECT band_1, "band_1.nodata", "band_1.scale", ".crs"
+FROM read_tiff(['rasters/elevation.tif'])
+LIMIT 1
+```
+
+## Atlas
+
+[Atlas](https://github.com/maris-development/atlas) is a directory-based array store designed for fast analytical access to multi-dimensional scientific data. Like Parquet or Zarr, it is just another file format: place Atlas stores in the datasets folder and Beacon discovers and queries them automatically — no registration step is required. An Atlas store is a directory containing a single `atlas.json` registry that describes one or more named datasets, each holding its own set of arrays.
+
+What it does:
+
+- **Statistics-based dataset pruning.** Atlas keeps per-dataset, per-column statistics. When a query carries a predicate (e.g. a time or latitude range), Beacon drops whole datasets that cannot match *before reading any array data*, so range queries over large collections only touch the relevant data.
+- **Column projection.** Only the arrays referenced by a query are read, keeping I/O proportional to the columns actually selected.
+- **Compact, self-describing layout.** Arrays are stored compressed (zstd) and the `atlas.json` registry is opened once and cached for the lifetime of the process, avoiding repeated metadata parsing across queries.
+- **Object-store friendly.** Atlas stores can live on local disk or S3-compatible object storage.
+
+Query an Atlas store with the [`read_atlas()`](../sql/table-functions.md#read_atlas) table function, pointing at its `atlas.json` marker file — an exact path or a glob such as `**/atlas.json`. An optional second argument filters the arrays to those matching the listed dimensions.
+
+```sql
+SELECT * FROM read_atlas(['collections/sensor/atlas.json'])
+```
+
+### External tables over Atlas
+
+For a stable, reusable table name, register the store as an [External Table](./external-tables.md#atlas). Like Zarr, point the `LOCATION` at the `atlas.json` marker (or a glob over several markers):
+
+```sql
+CREATE EXTERNAL TABLE sensor_atlas
+STORED AS ATLAS
+LOCATION 'collections/sensor/atlas.json';
+
+SELECT time, temperature
+FROM sensor_atlas
+WHERE time >= '2024-01-01';
+```
+
+### Optimizing NetCDF and Zarr with Atlas
+
+Atlas is the recommended way to speed up repeated queries over large NetCDF or Zarr collections: convert the source files into a single Atlas collection. Consolidating many NetCDF or Zarr files into one statistics-aware store lets Beacon prune whole datasets using column statistics and read only the projected arrays, so spatial and temporal range queries are typically much faster than scanning the original files directly.
+
+See the [Atlas repository](https://github.com/maris-development/atlas) for the store format and tooling to build Atlas collections.
+
+:::tip
+Heavy, repeated aggregations over an Atlas collection — or any other table — can be cached with a [materialized view](../sql/create-materialized-view.md) and recomputed with `REFRESH` when the underlying data changes.
+:::
+
+## Beacon Binary Format (BBF)
+
+Beacon's own columnar format, optimized for the kinds of queries common in earth-science and oceanographic workloads.
+
+- Full S3 / object-store support with authenticated access.
+- Chunk-level predicate pruning similar to Parquet row-group filtering.
+- Efficient for repeated range queries over coordinate columns (time, depth, lat/lon).
+
+Convert existing NetCDF files to BBF using the beacon-binary-format-toolbox for significant query speedups on large collections.

--- a/docs/docs/1.8.0/data-lake/delta-lake.md
+++ b/docs/docs/1.8.0/data-lake/delta-lake.md
@@ -1,0 +1,139 @@
+# Delta Lake
+
+```sql
+CREATE EXTERNAL TABLE ocean_profiles
+STORED AS DELTA
+LOCATION 'delta/ocean_profiles'
+```
+
+A **Delta Lake table** is a directory containing a `_delta_log` transaction log alongside its Parquet data files — not a single file or a glob of files. Beacon reads the transaction log to resolve exactly which Parquet files make up the current (or a historical) version of the table, so you get consistent snapshots, **time travel**, and `INSERT` support that ordinary file-format tables don't have.
+
+Delta tables work over both local storage and S3 / object storage, resolved against Beacon's configured dataset storage root just like every other source.
+
+:::tip External vs managed vs Delta
+- An [**external table**](./external-tables.md) (`STORED AS PARQUET`, `NETCDF`, …) reads a folder/glob of files in place; it is read-only.
+- A [**managed table**](../sql/managed-tables.md) is owned by Beacon (Lance-backed by default, or Iceberg) and mutable with `INSERT` / `UPDATE` / `DELETE`.
+- A **Delta table** points at an existing Delta Lake table directory. It is read in place, supports snapshot-consistent reads and time travel, and accepts `INSERT INTO` which commits a new Delta version.
+:::
+
+:::info The Delta table must already exist
+Beacon registers and reads (and appends to) an **existing** Delta table. It does not yet create a brand-new, empty Delta table from a `CREATE EXTERNAL TABLE` column list, and `CREATE TABLE AS … STORED AS DELTA` is not supported — use a managed table for those. Create the Delta table with any Delta writer (delta-rs, Spark, etc.), then register it in Beacon.
+:::
+
+## Two ways to query a Delta table
+
+### Ad-hoc with `read_delta`
+
+Query a Delta table directly in a `FROM` clause without registering it first — useful for exploration. See the [`read_delta`](../sql/table-functions.md#read_delta) table function.
+
+```sql
+SELECT count(*) FROM read_delta('delta/ocean_profiles');
+```
+
+### Persisted external table
+
+`CREATE EXTERNAL TABLE … STORED AS DELTA` registers the table in the catalog so it can be `SELECT`ed, `JOIN`ed, inserted into, and reloaded on restart like any other table.
+
+DDL can be submitted through any of Beacon's SQL surfaces:
+
+- **HTTP** — `POST /api/query` with `{ "sql": "CREATE EXTERNAL TABLE ... STORED AS DELTA ..." }`
+- **Arrow Flight SQL** — any Flight SQL client (DataGrip, ADBC, DBeaver, …)
+
+:::info
+Creating an external table is admin-only DDL. SQL must be enabled (`BEACON_ENABLE_SQL=true`) to run DDL over the HTTP API; Arrow Flight SQL does not require this flag.
+:::
+
+## Defining a Delta external table
+
+```sql
+CREATE EXTERNAL TABLE <name>
+STORED AS DELTA
+LOCATION '<table-directory>'
+OPTIONS ('version' '12')
+```
+
+### `LOCATION`
+
+Unlike file-format tables, the `LOCATION` points at the **Delta table directory** (the folder that contains `_delta_log/`), not a folder of loose files or a glob:
+
+```sql
+CREATE EXTERNAL TABLE ocean_profiles
+STORED AS DELTA
+LOCATION 'delta/ocean_profiles'
+```
+
+The path is resolved relative to Beacon's configured dataset storage root (`/beacon/data/datasets` in the default Docker container, or the S3 prefix when using object storage). The table's schema is read from the transaction log — you do not declare columns.
+
+### `OPTIONS` — time travel
+
+Pin the table to a historical snapshot. Use **one** of:
+
+| Option      | Description                                                                 |
+| ----------- | --------------------------------------------------------------------------- |
+| `version`   | A Delta version number (snapshot), e.g. `'12'`.                             |
+| `timestamp` | An RFC-3339 timestamp; the latest version at or before it, e.g. `'2026-01-01T00:00:00Z'`. |
+
+```sql
+-- Register the table as it looked at version 12
+CREATE EXTERNAL TABLE ocean_profiles_v12
+STORED AS DELTA
+LOCATION 'delta/ocean_profiles'
+OPTIONS ('version' '12');
+
+-- ...or as of a point in time
+CREATE EXTERNAL TABLE ocean_profiles_jan
+STORED AS DELTA
+LOCATION 'delta/ocean_profiles'
+OPTIONS ('timestamp' '2026-01-01T00:00:00Z');
+```
+
+Without a `version`/`timestamp` option the table always tracks the latest committed version.
+
+## Writing: `INSERT INTO`
+
+A Delta external table accepts `INSERT INTO`, which appends the rows as a **new Delta version** (committed atomically through the transaction log):
+
+```sql
+INSERT INTO ocean_profiles
+SELECT * FROM read_parquet('staging/new_profiles.parquet');
+```
+
+The commit is written through Beacon's storage backend, so it lands in the same local-FS or S3 location as the rest of the table. On S3 the commit uses object-store conditional writes, so no external lock table is required.
+
+:::tip
+Pinning the table to a historical `version`/`timestamp` is intended for reading old snapshots; insert into a table registered at the latest version.
+:::
+
+## Storage backends
+
+Delta tables resolve through Beacon's dataset store, so they work the same way on:
+
+- **Local filesystem** — under the configured datasets directory.
+- **S3 / object storage** — under the configured bucket/prefix.
+
+No Delta-specific configuration is needed; the table location is interpreted exactly like other dataset paths. See [Configuration](./configuration.md) for storage setup.
+
+## Querying and inspecting
+
+A Delta table behaves like any other registered table:
+
+```http
+GET /api/tables
+GET /api/table-schema?table_name=ocean_profiles
+```
+
+For the SQL equivalents (`SHOW TABLES`, `DESCRIBE`), see the [`CREATE EXTERNAL TABLE`](../sql/create-table.md#querying-and-inspecting) reference.
+
+## Removing a Delta table
+
+Dropping the table removes it from the catalog — the underlying Delta table directory and its files are **not** deleted.
+
+```sql
+DROP TABLE ocean_profiles;
+```
+
+## Limitations
+
+- **The Delta table must already exist.** Beacon does not create an empty Delta table from a column list, and `CREATE TABLE AS … STORED AS DELTA` is not supported. Use a managed table or an external Delta writer to create one.
+- **`INSERT` appends.** `UPDATE` / `DELETE` / `MERGE` on Delta tables are not exposed through Beacon's SQL; use a [managed table](../sql/managed-tables.md) when you need full row mutation.
+- **One directory per table.** A Delta table maps to a single table directory containing `_delta_log/`; it is not a glob over many tables.

--- a/docs/docs/1.8.0/data-lake/external-tables.md
+++ b/docs/docs/1.8.0/data-lake/external-tables.md
@@ -1,0 +1,187 @@
+# External Tables
+
+```sql
+CREATE EXTERNAL TABLE ocean_profiles
+STORED AS PARQUET
+LOCATION 'profiles/'
+```
+
+An external table is a standard SQL table backed by files in Beacon's storage. Once created, you can `SELECT`, `JOIN`, and `DROP` it like any other table — Beacon reads the underlying files on demand without copying them. Table definitions are persisted automatically and survive restarts.
+
+:::tip External vs managed tables
+An **external table** only points at existing files — Beacon reads them in place and never writes to them. If you want a table Beacon **owns** and can mutate with `INSERT` / `UPDATE` / `DELETE`, use a [managed table](../sql/managed-tables.md) instead.
+:::
+
+:::tip Registering many datasets at once
+To auto-discover and register many datasets under a prefix — including partitioned layouts — without writing DDL for each one, use a [crawler](./crawlers.md).
+:::
+
+This page is a **setup guide** with per-format examples. For the full statement grammar and every clause (`OR REPLACE`, `IF NOT EXISTS`, `PARTITIONED BY`, `DROP TABLE`), see the [`CREATE EXTERNAL TABLE`](../sql/create-table.md) reference.
+
+DDL can be submitted through any of Beacon's SQL surfaces:
+
+- **HTTP** — `POST /api/query` with `{ "sql": "CREATE EXTERNAL TABLE ..." }`
+- **Arrow Flight SQL** — any Flight SQL client (DataGrip, ADBC, DBeaver, …)
+
+:::info
+SQL must be enabled (`BEACON_ENABLE_SQL=true`) to run DDL statements over the HTTP API. Arrow Flight SQL does not require this flag.
+:::
+
+## Where files live
+
+The `LOCATION` is resolved relative to Beacon's configured dataset storage root (`/beacon/data/datasets` in the default Docker container, or the S3 prefix when using object storage). It may be:
+
+- A folder path — Beacon scans all matching files inside it
+- A glob pattern — e.g. `argo/**/*.nc`, `data/*.parquet`
+
+## Formats
+
+### Parquet
+
+```sql
+CREATE EXTERNAL TABLE ocean_profiles
+STORED AS PARQUET
+LOCATION 'profiles/'
+```
+
+Point at a folder and Beacon will glob all `.parquet` files under it automatically. You can also be explicit:
+
+```sql
+CREATE EXTERNAL TABLE ocean_profiles
+STORED AS PARQUET
+LOCATION 'profiles/**/*.parquet'
+```
+
+### GeoParquet
+
+```sql
+CREATE EXTERNAL TABLE stations
+STORED AS GEOPARQUET
+LOCATION 'spatial/stations/*.geoparquet'
+```
+
+Geometry columns are decoded to their native [GeoArrow](https://geoarrow.org/) representation on read. See [GeoParquet in Supported Formats](./datasets.md#geoparquet) for details.
+
+### NetCDF
+
+```sql
+CREATE EXTERNAL TABLE argo
+STORED AS NC
+LOCATION 'argo/**/*.nc'
+```
+
+### Zarr
+
+Zarr tables should point at `zarr.json` entry files rather than a folder:
+
+```sql
+CREATE EXTERNAL TABLE sst_zarr
+STORED AS ZARR
+LOCATION 'sst/zarr.json'
+```
+
+To span multiple Zarr stores with a glob:
+
+```sql
+CREATE EXTERNAL TABLE sst_zarr
+STORED AS ZARR
+LOCATION 'sst/*/zarr.json'
+```
+
+### Atlas
+
+Like Zarr, Atlas tables point at the store's `atlas.json` marker file rather than a folder:
+
+```sql
+CREATE EXTERNAL TABLE sensor_atlas
+STORED AS ATLAS
+LOCATION 'collections/sensor/atlas.json'
+```
+
+To combine several Atlas stores under one table, use a glob over their markers:
+
+```sql
+CREATE EXTERNAL TABLE sensor_atlas
+STORED AS ATLAS
+LOCATION 'collections/*/atlas.json'
+```
+
+See [Atlas](./datasets.md#atlas) for what the format does and how it speeds up NetCDF/Zarr workloads.
+
+### CSV
+
+```sql
+CREATE EXTERNAL TABLE station_metadata
+STORED AS CSV
+LOCATION 'metadata/stations/'
+```
+
+### Arrow IPC
+
+```sql
+CREATE EXTERNAL TABLE cruise_data
+STORED AS ARROW
+LOCATION 'cruises/'
+```
+
+### ODV ASCII
+
+ODV ASCII is **not** an external-table format — there is no `STORED AS ODV`. Read
+ODV files directly with the [`read_odv_ascii()`](../sql/table-functions.md#read_odv_ascii)
+table function (or the `odv` source in the JSON query API):
+
+```sql
+SELECT * FROM read_odv_ascii('odv/*.txt') LIMIT 100;
+```
+
+### GeoTIFF / COG
+
+```sql
+CREATE EXTERNAL TABLE elevation
+STORED AS TIFF
+LOCATION 'rasters/elevation.tif'
+```
+
+### Delta Lake
+
+`STORED AS DELTA` registers an existing [Delta Lake](./delta-lake.md) table. The `LOCATION` points at the Delta **table directory** (the folder containing `_delta_log/`), not a glob of files:
+
+```sql
+CREATE EXTERNAL TABLE ocean_profiles
+STORED AS DELTA
+LOCATION 'delta/ocean_profiles'
+```
+
+Delta tables support snapshot-consistent reads, **time travel** (via `OPTIONS ('version' '12')` or `('timestamp' '…')`), and `INSERT INTO`, which commits a new Delta version. See [Delta Lake](./delta-lake.md) for the full reference.
+
+## Partitioned data
+
+If your files are laid out in Hive-style partition directories (`year=2024/month=01/...`), declare the partition columns so Beacon can prune them at query time. The columns are encoded in the directory names and become queryable columns. See [`PARTITIONED BY`](../sql/create-table.md#partitioned-by) for the syntax.
+
+## Remote tables
+
+`STORED AS REMOTE` registers a table that points at a table on **another Beacon instance** instead of at local files. Queries push filters, projection, limits, and whole joins/aggregates down to the remote over Arrow Flight SQL. See [Remote Tables (Federation)](./remote-tables.md) for the full reference.
+
+## Views
+
+Views let you define a persistent SQL query over any external table or table function. See the [Views](./view.md) page for the full reference, including `UNION ALL BY NAME` for harmonizing datasets with different schemas.
+
+## Removing a table
+
+Dropping an external table removes it from the catalog — the underlying files are **not** deleted. See [`DROP TABLE`](../sql/create-table.md#drop-table).
+
+## Listing and inspecting tables
+
+List all registered tables:
+
+```http
+GET /api/tables
+```
+
+Inspect a table's columns and data types:
+
+```http
+GET /api/table-schema?table_name=ocean_profiles
+```
+
+For the SQL equivalents (`SHOW TABLES`, `DESCRIBE`), see the [`CREATE EXTERNAL TABLE`](../sql/create-table.md#querying-and-inspecting) reference.

--- a/docs/docs/1.8.0/data-lake/geoparquet.md
+++ b/docs/docs/1.8.0/data-lake/geoparquet.md
@@ -1,0 +1,33 @@
+# GeoParquet
+
+[GeoParquet](https://geoparquet.org/) files (`.geoparquet`) are Parquet files that carry geospatial geometry columns and a `geo` metadata key. Beacon reads them in addition to writing them. This chapter covers setting GeoParquet up as a dataset and external table; for querying geometry with SQL see the [GeoParquet SQL chapter](../sql/geoparquet.md).
+
+## Auto-discovery
+
+Like every other format, GeoParquet datasets are discovered from the configured storage root automatically — no registration step is required. Drop `.geoparquet` files into the datasets folder (or an S3 prefix) and they become immediately queryable with the [`read_geoparquet()`](../sql/geoparquet.md#querying-with-read_geoparquet) table function. Reading works the same over local disk and S3-compatible object stores.
+
+- Geometry columns described in the file's `geo` metadata are decoded to their native [GeoArrow](https://geoarrow.org/) representation on read.
+- A non-geospatial Parquet file (no `geo` metadata) is read like ordinary Parquet, so the format is safe to point at mixed folders.
+- Column projection is applied — only the columns a query selects are materialized.
+
+## Registering an external table
+
+Register a stable table name over one or more files with `STORED AS GEOPARQUET`:
+
+```sql
+CREATE EXTERNAL TABLE stations
+STORED AS GEOPARQUET
+LOCATION 'spatial/stations/*.geoparquet';
+
+SELECT * FROM stations LIMIT 10;
+```
+
+The `LOCATION` follows the same glob/folder semantics as other [external tables](./external-tables.md): point at a folder to glob every `.geoparquet` under it, or give an explicit glob pattern.
+
+## Writing GeoParquet
+
+Beacon can also *write* GeoParquet. When a query result is written in GeoParquet output, longitude/latitude columns are mapped into a geometry column automatically. Beacon detects them by name — common longitude names (`lon`, `long`, `lng`, `longitude`, `easting`, `x`) and latitude names (`lat`, `latitude`, `northing`, `y`) — or you can set the columns explicitly via `OPTIONS`. See [querying output formats](../api/querying/index.md).
+
+:::warning
+Spatial bounding-box pruning (row-group skipping via the GeoParquet `bbox` covering) is not yet applied on read — queries perform a full scan with column projection. Geometry-aware predicate pushdown is planned.
+:::

--- a/docs/docs/1.8.0/data-lake/index.md
+++ b/docs/docs/1.8.0/data-lake/index.md
@@ -1,0 +1,20 @@
+# Data lake
+
+Beacon provides a lightweight data lake model that makes scientific datasets easy to discover, query, and serve through a single API. It supports array and tabular formats (NetCDF, Zarr, Parquet, ODV, CSV) and exposes them through Arrow + DataFusion for fast columnar reads.
+
+## Core concepts
+
+- **Datasets**: Individual files or stores (for example `.nc`, `.zarr`, `.parquet`). Datasets can be queried directly and are the smallest unit in Beacon.
+- **External tables**: A registered name over one or more files (a folder or glob pattern) with a merged schema, queryable as one logical table. See [External Tables](./external-tables.md).
+- **Managed tables**: tables Beacon owns and can mutate with `INSERT` / `UPDATE` / `DELETE`, backed by the Lance engine (default) or Iceberg. See [Managed Tables](../sql/managed-tables.md).
+- **Views**: A saved query exposed as a table. See [Views](./view.md).
+- **Metadata & schema**: Beacon inspects dataset metadata and builds schemas so you can discover available columns before running queries.
+- **Pushdown & partitioning**: Filters and projections are pushed down to reduce IO and speed up queries over large data.
+
+## How it works at a glance
+
+1. **Register or place datasets** in the configured data directories or object store.
+2. **Inspect schemas** through the API to understand available columns.
+3. **Query datasets or tables** using SQL or the JSON query DSL.
+
+For detailed guidance, see the [SQL query docs](../api/querying/sql.md) and [JSON query docs](../api/querying/json.md).

--- a/docs/docs/1.8.0/data-lake/performance-tuning.md
+++ b/docs/docs/1.8.0/data-lake/performance-tuning.md
@@ -1,0 +1,178 @@
+# Performance Tuning
+
+## Beacon Query Engine Settings
+
+This chapter focuses on practical performance knobs that are safe to tune in production.
+
+Beacon is built on DataFusion. Most performance tuning comes down to:
+
+- How much parallelism Beacon is allowed to use (threads)
+- How much memory is available to the query engine before spilling to disk
+- Whether Beacon can avoid unnecessary IO (projection pushdown, caches)
+
+::: tip
+All settings below are environment variables. See the full list in [configuration.md](configuration.md).
+:::
+
+### CPU and concurrency
+
+#### `BEACON_WORKER_THREADS`
+
+Beacon uses this value to size its Tokio runtime (the executor that runs API requests and query work).
+
+- If you run Beacon on a dedicated machine, start with `BEACON_WORKER_THREADS` ~= number of physical cores.
+- If the same host also runs other heavy services, cap this to leave headroom.
+
+For IO-heavy workloads (remote object storage, NetCDF reads over HTTP), more threads can help. For CPU-heavy workloads (aggregations, joins), scaling is limited by CPU.
+
+### Memory and disk spilling
+
+#### `BEACON_VM_MEMORY_SIZE`
+
+This controls the DataFusion memory pool size (in MB). When queries exceed this pool, DataFusion can spill to disk.
+
+- Larger values generally improve performance by reducing spill frequency.
+- If you see high disk activity and slow queries under load, increase this first.
+
+::: warning
+Spilling uses the OS temp area (DataFusion disk manager). For best performance, ensure your temp directory is on fast storage and has enough free space.
+:::
+
+### Avoiding unnecessary reads
+
+#### `BEACON_ENABLE_PUSHDOWN_PROJECTION`
+
+When enabled, Beacon will attempt to project only the columns referenced by your JSON query `select` list when building the scan.
+
+- Enabled by default (`true`), so queries on “wide” datasets only decode the columns they select.
+- Set to `false` only to work around a suspected projection bug or to force the simplest scan behavior.
+
+### Query language and parsing
+
+#### `BEACON_ENABLE_SQL`
+
+SQL parsing/execution is guarded by this flag.
+
+- Set to `true` to allow SQL queries.
+- Keep `false` if you only use the JSON query API and want to reduce exposed surface area.
+
+### Geospatial function cache
+
+#### `BEACON_ST_WITHIN_POINT_CACHE_SIZE`
+
+Controls the cache capacity used by the `ST_WithinPoint` implementation.
+
+- Increase this if you run many repeated point-in-polygon style queries over similar geometries.
+- Reduce it if memory pressure is an issue and you don’t benefit from reuse.
+
+### Filesystem and object-store listing
+
+#### `BEACON_ENABLE_FS_EVENTS`
+
+When using local filesystem datasets, enabling filesystem events allows Beacon’s object-store layer to maintain an in-memory view of changes and avoid expensive directory rescans.
+
+- Enable (`true`) when datasets change frequently and you care about fast “list/search datasets” operations.
+- Keep disabled if you are on a platform where file watching is noisy/unsupported.
+
+#### `BEACON_S3_DATA_LAKE`, `BEACON_ENABLE_S3_EVENTS`, `BEACON_S3_BUCKET`, `BEACON_S3_ENABLE_VIRTUAL_HOSTING`
+
+These control whether Beacon uses S3-compatible object storage for datasets and how it addresses buckets.
+
+- For performance, prefer placing Beacon close (network-wise) to the object store.
+- If you see high latency when listing, consider enabling event-driven updates (`BEACON_ENABLE_S3_EVENTS`) if your S3 backend supports it.
+
+## NetCDF Tuning
+
+NetCDF performance in Beacon is mainly affected by:
+
+- How often Beacon needs to open the file and infer schema
+- Whether opened readers are cached
+
+::: tip
+For extremely large `.nc` files, performance may improve by splitting them into smaller files or converting to chunk-friendly formats (e.g. Zarr), depending on your access pattern. Scans are emitted in batches of `BEACON_BATCH_SIZE` rows (default `64000`).
+:::
+
+### Reader cache (avoid reopening files)
+
+#### `BEACON_NETCDF_USE_READER_CACHE` and `BEACON_NETCDF_READER_CACHE_SIZE`
+
+With reader caching enabled, Beacon reuses opened NetCDF readers (also keyed by path + last-modified time). This helps when the same files are accessed repeatedly across queries.
+
+Recommendations:
+
+- Keep `BEACON_NETCDF_USE_READER_CACHE=true` (default) for repeated-access workloads.
+- Increase `BEACON_NETCDF_READER_CACHE_SIZE` if your “hot set” of NetCDF files is larger than the default (128).
+- Disable reader caching if you have extremely high file churn and want to minimize open file handles.
+
+### Suggested starting points
+
+For a “many NetCDF files” deployment:
+
+- `BEACON_NETCDF_USE_READER_CACHE=true`
+- `BEACON_NETCDF_READER_CACHE_SIZE=16384` (size the cache to your hot set of files)
+
+Per-file statistics used for query pruning are controlled separately by
+`BEACON_NETCDF_ENABLE_STATISTICS` (default `true`); keep it on unless you are
+debugging pruning behavior.
+
+## Zarr predicate pushdown
+
+Beacon’s Zarr reader applies predicate pushdown **automatically** through the shared N-dimensional engine. Based on your query’s filters, Beacon:
+
+- Prunes Zarr chunks that cannot satisfy the predicate, so only the relevant chunks are read.
+- Slices 1D “coordinate-like” arrays (for example `time`, `latitude`, `longitude`) to the requested ranges.
+
+There is nothing to configure — no `statistics_columns` to declare and no statistics to pre-compute. Just read the store and filter; the engine handles the rest.
+
+### SQL
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+	"sql": "SELECT * FROM read_zarr(['datasets/**/*.zarr/zarr.json']) WHERE valid_time >= '2025-01-01' AND longitude < 30 LIMIT 100",
+	"output": { "format": "csv" }
+}
+```
+
+### JSON
+
+```http
+POST /api/query
+Content-Type: application/json
+
+{
+	"from": {
+		"zarr": {
+			"paths": ["datasets/**/*.zarr/zarr.json"]
+		}
+	},
+	"select": ["valid_time", "latitude", "longitude"],
+	"filters": [
+        { "column": "valid_time", "min": "2025-01-01" },
+        { "column": "longitude", "min": 15, "max": 30 }
+    ],
+	"limit": 100,
+	"output": { "format": "csv" }
+}
+```
+
+::: tip
+For collections that are queried repeatedly, re-encode the Zarr stores into a single [Atlas](./datasets.md#atlas) collection. Atlas adds per-dataset statistics pruning on top of chunk pruning, dropping whole datasets before any chunk is read.
+:::
+
+## Atlas Tuning
+
+[Atlas](./datasets.md#atlas) stores are opened through a `atlas.json` registry. To avoid re-opening the same store on every query, Beacon keeps a cache of opened Atlas readers.
+
+### Reader cache (avoid reopening stores)
+
+#### `BEACON_ATLAS_USE_READER_CACHE` and `BEACON_ATLAS_READER_CACHE_SIZE`
+
+With reader caching enabled, Beacon reuses opened Atlas readers across queries instead of re-parsing the `atlas.json` registry each time.
+
+Recommendations:
+
+- Keep `BEACON_ATLAS_USE_READER_CACHE=true` (default) when the same Atlas collections are queried repeatedly.
+- Increase `BEACON_ATLAS_READER_CACHE_SIZE` (default `32`) if you query more distinct Atlas stores than the cache can hold at once.

--- a/docs/docs/1.8.0/data-lake/remote-tables.md
+++ b/docs/docs/1.8.0/data-lake/remote-tables.md
@@ -1,0 +1,121 @@
+# Remote Tables (Federation)
+
+```sql
+CREATE EXTERNAL TABLE remote_profiles
+STORED AS REMOTE
+LOCATION 'beacon://other-beacon:50051/ocean_profiles'
+```
+
+A **remote table** points at a table living on **another Beacon instance**. Once created, you can `SELECT`, `JOIN`, aggregate, and `DROP` it like any other table — but the data stays on the remote. When you query it, Beacon pushes as much of the work as possible (filters, projected columns, `LIMIT`, and whole joins/aggregates between remote tables) **down to the remote instance**, so only the reduced result set travels over the network.
+
+This is built on Arrow Flight SQL: the remote Beacon already exposes a Flight SQL server, and your local instance acts as a client to it.
+
+:::warning Anonymous access required
+Remote tables connect to the remote **anonymously** — no credentials are stored anywhere. The remote Beacon instance must therefore **allow anonymous Flight SQL access** (`BEACON_FLIGHT_SQL_ALLOW_ANONYMOUS=true` on the remote). If anonymous access is disabled there, queries against the remote table fail with an authentication error. Anonymous Flight SQL access is read-only, which is exactly what federation needs.
+:::
+
+:::tip External vs managed vs remote
+- An [**external table**](./external-tables.md) reads files in Beacon's own storage in place.
+- A [**managed table**](../sql/managed-tables.md) is owned by Beacon and mutable with `INSERT` / `UPDATE` / `DELETE`.
+- A **remote table** owns no data locally at all — it is a federated pointer at a table on another Beacon, queried on demand.
+:::
+
+DDL can be submitted through any of Beacon's SQL surfaces:
+
+- **HTTP** — `POST /api/query` with `{ "sql": "CREATE EXTERNAL TABLE ... STORED AS REMOTE ..." }`
+- **Arrow Flight SQL** — any Flight SQL client (DataGrip, ADBC, DBeaver, …)
+
+:::info
+Creating a remote table is admin-only DDL. SQL must be enabled (`BEACON_ENABLE_SQL=true`) to run DDL over the HTTP API; Arrow Flight SQL does not require this flag.
+:::
+
+## Defining a remote table
+
+```sql
+CREATE EXTERNAL TABLE <local_name>
+STORED AS REMOTE
+LOCATION 'beacon://<host>:<port>/<remote_table>'
+OPTIONS ('tls' 'false')
+```
+
+### `LOCATION`
+
+The location encodes the remote Flight SQL endpoint and the table name on that instance:
+
+```
+beacon://<host>:<port>/<remote_table>
+```
+
+- `<host>:<port>` — the remote Beacon's Flight SQL address (its Flight SQL port, **not** the HTTP port).
+- `<remote_table>` — the name of the table as it is registered on the remote instance.
+
+### `OPTIONS`
+
+| Option | Required | Description                                                |
+| ------ | -------- | ---------------------------------------------------------- |
+| `tls`  | No (default `false`) | Set to `'true'` to connect over `https` instead of `http`. |
+
+No credentials are configured: remote tables connect anonymously, so the table definition (`table.json`) never contains secrets. The remote must allow anonymous Flight SQL access — see the note above.
+
+## How pushdown works
+
+When you query a remote table, Beacon's planner federates the largest sub-plan rooted at it and sends it to the remote as SQL. For example:
+
+```sql
+SELECT count(*), avg(temperature)
+FROM remote_profiles
+WHERE depth < 50 AND platform = 'argo';
+```
+
+The `WHERE` filter and the aggregate are executed **on the remote**, and only the small aggregated result is returned. You can confirm what gets pushed down with `EXPLAIN`:
+
+```sql
+EXPLAIN SELECT count(*) FROM remote_profiles WHERE depth < 50;
+```
+
+The plan shows a federated (virtual) scan node in place of a local table scan.
+
+### Joins across the same remote
+
+Tables that live on the **same** remote instance federate together, so a join between two remote tables on that instance is pushed down and executed remotely:
+
+```sql
+SELECT p.id, m.station_name
+FROM remote_profiles p
+JOIN remote_stations m ON p.station_id = m.id;
+```
+
+Joins that mix a remote table with a **local** table (or with a table on a *different* remote) are executed locally: Beacon fetches the needed remote rows and joins them on this instance.
+
+## Schema handling
+
+The remote table's schema is fetched from the remote instance **once, when the table is created**, and pinned into the table definition. This means:
+
+- After creation, planning is fast and offline — `SELECT`, schema inspection, and joins do not need a round-trip just to learn the columns.
+- On restart, the table reloads from its pinned schema, so a temporarily unreachable remote does **not** block Beacon from starting (only querying the table requires the remote to be up).
+- If the remote table's schema changes, drop and recreate the remote table to pick up the new schema.
+
+## Querying and inspecting
+
+A remote table behaves like any other table:
+
+```http
+GET /api/tables
+GET /api/table-schema?table_name=remote_profiles
+```
+
+For the SQL equivalents (`SHOW TABLES`, `DESCRIBE`), see the [`CREATE EXTERNAL TABLE`](../sql/create-table.md#querying-and-inspecting) reference.
+
+## Removing a remote table
+
+Dropping a remote table removes it from the local catalog only — nothing on the remote instance is affected.
+
+```sql
+DROP TABLE remote_profiles;
+```
+
+## Limitations
+
+- **Custom functions must exist on both sides.** A filter or projection that uses a Beacon UDF (e.g. a geospatial `st_*` function) is only pushed down if the remote instance has the same function. When in doubt, the safe pattern is to keep remote-pushed predicates to standard SQL comparisons; Beacon falls back to local execution where it must.
+- **One endpoint per table.** A remote table maps to a single remote Flight SQL endpoint; it does not shard across multiple remotes.
+- **Remote connections are anonymous.** A remote table connects to its target Flight SQL endpoint without credentials, so the remote instance must allow anonymous access. The only connection `OPTIONS` key is `tls`.

--- a/docs/docs/1.8.0/data-lake/sql-databases.md
+++ b/docs/docs/1.8.0/data-lake/sql-databases.md
@@ -1,0 +1,142 @@
+# SQL Database Tables (PostgreSQL / MySQL)
+
+```sql
+CREATE EXTERNAL TABLE orders
+STORED AS POSTGRES
+LOCATION 'public.orders'
+OPTIONS (
+  'host' 'db.internal',
+  'port' '5432',
+  'user' 'beacon_ro',
+  'password' 'secret',
+  'database' 'shop',
+  'sslmode' 'require'
+)
+```
+
+A **SQL database table** points at a table living in an external **PostgreSQL** or **MySQL** database. Once created, you can `SELECT`, `JOIN`, aggregate, and `DROP` it like any other table — but the data stays in the source database. When you query it, Beacon pushes as much work as possible (filters, projected columns, `LIMIT`, and aggregates) **down to the database**, so only the reduced result set travels over the wire.
+
+This is built on [`datafusion-table-providers`](https://github.com/datafusion-contrib/datafusion-table-providers) and DataFusion's federation layer — the same pushdown mechanism used by [remote tables](./remote-tables.md).
+
+:::tip External vs managed vs remote vs database
+- An [**external table**](./external-tables.md) reads files in Beacon's own storage in place.
+- A [**managed table**](../sql/managed-tables.md) is owned by Beacon and mutable with `INSERT` / `UPDATE` / `DELETE`.
+- A [**remote table**](./remote-tables.md) is a federated pointer at a table on another Beacon instance.
+- A **SQL database table** is a federated pointer at a table in an external PostgreSQL/MySQL database, queried on demand. It is read-only.
+:::
+
+DDL can be submitted through any of Beacon's SQL surfaces:
+
+- **HTTP** — `POST /api/query` with `{ "sql": "CREATE EXTERNAL TABLE ... STORED AS POSTGRES ..." }`
+- **Arrow Flight SQL** — any Flight SQL client (DataGrip, ADBC, DBeaver, …)
+
+:::info
+Creating a SQL database table is admin-only DDL. SQL must be enabled (`BEACON_ENABLE_SQL=true`) to run DDL over the HTTP API; Arrow Flight SQL does not require this flag.
+:::
+
+## Credentials and `BEACON_SECRETS_KEY` {#credentials}
+
+The `password` option is **encrypted at rest**. Beacon encrypts it with a deployment master key before it is ever written to the table definition (`table.json`), and only decrypts it in memory when the table is queried.
+
+You must therefore configure a master key:
+
+```bash
+# Generate once: 32 random bytes, base64-encoded.
+export BEACON_SECRETS_KEY="$(openssl rand -base64 32)"
+```
+
+| Behavior | Without `BEACON_SECRETS_KEY` | With `BEACON_SECRETS_KEY` |
+| -------- | ---------------------------- | ------------------------- |
+| `CREATE` with a `password` | **Rejected** (fails closed) | Password encrypted and persisted |
+| `CREATE` without a `password` | Allowed | Allowed |
+
+:::warning Key management
+- The persisted credential can only be decrypted with the **same** key. If you lose or rotate `BEACON_SECRETS_KEY`, existing SQL database tables can no longer be queried — drop and recreate them with the new key.
+- The password is **never** returned by the API. `GET /api/admin/table-config` (admin basic-auth required) shows the `secret` field as `***`, and the encrypted material never appears in logs.
+:::
+
+## Defining a SQL database table
+
+```sql
+CREATE EXTERNAL TABLE <local_name>
+STORED AS POSTGRES        -- or MYSQL
+LOCATION '<remote_table>'
+OPTIONS ( ... )
+```
+
+### `STORED AS`
+
+| Keyword | Engine |
+| ------- | ------ |
+| `POSTGRES` (or `POSTGRESQL`) | PostgreSQL |
+| `MYSQL` | MySQL |
+
+### `LOCATION`
+
+The name of the table in the source database. It may be schema-qualified:
+
+```
+public.orders      -- schema.table
+orders             -- bare table name
+```
+
+### `OPTIONS`
+
+| Option | Required | Description |
+| ------ | -------- | ----------- |
+| `host` | Yes\* | Database host. |
+| `port` | No | TCP port (Postgres default `5432`, MySQL default `3306`). |
+| `user` | Yes\* | Username. |
+| `password` | No | Password. Encrypted at rest; requires `BEACON_SECRETS_KEY`. |
+| `database` | Yes\* | Database/schema name to connect to. |
+| `sslmode` | No | TLS mode, e.g. `require` / `disable` (Postgres) or `required` / `disabled` (MySQL). |
+| `connection_string` | No | Full driver connection string, as an alternative to the discrete options above. |
+
+\* Required unless supplied via `connection_string`.
+
+## How pushdown works
+
+When you query a SQL database table, Beacon federates the largest sub-plan rooted at it and sends it to the database as SQL. For example:
+
+```sql
+SELECT count(*), avg(total)
+FROM orders
+WHERE status = 'shipped';
+```
+
+The `WHERE` filter and the aggregate run **on the database**, and only the small aggregated result returns. Confirm what is pushed down with `EXPLAIN`:
+
+```sql
+EXPLAIN SELECT count(*) FROM orders WHERE status = 'shipped';
+```
+
+The plan shows a federated (virtual) scan node in place of a local table scan. Joins between tables on the **same** database connection are pushed down together; joins that mix a database table with a local table (or a different connection) are executed locally.
+
+## Schema handling
+
+The table's schema is resolved from the database when the table is created and pinned into the definition. On restart the table reloads from its definition. If the source table's schema changes, drop and recreate the Beacon table to pick it up.
+
+## Querying and inspecting
+
+A SQL database table behaves like any other table:
+
+```http
+GET /api/tables
+GET /api/table-schema?table_name=orders
+GET /api/admin/table-config?table_name=orders   # admin basic-auth; the `secret` field is shown as ***
+```
+
+## Removing a SQL database table
+
+Dropping the table removes it from the local catalog only — nothing in the source database is affected.
+
+```sql
+DROP TABLE orders;
+```
+
+## Limitations
+
+- **Read-only.** `INSERT` / `UPDATE` / `DELETE` against a SQL database table are not supported.
+- **One connection per table.** Each table maps to a single database connection; it does not shard across hosts.
+- **Custom functions are not pushed down.** Predicates using Beacon UDFs (e.g. geospatial `st_*`) are evaluated locally; standard SQL comparisons push down.
+- **Credentials require a master key.** Persisting a password requires `BEACON_SECRETS_KEY` (see [above](#credentials)).

--- a/docs/docs/1.8.0/data-lake/view.md
+++ b/docs/docs/1.8.0/data-lake/view.md
@@ -1,0 +1,33 @@
+# Views
+
+```sql
+CREATE VIEW north_atlantic AS
+    SELECT * FROM ocean_profiles
+    WHERE latitude BETWEEN 0 AND 70
+```
+
+A view is a saved `SELECT` statement that behaves like a table. It holds no data — Beacon runs the query on the fly whenever the view is referenced. Views are persisted and survive restarts.
+
+## Creating a view
+
+```sql
+CREATE VIEW <view_name> AS
+    <select_statement>
+```
+
+## Replacing a view
+
+```sql
+CREATE OR REPLACE VIEW <view_name> AS
+    <select_statement>
+```
+
+## Dropping a view
+
+```sql
+DROP TABLE <view_name>
+```
+
+:::info
+`DROP TABLE` removes both external tables and views — there is no separate `DROP VIEW` statement.
+:::

--- a/docs/docs/1.8.0/getting-started.md
+++ b/docs/docs/1.8.0/getting-started.md
@@ -1,0 +1,121 @@
+---
+description: Run Beacon with Docker in minutes — locally or against S3-compatible object storage — then point it at your files and query them over SQL or JSON.
+---
+
+# Getting Started
+
+This guide gets a Beacon instance running with Docker Compose. For ready-made examples including MinIO and sample datasets, see the [beacon-example repository](https://github.com/maris-development/beacon-example).
+
+::: tip In a hurry?
+The [Quick Start guide](https://github.com/maris-development/beacon/blob/main/QUICKSTART.md) gets you running and querying — with the admin UI — in a couple of minutes.
+:::
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+## Local
+
+Start Beacon with a single `docker run`, or define a `docker-compose.yml` for a reproducible setup. Either way, adjust the volume paths to point at your datasets:
+
+::: code-group
+
+```bash [docker run]
+docker run -d \
+    --name beacon \
+    --restart unless-stopped \
+    -p 5001:5001 \
+    -p 32011:32011 \
+    -e BEACON_ADMIN_USERNAME=admin \
+    -e BEACON_ADMIN_PASSWORD=securepassword \
+    -v ./datasets:/beacon/data/datasets \
+    -v ./tables:/beacon/data/tables \
+    ghcr.io/maris-development/beacon:latest
+```
+
+```yaml [docker-compose.yml]
+services:
+    beacon:
+        image: ghcr.io/maris-development/beacon:latest
+        container_name: beacon
+        restart: unless-stopped
+        ports:
+            - "5001:5001"   # HTTP API
+            - "32011:32011" # Arrow Flight SQL
+        environment:
+            - BEACON_ADMIN_USERNAME=admin
+            - BEACON_ADMIN_PASSWORD=securepassword
+        volumes:
+            - ./datasets:/beacon/data/datasets
+            - ./tables:/beacon/data/tables
+```
+
+:::
+
+If you used Compose, start it with `docker compose up -d`. Beacon is now running. Open `http://localhost:5001/swagger` to verify and explore the API. Any files placed in `./datasets` are immediately available for querying.
+
+::: tip Two ways to connect
+Beacon exposes two endpoints. The **HTTP API** on port `5001` serves SQL/JSON queries and the OpenAPI docs. The **Arrow Flight SQL** server on port `32011` is a high-throughput, columnar protocol used by clients such as [JetBrains DataGrip](./connect/jetbrains-datagrip.md) and the [Python ADBC driver](./connect/python-adbc.md). Flight SQL uses bearer-token authentication and can be tuned or disabled via the `BEACON_FLIGHT_SQL_*` [settings](./data-lake/configuration.md#arrow-flight-sql).
+:::
+
+## S3-Compatible Object Storage
+
+Add the S3 environment variables and remove the datasets volume:
+
+::: code-group
+
+```bash [docker run]
+docker run -d \
+    --name beacon \
+    --restart unless-stopped \
+    -p 5001:5001 \
+    -p 32011:32011 \
+    -e BEACON_ADMIN_USERNAME=admin \
+    -e BEACON_ADMIN_PASSWORD=securepassword \
+    -e AWS_ENDPOINT=https://s3.amazonaws.com \
+    -e AWS_ACCESS_KEY_ID=your-access-key \
+    -e AWS_SECRET_ACCESS_KEY=your-secret-key \
+    -e BEACON_S3_BUCKET=your-bucket-name \
+    -e BEACON_S3_DATA_LAKE=true \
+    -v ./tables:/beacon/data/tables \
+    ghcr.io/maris-development/beacon:latest
+```
+
+```yaml [docker-compose.yml]
+services:
+    beacon:
+        image: ghcr.io/maris-development/beacon:latest
+        container_name: beacon
+        restart: unless-stopped
+        ports:
+            - "5001:5001"
+            - "32011:32011"
+        environment:
+            - BEACON_ADMIN_USERNAME=admin
+            - BEACON_ADMIN_PASSWORD=securepassword
+            - AWS_ENDPOINT=https://s3.amazonaws.com
+            - AWS_ACCESS_KEY_ID=your-access-key
+            - AWS_SECRET_ACCESS_KEY=your-secret-key
+            - BEACON_S3_BUCKET=your-bucket-name
+            - BEACON_S3_DATA_LAKE=true
+        volumes:
+            - ./tables:/beacon/data/tables
+```
+
+:::
+
+:::tip Anonymous / public buckets
+For publicly accessible buckets, omit `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and add `AWS_SKIP_SIGNATURE=true` instead.
+:::
+
+If you used Compose, start it with `docker compose up -d`. Files already in the S3 bucket are available for querying immediately. The `./tables` volume persists any external tables or views you create.
+
+## Next steps
+
+| | |
+| - | - |
+| **Connect a client** | [JetBrains DataGrip](./connect/jetbrains-datagrip.md) · [Python ADBC](./connect/python-adbc.md) |
+| **Register datasets as SQL tables** | [External Tables](./data-lake/external-tables.md) · [Views](./data-lake/view.md) |
+| **Write queries** | [SQL Guide](./sql/index.md) |
+| **Tune performance** | [Performance Tuning](./data-lake/performance-tuning.md) |

--- a/docs/docs/1.8.0/getting-started.md
+++ b/docs/docs/1.8.0/getting-started.md
@@ -1,23 +1,69 @@
 ---
-description: Run Beacon with Docker in minutes — locally or against S3-compatible object storage — then point it at your files and query them over SQL or JSON.
+description: Run Beacon with Docker in minutes — locally or against S3-compatible object storage — explore it in the bundled admin UI, then query your files over SQL or JSON.
 ---
 
 # Getting Started
 
-This guide gets a Beacon instance running with Docker Compose. For ready-made examples including MinIO and sample datasets, see the [beacon-example repository](https://github.com/maris-development/beacon-example).
-
-::: tip In a hurry?
-The [Quick Start guide](https://github.com/maris-development/beacon/blob/main/QUICKSTART.md) gets you running and querying — with the admin UI — in a couple of minutes.
-:::
+This guide gets a Beacon instance running with Docker. The **[Quick Start](#quick-start)** below is the fastest path — run, add data, and explore in the bundled admin UI. The **[Local](#local)** and **[S3](#s3-compatible-object-storage)** sections that follow cover reproducible Docker Compose setups. For ready-made examples including MinIO and sample datasets, see the [beacon-example repository](https://github.com/maris-development/beacon-example).
 
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/)
-- [Docker Compose](https://docs.docker.com/compose/install/)
+- [Docker Compose](https://docs.docker.com/compose/install/) — for the reproducible setups below
+
+## Quick Start
+
+Get running and querying in a couple of minutes.
+
+### 1. Run Beacon
+
+From a folder where you want your data to live:
+
+```bash
+docker run -d \
+  --name beacon \
+  -p 5001:5001 \
+  -e BEACON_ADMIN_USERNAME=admin \
+  -e BEACON_ADMIN_PASSWORD=securepassword \
+  -v ./datasets:/beacon/data/datasets \
+  -v ./tables:/beacon/data/tables \
+  ghcr.io/maris-development/beacon:latest
+```
+
+That's it — Beacon is now serving on <http://localhost:5001>.
+
+### 2. Add data
+
+Drop any supported files (e.g. `.parquet`, `.nc`, `.zarr`, `.csv`) into the `./datasets` folder you just mounted. Beacon discovers them automatically — there is no import step.
+
+### 3. Explore in the Admin UI
+
+Open <http://localhost:5001/admin> and sign in with the admin username and password you set above (`admin` / `securepassword`). Beacon bundles an [admin web UI](./connect/web-admin-ui.md) into the server and Docker image — nothing extra to deploy. From it you can:
+
+- **Query editor** — write SQL, run it (⌘/Ctrl + Enter), view results, and download CSV/Parquet.
+- **Datasets** — browse discovered files and inspect their schemas.
+- **Tables** — register and manage queryable tables over your datasets.
+- **Crawlers & external tables** — automate discovery and register external sources.
+- **Server** — runtime info, health, and the available functions.
+
+### 4. Or query over HTTP
+
+Every request goes to a single endpoint and streams back a file in the format you ask for:
+
+```bash
+curl -X POST http://localhost:5001/api/query \
+  -H "Content-Type: application/json" \
+  -d '{
+    "sql": "SELECT * FROM read_parquet([\"datasets/**/*.parquet\"]) LIMIT 10",
+    "output": { "format": "csv" }
+  }'
+```
+
+Interactive API docs are at <http://localhost:5001/swagger/>.
 
 ## Local
 
-Start Beacon with a single `docker run`, or define a `docker-compose.yml` for a reproducible setup. Either way, adjust the volume paths to point at your datasets:
+For a reproducible setup, define a `docker-compose.yml` (or use the fuller `docker run` below). Either way, adjust the volume paths to point at your datasets:
 
 ::: code-group
 
@@ -53,10 +99,14 @@ services:
 
 :::
 
-If you used Compose, start it with `docker compose up -d`. Beacon is now running. Open `http://localhost:5001/swagger` to verify and explore the API. Any files placed in `./datasets` are immediately available for querying.
+If you used Compose, start it with `docker compose up -d`. Beacon is now running. Open the [admin UI](./connect/web-admin-ui.md) at `http://localhost:5001/admin` to explore and query, or `http://localhost:5001/swagger` for the API docs. Any files placed in `./datasets` are immediately available for querying.
 
 ::: tip Two ways to connect
-Beacon exposes two endpoints. The **HTTP API** on port `5001` serves SQL/JSON queries and the OpenAPI docs. The **Arrow Flight SQL** server on port `32011` is a high-throughput, columnar protocol used by clients such as [JetBrains DataGrip](./connect/jetbrains-datagrip.md) and the [Python ADBC driver](./connect/python-adbc.md). Flight SQL uses bearer-token authentication and can be tuned or disabled via the `BEACON_FLIGHT_SQL_*` [settings](./data-lake/configuration.md#arrow-flight-sql).
+Beacon exposes two endpoints. The **HTTP API** on port `5001` serves SQL/JSON queries, the admin UI, and the OpenAPI docs. The **Arrow Flight SQL** server on port `32011` is a high-throughput, columnar protocol used by clients such as [JetBrains DataGrip](./connect/jetbrains-datagrip.md) and the [Python ADBC driver](./connect/python-adbc.md). Flight SQL uses bearer-token authentication and can be tuned or disabled via the `BEACON_FLIGHT_SQL_*` [settings](./data-lake/configuration.md#arrow-flight-sql).
+:::
+
+::: warning Secure your instance
+The `BEACON_ADMIN_*` credentials gate the admin UI and all write/management operations — **change them from the defaults** before exposing Beacon. To restrict who can read data, enable [access control](./security/access-control.md) (`BEACON_AUTH_ENFORCE=true`).
 :::
 
 ## S3-Compatible Object Storage
@@ -115,7 +165,9 @@ If you used Compose, start it with `docker compose up -d`. Files already in the 
 
 | | |
 | - | - |
-| **Connect a client** | [JetBrains DataGrip](./connect/jetbrains-datagrip.md) · [Python ADBC](./connect/python-adbc.md) |
+| **Explore in the browser** | [Admin Web UI](./connect/web-admin-ui.md) |
+| **Connect a client** | [JetBrains DataGrip](./connect/jetbrains-datagrip.md) · [Python ADBC](./connect/python-adbc.md) · [TypeScript SDK](./connect/beacon-typescript-sdk.md) |
 | **Register datasets as SQL tables** | [External Tables](./data-lake/external-tables.md) · [Views](./data-lake/view.md) |
 | **Write queries** | [SQL Guide](./sql/index.md) |
+| **Secure access** | [Authentication & Access Control](./security/access-control.md) |
 | **Tune performance** | [Performance Tuning](./data-lake/performance-tuning.md) |

--- a/docs/docs/1.8.0/introduction.md
+++ b/docs/docs/1.8.0/introduction.md
@@ -102,3 +102,4 @@ A few terms used throughout the docs:
 - **[Connect a client](/docs/1.8.0/connect/jetbrains-datagrip)** — JetBrains DataGrip, Python ADBC/SDK, or the CLI.
 - **[Write queries](/docs/1.8.0/sql/)** — the SQL guide.
 - **[Register your data](/docs/1.8.0/data-lake/)** — external tables and views.
+- **[Secure it](/docs/1.8.0/security/access-control)** — authentication, roles, and grants.

--- a/docs/docs/1.8.0/introduction.md
+++ b/docs/docs/1.8.0/introduction.md
@@ -1,0 +1,104 @@
+---
+description: How Beacon fits together — send SQL or JSON to the query engine, read NetCDF, Zarr, Parquet, GeoTIFF and more in place from local files or S3, and stream results back as Parquet, NetCDF or Arrow.
+---
+
+# Introduction
+
+:::info Open Source (AGPL V3)
+Beacon is open source under the AGPL V3 license. Source code and contributions: [github.com/maris-development/beacon](https://github.com/maris-development/beacon)
+:::
+
+Beacon is a data lakehouse query engine built for scientific datasets. Point it at your existing files — on disk or in S3 — and it exposes a SQL query API instantly, with no data migration or preprocessing required.
+
+<QueryFlow />
+
+Clients query Beacon using **SQL** or **JSON** and receive results as a file (Parquet, NetCDF, Arrow IPC, …) or a streaming Arrow IPC response. Beacon handles filtering, aggregation, and joins across files entirely server-side.
+
+## Quick setup
+
+Start Beacon with Docker, mounting a local `datasets` folder that holds your files:
+
+```bash
+docker run -d \
+  --name beacon \
+  -p 5001:5001 \
+  -v ./datasets:/beacon/data/datasets \
+  ghcr.io/maris-development/beacon:latest
+```
+
+Drop your `.nc` (or Parquet, Zarr, CSV, …) files into `./datasets` and they are queryable immediately at `http://localhost:5001`. For Compose, S3-backed storage, and more, see the [getting started guide](/docs/1.8.0/getting-started).
+
+## Your first query
+
+The same query several ways — sent over the HTTP API against Parquet or NetCDF files, or from the Python SDK. No table registration required: the `read_*()` functions read the files in place. The paths are always relative to the `datasets` directory you mounted.
+
+::: code-group
+
+```http [HTTP · Parquet]
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT time, latitude, longitude, temperature FROM read_parquet(['example.parquet']) WHERE temperature > 20 LIMIT 100",
+  "output": { "format": "csv" }
+}
+```
+
+```http [HTTP · NetCDF]
+POST /api/query
+Content-Type: application/json
+
+{
+  "sql": "SELECT time, latitude, longitude, temperature FROM read_netcdf(['example.nc']) WHERE temperature > 20 LIMIT 100",
+  "output": { "format": "csv" }
+}
+```
+
+```python [Python]
+%pip install beacon-api --upgrade
+from beacon_api import Client
+
+client = Client("https://your-beacon-node")
+
+df = client.sql_query(
+    "SELECT time, latitude, longitude, temperature "
+    "FROM read_netcdf(['example.nc']) "
+    "WHERE temperature > 20 LIMIT 100"
+).to_pandas_dataframe()
+```
+
+:::
+
+SQL is sent over the HTTP API (`POST /api/query`, with `BEACON_ENABLE_SQL=true`) or Arrow Flight SQL. Prefer querying by name? Register the files as an [external table](/docs/1.8.0/data-lake/external-tables) first.
+
+## Supported formats
+
+| Format | Notes |
+| ------ | ----- |
+| NetCDF | `.nc` |
+| Zarr | v3 stores (`zarr.json`) |
+| Atlas | Array store optimized for NetCDF/Zarr query performance |
+| Parquet | Native columnar, Hive partitioning supported |
+| [GeoParquet](/docs/1.8.0/data-lake/geoparquet) | Parquet with geometry columns (WKB) |
+| GeoTIFF / COG | Cloud-Optimized GeoTIFF supported |
+| ODV ASCII | Ocean Data View spreadsheet format |
+| CSV | Header row required, delimiter configurable |
+| Arrow IPC | `.arrow`, `.feather` stream files |
+| [Delta Lake](/docs/1.8.0/data-lake/delta-lake) | Read & append, with time travel |
+| [Beacon Binary Format](/docs/1.8.0/data-lake/datasets#beacon-binary-format-bbf) | Beacon's native columnar format (BBF) |
+
+## Key concepts
+
+A few terms used throughout the docs:
+
+- **[Dataset](/docs/1.8.0/data-lake/datasets)** — an individual file Beacon reads in place (NetCDF, Zarr, Parquet, …).
+- **[External table](/docs/1.8.0/data-lake/external-tables)** — a registered name over one or more files (a folder or glob pattern), with a merged schema across them.
+- **[View](/docs/1.8.0/data-lake/view)** — a saved query exposed as a table.
+- **[Managed table](/docs/1.8.0/sql/managed-tables)** — a table Beacon owns and can mutate (`INSERT` / `UPDATE` / `DELETE` / `ALTER` / `CREATE INDEX`), backed by Lance (default) or Iceberg.
+
+## Next steps
+
+- **[Get started](/docs/1.8.0/getting-started)** — run Beacon with Docker, locally or against S3.
+- **[Connect a client](/docs/1.8.0/connect/jetbrains-datagrip)** — JetBrains DataGrip, Python ADBC/SDK, or the CLI.
+- **[Write queries](/docs/1.8.0/sql/)** — the SQL guide.
+- **[Register your data](/docs/1.8.0/data-lake/)** — external tables and views.

--- a/docs/docs/1.8.0/security/access-control.md
+++ b/docs/docs/1.8.0/security/access-control.md
@@ -1,0 +1,179 @@
+---
+description: Beacon's authentication and role-based access control — a single config-defined super-user, read-only SQL-managed users and roles, table/path grants and denies with deny-wins semantics, anonymous access, and optional OIDC.
+---
+
+# Authentication & Access Control
+
+Beacon has a built-in authentication and **role-based access control (RBAC)**
+layer. Authentication answers *who is this principal and what roles do they have*;
+authorization — which Beacon owns entirely — answers *what may they read*. The two
+are deliberately separable, so an external identity provider (OIDC) can supply
+identities while grants stay expressed in Beacon's own role model.
+
+## The model at a glance
+
+- **One super-user**, defined entirely by configuration (`BEACON_ADMIN_USERNAME` /
+  `BEACON_ADMIN_PASSWORD`). It is the only principal that can write — run DDL/DML,
+  manage users and roles, and call the admin endpoints — and it **bypasses
+  authorization** entirely.
+- **Users and roles created through SQL are always read-only.** There is no way to
+  create a second super-user or grant write privileges to a role; the super-user
+  is a fixed credential, never a stored user.
+- **Authorization governs reads.** Grants and denies are attached to roles and
+  evaluated when a query scans a table or files. Writes and management are not
+  role-grantable — they require the super-user.
+- **Deny-wins, default-deny.** When enforcement is on, a read is allowed only if a
+  matching grant exists and no matching deny does.
+
+## Principals
+
+| Principal | How it authenticates | Capabilities |
+| --- | --- | --- |
+| **Super-user** | `BEACON_ADMIN_*` credentials, checked directly (constant-time) | Full read + write + management; bypasses authorization |
+| **User** | Local username/password, or an OIDC token | Read-only, limited by the roles assigned to it |
+| **Anonymous** | No credentials (when enabled) | Read-only, limited by the roles assigned to the `anonymous` user |
+
+Local users are stored in a SQLite directory database (`users/directory.db` under
+the data directory), with passwords hashed using Argon2. The super-user is **not**
+in this store — it is a fixed credential sourced from the environment, so it can't
+be altered or duplicated through SQL.
+
+## Enforcement
+
+Authorization is **off by default** so a fresh deployment is open and easy to try.
+Turn it on with:
+
+```bash
+BEACON_AUTH_ENFORCE=true
+```
+
+| `BEACON_AUTH_ENFORCE` | Behaviour |
+| --- | --- |
+| `false` *(default)* | Authorization is a no-op. Any principal that can authenticate (including anonymous, if enabled) can read everything. |
+| `true` | Default-deny. Every table/file read must be allowed by a grant on the principal's roles, with no overriding deny. The super-user still bypasses all checks. |
+
+Only **reads** (table and file scans) are subject to grant evaluation. All writes
+and DDL/DML are gated separately and always require the super-user.
+
+## Roles, privileges and targets
+
+A **role** holds a set of **grant** and **deny** rules. A rule is a *privilege*
+optionally scoped to a *target*.
+
+| Privilege | Meaning for read enforcement |
+| --- | --- |
+| `SELECT` | Read the target. This is the privilege that matters for query authorization. |
+| `INSERT`, `UPDATE`, `DELETE`, `CREATE`, `DROP` | Accepted by the grammar for completeness, but **writes require the super-user** — granting them to a role does not confer write access. |
+| `ALL` | Matches any privilege. |
+
+| Target | Matches |
+| --- | --- |
+| `ON TABLE <name>` | A registered table accessed by name. |
+| `ON PATH '<glob>'` | Files accessed by path, relative to the datasets root. Supports glob patterns (e.g. `argo/**/*.nc`). |
+| *(omitted)* | Every target for that privilege. |
+
+## Managing users and roles (SQL)
+
+All of the statements below are **super-user-only** management DDL. Submit them
+over any SQL surface — `POST /api/query` (with `BEACON_ENABLE_SQL=true`) or Arrow
+Flight SQL.
+
+### Users
+
+```sql
+CREATE USER alice WITH PASSWORD 'secret';
+DROP USER alice;
+```
+
+### Roles
+
+```sql
+CREATE ROLE reader;
+DROP ROLE reader;
+
+-- Assign / unassign a role to a user
+GRANT ROLE reader TO USER alice;
+REVOKE ROLE reader FROM USER alice;
+```
+
+### Grants and denies
+
+```sql
+-- Allow a role to read a specific table
+GRANT SELECT ON TABLE observations TO ROLE reader;
+
+-- Allow a role to read files under a path glob
+GRANT SELECT ON PATH 'argo/**/*.nc' TO ROLE reader;
+
+-- Carve out an exception — deny-wins over any matching grant
+DENY SELECT ON PATH 'argo/restricted/*' TO ROLE reader;
+
+-- Grant every privilege on every target (still read-only in practice)
+GRANT ALL TO ROLE reader;
+```
+
+Remove a rule with `REVOKE`. Use the `DENY` keyword to remove a *deny* rule rather
+than a *grant*:
+
+```sql
+REVOKE SELECT ON TABLE observations FROM ROLE reader;
+REVOKE DENY SELECT ON PATH 'argo/restricted/*' FROM ROLE reader;
+```
+
+### Anonymous access
+
+When `BEACON_AUTH_ANONYMOUS_ENABLED=true` (the default), unauthenticated requests
+resolve to the built-in `anonymous` user. Give anonymous callers read access by
+assigning roles to it like any other user:
+
+```sql
+CREATE ROLE public_reader;
+GRANT SELECT ON TABLE observations TO ROLE public_reader;
+GRANT ROLE public_reader TO USER anonymous;
+```
+
+Set `BEACON_AUTH_ANONYMOUS_ENABLED=false` to require authentication for every
+request.
+
+## OIDC (single sign-on)
+
+Beacon can validate **OIDC bearer tokens** in addition to local passwords. When
+enabled, a request carrying a `Bearer <jwt>` token is validated against the
+issuer's JWKS; the username and role names are read from token claims. Beacon
+still owns authorization — the token supplies *identity and role names*, and the
+grants for those roles live in Beacon's role model.
+
+```bash
+BEACON_OIDC_ENABLED=true
+BEACON_OIDC_ISSUER=https://keycloak.example.com/realms/beacon
+BEACON_OIDC_JWKS_URL=https://keycloak.example.com/realms/beacon/protocol/openid-connect/certs
+BEACON_OIDC_AUDIENCE=beacon                      # optional; validated when set
+BEACON_OIDC_ROLES_CLAIM=realm_access.roles       # default
+BEACON_OIDC_USERNAME_CLAIM=preferred_username    # default
+```
+
+A role named in a token only confers access if it has been created and granted in
+Beacon (`CREATE ROLE <name>` + `GRANT … TO ROLE <name>`). OIDC principals, like
+all non-super-user principals, are read-only.
+
+## Configuration reference
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BEACON_ADMIN_USERNAME` | `beacon-admin` | Super-user username. **Change in production.** |
+| `BEACON_ADMIN_PASSWORD` | `beacon-password` | Super-user password. **Change in production.** |
+| `BEACON_AUTH_ENFORCE` | `false` | Enforce read authorization (default-deny). |
+| `BEACON_AUTH_ANONYMOUS_ENABLED` | `true` | Allow unauthenticated requests as the `anonymous` user. |
+| `BEACON_OIDC_ENABLED` | `false` | Accept OIDC bearer tokens. |
+| `BEACON_OIDC_ISSUER` | _(none)_ | Expected token issuer. |
+| `BEACON_OIDC_JWKS_URL` | _(none)_ | JWKS endpoint used to validate token signatures. |
+| `BEACON_OIDC_AUDIENCE` | _(none)_ | Expected audience; validated only when set. |
+| `BEACON_OIDC_ROLES_CLAIM` | `realm_access.roles` | Token claim (dot-path) holding role names. |
+| `BEACON_OIDC_USERNAME_CLAIM` | `preferred_username` | Token claim holding the username. |
+| `BEACON_OIDC_JWKS_CACHE_TTL_SECS` | `300` | How long to cache the issuer's JWKS. |
+
+::: tip Transport authentication
+Over HTTP, credentials are sent with **Basic auth** (or a `Bearer` token for
+OIDC). Arrow Flight SQL authenticates over its handshake and issues a bearer
+token; see the [Flight SQL settings](/docs/1.8.0/data-lake/configuration#arrow-flight-sql).
+:::

--- a/docs/docs/1.8.0/security/access-control.md
+++ b/docs/docs/1.8.0/security/access-control.md
@@ -156,6 +156,69 @@ A role named in a token only confers access if it has been created and granted i
 Beacon (`CREATE ROLE <name>` + `GRANT … TO ROLE <name>`). OIDC principals, like
 all non-super-user principals, are read-only.
 
+### How a token is validated
+
+When a request carries `Authorization: Bearer <jwt>`, Beacon validates it as a
+JWT access token:
+
+1. **Read the header.** The token's JOSE header is decoded to read its key id
+   (`kid`) and signing algorithm (`alg`). A token without a `kid` is rejected.
+2. **Resolve the signing key.** The issuer's JWKS (fetched from
+   `BEACON_OIDC_JWKS_URL`) is searched for a key matching the `kid`. If no key
+   matches, the token is rejected — re-fetching only happens on the cache TTL (see
+   below), so brand-new signing keys become usable once the cache expires.
+3. **Verify signature and claims.** The signature is checked with the matched key
+   using the token's own algorithm (whatever the JWK supports — RS256, ES256, …).
+   Expiry (`exp`) and the issuer (`iss`, against `BEACON_OIDC_ISSUER`) are always
+   validated. The audience (`aud`) is validated **only when** `BEACON_OIDC_AUDIENCE`
+   is set; otherwise audience checking is disabled.
+4. **Extract identity and roles** from the claims (below).
+
+Any failure along the way is an authentication failure: a request that **presents**
+an invalid or expired token is rejected with `401 Unauthorized` — it does **not**
+fall back to anonymous. Anonymous access applies only when a request carries **no**
+credentials at all.
+
+### Username and roles claims
+
+Both `BEACON_OIDC_USERNAME_CLAIM` and `BEACON_OIDC_ROLES_CLAIM` are **dotted
+paths**, resolved against the (possibly nested) claims object — e.g.
+`realm_access.roles` reads `claims["realm_access"]["roles"]`.
+
+- The **username** claim must resolve to a string; a token missing it is rejected.
+- The **roles** claim is optional and accepts either shape commonly seen in OIDC
+  tokens: a **JSON array of strings** (`["reader", "writer"]`) or a single
+  **space-delimited string** (`"reader writer"`). A missing or non-string/array
+  roles claim simply yields **no roles** (not an error) — the principal
+  authenticates but, under enforcement, can read nothing until granted roles.
+
+For a Keycloak realm, the defaults (`realm_access.roles` and
+`preferred_username`) work out of the box.
+
+### JWKS caching
+
+The JWKS document is fetched lazily and cached in memory for
+`BEACON_OIDC_JWKS_CACHE_TTL_SECS` (default `300`). Within that window, token
+validation does no network I/O; after it, the next validation re-fetches. The
+cache lock is never held across the network fetch, so token validation doesn't
+serialize behind a slow JWKS endpoint.
+
+### Credential routing (Basic vs Bearer)
+
+When OIDC is enabled, Beacon runs a **composite** provider that routes by
+credential kind:
+
+| Request header | Routed to | Used for |
+| --- | --- | --- |
+| `Authorization: Basic …` | Local provider (SQLite user store) | The super-user and SQL-managed users |
+| `Authorization: Bearer …` | OIDC provider | External IdP tokens |
+
+So local admin users and external IdP users coexist. User-management DDL
+(`CREATE USER`, `DROP USER`, …) always targets the **local** directory — the OIDC
+provider holds no user store, because OIDC users live in your identity provider,
+not in Beacon. (The super-user credential is still checked directly and
+short-circuits before either provider runs.)
+
 ## Configuration reference
 
 | Variable | Default | Description |

--- a/docs/docs/1.8.0/sql/create-materialized-view.md
+++ b/docs/docs/1.8.0/sql/create-materialized-view.md
@@ -1,0 +1,103 @@
+# CREATE MATERIALIZED VIEW
+
+```sql
+CREATE MATERIALIZED VIEW monthly_sales AS
+    SELECT
+        customer_id,
+        date_trunc('month', order_date) AS month,
+        SUM(amount) AS total_amount
+    FROM orders
+    GROUP BY customer_id, date_trunc('month', order_date)
+```
+
+A materialized view runs its defining query **once**, at creation time, and persists the result
+set as a single Parquet file. Querying the view reads straight from the persisted Parquet instead of
+recomputing the original query — useful for expensive, repeated, or aggregation-heavy queries.
+
+The defining query can read from any source Beacon knows about — registered tables,
+[external tables](../data-lake/external-tables.md), [views](./create-view.md), or table functions
+such as `read_netcdf()`, `read_zarr()`, or `read_atlas()`.
+
+Unlike a regular [view](./create-view.md) (which recomputes on every reference), a materialized
+view only changes when you explicitly [`REFRESH`](#refresh) it.
+
+## Syntax
+
+```sql
+CREATE MATERIALIZED VIEW <view_name> AS
+    <select_statement>
+```
+
+When the statement runs, Beacon:
+
+1. Stores the materialized view definition in the catalog as a table provider.
+2. Executes the defining query immediately.
+3. Writes the result as a single `part.parquet` file in a per-refresh versioned subdirectory
+   under the reserved `__beacon__/<view_name>/` prefix in the datasets object store.
+4. Serves future reads from the persisted Parquet result.
+
+The catalog records the view name, original SQL query, output schema, storage location, creation
+timestamp, and last-refresh timestamp.
+
+## Querying
+
+```sql
+SELECT * FROM monthly_sales
+```
+
+This scans the Parquet-backed result and benefits from columnar projection and predicate
+pushdown — it does **not** re-run the original query.
+
+## REFRESH
+
+```sql
+REFRESH monthly_sales
+```
+
+A refresh recomputes the original query and replaces the stored Parquet data with the new result
+(full refresh). The new data is written to a fresh directory and the catalog pointer is swapped
+atomically, so a failed refresh leaves the previous result intact and queryable.
+
+::: info
+Only **full refresh** is supported in this version. Incremental refresh, scheduled refresh, and
+dependency-based invalidation are planned for later releases.
+:::
+
+### Errors
+
+Refreshing a name that is not a materialized view fails clearly:
+
+```text
+Materialized view 'unknown_view' does not exist
+```
+
+```text
+Object 'orders' is not a materialized view
+```
+
+## DROP
+
+```sql
+DROP TABLE monthly_sales
+
+DROP TABLE IF EXISTS monthly_sales
+```
+
+Dropping a materialized view removes it from the catalog and deletes its persisted Parquet data.
+
+## Example
+
+```sql
+CREATE MATERIALIZED VIEW top_customers AS
+    SELECT
+        customer_id,
+        SUM(total) AS lifetime_value
+    FROM orders
+    GROUP BY customer_id
+    ORDER BY lifetime_value DESC
+    LIMIT 100;
+
+SELECT * FROM top_customers;
+
+REFRESH top_customers;
+```

--- a/docs/docs/1.8.0/sql/create-table.md
+++ b/docs/docs/1.8.0/sql/create-table.md
@@ -1,0 +1,112 @@
+# CREATE EXTERNAL TABLE
+
+```sql
+CREATE EXTERNAL TABLE ocean_profiles
+STORED AS PARQUET
+LOCATION 'profiles/'
+```
+
+An external table is a SQL table backed by files in Beacon's storage. Once registered, you can query it with `SELECT`, `JOIN`, or reference it from a `VIEW` — Beacon reads the files on demand without copying them. Table definitions survive restarts.
+
+## Syntax
+
+```sql
+CREATE [OR REPLACE] EXTERNAL TABLE [IF NOT EXISTS] <table_name>
+STORED AS <format>
+LOCATION '<path>'
+[PARTITIONED BY (<col>, ...)]
+```
+
+`LOCATION` is resolved relative to Beacon's storage root. It can be a folder or a glob pattern:
+
+```sql
+-- Entire folder
+CREATE EXTERNAL TABLE argo STORED AS NC LOCATION 'argo/'
+
+-- Explicit glob
+CREATE EXTERNAL TABLE argo STORED AS NC LOCATION 'argo/**/*.nc'
+```
+
+## Formats
+
+| `STORED AS` | File types |
+| ----------- | ---------- |
+| `PARQUET`   | `.parquet` |
+| `GEOPARQUET` | `.geoparquet` |
+| `NC`        | `.nc` |
+| `ZARR`      | Zarr v3 (`zarr.json`) |
+| `ATLAS`     | Atlas array store (`atlas.json`) |
+| `CSV`       | `.csv` |
+| `ARROW`     | Arrow IPC (`.arrow`, `.feather`) |
+| `TIFF`      | GeoTIFF / Cloud-Optimized GeoTIFF |
+| `BBF`       | Beacon Binary Format |
+| `DELTA`     | Delta Lake table directory (`_delta_log/`) |
+| `POSTGRES`  | External PostgreSQL table (federated) |
+| `MYSQL`     | External MySQL table (federated) |
+
+`DELTA` points at an existing [Delta Lake](../data-lake/delta-lake.md) table directory and additionally supports time travel and `INSERT INTO`. `REMOTE` federates a table on another Beacon instance — see [Remote Tables](../data-lake/remote-tables.md). `POSTGRES` / `MYSQL` federate a table in an external SQL database — see [SQL Databases](../data-lake/sql-databases.md); their `LOCATION` is the remote table name and connection details (including an encrypted `password`) go in `OPTIONS`.
+
+Zarr tables should point at `zarr.json` entry files, and Atlas tables at `atlas.json` markers:
+
+```sql
+CREATE EXTERNAL TABLE sst STORED AS ZARR LOCATION 'sst/*/zarr.json'
+
+CREATE EXTERNAL TABLE sensor STORED AS ATLAS LOCATION 'sensor/atlas.json'
+```
+
+`GEOPARQUET` reads Parquet files whose geometry columns are decoded to native GeoArrow — see the [GeoParquet chapter](./geoparquet.md) for querying geometry and the [data-lake setup](../data-lake/geoparquet.md) for details.
+
+## `IF NOT EXISTS`
+
+Silently skip registration if the table name is already taken:
+
+```sql
+CREATE EXTERNAL TABLE IF NOT EXISTS argo
+STORED AS NC
+LOCATION 'argo/**/*.nc'
+```
+
+## `OR REPLACE`
+
+Re-register and overwrite an existing table definition:
+
+```sql
+CREATE OR REPLACE EXTERNAL TABLE argo
+STORED AS NC
+LOCATION 'argo/**/*.nc'
+```
+
+## `PARTITIONED BY`
+
+When files are organized in Hive-style directories (`year=2024/month=01/...`), declare the partition columns so Beacon can prune them at query time:
+
+```sql
+CREATE EXTERNAL TABLE observations
+STORED AS PARQUET
+LOCATION 'obs/'
+PARTITIONED BY (year, month)
+```
+
+```sql
+SELECT * FROM observations WHERE year = 2024 AND month = 6
+```
+
+## `DROP TABLE`
+
+Remove a table from the catalog. The underlying files are not deleted.
+
+```sql
+DROP TABLE argo
+
+DROP TABLE IF EXISTS argo
+```
+
+## Querying and inspecting
+
+```sql
+SHOW TABLES;
+
+DESCRIBE ocean_profiles;
+```
+
+See the [External Tables](../data-lake/external-tables.md) setup guide for per-format examples and the HTTP API for listing tables.

--- a/docs/docs/1.8.0/sql/create-view.md
+++ b/docs/docs/1.8.0/sql/create-view.md
@@ -1,0 +1,63 @@
+# CREATE VIEW
+
+```sql
+CREATE VIEW north_atlantic AS
+    SELECT * FROM ocean_profiles
+    WHERE latitude BETWEEN 0 AND 70
+```
+
+A view is a saved `SELECT` statement that behaves like a table. It holds no data — Beacon runs the query on the fly whenever the view is referenced. Views are persisted and survive restarts.
+
+## Syntax
+
+```sql
+CREATE [OR REPLACE] VIEW <view_name> AS
+    <select_statement>
+```
+
+## `OR REPLACE`
+
+Redefine an existing view without dropping it first:
+
+```sql
+CREATE OR REPLACE VIEW north_atlantic AS
+    SELECT * FROM ocean_profiles
+    WHERE latitude BETWEEN 0 AND 70
+      AND longitude BETWEEN -80 AND 0
+```
+
+## Querying over a table function
+
+Views work over [table functions](./table-functions.md) as well as external tables — useful when you want to expose a specific file set as a named table:
+
+```sql
+CREATE VIEW argo_2024 AS
+    SELECT *
+    FROM read_netcdf(['argo/2024/**/*.nc'])
+    WHERE time >= '2024-01-01'
+```
+
+## Harmonizing datasets with `UNION ALL BY NAME`
+
+Use a view to expose multiple datasets with different schemas as a single unified table. See [UNION ALL BY NAME](./union-by-name.md) for how column matching and type widening work.
+
+```sql
+CREATE VIEW all_profiles AS
+    SELECT * FROM read_netcdf(['argo/**/*.nc'])
+    UNION ALL BY NAME
+    SELECT * FROM read_netcdf(['wod/**/*.nc'])
+```
+
+## `DROP TABLE`
+
+Remove a view from the catalog:
+
+```sql
+DROP TABLE north_atlantic
+
+DROP TABLE IF EXISTS north_atlantic
+```
+
+:::info
+`DROP TABLE` removes both external tables and views — there is no separate `DROP VIEW` statement.
+:::

--- a/docs/docs/1.8.0/sql/function-reference.md
+++ b/docs/docs/1.8.0/sql/function-reference.md
@@ -1,0 +1,449 @@
+# Function Reference
+
+Beacon's SQL runtime exposes two families of functions:
+
+1. **DataFusion built-ins** — Beacon inherits Apache DataFusion's full scalar and
+   aggregate function library. The tables below are a curated selection; for the
+   exhaustive list see DataFusion's
+   [scalar](https://datafusion.apache.org/user-guide/sql/scalar_functions.html)
+   and [aggregate](https://datafusion.apache.org/user-guide/sql/aggregate_functions.html)
+   references.
+2. **[Beacon-specific functions](#beacon-specific-functions)** — added by Beacon
+   for geospatial filtering, type conversion, and domain-specific vocabulary
+   mapping. That section is exhaustive.
+
+## DataFusion built-in functions (inherited)
+
+A curated selection of the inherited DataFusion library — anything in
+DataFusion's reference works even if it is not listed here.
+
+### Aggregate functions
+
+| Function | Description |
+| -------- | ----------- |
+| `COUNT(*)` | Number of rows |
+| `COUNT(col)` | Number of non-NULL values |
+| `SUM(col)` | Sum |
+| `AVG(col)` | Mean |
+| `MIN(col)` | Minimum |
+| `MAX(col)` | Maximum |
+| `STDDEV(col)` | Standard deviation |
+| `VARIANCE(col)` | Variance |
+| `MEDIAN(col)` | Median |
+| `APPROX_PERCENTILE_CONT(col, p)` | Approximate percentile (0–1) |
+
+### Math functions
+
+| Function | Description |
+| -------- | ----------- |
+| `abs(x)` | Absolute value |
+| `acos(x)` | Inverse cosine |
+| `acosh(x)` | Inverse hyperbolic cosine |
+| `asin(x)` | Inverse sine |
+| `asinh(x)` | Inverse hyperbolic sine |
+| `atan(x)` | Inverse tangent |
+| `atan2(y, x)` | Arc tangent of `y / x` |
+| `atanh(x)` | Inverse hyperbolic tangent |
+| `cbrt(x)` | Cube root |
+| `ceil(x)` | Round up to nearest integer |
+| `cos(x)` | Cosine |
+| `cosh(x)` | Hyperbolic cosine |
+| `cot(x)` | Cotangent |
+| `degrees(x)` | Convert radians to degrees |
+| `exp(x)` | `e^x` |
+| `factorial(x)` | Factorial (returns 1 for values less than 2) |
+| `floor(x)` | Round down to nearest integer |
+| `gcd(x, y)` | Greatest common divisor |
+| `isnan(x)` | Returns `true` if `x` is `+NaN` or `-NaN` |
+| `iszero(x)` | Returns `true` if `x` is `+0.0` or `-0.0` |
+| `lcm(x, y)` | Least common multiple |
+| `ln(x)` | Natural logarithm |
+| `log(base, x)` | Logarithm with specified base |
+| `log(x)` | Natural logarithm (single-argument form) |
+| `log10(x)` | Base-10 logarithm |
+| `log2(x)` | Base-2 logarithm |
+| `nanvl(x, fallback)` | Returns `x` if not NaN, otherwise `fallback` |
+| `pi()` | π (3.14159…) |
+| `pow(base, exp)` | Alias for `power` |
+| `power(base, exp)` | `base` raised to `exp` |
+| `radians(x)` | Convert degrees to radians |
+| `random()` | Random float in `[0, 1)` |
+| `round(x[, d])` | Round to `d` decimal places (default 0) |
+| `signum(x)` | Sign of `x` (−1, 0, or 1) |
+| `sin(x)` | Sine |
+| `sinh(x)` | Hyperbolic sine |
+| `sqrt(x)` | Square root |
+| `tan(x)` | Tangent |
+| `tanh(x)` | Hyperbolic tangent |
+| `trunc(x[, d])` | Truncate to `d` decimal places (default 0) |
+
+### String functions
+
+| Function | Description |
+| -------- | ----------- |
+| `ascii(s)` | Unicode scalar value of the first character |
+| `bit_length(s)` | Length in bits |
+| `btrim(s[, chars])` | Remove leading and trailing `chars` (default: whitespace) |
+| `char_length(s)` | Alias for `character_length` |
+| `character_length(s)` | Number of characters |
+| `chr(n)` | Character with Unicode scalar value `n` |
+| `concat(s1, s2, …)` | Concatenate strings |
+| `concat_ws(sep, s1, s2, …)` | Concatenate with separator |
+| `contains(s, substr)` | Returns `true` if `substr` is found in `s` |
+| `ends_with(s, suffix)` | Returns `true` if `s` ends with `suffix` |
+| `find_in_set(s, list)` | Position of `s` in comma-separated `list` (1-based) |
+| `initcap(s)` | Capitalize first letter of each word |
+| `instr(s, substr)` | Alias for `strpos` |
+| `left(s, n)` | First `n` characters |
+| `length(s)` | Alias for `character_length` |
+| `levenshtein(s1, s2)` | Edit distance between two strings |
+| `lower(s)` | Lowercase |
+| `lpad(s, n[, pad])` | Left-pad to length `n` with `pad` (default: space) |
+| `ltrim(s[, chars])` | Remove leading `chars` (default: whitespace) |
+| `octet_length(s)` | Length in bytes |
+| `overlay(s PLACING repl FROM pos [FOR len])` | Replace a substring at position |
+| `position(substr IN s)` | Alias for `strpos` |
+| `repeat(s, n)` | Repeat `s` `n` times |
+| `replace(s, from, to)` | Replace all occurrences of `from` with `to` |
+| `reverse(s)` | Reverse character order |
+| `right(s, n)` | Last `n` characters |
+| `rpad(s, n[, pad])` | Right-pad to length `n` with `pad` (default: space) |
+| `rtrim(s[, chars])` | Remove trailing `chars` (default: whitespace) |
+| `split_part(s, delim, n)` | `n`-th field after splitting `s` on `delim` |
+| `starts_with(s, prefix)` | Returns `true` if `s` starts with `prefix` |
+| `strpos(s, substr)` | 1-based position of `substr` in `s` (0 if not found) |
+| `substr(s, start[, len])` | Substring starting at `start` with optional length |
+| `substr_index(s, delim, n)` | Substring before `n`-th occurrence of `delim` |
+| `substring(s, start[, len])` | Alias for `substr` |
+| `substring_index(s, delim, n)` | Alias for `substr_index` |
+| `to_hex(n)` | Integer to hexadecimal string |
+| `translate(s, from, to)` | Character-wise substitution |
+| `trim(s[, chars])` | Alias for `btrim` |
+| `upper(s)` | Uppercase |
+| `uuid()` | Random UUID v4 string (unique per row) |
+
+### Regular expression functions
+
+| Function | Description |
+| -------- | ----------- |
+| `regexp_count(s, pattern[, start, flags])` | Number of times `pattern` matches in `s` |
+| `regexp_instr(s, pattern[, start[, n[, flags[, subexpr]]]])` | Position of the `n`-th match |
+| `regexp_like(s, pattern[, flags])` | Returns `true` if `pattern` has at least one match |
+| `regexp_match(s, pattern[, flags])` | Returns the first match as an array of capture groups |
+| `regexp_replace(s, pattern, replacement[, flags])` | Replace matches with `replacement` |
+
+Common flags: `i` (case-insensitive), `g` (global / all occurrences).
+
+### Binary string functions
+
+| Function | Description |
+| -------- | ----------- |
+| `encode(data, format)` | Encode binary data to text (`'hex'`, `'base64'`, `'escape'`) |
+| `decode(text, format)` | Decode text back to binary |
+
+### Date and time functions
+
+| Function | Description |
+| -------- | ----------- |
+| `current_date()` | Current date in the session time zone |
+| `current_time()` | Current time in the session time zone |
+| `current_timestamp()` | Alias for `now()` |
+| `today()` | Alias for `current_date()` |
+| `now()` | Current timestamp in the configured time zone |
+| `date_bin(interval, ts, origin)` | Truncate `ts` to the start of a fixed-width interval |
+| `date_trunc(precision, ts)` | Truncate to `'year'`, `'month'`, `'day'`, `'hour'`, `'minute'`, `'second'` |
+| `datetrunc(precision, ts)` | Alias for `date_trunc` |
+| `date_part(part, ts)` | Extract a numeric part from a timestamp |
+| `datepart(part, ts)` | Alias for `date_part` |
+| `extract(part FROM ts)` | SQL-standard equivalent of `date_part` |
+| `date_format(ts, fmt)` | Alias for `to_char` |
+| `to_char(ts, fmt)` | Format a timestamp as a string using [Chrono format](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) |
+| `to_date(expr[, fmt…])` | Parse to a date (`YYYY-MM-DD`) |
+| `to_time(expr[, fmt…])` | Parse to a time (`HH:MM:SS.nnnnnnnnn`) |
+| `to_timestamp(expr[, fmt…])` | Parse to a timestamp in the session time zone |
+| `to_timestamp_seconds(expr[, fmt…])` | Parse, interpreting integers as seconds since epoch |
+| `to_timestamp_millis(expr[, fmt…])` | Parse, interpreting integers as milliseconds since epoch |
+| `to_timestamp_micros(expr[, fmt…])` | Parse, interpreting integers as microseconds since epoch |
+| `to_timestamp_nanos(expr[, fmt…])` | Parse, interpreting integers as nanoseconds since epoch |
+| `from_unixtime(n[, tz])` | Convert an integer (seconds since epoch) to a timestamp |
+| `to_unixtime(ts)` | Convert a timestamp to seconds since epoch |
+| `to_local_time(ts)` | Strip the time zone from a timestamp-with-timezone |
+| `make_date(y, m, d)` | Construct a date from year, month, and day |
+| `make_time(h, min, s)` | Construct a time from hour, minute, and second |
+
+```sql
+-- Monthly averages
+SELECT DATE_TRUNC('month', time) AS month, AVG(temperature)
+FROM ocean_profiles
+GROUP BY month
+ORDER BY month
+
+-- Extract year
+SELECT EXTRACT(year FROM time) AS year, COUNT(*)
+FROM ocean_profiles
+GROUP BY year
+
+-- Fixed-width 6-hour bins
+SELECT DATE_BIN(INTERVAL '6 hours', time, '2024-01-01') AS bin, COUNT(*)
+FROM ocean_profiles
+GROUP BY bin
+```
+
+### Conditional expressions
+
+| Function | Description |
+| -------- | ----------- |
+| `coalesce(e1, e2, …)` | First non-NULL argument |
+| `nullif(e1, e2)` | NULL if `e1 = e2`, otherwise `e1` |
+| `greatest(e1, e2, …)` | Largest value in the list |
+| `least(e1, e2, …)` | Smallest value in the list |
+| `nvl(e1, e2)` | `e2` if `e1` is NULL, otherwise `e1` |
+| `nvl2(e1, e2, e3)` | `e2` if `e1` is not NULL, otherwise `e3` |
+| `ifnull(e1, e2)` | Alias for `nvl` |
+
+```sql
+-- CASE WHEN
+SELECT
+    time,
+    temperature,
+    CASE
+        WHEN temperature < 5  THEN 'cold'
+        WHEN temperature < 15 THEN 'cool'
+        ELSE 'warm'
+    END AS temp_class
+FROM ocean_profiles
+
+-- First non-NULL
+SELECT COALESCE(temperature_corrected, temperature) AS temp
+FROM ocean_profiles
+
+-- Mask a sentinel value
+SELECT NULLIF(quality_flag, 9) AS qc_flag
+FROM ocean_profiles
+```
+
+### Casting
+
+```sql
+SELECT CAST(pressure AS DOUBLE) AS pressure_dbar
+FROM ocean_profiles
+
+-- Short form
+SELECT pressure::DOUBLE AS pressure_dbar
+FROM ocean_profiles
+```
+
+### `try_arrow_cast(expr, type_str)`
+
+Like `TRY_CAST`, but uses Arrow type names instead of SQL type names. Returns NULL if the cast fails rather than raising an error.
+
+```sql
+-- Cast using an Arrow type name
+SELECT try_arrow_cast(raw_value, 'Float32') AS val
+FROM sensor_data
+
+-- Cast to a timestamp with timezone
+SELECT try_arrow_cast(epoch_str, 'Timestamp(Microsecond, Some("UTC"))') AS ts
+FROM events
+```
+
+### `cast_int8_as_char(n)`
+
+Interprets an `Int8` value as an ASCII code and returns the corresponding single-character string. Useful for NetCDF3 `char` variables stored as `Int8`.
+
+```sql
+SELECT cast_int8_as_char(platform_type_code) AS platform_type
+FROM argo_profiles
+```
+
+---
+
+## Beacon-specific functions
+
+### `beacon_version()`
+
+Returns the current Beacon server version as a string.
+
+```sql
+SELECT beacon_version()
+```
+
+### `coalesce_label(col1, 'label1', col2, 'label2', …)`
+
+Returns the label corresponding to the first non-NULL column from a list of `(column, label)` pairs. All labels must be non-NULL string literals.
+
+```sql
+SELECT coalesce_label(
+    temperature_corrected, 'corrected',
+    temperature,           'raw'
+) AS temp_source
+FROM ocean_profiles
+```
+
+---
+
+## Geospatial functions
+
+### `st_within_point(wkt, lon, lat)`
+
+Returns `true` if the point `(lon, lat)` lies within the geometry described by the WKT string. Supports any WKT geometry type (polygon, multipolygon, etc.). When the geometry is a scalar constant, Beacon uses a bounding-rectangle pre-filter and an LRU cache to accelerate repeated evaluations.
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| `wkt` | `VARCHAR` | Well-Known Text geometry |
+| `lon` | `DOUBLE` | Longitude |
+| `lat` | `DOUBLE` | Latitude |
+
+Returns `BOOLEAN`. Returns `false` if any argument is NULL.
+
+```sql
+SELECT *
+FROM read_netcdf(['argo/**/*.nc'])
+WHERE st_within_point(
+    'POLYGON ((−10 35, 40 35, 40 60, −10 60, −10 35))',
+    longitude,
+    latitude
+)
+```
+
+### `st_geojson_as_wkt(geojson)`
+
+Converts a GeoJSON geometry string to WKT. Use this to pass GeoJSON bounding polygons to `st_within_point`.
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| `geojson` | `VARCHAR` | GeoJSON geometry object |
+
+Returns `VARCHAR`.
+
+```sql
+SELECT st_geojson_as_wkt('{"type":"Polygon","coordinates":[[[0,50],[10,50],[10,60],[0,60],[0,50]]]}')
+```
+
+---
+
+## Domain mapping functions
+
+These functions map vocabulary codes between standards used in oceanographic datasets. They are provided for datasets ingested through the BlueCloud / SeaDataNet ecosystem.
+
+**Vocabulary abbreviations used below:**
+
+| Code | Description |
+| ---- | ----------- |
+| C17 | ICES vessel country codes |
+| EDMO | European Directory of Marine Organisations (numeric ID) |
+| L05 | SeaDataNet instrument type (broad category) |
+| L06 | SeaDataNet platform type |
+| L22 | SeaDataNet instrument type (specific model) |
+| L33 | SeaDataNet parameter discovery vocabulary |
+| P01 | SeaDataNet parameter codes |
+| P35 | EMODnet Chemistry parameter codes |
+| WMO | World Meteorological Organization instrument codes |
+
+### Physical / scientific
+
+#### `pressure_to_depth_teos_10(pressure, latitude)`
+
+Converts pressure in dbar to depth in metres using the TEOS-10 formula. Latitude is required because the geoid shape affects the conversion.
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| `pressure` | `DOUBLE` | Pressure in dbar |
+| `latitude` | `DOUBLE` | Latitude in decimal degrees |
+
+Returns `DOUBLE` (depth in metres, positive downward).
+
+```sql
+SELECT pressure_to_depth_teos_10(pressure, latitude) AS depth_m
+FROM argo_profiles
+```
+
+#### `map_units(unit, target_unit, value)`
+
+Converts a numeric `value` from `unit` to `target_unit` using the SeaDataNet unit registry. Unit strings must be valid SeaDataNet unit identifiers (e.g. `'SDN:P06::UPAA'`).
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| `unit` | `VARCHAR` | Source unit identifier |
+| `target_unit` | `VARCHAR` | Target unit identifier |
+| `value` | `DOUBLE` | Value to convert |
+
+Returns `DOUBLE`.
+
+```sql
+SELECT map_units("temperature.units", 'SDN:P06::UPAA', temperature) AS temperature_celsius
+FROM seadatanet_profiles
+```
+
+### Cross-vocabulary mapping
+
+All mapping functions return `NULL` when the input code is not found in the lookup table.
+
+#### Common
+
+| Function | Input | Returns | Description |
+| -------- | ----- | ------- | ----------- |
+| `map_c17(c17)` | `VARCHAR` | `VARCHAR` | C17 country code → country name |
+| `map_c17_l06(c17)` | `VARCHAR` | `VARCHAR` | C17 country code → L06 platform type |
+| `map_call_sign_c17(call_sign, timestamp)` | `VARCHAR`, `TIMESTAMP` | `VARCHAR` | Vessel call sign at a given time → C17 country code |
+| `map_l22_l05(l22)` | `VARCHAR` | `VARCHAR` | L22 instrument → L05 broad category |
+| `map_measuring_area_type_feature_type(type)` | `VARCHAR` | `VARCHAR` | Measuring area type → CDI feature type |
+| `map_wmo_instrument_type_l05(wmo)` | `VARCHAR` | `VARCHAR` | WMO instrument code → L05 |
+| `map_wmo_instrument_type_l22(wmo)` | `VARCHAR` | `VARCHAR` | WMO instrument code → L22 |
+
+#### CMEMS
+
+| Function | Input | Returns | Description |
+| -------- | ----- | ------- | ----------- |
+| `map_cmems_bigram_l05(bigram)` | `VARCHAR` | `VARCHAR` | CMEMS platform bigram → L05 |
+| `map_cmems_bigram_l06(bigram, wmo_instrument_type)` | `VARCHAR`, `VARCHAR` | `VARCHAR` | CMEMS platform bigram + WMO instrument type → L06 |
+
+#### CORA
+
+| Function | Input | Returns | Description |
+| -------- | ----- | ------- | ----------- |
+| `map_cora_instrument_l05(instrument)` | `VARCHAR` | `VARCHAR` | CORA instrument type → L05 |
+| `map_cora_instrument_l22(instrument)` | `VARCHAR` | `VARCHAR` | CORA instrument type → L22 |
+| `map_cora_platform_l06(bigram, wmo_instrument_type)` | `VARCHAR`, `VARCHAR` | `VARCHAR` | CORA platform bigram + WMO instrument type → L06 |
+
+#### EMODnet Chemistry
+
+| Function | Input | Returns | Description |
+| -------- | ----- | ------- | ----------- |
+| `map_emodnet_chemistry_instrument_l05(instrument)` | `VARCHAR` | `VARCHAR` | EMODnet Chemistry instrument code → L05 |
+| `map_emodnet_chemistry_instrument_l05_multi(instrument)` | `VARCHAR` | `VARCHAR` | EMODnet Chemistry instrument code → comma-separated L05 labels |
+| `map_emodnet_chemistry_instrument_info_l22(line, p01)` | `VARCHAR`, `VARCHAR` | `VARCHAR` | EMODnet Chemistry instrument line + P01 code → L22 |
+| `map_emodnet_chemistry_originator_edmo(originator)` | `VARCHAR` | `VARCHAR` | EMODnet Chemistry originator code → EDMO identifier |
+| `map_emodnet_chemistry_p35_contributor_codes_p01(codes)` | `VARCHAR` | `VARCHAR` | EMODnet Chemistry P35 contributor codes → P01 parameter codes |
+| `map_emodnet_chemistry_platform_l06(platform)` | `VARCHAR` | `VARCHAR` | EMODnet Chemistry platform code → L06 |
+
+#### SeaDataNet
+
+| Function | Input | Returns | Description |
+| -------- | ----- | ------- | ----------- |
+| `map_seadatanet_instrument_l05(instrument)` | `VARCHAR` | `VARCHAR` | SeaDataNet instrument code → L05 |
+| `map_seadatanet_platform_l06(platform)` | `VARCHAR` | `VARCHAR` | SeaDataNet platform code → L06 |
+| `map_platform_c17_l06(c17)` | `VARCHAR` | `VARCHAR` | SeaDataNet C17 country code → L06 |
+| `map_seadatanet_instrument_l05_salinity(instrument)` | `VARCHAR` | `VARCHAR` | SeaDataNet instrument code → L05, disambiguated for salinity sensors |
+| `map_seadatanet_instrument_l05_temperature(instrument)` | `VARCHAR` | `VARCHAR` | SeaDataNet instrument code → L05, disambiguated for temperature sensors |
+| `map_originator_edmo(originator)` | `VARCHAR` | `VARCHAR` | SeaDataNet originator code → EDMO identifier |
+
+#### Argo
+
+| Function | Input | Returns | Description |
+| -------- | ----- | ------- | ----------- |
+| `map_argo_instrument_l05(sensor_model)` | `BIGINT` | `VARCHAR` | Argo sensor model code → L05 |
+| `map_argo_platform_l06(platform_type)` | `BIGINT` | `VARCHAR` | Argo platform type code → L06 |
+| `map_argo_platform_edmo(platform_code)` | `VARCHAR` | `VARCHAR` | Argo platform code → EDMO institution identifier |
+
+#### World Ocean Database (WOD)
+
+| Function | Input | Returns | Description |
+| -------- | ----- | ------- | ----------- |
+| `map_wod_instrument_l05(instrument)` | `VARCHAR` | `VARCHAR` | WOD instrument code → L05 |
+| `map_wod_instrument_l22(instrument)` | `VARCHAR` | `VARCHAR` | WOD instrument code → L22 |
+| `map_wod_instrument_l33(instrument)` | `VARCHAR` | `VARCHAR` | WOD instrument code → L33 |
+| `map_wod_platform_c17(platform)` | `VARCHAR` | `VARCHAR` | WOD platform code → C17 |
+| `map_wod_quality_flag(flag)` | `BIGINT` | `VARCHAR` | WOD numeric quality flag → description string |
+| `map_wod_edmo(country_institute)` | `VARCHAR` | `BIGINT` | WOD country/institute code → EDMO ID |
+| `map_wod_edmo_approx(country_institute)` | `VARCHAR` | `BIGINT` | WOD country/institute code → nearest EDMO ID (approximate) |

--- a/docs/docs/1.8.0/sql/geoparquet.md
+++ b/docs/docs/1.8.0/sql/geoparquet.md
@@ -1,0 +1,68 @@
+# GeoParquet
+
+[GeoParquet](https://geoparquet.org/) files (`.geoparquet`) are Parquet files that carry geospatial geometry columns plus a `geo` metadata key. Beacon reads them like any other dataset: geometry columns are decoded to their native [GeoArrow](https://geoarrow.org/) representation, and everything you can do in SQL — `SELECT`, `WHERE`, `JOIN`, aggregates — works on top.
+
+This chapter covers querying GeoParquet with SQL. For registering GeoParquet datasets as tables and the format's read behaviour, see [GeoParquet in the data-lake setup](../data-lake/geoparquet.md).
+
+## Querying with `read_geoparquet()`
+
+The `read_geoparquet()` table function reads one or more files matched by a glob, with no registration step:
+
+```sql
+SELECT * FROM read_geoparquet(['spatial/**/*.geoparquet']) LIMIT 100
+```
+
+A file without geometry (a plain Parquet file with no `geo` metadata) is read exactly like ordinary Parquet, so `read_geoparquet()` is safe to point at mixed folders.
+
+Only the columns a query selects are materialized — column projection is pushed into the Parquet reader:
+
+```sql
+SELECT station_id, geometry
+FROM read_geoparquet(['spatial/stations/*.geoparquet'])
+WHERE station_id = 'GL_001'
+```
+
+## Geometry columns
+
+Geometry columns named in the file's `geo` metadata are decoded to native GeoArrow on read. For point data with separated coordinates this surfaces as a `Struct` column with `x` / `y` child fields, which you can address with standard struct accessors:
+
+```sql
+SELECT geometry['x'] AS lon, geometry['y'] AS lat
+FROM read_geoparquet(['spatial/stations/*.geoparquet'])
+```
+
+## Querying a GeoParquet external table
+
+Register a stable name once with a [`STORED AS GEOPARQUET`](../data-lake/geoparquet.md) external table, then query it like any table:
+
+```sql
+CREATE EXTERNAL TABLE stations
+STORED AS GEOPARQUET
+LOCATION 'spatial/stations/*.geoparquet';
+
+SELECT * FROM stations LIMIT 10;
+```
+
+## Spatial filtering
+
+Geometry data pairs naturally with Beacon's [geospatial functions](./function-reference.md#geospatial-functions). For example, keep only rows whose longitude/latitude fall inside a bounding polygon with [`st_within_point`](./function-reference.md#st_within_point):
+
+```sql
+SELECT station_id, geometry
+FROM stations
+WHERE st_within_point(
+    'POLYGON ((-10 35, 40 35, 40 60, -10 60, -10 35))',
+    geometry['x'],
+    geometry['y']
+)
+```
+
+You can pass a GeoJSON polygon instead by wrapping it with [`st_geojson_as_wkt`](./function-reference.md#st_geojson_as_wkt).
+
+:::warning
+Spatial bounding-box pruning (row-group skipping via the GeoParquet `bbox` covering) is not yet applied on read — queries perform a full scan with column projection. Geometry-aware predicate pushdown is planned, so `st_*` filters above run on the full scan rather than skipping row groups.
+:::
+
+:::tip Writing GeoParquet
+Beacon can also *write* GeoParquet: a query result with longitude/latitude columns is mapped into a geometry column on output. See [querying output formats](../api/querying/index.md).
+:::

--- a/docs/docs/1.8.0/sql/group-by.md
+++ b/docs/docs/1.8.0/sql/group-by.md
@@ -1,0 +1,58 @@
+# GROUP BY
+
+Aggregate rows into groups:
+
+```sql
+SELECT
+    DATE_TRUNC('month', time) AS month,
+    AVG(temperature)          AS avg_temp,
+    MIN(temperature)          AS min_temp,
+    MAX(temperature)          AS max_temp,
+    COUNT(*)                  AS observations
+FROM ocean_profiles
+WHERE depth < 10
+GROUP BY DATE_TRUNC('month', time)
+ORDER BY month
+```
+
+## Grouping by multiple columns
+
+```sql
+SELECT
+    DATE_TRUNC('year', time) AS year,
+    FLOOR(latitude / 10) * 10 AS lat_band,
+    AVG(temperature) AS avg_temp
+FROM ocean_profiles
+GROUP BY year, lat_band
+ORDER BY year, lat_band
+```
+
+## HAVING
+
+Filter groups after aggregation (unlike `WHERE`, which filters rows before grouping):
+
+```sql
+SELECT
+    FLOOR(latitude / 5) * 5 AS lat_bin,
+    AVG(temperature)        AS avg_temp,
+    COUNT(*)                AS observations
+FROM ocean_profiles
+GROUP BY lat_bin
+HAVING COUNT(*) > 100
+ORDER BY lat_bin
+```
+
+## Common aggregate functions
+
+| Function | Description |
+| -------- | ----------- |
+| `COUNT(*)` | Total rows in the group |
+| `COUNT(col)` | Non-NULL values in the group |
+| `SUM(col)` | Sum |
+| `AVG(col)` | Mean |
+| `MIN(col)` | Minimum |
+| `MAX(col)` | Maximum |
+| `STDDEV(col)` | Standard deviation |
+| `MEDIAN(col)` | Median |
+
+See [Function Reference](./function-reference.md#aggregate-functions) for the full list.

--- a/docs/docs/1.8.0/sql/index.md
+++ b/docs/docs/1.8.0/sql/index.md
@@ -1,0 +1,28 @@
+---
+description: Query Beacon with standard SQL (Apache DataFusion) — SELECT, WHERE, GROUP BY, JOIN, table functions like read_netcdf(), DDL, and a full function reference.
+---
+
+# SQL Guide
+
+Beacon embeds [Apache DataFusion](https://datafusion.apache.org/) as its query engine, giving you a broad standard SQL dialect — `SELECT`, `WHERE`, `GROUP BY`, `JOIN`, `ORDER BY`, window functions, and more.
+
+## Running SQL
+
+| Surface | How | Requirement |
+| ------- | --- | ----------- |
+| **HTTP API** | `POST /api/query` with `{ "sql": "..." }` | `BEACON_ENABLE_SQL=true` |
+| **Arrow Flight SQL** | Any Flight SQL client (DataGrip, ADBC, DBeaver) | Enabled by default |
+
+## What you can query
+
+**Registered tables** — any [External Table](../data-lake/external-tables.md) or [View](../data-lake/view.md):
+
+```sql
+SELECT * FROM ocean_profiles LIMIT 100
+```
+
+**Files on the fly** — using [Table Functions](./table-functions.md) without a persistent table:
+
+```sql
+SELECT * FROM read_netcdf(['argo/**/*.nc']) LIMIT 100
+```

--- a/docs/docs/1.8.0/sql/join.md
+++ b/docs/docs/1.8.0/sql/join.md
@@ -1,0 +1,63 @@
+# JOIN
+
+Combine rows from two tables by matching a condition:
+
+```sql
+SELECT p.time, p.latitude, p.longitude, p.temperature, m.platform_name
+FROM ocean_profiles p
+JOIN platform_metadata m ON p.platform_code = m.platform_code
+WHERE p.time >= '2024-01-01'
+```
+
+## INNER JOIN
+
+Returns only rows where the join condition matches in both tables. `JOIN` and `INNER JOIN` are equivalent:
+
+```sql
+SELECT p.time, p.temperature, m.platform_name
+FROM ocean_profiles p
+INNER JOIN platform_metadata m ON p.platform_code = m.platform_code
+```
+
+## LEFT JOIN
+
+Returns all rows from the left table. Rows with no match in the right table get `NULL` for the right-side columns:
+
+```sql
+SELECT p.time, p.temperature, m.platform_name
+FROM ocean_profiles p
+LEFT JOIN platform_metadata m ON p.platform_code = m.platform_code
+```
+
+## Joining on multiple columns
+
+```sql
+SELECT *
+FROM observations o
+JOIN qc_flags q
+  ON o.platform_code = q.platform_code
+ AND o.time          = q.time
+ AND o.depth         = q.depth
+```
+
+## Joining a table function
+
+You can join directly against a `read_*` table function without creating an external table first:
+
+```sql
+SELECT p.time, p.temperature, m.platform_name
+FROM read_netcdf(['argo/**/*.nc']) p
+JOIN platform_metadata m ON p.platform_code = m.platform_code
+```
+
+## Subquery join
+
+```sql
+SELECT *
+FROM ocean_profiles
+WHERE platform_code IN (
+    SELECT platform_code
+    FROM platform_metadata
+    WHERE ocean_basin = 'North Atlantic'
+)
+```

--- a/docs/docs/1.8.0/sql/managed-tables.md
+++ b/docs/docs/1.8.0/sql/managed-tables.md
@@ -1,0 +1,188 @@
+# CREATE TABLE (Managed)
+
+```sql
+CREATE TABLE observations (id BIGINT, name VARCHAR);
+INSERT INTO observations VALUES (1, 'a'), (2, 'b');
+SELECT * FROM observations;
+```
+
+A **managed table** is a SQL table whose data Beacon owns and stores itself. Unlike an [external table](../data-lake/external-tables.md) — which only points at existing files — a managed table is created empty (or from a query) and populated with `INSERT`. It supports `UPDATE`, `DELETE`, schema evolution with `ALTER TABLE`, and secondary `INDEX`es. Table definitions and data survive restarts.
+
+Managed tables are an authenticated, write capability: `CREATE`, `INSERT`, `UPDATE`, `DELETE`, `ALTER`, and `CREATE/DROP INDEX` require admin credentials. Anonymous access remains read-only.
+
+## Choosing the storage engine
+
+Managed tables can be backed by one of two engines:
+
+| Engine | Best for | Storage | Updates/Deletes | Indexes |
+| --- | --- | --- | --- | --- |
+| **Lance** *(default)* | fast local CRUD, secondary indexes | local filesystem (tables directory) | native — deletion vectors / fragment rewrite | ✅ scalar (btree, bitmap, full‑text) |
+| **Iceberg** | object‑store / cloud deployments | object store (alongside datasets, local or S3) | copy‑on‑write | ❌ |
+
+The engine is chosen **when the table is created** and recorded with the table; later `INSERT`/`UPDATE`/`DELETE`/`ALTER` automatically use the right engine.
+
+The default is **Lance**. Override it per session before creating a table:
+
+```sql
+SET beacon.table_engine = 'iceberg';
+CREATE TABLE archived (id BIGINT, name VARCHAR);   -- Iceberg-backed
+
+SET beacon.table_engine = 'lance';                 -- back to the default
+```
+
+Or change the deployment-wide default with the `BEACON_DEFAULT_TABLE_ENGINE` environment variable (`lance` or `iceberg`).
+
+::: tip
+Lance managed tables live on the **local filesystem** (the tables directory), even when your datasets are on S3. If you run Beacon with an S3 data lake and want managed tables on object storage, use the Iceberg engine.
+:::
+
+## `CREATE TABLE`
+
+Define columns explicitly:
+
+```sql
+CREATE TABLE measurements (
+  id     BIGINT,
+  name   VARCHAR,
+  value  DOUBLE
+);
+```
+
+`IF NOT EXISTS` makes creation a no-op when the table already exists:
+
+```sql
+CREATE TABLE IF NOT EXISTS measurements (id BIGINT, name VARCHAR);
+```
+
+### `CREATE TABLE AS SELECT`
+
+Create and populate a table from a query (CTAS). The table's schema is the schema of the query result:
+
+```sql
+CREATE TABLE warm_profiles AS
+SELECT platform, temperature, depth
+FROM read_parquet('profiles/*.parquet')
+WHERE temperature > 20;
+```
+
+## `INSERT INTO`
+
+Append rows from literal values or a query:
+
+```sql
+INSERT INTO measurements VALUES (1, 'argo', 12.5), (2, 'glider', 9.0);
+
+INSERT INTO measurements
+SELECT id, name, value FROM staging;
+```
+
+## `SELECT`
+
+Query a managed table like any other table:
+
+```sql
+SELECT name, avg(value) FROM measurements GROUP BY name;
+```
+
+## `DELETE`
+
+Remove rows matching a predicate, or all rows when no `WHERE` is given:
+
+```sql
+DELETE FROM measurements WHERE value IS NULL;
+
+DELETE FROM measurements;        -- empties the table
+```
+
+On **Lance** tables this is a native delete (deletion vectors) — it does not rewrite the whole table. On **Iceberg** tables it is copy-on-write.
+
+## `UPDATE`
+
+Change column values for matching rows; unmatched rows are untouched:
+
+```sql
+UPDATE measurements SET name = 'unknown' WHERE name IS NULL;
+
+UPDATE measurements SET value = value * 1.0;   -- every row
+```
+
+On **Lance** tables this rewrites only the affected fragments; on **Iceberg** it is copy-on-write. `UPDATE ... FROM` / joins are not supported.
+
+## `ALTER TABLE`
+
+Evolve the schema. Existing rows keep reading correctly: added columns read `NULL`, renames preserve values.
+
+```sql
+-- Add a (nullable) column
+ALTER TABLE measurements ADD COLUMN quality_flag INT;
+
+-- Rename a column
+ALTER TABLE measurements RENAME COLUMN name TO platform;
+
+-- Drop a column
+ALTER TABLE measurements DROP COLUMN quality_flag;
+
+-- Widen a column's type (safe promotions only)
+ALTER TABLE measurements ALTER COLUMN id TYPE BIGINT;
+```
+
+On **Lance** tables schema changes are applied natively (no table rebuild). On **Iceberg** tables, only safe type promotions are allowed: `INT → BIGINT`, `FLOAT → DOUBLE`, and decimal precision increases at the same scale; narrowing or incompatible changes are rejected.
+
+## Indexes
+
+::: info Lance engine only
+Secondary indexes are a feature of the **Lance** engine. They are not available on Iceberg-backed tables.
+:::
+
+Create a scalar index on a column to speed up filters. Once created, queries use it automatically — no query changes are needed.
+
+```sql
+-- Default (BTREE) index; auto-named <table>_<column>_idx
+CREATE INDEX ON measurements (platform);
+
+-- Named index, explicit type
+CREATE INDEX value_idx  ON measurements (value)        USING btree;
+CREATE INDEX flag_idx   ON measurements (quality_flag) USING bitmap;
+CREATE INDEX name_idx   ON measurements (name)         USING inverted;
+```
+
+| Type | Use for |
+| --- | --- |
+| `btree` *(default)* | range / equality filters (`=`, `<`, `BETWEEN`, …) |
+| `bitmap` | low-cardinality columns (few distinct values) |
+| `inverted` | full-text search over string columns |
+
+List a table's indexes, or drop one by name:
+
+```sql
+SHOW INDEXES ON measurements;
+
+DROP INDEX value_idx ON measurements;
+```
+
+## `DROP TABLE`
+
+Remove a managed table. Unlike an external table, this **deletes the table's data**:
+
+```sql
+DROP TABLE measurements;
+
+DROP TABLE IF EXISTS measurements;
+```
+
+## Notes & limitations
+
+- **Storage**: Lance tables live on the local filesystem (the tables directory); Iceberg tables live in Beacon's internal storage area alongside the datasets (local or S3). There is nothing extra to configure.
+- **Lance write model**: `INSERT` streams directly into the table; `DELETE`/`UPDATE` are native (deletion vectors / fragment rewrite); `ALTER` is applied without a rebuild. Each write commits a new dataset version, and readers always see a consistent snapshot.
+- **Iceberg write model**: `DELETE`/`UPDATE` are copy-on-write and `ALTER` rebuilds the table; best suited to moderate-sized tables and occasional schema changes rather than high-frequency row churn.
+- **Scope**: `ALTER` supports single-table `ADD` / `DROP` / `RENAME COLUMN` and `ALTER COLUMN TYPE`; added columns are nullable. Indexes are scalar only (vector/ANN indexes are not yet exposed).
+
+## Querying and inspecting
+
+```sql
+SHOW TABLES;
+
+DESCRIBE measurements;
+
+SHOW INDEXES ON measurements;   -- Lance tables
+```

--- a/docs/docs/1.8.0/sql/remote-tables.md
+++ b/docs/docs/1.8.0/sql/remote-tables.md
@@ -1,0 +1,43 @@
+# Remote Tables
+
+A **remote table** points at a table living on **another Beacon instance** and is queried over Arrow Flight SQL. Once created it behaves like any other table in your SQL — you `SELECT`, `JOIN`, and aggregate over it — but the data stays on the remote, and Beacon pushes as much work as possible down to it so only the reduced result set travels the network.
+
+This chapter covers querying remote tables. For the DDL that creates them (`LOCATION`, `OPTIONS`, TLS), schema handling, and the full list of limitations, see the [Remote Tables (Federation) setup chapter](../data-lake/remote-tables.md).
+
+## Querying a remote table
+
+Assuming a remote table `remote_profiles` has been registered, it is queried exactly like a local table:
+
+```sql
+SELECT count(*), avg(temperature)
+FROM remote_profiles
+WHERE depth < 50 AND platform = 'argo';
+```
+
+The `WHERE` filter and the aggregate are executed **on the remote**, and only the small aggregated result is returned over the wire.
+
+## How pushdown works
+
+When you query a remote table, Beacon's planner federates the largest sub-plan rooted at it and sends it to the remote as SQL. Filters, projected columns, `LIMIT`, and whole aggregates push down. Confirm what gets pushed with `EXPLAIN`:
+
+```sql
+EXPLAIN SELECT count(*) FROM remote_profiles WHERE depth < 50;
+```
+
+The plan shows a federated (virtual) scan node in place of a local table scan — everything below it runs remotely.
+
+## Joins across the same remote
+
+Tables that live on the **same** remote instance federate together, so a join between two remote tables on that instance is pushed down and executed remotely:
+
+```sql
+SELECT p.id, m.station_name
+FROM remote_profiles p
+JOIN remote_stations m ON p.station_id = m.id;
+```
+
+Joins that mix a remote table with a **local** table (or with a table on a *different* remote) are executed locally: Beacon fetches the needed remote rows and joins them on this instance.
+
+:::tip
+Keep remote-pushed predicates to standard SQL comparisons. A filter or projection that uses a Beacon UDF (e.g. a geospatial `st_*` function) is only pushed down if the remote instance has the same function; otherwise Beacon falls back to local execution. See the [setup chapter's limitations](../data-lake/remote-tables.md#limitations).
+:::

--- a/docs/docs/1.8.0/sql/select.md
+++ b/docs/docs/1.8.0/sql/select.md
@@ -1,0 +1,46 @@
+# SELECT
+
+## Basic select
+
+Choose specific columns or use `*` for all:
+
+```sql
+SELECT time, latitude, longitude, temperature
+FROM ocean_profiles
+
+SELECT * FROM ocean_profiles LIMIT 100
+```
+
+## Expressions and aliases
+
+```sql
+SELECT
+    time,
+    latitude,
+    longitude,
+    temperature - 273.15 AS temperature_celsius,
+    ROUND(salinity, 2)   AS salinity_psu
+FROM ocean_profiles
+```
+
+## ORDER BY
+
+```sql
+SELECT time, latitude, longitude, temperature
+FROM ocean_profiles
+ORDER BY time DESC, latitude ASC
+```
+
+## LIMIT and OFFSET
+
+```sql
+SELECT * FROM ocean_profiles LIMIT 100
+
+SELECT * FROM ocean_profiles LIMIT 100 OFFSET 200
+```
+
+## DISTINCT
+
+```sql
+SELECT DISTINCT platform_code FROM ocean_profiles
+```

--- a/docs/docs/1.8.0/sql/table-functions-utility.md
+++ b/docs/docs/1.8.0/sql/table-functions-utility.md
@@ -1,0 +1,116 @@
+# Introspection
+
+These table functions inspect schemas, file listings, and statistics without reading dataset rows. Use them to explore an unfamiliar data lake before writing queries.
+
+## `read_schema`
+
+```text
+read_schema(glob_paths, file_format)
+```
+
+Returns the inferred schema (column names and types) for a set of files without reading any data.
+
+`glob_paths` accepts either a single glob/path string or a list of strings. `file_format` must be one of: `parquet`, `netcdf` (or `nc`), `zarr`, `arrow`, `csv`, `bbf`, `tiff` (or `tif`).
+
+```sql
+-- Single path or glob
+SELECT * FROM read_schema('argo/**/*.nc', 'netcdf')
+
+SELECT * FROM read_schema('obs/*.parquet', 'parquet')
+
+-- A list, to inspect the combined schema across multiple sources
+SELECT * FROM read_schema(['obs/2023/*.parquet', 'obs/2024/*.parquet'], 'parquet')
+```
+
+## `list_datasets`
+
+```text
+list_datasets()
+```
+
+Lists all files currently stored in Beacon's dataset storage root. Returns one row per file.
+
+| Column | Type | Description |
+| ------ | ---- | ----------- |
+| `file_name` | `TEXT` | Path relative to the storage root |
+| `file_format` | `TEXT` | Detected format |
+
+```sql
+SELECT * FROM list_datasets()
+
+-- Find all NetCDF files
+SELECT file_name FROM list_datasets() WHERE file_format = 'nc'
+```
+
+## `view_dataset_statistics`
+
+```text
+view_dataset_statistics(path)
+```
+
+Returns per-column min/max statistics for a single file. Statistics are read from the cache when available and computed on demand otherwise.
+
+| Column | Type | Description |
+| ------ | ---- | ----------- |
+| `column_name` | `TEXT` | Column name |
+| `data_type` | `TEXT` | Column data type |
+| `min_value` | `TEXT` | Minimum value (NULL if unknown) |
+| `max_value` | `TEXT` | Maximum value (NULL if unknown) |
+| `is_exact` | `BOOLEAN` | Whether the statistics are exact |
+
+```sql
+SELECT * FROM view_dataset_statistics('argo/2024/R6900001.nc')
+```
+
+## `view_external_table_statistics`
+
+```text
+view_external_table_statistics(table_name)
+```
+
+Returns per-file statistics for every file that backs an external table — useful for checking which files have cached statistics and what their value ranges are.
+
+| Column | Type | Description |
+| ------ | ---- | ----------- |
+| `path` | `TEXT` | File path |
+| `file_size` | `UINT64` | File size in bytes |
+| `cached` | `BOOLEAN` | Whether statistics are cached for this file |
+| `column_name` | `TEXT` | Column name (NULL if not cached) |
+| `data_type` | `TEXT` | Column data type |
+| `min_value` | `TEXT` | Minimum value |
+| `max_value` | `TEXT` | Maximum value |
+| `is_exact` | `BOOLEAN` | Whether the statistics are exact |
+
+```sql
+SELECT * FROM view_external_table_statistics('ocean_profiles')
+
+-- Find files with no cached statistics
+SELECT path FROM view_external_table_statistics('ocean_profiles')
+WHERE cached = false
+```
+
+## `view_statistics_cache`
+
+```text
+view_statistics_cache()
+```
+
+Streams all entries from the global file statistics cache. Each row is validated against the object store — the `is_valid` flag indicates whether the cached file still exists and its size matches.
+
+| Column | Type | Description |
+| ------ | ---- | ----------- |
+| `path` | `TEXT` | File path |
+| `file_size` | `UINT64` | File size in bytes |
+| `is_valid` | `BOOLEAN` | Whether the cached entry is still valid |
+| `column_name` | `TEXT` | Column name |
+| `data_type` | `TEXT` | Column data type |
+| `min_value` | `TEXT` | Minimum value |
+| `max_value` | `TEXT` | Maximum value |
+| `is_exact` | `BOOLEAN` | Whether the statistics are exact |
+
+```sql
+SELECT * FROM view_statistics_cache()
+
+-- Find stale cache entries
+SELECT path FROM view_statistics_cache() WHERE is_valid = false
+```

--- a/docs/docs/1.8.0/sql/table-functions.md
+++ b/docs/docs/1.8.0/sql/table-functions.md
@@ -1,0 +1,243 @@
+# Reading Files
+
+Table functions let you query files directly in a `FROM` clause without creating a persistent [External Table](../data-lake/external-tables.md) first. They are useful for ad-hoc exploration or when you want to embed the file path logic inside a [View](../data-lake/view.md).
+
+All functions take the file path(s) to read as their first argument. This can be **either a single glob/path string** or **a list of strings**. Globs are resolved relative to Beacon's configured dataset storage root.
+
+```sql
+-- Single path
+SELECT * FROM read_parquet('profiles/2024.parquet')
+
+-- Single folder glob
+SELECT * FROM read_netcdf('argo/**/*.nc')
+
+-- A list, to combine multiple paths or globs in one call
+SELECT * FROM read_netcdf(['argo/**/*.nc', 'wod/**/*.nc'])
+```
+
+In every signature below, the `glob_paths` argument accepts either form — a single string or a list of strings.
+
+## `read_netcdf`
+
+```text
+read_netcdf(glob_paths)
+read_netcdf(glob_paths, dimensions)
+```
+
+Reads NetCDF files matching one or more glob patterns.
+
+The optional `dimensions` argument filters which variables are returned: a variable is included only if all of its dimensions are a subset of the provided list. Use it to exclude high-dimensional variables you don't need, or to resolve ambiguity when files contain variables with incompatible dimensionalities.
+
+```sql
+SELECT time, latitude, longitude, temperature
+FROM read_netcdf('argo/**/*.nc')
+
+-- With explicit dimension columns
+SELECT *
+FROM read_netcdf(['argo/**/*.nc'], ['time', 'pressure'])
+```
+
+### Variable attributes
+
+NetCDF variable attributes (e.g. `units`, `long_name`) are exposed as additional columns using the pattern `<variable>.<attribute>`. Attribute columns preserve the original type (string, integer, float, …). File-level global attributes use a leading dot with no variable prefix: `.<attribute>`. Quote these column names because they contain a dot.
+
+```sql
+-- Variable attribute
+SELECT temperature, "temperature.units", "temperature.long_name"
+FROM read_netcdf('argo/**/*.nc')
+LIMIT 1
+
+-- Global attribute
+SELECT ".source", temperature
+FROM read_netcdf('argo/**/*.nc')
+LIMIT 1
+```
+
+## `read_zarr`
+
+```text
+read_zarr(glob_paths)
+read_zarr(glob_paths, dimensions)
+```
+
+Reads Zarr stores matching one or more glob patterns. Each path should point at a `zarr.json` entry file.
+
+The optional `dimensions` argument restricts the arrays returned to those whose dimensions are a subset of the provided list — use it to drop high-dimensional arrays you don't need.
+
+Predicate pushdown is automatic: Beacon prunes chunks and slices coordinate dimensions (e.g. `time`, `latitude`, `longitude`) based on the query's `WHERE` clause — no statistics columns need to be declared.
+
+```sql
+SELECT * FROM read_zarr('sst/*/zarr.json')
+
+-- Range queries are pruned automatically
+SELECT time, sst
+FROM read_zarr('sst/*/zarr.json')
+WHERE time >= '2024-01-01'
+```
+
+### Array attributes
+
+Per-array attributes are exposed as additional columns using the pattern `<array>.<attribute>`. Attribute columns preserve the original type (string, integer, float, …). Root-level store attributes use a leading dot with no array prefix: `.<attribute>`. Quote these column names because they contain a dot.
+
+```sql
+-- Array attribute
+SELECT sst, "sst.units", "sst.long_name"
+FROM read_zarr('sst/*/zarr.json')
+LIMIT 1
+
+-- Root-level global attribute
+SELECT ".Conventions", sst
+FROM read_zarr('sst/*/zarr.json')
+LIMIT 1
+```
+
+## `read_atlas`
+
+```text
+read_atlas(glob_paths)
+read_atlas(glob_paths, dimensions)
+```
+
+Reads [Atlas](../data-lake/datasets.md#atlas) array stores matching one or more glob patterns. Each path must point at an `atlas.json` marker file — an exact path or a glob such as `**/atlas.json`.
+
+The optional `dimensions` argument filters the arrays to those matching the listed dimension names. Atlas prunes whole datasets using per-column statistics, so range queries over large collections only read the datasets that can match the predicate.
+
+```sql
+SELECT * FROM read_atlas('collections/sensor/atlas.json')
+
+-- Combine every Atlas store under a prefix, keeping a subset of dimensions
+SELECT time, temperature
+FROM read_atlas(['collections/**/atlas.json'], ['time', 'latitude', 'longitude'])
+WHERE time >= '2024-01-01'
+```
+
+## `read_parquet`
+
+```text
+read_parquet(glob_paths)
+```
+
+```sql
+SELECT * FROM read_parquet('obs/**/*.parquet') LIMIT 100
+```
+
+## `read_geoparquet`
+
+```text
+read_geoparquet(glob_paths)
+```
+
+Reads [GeoParquet](https://geoparquet.org/) files. Geometry columns described in the file's `geo` metadata are decoded to their native [GeoArrow](https://geoarrow.org/) representation; files without geometry are read like ordinary Parquet.
+
+```sql
+SELECT * FROM read_geoparquet('spatial/**/*.geoparquet') LIMIT 100
+```
+
+## `read_arrow`
+
+```text
+read_arrow(glob_paths)
+```
+
+Reads Arrow IPC stream files (`.arrow`, `.feather`).
+
+```sql
+SELECT * FROM read_arrow('streams/*.arrow')
+```
+
+## `read_csv`
+
+```text
+read_csv(glob_paths)
+read_csv(glob_paths, delimiter)
+read_csv(glob_paths, delimiter, infer_records)
+```
+
+Schema is inferred from the file contents. The first row must be a header row.
+
+- `delimiter` — single-character field separator (default: `,`)
+- `infer_records` — number of rows to sample when inferring column types (default: `128000`)
+
+```sql
+SELECT * FROM read_csv('metadata/*.csv')
+
+-- Tab-separated, sample 500 rows for type inference
+SELECT * FROM read_csv(['data/*.tsv'], '\t', 500)
+```
+
+## `read_odv_ascii`
+
+```text
+read_odv_ascii(glob_paths)
+```
+
+```sql
+SELECT * FROM read_odv_ascii('odv/**/*.txt')
+```
+
+## `read_bbf`
+
+```text
+read_bbf(glob_paths)
+```
+
+Reads Beacon Binary Format files.
+
+```sql
+SELECT * FROM read_bbf('bbf/**/*.bbf')
+```
+
+## `read_tiff`
+
+```text
+read_tiff(glob_paths)
+```
+
+Reads GeoTIFF and Cloud-Optimized GeoTIFF files.
+
+```sql
+SELECT * FROM read_tiff('rasters/elevation.tif')
+```
+
+### Tag attributes
+
+Per-band TIFF tags are exposed as additional columns using the pattern `<band>.<attribute>`. Attribute columns preserve the original type (string, integer, float, …). File-level tags not tied to a specific band use a leading dot with no band prefix: `.<attribute>`. Quote these column names because they contain a dot.
+
+```sql
+-- Band attribute
+SELECT band_1, "band_1.nodata", "band_1.scale"
+FROM read_tiff('rasters/elevation.tif')
+LIMIT 1
+
+-- File-level global tag
+SELECT ".crs", band_1
+FROM read_tiff('rasters/elevation.tif')
+LIMIT 1
+```
+
+## `read_delta`
+
+```text
+read_delta(location)
+read_delta(location, version_or_timestamp)
+```
+
+Reads a [Delta Lake](../data-lake/delta-lake.md) table. Unlike the other functions, `location` is a **single path to the Delta table directory** (the folder containing `_delta_log/`) — not a glob or a list. The schema is read from the transaction log.
+
+The optional second argument selects a snapshot for **time travel**:
+
+- an integer is a Delta **version** number, e.g. `12`
+- any other string is an RFC-3339 **timestamp** — the latest version at or before it
+
+```sql
+-- Latest version
+SELECT * FROM read_delta('delta/ocean_profiles') LIMIT 100
+
+-- Time travel to a specific version
+SELECT count(*) FROM read_delta('delta/ocean_profiles', 12)
+
+-- Time travel as of a timestamp
+SELECT * FROM read_delta('delta/ocean_profiles', '2026-01-01T00:00:00Z')
+```
+
+To register a Delta table persistently (and to `INSERT INTO` it), use [`CREATE EXTERNAL TABLE … STORED AS DELTA`](../data-lake/delta-lake.md).

--- a/docs/docs/1.8.0/sql/union-by-name.md
+++ b/docs/docs/1.8.0/sql/union-by-name.md
@@ -1,0 +1,75 @@
+# UNION ALL BY NAME
+
+`UNION ALL BY NAME` merges rows from multiple queries by matching columns by **name** rather than position. It is the standard way to harmonize datasets that share a common set of column names but may differ in column order, optional variables, or numeric precision.
+
+```sql
+SELECT * FROM read_netcdf(['argo/**/*.nc'])
+UNION ALL BY NAME
+SELECT * FROM read_netcdf(['wod/**/*.nc'])
+UNION ALL BY NAME
+SELECT * FROM read_netcdf(['cora/**/*.nc'])
+```
+
+## How it differs from plain `UNION ALL`
+
+| | `UNION ALL` | `UNION ALL BY NAME` |
+| --- | --- | --- |
+| Column matching | By position | By name |
+| Column order must match | Yes | No |
+| Missing columns | Error | Filled with `NULL` |
+| Type mismatches | Error | Widened automatically |
+
+## Missing columns become NULL
+
+If a column exists in one input but not another, the missing side is filled with `NULL` and the column is marked nullable in the result:
+
+```sql
+-- argo has 'salinity', wod does not
+SELECT * FROM argo_table
+UNION ALL BY NAME
+SELECT * FROM wod_table
+-- salinity is NULL for all wod rows
+```
+
+## Automatic type widening
+
+When the same column name has different numeric types across inputs, Beacon widens to a common supertype:
+
+| Left | Right | Result |
+| ---- | ----- | ------ |
+| `Float32` | `Float64` | `Float64` |
+| `Int8` | `Int32` | `Int32` |
+| `Int32` | `Int64` | `Int64` |
+| `Int32` | `Float64` | `Float64` |
+| `Utf8` | `LargeUtf8` | `LargeUtf8` |
+| `Date32` | `Date64` | `Date64` |
+| any | `Null` | the non-null type |
+
+Incompatible types (e.g. `Boolean` and `Int32`) produce a planning error.
+
+## Narrowing to a shared schema
+
+Select only the columns you want before the union to keep the output schema clean, regardless of what extra variables each source file contains:
+
+```sql
+SELECT time, latitude, longitude, temperature, salinity
+FROM read_netcdf(['argo/**/*.nc'])
+
+UNION ALL BY NAME
+
+SELECT time, latitude, longitude, temperature, salinity
+FROM read_netcdf(['wod/**/*.nc'])
+```
+
+## Persisting the result as a view
+
+Wrap the union in a `CREATE VIEW` to give it a stable name:
+
+```sql
+CREATE VIEW all_profiles AS
+    SELECT time, latitude, longitude, temperature, salinity
+    FROM read_netcdf(['argo/**/*.nc'])
+    UNION ALL BY NAME
+    SELECT time, latitude, longitude, temperature, salinity
+    FROM read_netcdf(['wod/**/*.nc'])
+```

--- a/docs/docs/1.8.0/sql/where.md
+++ b/docs/docs/1.8.0/sql/where.md
@@ -1,0 +1,82 @@
+# WHERE
+
+Filter rows by adding a `WHERE` clause after `FROM`:
+
+```sql
+SELECT *
+FROM ocean_profiles
+WHERE latitude  BETWEEN 50 AND 60
+  AND longitude BETWEEN -10 AND 10
+  AND time >= '2024-01-01'
+  AND temperature IS NOT NULL
+```
+
+## Comparison operators
+
+`=`, `!=`, `<`, `>`, `<=`, `>=` work on numbers, strings, and timestamps:
+
+```sql
+WHERE quality_flag = 1
+WHERE depth <= 200
+WHERE time > '2024-01-01'
+```
+
+## BETWEEN
+
+Inclusive range check:
+
+```sql
+WHERE depth BETWEEN 0 AND 200
+WHERE time BETWEEN '2024-01-01' AND '2024-12-31'
+WHERE latitude BETWEEN -60 AND 60
+```
+
+## IN
+
+Match against a list of values:
+
+```sql
+WHERE platform_code IN ('6900001', '6900002', '6900003')
+WHERE quality_flag IN (1, 2)
+```
+
+## LIKE
+
+Pattern matching — `%` matches any sequence of characters, `_` matches one character:
+
+```sql
+WHERE cruise_id LIKE '2024%'
+WHERE station_id LIKE 'ARGO___'
+```
+
+## IS NULL / IS NOT NULL
+
+```sql
+WHERE temperature IS NOT NULL
+WHERE doxy IS NULL
+```
+
+## AND / OR / NOT
+
+Combine conditions with logical operators:
+
+```sql
+WHERE temperature > 0 AND salinity > 30
+
+WHERE temperature < 0 OR depth > 500
+
+WHERE NOT (quality_flag = 9)
+
+WHERE depth BETWEEN 0 AND 200
+  AND (temperature IS NOT NULL OR salinity IS NOT NULL)
+```
+
+## Date and time filtering
+
+```sql
+WHERE time >= '2024-01-01'
+
+WHERE time BETWEEN '2024-01-01' AND '2024-12-31'
+
+WHERE DATE_TRUNC('month', time) = '2024-06-01'
+```

--- a/docs/docs/changelog/index.md
+++ b/docs/docs/changelog/index.md
@@ -1,10 +1,84 @@
 # Changelog
 
-> **Release posts:** [What's new since 1.7.0](/docs/changelog/release-1.7.0) · [What's new in 1.6.0](/docs/changelog/release-1.6.0)
+> **Release posts:** [What's new in 1.8.0](/docs/changelog/release-1.8.0) · [What's new since 1.7.0](/docs/changelog/release-1.7.0) · [What's new in 1.6.0](/docs/changelog/release-1.6.0)
 
 All notable changes to Beacon are documented here, newest first. Entries are
 grouped into **Added** (new features), **Changed** (behaviour or internal
 changes), and **Fixed** (bug fixes).
+
+## v1.8.0 — 2026-06-26
+
+### Added
+
+- **Lance-backed managed tables — the new default engine.** Managed tables
+  (`CREATE TABLE`) are now backed by [Lance](https://lancedb.github.io/lance/) by
+  default: fast local CRUD, native updates/deletes via deletion vectors, and
+  secondary `INDEX`es (btree, bitmap, full-text). [Apache Iceberg](https://iceberg.apache.org/)
+  remains available for object-store/cloud deployments. Pick the engine per
+  session with `SET beacon.table_engine = 'lance' | 'iceberg'`, or set the
+  deployment-wide default with `BEACON_DEFAULT_TABLE_ENGINE`. See
+  [CREATE TABLE (Managed)](/docs/1.8.0/sql/managed-tables).
+- **Delta Lake tables.** Read [Delta Lake](https://delta.io/) tables in place with
+  `read_delta()` or `CREATE EXTERNAL TABLE … STORED AS DELTA`, including time
+  travel, and append with `INSERT INTO`. See the
+  [Delta Lake chapter](/docs/1.8.0/data-lake/delta-lake).
+- **PostgreSQL / MySQL external tables.** `CREATE EXTERNAL TABLE … STORED AS
+  POSTGRES | MYSQL` registers a federated pointer at a table in an external
+  relational database; Beacon pushes filters, projected columns, `LIMIT`, and
+  aggregates down to the source. Passwords are encrypted at rest with
+  `BEACON_SECRETS_KEY`. See the
+  [SQL Databases chapter](/docs/1.8.0/data-lake/sql-databases).
+- **Crawlers.** `CREATE CRAWLER` discovers files in the datasets store and
+  registers external tables automatically — AWS Glue-style — with partition
+  detection and triggers, plus admin REST endpoints to list, run, and delete
+  them. See the [Crawlers chapter](/docs/1.8.0/data-lake/crawlers).
+- **Admin Web UI.** A React admin console is now bundled into the Beacon server
+  and Docker image and served at `/admin`: an Athena-style SQL workbench plus
+  pages to manage tables, datasets, crawlers, and external tables. See the
+  [Admin Web UI guide](/docs/1.8.0/connect/web-admin-ui).
+- **TypeScript / JavaScript SDK** (`@beacon/client`). An isomorphic SDK for
+  Node.js and the browser, with an EF Core / LINQ-style query builder and Arrow
+  result decoding. See the [TypeScript SDK guide](/docs/1.8.0/connect/beacon-typescript-sdk).
+- **`beacon-cli`.** A Python terminal client (interactive REPL and one-shot
+  subcommands) that runs SQL, explores tables / datasets / schemas, and exports
+  to CSV, Parquet, Arrow IPC, or NetCDF. See the
+  [Beacon CLI guide](/docs/1.8.0/connect/beacon-cli).
+- **`EXPLAIN ANALYZE` endpoint.** `POST /api/explain-analyze-query` runs a query
+  and returns the physical plan annotated with per-operator runtime metrics
+  (rows, bytes, time). See the [API querying chapter](/docs/1.8.0/api/querying/).
+- **Per-format configuration & per-table `OPTIONS`.** NetCDF, Atlas, and BBF
+  accept per-format configuration and per-table `OPTIONS (...)` clauses.
+- **Broadcast-compatible `SELECT *` for n-dimensional data.** `SELECT *` over
+  NetCDF and Zarr datasets auto-narrows to a broadcast-compatible default set of
+  dimensions, with the selection now robust across irregular variable shapes.
+
+### Changed
+
+- **Runtime-owned configuration.** Configuration is threaded through
+  `Runtime::new(Arc<Config>)` instead of being process-global. The storage config
+  owns the data directories and optional S3 settings, with `S3Config` as the
+  single source of truth for object storage.
+- **Slimmer data lake.** The bespoke `TableManager` / `FileManager` / `DataLake`
+  layers were replaced with a native DataFusion `SessionContext`.
+- **`table-config` is now an admin-only REST endpoint** (`GET /api/admin/table-config`).
+- **Legacy logical tables are read as external tables**, so tables created by
+  older versions keep resolving.
+- **Reduced dependencies and tuned the build** for faster compile times; the
+  `beacon-iceberg` crate moved under `beacon-file-formats/`.
+- **File-format table functions accept a single path/glob string** in addition to
+  a list, and the dataset-schema endpoint now accepts `.tif` as well as `.tiff`.
+- **Enriched OpenAPI / Swagger documentation** for the REST API.
+
+### Fixed
+
+- A batch of bugs surfaced by an expanded integration-test suite: CTAS / `INSERT`
+  row truncation, Lance string-predicate `UPDATE` / `DELETE`, `ALTER TABLE ADD
+  COLUMN` for `VARCHAR` / `Utf8View`, inverted-index lookups, MySQL TLS
+  connections, Delta `INSERT` reopen, n-dimensional `count(*)` returning `0`,
+  PostgreSQL / MySQL federated execution, NetCDF explicit-dimension subsetting,
+  and `read_zarr` directory listing.
+- **`EXPLAIN ANALYZE` panic** over external NetCDF / n-dimensional tables.
+- **Root redirect** now always points to the Swagger UI.
 
 ## v1.7.3 — 2026-06-19
 

--- a/docs/docs/changelog/index.md
+++ b/docs/docs/changelog/index.md
@@ -6,10 +6,20 @@ All notable changes to Beacon are documented here, newest first. Entries are
 grouped into **Added** (new features), **Changed** (behaviour or internal
 changes), and **Fixed** (bug fixes).
 
-## v1.8.0 — 2026-06-26
+## v1.8.0 — 2026-06-27
 
 ### Added
 
+- **Authentication & role-based access control.** Beacon gains a built-in
+  auth/RBAC layer: a single config-defined super-user (`BEACON_ADMIN_*`) that owns
+  all writes and management, read-only SQL-managed users and roles
+  (`CREATE USER` / `CREATE ROLE` / `GRANT` / `DENY` / `REVOKE`), and `SELECT`
+  grants/denies scoped to tables (`ON TABLE`) or file globs (`ON PATH`) with
+  deny-wins, default-deny evaluation. Enforcement is opt-in
+  (`BEACON_AUTH_ENFORCE`), anonymous access is configurable
+  (`BEACON_AUTH_ANONYMOUS_ENABLED`), and **OIDC** bearer tokens are supported
+  (`BEACON_OIDC_*`) with Beacon still owning the grant model. See the
+  [Access Control guide](/docs/1.8.0/security/access-control).
 - **Lance-backed managed tables — the new default engine.** Managed tables
   (`CREATE TABLE`) are now backed by [Lance](https://lancedb.github.io/lance/) by
   default: fast local CRUD, native updates/deletes via deletion vectors, and
@@ -79,6 +89,10 @@ changes), and **Fixed** (bug fixes).
   and `read_zarr` directory listing.
 - **`EXPLAIN ANALYZE` panic** over external NetCDF / n-dimensional tables.
 - **Root redirect** now always points to the Swagger UI.
+- **Clear error for output formats on non-`SELECT` statements.** Requesting an
+  output format for a statement that produces no result set (DDL/DML) now returns
+  an explanatory error instead of failing obscurely.
+- **`super_type` Arrow coercion bugs** surfaced by expanded unit-test coverage.
 
 ## v1.7.3 — 2026-06-19
 

--- a/docs/docs/changelog/release-1.8.0.md
+++ b/docs/docs/changelog/release-1.8.0.md
@@ -4,9 +4,9 @@ Beacon is an open-source data lakehouse query engine for scientific and climate
 data, with native subsetting over NetCDF, Zarr, Parquet, Arrow IPC, CSV,
 GeoTIFF, GeoParquet, Atlas and BBF. 1.8.0 is a big one: managed tables get a
 fast new **Lance** engine, Beacon learns to read **Delta Lake** and **federate to
-PostgreSQL/MySQL**, file discovery is automated with **crawlers**, and the server
-now ships a bundled **admin web UI** alongside a new **TypeScript SDK** and a
-**Python CLI**.
+PostgreSQL/MySQL**, file discovery is automated with **crawlers**, the server now
+ships a bundled **admin web UI** alongside a new **TypeScript SDK** and a **Python
+CLI**, and a built-in **authentication & role-based access control** layer lands.
 
 Here's everything that landed.
 
@@ -162,6 +162,36 @@ Two new ways to talk to Beacon from outside the browser:
   tables/datasets/schemas, render results in the terminal, and export to CSV,
   Parquet, Arrow IPC, or NetCDF without leaving the shell.
 
+## Authentication & role-based access control
+
+Beacon now has a built-in **authentication and RBAC** layer. The model is small
+on purpose:
+
+- A **single super-user**, defined entirely by configuration
+  (`BEACON_ADMIN_USERNAME` / `BEACON_ADMIN_PASSWORD`), owns every write and all
+  management and bypasses authorization. It is a fixed credential, never a stored
+  user — so you can't create a second super-user through SQL.
+- **Users and roles created through SQL are read-only.** Authorization governs
+  *reads*; grants and denies attach to roles and are scoped to tables or file
+  globs, evaluated **deny-wins, default-deny**.
+
+```sql
+CREATE ROLE reader;
+GRANT SELECT ON TABLE observations TO ROLE reader;
+GRANT SELECT ON PATH 'argo/**/*.nc'   TO ROLE reader;
+DENY  SELECT ON PATH 'argo/restricted/*' TO ROLE reader;   -- deny-wins
+
+CREATE USER alice WITH PASSWORD 'secret';
+GRANT ROLE reader TO USER alice;
+```
+
+Enforcement is opt-in (`BEACON_AUTH_ENFORCE=true`) so existing deployments stay
+open until you turn it on, and anonymous access is configurable — assign roles to
+the built-in `anonymous` user to control what unauthenticated callers can read.
+For single sign-on, Beacon validates **OIDC bearer tokens** (`BEACON_OIDC_*`),
+taking the identity and role names from the token while still owning the grants.
+Full details are in the [Access Control guide](/docs/1.8.0/security/access-control).
+
 ## EXPLAIN ANALYZE over the API
 
 Performance work gets a new endpoint: `POST /api/explain-analyze-query` **runs**
@@ -204,6 +234,9 @@ the [changelog](/docs/changelog/).
   to stay on Iceberg.
 - **PostgreSQL/MySQL external tables** require `BEACON_SECRETS_KEY` to be set when
   a `password` is supplied — `CREATE` fails closed without it.
+- **Access control is opt-in.** Existing deployments are unaffected until you set
+  `BEACON_AUTH_ENFORCE=true`. As always, change the default `BEACON_ADMIN_*`
+  credentials before exposing Beacon.
 
 ---
 

--- a/docs/docs/changelog/release-1.8.0.md
+++ b/docs/docs/changelog/release-1.8.0.md
@@ -1,0 +1,211 @@
+# What's new in Beacon 1.8.0 — Lance tables, Delta Lake, database federation, and an admin UI
+
+Beacon is an open-source data lakehouse query engine for scientific and climate
+data, with native subsetting over NetCDF, Zarr, Parquet, Arrow IPC, CSV,
+GeoTIFF, GeoParquet, Atlas and BBF. 1.8.0 is a big one: managed tables get a
+fast new **Lance** engine, Beacon learns to read **Delta Lake** and **federate to
+PostgreSQL/MySQL**, file discovery is automated with **crawlers**, and the server
+now ships a bundled **admin web UI** alongside a new **TypeScript SDK** and a
+**Python CLI**.
+
+Here's everything that landed.
+
+## Lance-backed managed tables — a new default engine
+
+Managed tables — the ones you create with `CREATE TABLE` and own, mutate, and
+index — are now backed by [**Lance**](https://lancedb.github.io/lance/) by
+default. Lance gives them fast local CRUD, native updates and deletes via
+deletion vectors, and **secondary indexes**:
+
+```sql
+CREATE TABLE observations (id BIGINT, platform VARCHAR, temperature DOUBLE);
+
+INSERT INTO observations VALUES (1, 'argo', 12.5), (2, 'glider', 9.0);
+UPDATE observations SET temperature = 12.6 WHERE id = 1;
+DELETE FROM observations WHERE temperature < 10;
+
+-- Secondary indexes: btree, bitmap, and full-text
+CREATE INDEX ON observations (platform);
+```
+
+The [**Apache Iceberg**](https://iceberg.apache.org/) engine introduced in 1.7 is
+still here for object-store and cloud deployments, where table data and metadata
+live alongside your datasets on S3. You choose per session — or set a
+deployment-wide default:
+
+```sql
+SET beacon.table_engine = 'iceberg';   -- next CREATE TABLE is Iceberg-backed
+SET beacon.table_engine = 'lance';     -- back to the default
+```
+
+```bash
+# Or deployment-wide:
+BEACON_DEFAULT_TABLE_ENGINE=iceberg
+```
+
+Lance tables live on the local filesystem (the tables directory) even when your
+datasets are on S3; if you want managed tables on object storage, use Iceberg.
+The full reference is in [CREATE TABLE (Managed)](/docs/1.8.0/sql/managed-tables).
+
+## Delta Lake
+
+Beacon can now read [**Delta Lake**](https://delta.io/) tables in place — locally
+or on S3 — with the `read_delta()` table function or a `STORED AS DELTA` external
+table, including **time travel** and **appends**:
+
+```sql
+-- Read the current version ad-hoc
+SELECT count(*) FROM read_delta('delta/ocean_profiles');
+
+-- Register it (optionally pinned to a historical snapshot via OPTIONS), then append
+CREATE EXTERNAL TABLE events STORED AS DELTA LOCATION 'delta/events';
+INSERT INTO events SELECT * FROM read_parquet('new/*.parquet');
+
+-- Time travel: register the table as it looked at a past version or timestamp
+CREATE EXTERNAL TABLE events_v12
+STORED AS DELTA LOCATION 'delta/events'
+OPTIONS ('version' '12');
+```
+
+Beacon reads the Delta transaction log to resolve exactly which Parquet files
+make up the current (or a historical) version, and injects its own object store
+so local and S3 Delta tables both work through the same path. See the
+[Delta Lake chapter](/docs/1.8.0/data-lake/delta-lake).
+
+## Query PostgreSQL and MySQL directly
+
+External tables can now point at a table in an external **PostgreSQL** or
+**MySQL** database. Once registered you `SELECT`, `JOIN`, and aggregate it like
+any other table, but the data stays in the source database — Beacon pushes
+filters, projected columns, `LIMIT`, and aggregates **down to the database** so
+only the reduced result crosses the wire:
+
+```sql
+CREATE EXTERNAL TABLE orders
+STORED AS POSTGRES
+LOCATION 'public.orders'
+OPTIONS (
+  'host' 'db.internal',
+  'port' '5432',
+  'user' 'beacon_ro',
+  'password' 'secret',
+  'database' 'shop'
+);
+
+-- Join a relational table against your in-place scientific data
+SELECT o.region, avg(m.temperature)
+FROM orders o JOIN read_netcdf('argo/*.nc') m ON o.station = m.platform
+GROUP BY o.region;
+```
+
+The `password` option is **encrypted at rest** with a deployment master key
+(`BEACON_SECRETS_KEY`) and never returned by the API. This is built on
+DataFusion's federation layer — the same pushdown mechanism behind 1.7's remote
+tables. See the [SQL Databases chapter](/docs/1.8.0/data-lake/sql-databases).
+
+## Crawlers — automatic external-table discovery
+
+Pointing Beacon at a bucket of files no longer means writing a `CREATE EXTERNAL
+TABLE` by hand. A **crawler** scans the datasets store, infers a merged schema,
+detects partitions, and registers external tables for you — AWS Glue-style:
+
+```sql
+CREATE CRAWLER argo
+ON 'argo/'
+WITH ('format' 'nc', 'detect_partitions' 'true', 'schedule' '15m');
+
+RUN CRAWLER argo;     -- discover files and (re)register the tables
+SHOW CRAWLERS;
+```
+
+Crawlers support partition detection and triggers, and can be managed over admin
+REST endpoints (and from the new web UI). See the
+[Crawlers chapter](/docs/1.8.0/data-lake/crawlers).
+
+## A bundled admin web UI
+
+Beacon now ships an **admin web interface** built into the server and the Docker
+image — no extra deployment. When present, it's served at **`/admin`**:
+
+```
+http://localhost:5001/admin
+```
+
+It's an Athena-style console: a SQL workbench with a searchable data panel, a
+CodeMirror editor (run with ⌘/Ctrl + Enter), a results grid, CSV/Parquet
+download, and an **Explain** plan tree — plus pages to manage tables, datasets,
+crawlers, and external tables. The UI is admin-only (gated by the
+`BEACON_ADMIN_USERNAME` / `BEACON_ADMIN_PASSWORD` credentials) and is built
+entirely on the new TypeScript SDK. See the
+[Admin Web UI guide](/docs/1.8.0/connect/web-admin-ui).
+
+## New clients: a TypeScript SDK and a Python CLI
+
+Two new ways to talk to Beacon from outside the browser:
+
+- **`@beacon/client`** — an isomorphic [**TypeScript/JavaScript SDK**](/docs/1.8.0/connect/beacon-typescript-sdk)
+  for Node.js and the browser. It runs SQL or the JSON DSL, decodes the
+  zstd-compressed Arrow result stream into plain JS objects, and ships an EF
+  Core / LINQ-style fluent query builder:
+
+  ```ts
+  const { rows } = await beacon
+    .from({ netcdf: { paths: ["argo.nc"] } })
+    .select("TEMP", column("PSAL", "salinity"))
+    .where((x) => x.depth.gte(0).and(x.depth.lte(100)))
+    .take(100)
+    .execute();
+  ```
+
+- **`beacon-cli`** — a [**Python terminal client**](/docs/1.8.0/connect/beacon-cli)
+  with an interactive REPL and one-shot subcommands. Run SQL, explore
+  tables/datasets/schemas, render results in the terminal, and export to CSV,
+  Parquet, Arrow IPC, or NetCDF without leaving the shell.
+
+## EXPLAIN ANALYZE over the API
+
+Performance work gets a new endpoint: `POST /api/explain-analyze-query` **runs**
+a query and returns the physical plan annotated with per-operator runtime metrics
+— rows, bytes, and time per node — the analog of SQL `EXPLAIN ANALYZE`. It sits
+alongside the existing `POST /api/explain-query` (plan only, no execution). See
+the [API querying chapter](/docs/1.8.0/api/querying/).
+
+## Under the hood
+
+A round of internal work makes Beacon leaner and easier to operate:
+
+- **Runtime-owned configuration.** Config is now threaded through
+  `Runtime::new(Arc<Config>)` rather than being process-global, with `S3Config`
+  the single source of truth for object storage and the storage config owning all
+  data directories.
+- **A slimmer data lake.** The bespoke `TableManager` / `FileManager` / `DataLake`
+  layers were replaced with a native DataFusion `SessionContext`.
+- **Per-format configuration & per-table `OPTIONS`** for NetCDF, Atlas, and BBF.
+- **Faster builds.** Dependencies were trimmed and the build tuned for compile
+  time; `table-config` moved to an admin-only REST endpoint; and the REST API's
+  OpenAPI/Swagger documentation was enriched.
+
+## Fixes
+
+1.8.0 also lands a batch of correctness fixes surfaced by a much-expanded
+integration-test suite — CTAS/`INSERT` row truncation, Lance string-predicate
+`UPDATE`/`DELETE`, `ALTER TABLE ADD COLUMN` for text types, MySQL TLS
+connections, Delta `INSERT` reopen, n-dimensional `count(*)`, PostgreSQL/MySQL
+federated execution, NetCDF explicit-dimension subsetting, `read_zarr` listing,
+and an `EXPLAIN ANALYZE` panic over external NetCDF tables. The full list is in
+the [changelog](/docs/changelog/).
+
+## Upgrading
+
+- **Datasets and external tables** (NetCDF, Zarr, Parquet, Atlas, Delta, …) are
+  unaffected and need no migration.
+- **Managed tables** default to the new **Lance** engine. Existing Iceberg tables
+  keep working; set `BEACON_DEFAULT_TABLE_ENGINE=iceberg` if you want new tables
+  to stay on Iceberg.
+- **PostgreSQL/MySQL external tables** require `BEACON_SECRETS_KEY` to be set when
+  a `password` is supplied — `CREATE` fails closed without it.
+
+---
+
+Full details are in the [changelog](/docs/changelog/) and on the
+[GitHub release page](https://github.com/maris-development/beacon/releases).

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,10 +11,10 @@ hero:
   actions:
     - theme: brand
       text: Get Started
-      link: /docs/1.7.3/getting-started
+      link: /docs/1.8.0/getting-started
     - theme: alt
       text: Read the Docs
-      link: /docs/1.7.3/introduction
+      link: /docs/1.8.0/introduction
     - theme: alt
       text: Explore Public Nodes 
       link: /available-nodes/available-nodes

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -169,7 +169,6 @@
       "integrity": "sha512-Mw6pAUF121MfngQtcUb5quZVqMC68pSYYjCRZkSITC085S3zdk+h/g7i6FxnVdbSU6OztxikSDMh1r7Z+4iPlA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.40.1",
         "@algolia/requester-browser-xhr": "5.40.1",
@@ -1519,7 +1518,6 @@
       "integrity": "sha512-iUNxcXUNg9085TJx0HJLjqtDE0r1RZ0GOGrt8KNQqQT5ugu8lZsHuMUYW/e0lHhq6xBvmktU9Bw4CXP9VQeKrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.6.1",
         "@algolia/client-abtesting": "5.40.1",
@@ -1713,7 +1711,6 @@
       "integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -2330,7 +2327,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -2433,7 +2429,6 @@
       "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.22",
         "@vue/compiler-sfc": "3.5.22",

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -3,11 +3,11 @@
 > Beacon is a high-performance, open-source (AGPL-3.0) data lakehouse query engine for scientific and climate data. Point it at existing files — NetCDF, Zarr, Parquet, GeoTIFF/COG, CSV, ODV ASCII, Arrow IPC, Atlas and BBF — on local storage or S3, and query them in place over SQL or a JSON API, with no data migration. Built in Rust on Apache Arrow and DataFusion.
 
 ## Documentation
-- [Introduction](https://maris-development.github.io/beacon/docs/1.7.3/introduction.html): What Beacon is and how a query flows through it.
-- [Getting started](https://maris-development.github.io/beacon/docs/1.7.3/getting-started.html): Run Beacon with Docker, locally or against S3.
-- [SQL guide](https://maris-development.github.io/beacon/docs/1.7.3/sql/): SELECT/WHERE/GROUP BY/JOIN, table functions, DDL, and the function reference.
-- [Data lakehouse setup](https://maris-development.github.io/beacon/docs/1.7.3/data-lake/): Supported formats, external tables, managed (Iceberg) tables, views, configuration, performance tuning.
-- [REST API](https://maris-development.github.io/beacon/docs/1.7.3/api/): HTTP query API (SQL and JSON DSL) and output formats.
+- [Introduction](https://maris-development.github.io/beacon/docs/1.8.0/introduction.html): What Beacon is and how a query flows through it.
+- [Getting started](https://maris-development.github.io/beacon/docs/1.8.0/getting-started.html): Run Beacon with Docker, locally or against S3.
+- [SQL guide](https://maris-development.github.io/beacon/docs/1.8.0/sql/): SELECT/WHERE/GROUP BY/JOIN, table functions, DDL, and the function reference.
+- [Data lakehouse setup](https://maris-development.github.io/beacon/docs/1.8.0/data-lake/): Supported formats, external tables, managed (Lance/Iceberg) tables, views, configuration, performance tuning.
+- [REST API](https://maris-development.github.io/beacon/docs/1.8.0/api/): HTTP query API (SQL and JSON DSL) and output formats.
 - [Changelog](https://maris-development.github.io/beacon/docs/changelog): Release history.
 
 ## Key facts


### PR DESCRIPTION
Prepares the **1.8.0** release: version bump, changelog, release blog, and versioned docs.

## Changes

**Version**
- Bump `1.7.3` → `1.8.0` in `beacon-core`, `beacon-common`, `beacon-api` (`beacon_version()` reports `CARGO_PKG_VERSION`).

**Changelog & blog**
- Add `v1.8.0 — 2026-06-26` entry to `docs/docs/changelog/index.md` (Added / Changed / Fixed), covering every commit since the `v1.7.3` tag.
- Add release blog `docs/docs/changelog/release-1.8.0.md`.

**Versioned docs**
- Add `docs/docs/1.8.0/` (copy of `1.7.3`, internal links rewritten).
- New pages for previously-undocumented flagship features:
  - `connect/beacon-typescript-sdk.md` (`@beacon/client`)
  - `connect/web-admin-ui.md` (bundled `/admin` UI)

**Site config & links**
- `docs/.vitepress/config.mts`: nav shows `1.8.0 (latest)` (1.7.3 kept reachable), new `/docs/1.8.0/` sidebar block, changelog release-posts + version list updated.
- Bump latest-pointing links in `README.md`, `QUICKSTART.md`, `docs/index.md`, `docs/public/llms.txt`.

## Release highlights documented
Lance-backed managed tables (new default engine), Delta Lake, PostgreSQL/MySQL federated external tables, crawlers, the bundled admin web UI, the TypeScript SDK, `beacon-cli`, the `EXPLAIN ANALYZE` endpoint, per-format config/OPTIONS, and a batch of integration-test fixes.

## Notes
- Every SQL snippet in the blog was cross-checked against the reference docs (corrected Delta time-travel `OPTIONS ('version' …)` and crawler `ON … WITH (…)` syntax).
- Versioning follows the docs/changelog `1.x` line (latest documented was `1.7.3`).
- Docs build not run locally (deps not installed); config validated by parsing.