### PR TITLE
Admin UI: dataset file management, resumable uploads, RBAC UI, SQL autocomplete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "beacon-api"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "arrow 58.3.0",
@@ -1295,6 +1295,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
+ "tempfile",
  "tikv-jemallocator",
  "tokio",
  "tokio-util",
@@ -1596,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "beacon-common"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -1631,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "beacon-core"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "arrow 58.3.0",
@@ -1658,6 +1659,7 @@ dependencies = [
  "beacon-lance",
  "beacon-object-storage",
  "beacon-sql-databases",
+ "bytes",
  "cast",
  "chrono",
  "datafusion",
@@ -1672,6 +1674,7 @@ dependencies = [
  "serde_json",
  "sysinfo",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",

--- a/beacon-api/Cargo.toml
+++ b/beacon-api/Cargo.toml
@@ -52,3 +52,5 @@ beacon-core = { path = "../beacon-core" }
 beacon-core = { path = "../beacon-core", features = ["test-util"] }
 # `tower::ServiceExt::oneshot` for driving the axum router in the HTTP auth tests.
 tower = { version = "0.5", features = ["util"] }
+# Temp storage roots for the admin dataset file-management HTTP tests.
+tempfile = { workspace = true }

--- a/beacon-api/src/axum/admin/auth.rs
+++ b/beacon-api/src/axum/admin/auth.rs
@@ -1,0 +1,44 @@
+//! Read-only admin endpoints exposing the auth model (users + roles) so the web
+//! UI can render current state. Mutations (CREATE USER / ROLE, GRANT, DENY, …)
+//! are performed through the SQL query endpoint as the super-user; there is no
+//! write endpoint here.
+
+use std::sync::Arc;
+
+use ::axum::{extract::State, http::StatusCode, Json};
+use beacon_core::api::{AuthRoleView, AuthUserView};
+use beacon_core::runtime::Runtime;
+
+use super::bad_request;
+
+/// Lists all principals: the config super-user (flagged) plus stored local users
+/// with their roles.
+#[tracing::instrument(level = "info", skip(state))]
+#[utoipa::path(
+    tag = "admin",
+    get,
+    path = "/api/admin/auth/users",
+    responses(
+        (status = 200, description = "Users with their roles", body = Vec<AuthUserView>),
+        (status = 400, description = "Failed to enumerate users")
+    ),
+    security(("basic-auth" = []))
+)]
+pub(crate) async fn list_users(
+    State(state): State<Arc<Runtime>>,
+) -> Result<Json<Vec<AuthUserView>>, (StatusCode, String)> {
+    state.list_auth_users().map(Json).map_err(bad_request)
+}
+
+/// Lists all roles with their grant and deny rules.
+#[tracing::instrument(level = "info", skip(state))]
+#[utoipa::path(
+    tag = "admin",
+    get,
+    path = "/api/admin/auth/roles",
+    responses((status = 200, description = "Roles with their rules", body = Vec<AuthRoleView>)),
+    security(("basic-auth" = []))
+)]
+pub(crate) async fn list_roles(State(state): State<Arc<Runtime>>) -> Json<Vec<AuthRoleView>> {
+    Json(state.list_auth_roles())
+}

--- a/beacon-api/src/axum/admin/datasets.rs
+++ b/beacon-api/src/axum/admin/datasets.rs
@@ -1,0 +1,320 @@
+//! Authenticated dataset file-management endpoints (upload / download / delete).
+//!
+//! These operate on the datasets store through the runtime, which owns the path
+//! safety, extension allowlist, size cap, and delete dependency check. All three
+//! routes sit behind the super-user `basic_auth` gate attached in `setup_router`.
+
+use std::sync::Arc;
+
+use ::axum::{
+    body::{to_bytes, Body},
+    extract::{Query, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use beacon_core::dataset_files::{FileError, UploadResult};
+use beacon_core::runtime::Runtime;
+use futures::TryStreamExt;
+
+/// Hard cap on a single chunked-upload part's body, bounding per-request memory
+/// (each part is buffered in full to make it atomically retryable). Generously
+/// above the advertised part size so a client choosing a larger part still works.
+const MAX_PART_BYTES: usize = 128 * 1024 * 1024;
+
+/// Query parameters for an upload: destination key plus an optional overwrite flag.
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct UploadParams {
+    /// Destination key relative to the datasets root, e.g. `ctd/cruise42/a.nc`.
+    path: String,
+    /// Replace an existing file instead of failing with `409`. Defaults to false.
+    #[serde(default)]
+    overwrite: bool,
+}
+
+/// Query parameters for download/delete: the dataset key.
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct PathParams {
+    /// Dataset key relative to the datasets root.
+    path: String,
+}
+
+/// Streams an uploaded file into the datasets store.
+///
+/// The body is the raw file bytes, streamed straight into a multipart writer so
+/// memory stays flat for large scientific files. The runtime validates the path
+/// (anti-traversal, internal-prefix guard), checks the extension against the
+/// readable-format allowlist, and enforces `BEACON_MAX_UPLOAD_BYTES`.
+#[tracing::instrument(level = "info", skip(state, body))]
+#[utoipa::path(
+    tag = "admin",
+    post,
+    path = "/api/admin/datasets/upload",
+    params(
+        ("path" = String, Query, description = "Destination key relative to the datasets root"),
+        ("overwrite" = Option<bool>, Query, description = "Replace an existing file (default false)")
+    ),
+    request_body(content = Vec<u8>, description = "Raw file bytes", content_type = "application/octet-stream"),
+    responses(
+        (status = 200, description = "File uploaded", body = UploadResult),
+        (status = 400, description = "Invalid path or unsupported extension"),
+        (status = 409, description = "A file already exists at the destination"),
+        (status = 413, description = "File exceeds the maximum upload size")
+    ),
+    security(("basic-auth" = []))
+)]
+pub(crate) async fn upload_dataset(
+    State(state): State<Arc<Runtime>>,
+    Query(params): Query<UploadParams>,
+    body: Body,
+) -> Result<Json<UploadResult>, (StatusCode, String)> {
+    let stream = body.into_data_stream().map_err(std::io::Error::other);
+    let result = state
+        .upload_dataset(&params.path, params.overwrite, stream)
+        .await
+        .map_err(file_error)?;
+    Ok(Json(result))
+}
+
+/// Streams a dataset file back to the caller as an attachment.
+#[tracing::instrument(level = "info", skip(state))]
+#[utoipa::path(
+    tag = "admin",
+    get,
+    path = "/api/admin/datasets/download",
+    params(("path" = String, Query, description = "Dataset key relative to the datasets root")),
+    responses(
+        (status = 200, description = "File contents", content_type = "application/octet-stream"),
+        (status = 400, description = "Invalid path"),
+        (status = 404, description = "Dataset not found")
+    ),
+    security(("basic-auth" = []))
+)]
+pub(crate) async fn download_dataset(
+    State(state): State<Arc<Runtime>>,
+    Query(params): Query<PathParams>,
+) -> Result<Response, (StatusCode, String)> {
+    let result = state.download_dataset(&params.path).await.map_err(file_error)?;
+    let size = result.meta.size;
+    let filename = attachment_filename(&params.path);
+    let body = Body::from_stream(result.into_stream());
+
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/octet-stream".to_string()),
+            (
+                header::CONTENT_DISPOSITION,
+                format!("attachment; filename=\"{filename}\""),
+            ),
+            (header::CONTENT_LENGTH, size.to_string()),
+        ],
+        body,
+    )
+        .into_response())
+}
+
+/// Query parameters identifying a chunked upload and a part within it.
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct PartParams {
+    /// The session id returned by `initiate`.
+    upload_id: String,
+    /// 1-based part number; parts must be submitted in order.
+    part_number: u32,
+}
+
+/// Query parameters identifying a chunked upload session.
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct UploadIdParams {
+    upload_id: String,
+}
+
+/// Response from initiating a chunked upload.
+#[derive(serde::Serialize, utoipa::ToSchema)]
+pub(crate) struct InitiateResult {
+    /// Session id to pass to subsequent part/complete/abort calls.
+    upload_id: String,
+    /// Size, in bytes, clients should slice the file into for each part.
+    part_size: usize,
+}
+
+/// Begins a chunked (resumable) upload for a large file.
+///
+/// The client then PUTs each part to `…/upload/part` in order and finishes with
+/// `…/upload/complete` (or `DELETE …/upload` to abort). Path/extension/overwrite
+/// are validated here, up front, before any part is accepted.
+#[tracing::instrument(level = "info", skip(state))]
+#[utoipa::path(
+    tag = "admin",
+    post,
+    path = "/api/admin/datasets/upload/initiate",
+    params(
+        ("path" = String, Query, description = "Destination key relative to the datasets root"),
+        ("overwrite" = Option<bool>, Query, description = "Replace an existing file (default false)")
+    ),
+    responses(
+        (status = 200, description = "Upload session created", body = InitiateResult),
+        (status = 400, description = "Invalid path or unsupported extension"),
+        (status = 409, description = "A file already exists at the destination")
+    ),
+    security(("basic-auth" = []))
+)]
+pub(crate) async fn initiate_upload(
+    State(state): State<Arc<Runtime>>,
+    Query(params): Query<UploadParams>,
+) -> Result<Json<InitiateResult>, (StatusCode, String)> {
+    let (id, part_size) = state
+        .initiate_dataset_upload(&params.path, params.overwrite)
+        .await
+        .map_err(file_error)?;
+    Ok(Json(InitiateResult {
+        upload_id: id.to_string(),
+        part_size,
+    }))
+}
+
+/// Submits one part of a chunked upload. The body is the raw bytes of the part;
+/// it is buffered in full (bounded by `MAX_PART_BYTES`) so the part is atomic and
+/// can be safely retried by resending the same `part_number`.
+#[tracing::instrument(level = "info", skip(state, body))]
+#[utoipa::path(
+    tag = "admin",
+    put,
+    path = "/api/admin/datasets/upload/part",
+    params(
+        ("upload_id" = String, Query, description = "Session id from initiate"),
+        ("part_number" = u32, Query, description = "1-based part number, submitted in order")
+    ),
+    request_body(content = Vec<u8>, description = "Raw part bytes", content_type = "application/octet-stream"),
+    responses(
+        (status = 204, description = "Part accepted"),
+        (status = 404, description = "Unknown or expired upload session"),
+        (status = 409, description = "Part out of order"),
+        (status = 413, description = "Part or cumulative size exceeds the limit")
+    ),
+    security(("basic-auth" = []))
+)]
+pub(crate) async fn upload_part(
+    State(state): State<Arc<Runtime>>,
+    Query(params): Query<PartParams>,
+    body: Body,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let id = parse_upload_id(&params.upload_id)?;
+    let bytes = to_bytes(body, MAX_PART_BYTES).await.map_err(|_| {
+        (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!("upload part exceeds the maximum part size of {MAX_PART_BYTES} bytes"),
+        )
+    })?;
+    state
+        .upload_dataset_part(id, params.part_number, bytes)
+        .await
+        .map_err(file_error)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Finalizes a chunked upload, assembling the parts into the destination object.
+#[tracing::instrument(level = "info", skip(state))]
+#[utoipa::path(
+    tag = "admin",
+    post,
+    path = "/api/admin/datasets/upload/complete",
+    params(("upload_id" = String, Query, description = "Session id from initiate")),
+    responses(
+        (status = 200, description = "Upload completed", body = UploadResult),
+        (status = 404, description = "Unknown or expired upload session")
+    ),
+    security(("basic-auth" = []))
+)]
+pub(crate) async fn complete_upload(
+    State(state): State<Arc<Runtime>>,
+    Query(params): Query<UploadIdParams>,
+) -> Result<Json<UploadResult>, (StatusCode, String)> {
+    let id = parse_upload_id(&params.upload_id)?;
+    let result = state.complete_dataset_upload(id).await.map_err(file_error)?;
+    Ok(Json(result))
+}
+
+/// Aborts and discards an in-progress chunked upload.
+#[tracing::instrument(level = "info", skip(state))]
+#[utoipa::path(
+    tag = "admin",
+    delete,
+    path = "/api/admin/datasets/upload",
+    params(("upload_id" = String, Query, description = "Session id from initiate")),
+    responses(
+        (status = 204, description = "Upload aborted"),
+        (status = 404, description = "Unknown or expired upload session")
+    ),
+    security(("basic-auth" = []))
+)]
+pub(crate) async fn abort_upload(
+    State(state): State<Arc<Runtime>>,
+    Query(params): Query<UploadIdParams>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let id = parse_upload_id(&params.upload_id)?;
+    state.abort_dataset_upload(id).await.map_err(file_error)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Parse an `upload_id` query value into a UUID, mapping a malformed id to `400`.
+fn parse_upload_id(raw: &str) -> Result<uuid::Uuid, (StatusCode, String)> {
+    uuid::Uuid::parse_str(raw)
+        .map_err(|_| (StatusCode::BAD_REQUEST, "invalid upload_id".to_string()))
+}
+
+/// Deletes a dataset file, refusing if a registered table references it.
+#[tracing::instrument(level = "info", skip(state))]
+#[utoipa::path(
+    tag = "admin",
+    delete,
+    path = "/api/admin/datasets",
+    params(("path" = String, Query, description = "Dataset key relative to the datasets root")),
+    responses(
+        (status = 204, description = "File deleted"),
+        (status = 400, description = "Invalid path"),
+        (status = 404, description = "Dataset not found"),
+        (status = 409, description = "Dataset is in use by one or more tables")
+    ),
+    security(("basic-auth" = []))
+)]
+pub(crate) async fn delete_dataset(
+    State(state): State<Arc<Runtime>>,
+    Query(params): Query<PathParams>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    state.delete_dataset(&params.path).await.map_err(file_error)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Derive a safe `Content-Disposition` filename from the dataset key: the last
+/// path segment with any quote/control characters stripped to prevent header
+/// injection.
+fn attachment_filename(path: &str) -> String {
+    let base = path.rsplit('/').next().unwrap_or("download");
+    let cleaned: String = base
+        .chars()
+        .filter(|c| *c != '"' && *c != '\\' && !c.is_control())
+        .collect();
+    if cleaned.is_empty() {
+        "download".to_string()
+    } else {
+        cleaned
+    }
+}
+
+/// Map a [`FileError`] to an HTTP status + message. The mapping is the contract
+/// the web UI relies on to distinguish (e.g.) "already exists" from "too large".
+fn file_error(err: FileError) -> (StatusCode, String) {
+    let status = match &err {
+        FileError::InvalidPath(_) | FileError::UnsupportedExtension(_) | FileError::Body(_) => {
+            StatusCode::BAD_REQUEST
+        }
+        FileError::AlreadyExists(_)
+        | FileError::InUse { .. }
+        | FileError::PartOutOfOrder { .. } => StatusCode::CONFLICT,
+        FileError::TooLarge { .. } => StatusCode::PAYLOAD_TOO_LARGE,
+        FileError::NotFound(_) | FileError::UnknownUpload(_) => StatusCode::NOT_FOUND,
+        FileError::Storage(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    tracing::warn!(error = %err, "dataset file operation failed");
+    (status, err.to_string())
+}

--- a/beacon-api/src/axum/admin/mod.rs
+++ b/beacon-api/src/axum/admin/mod.rs
@@ -10,8 +10,10 @@ use utoipa::{
 };
 use utoipa_axum::{router::OpenApiRouter, routes};
 
+mod auth;
 mod check;
 mod crawlers;
+mod datasets;
 mod external_tables;
 mod tables;
 
@@ -39,7 +41,16 @@ pub(crate) fn setup_admin_router() -> (Router<Arc<Runtime>>, utoipa::openapi::Op
         ))
         .routes(routes!(crawlers::run_crawler))
         .routes(routes!(external_tables::create_external_table))
+        .routes(routes!(datasets::upload_dataset))
+        .routes(routes!(datasets::download_dataset))
+        .routes(routes!(datasets::delete_dataset))
+        .routes(routes!(datasets::initiate_upload))
+        .routes(routes!(datasets::upload_part))
+        .routes(routes!(datasets::complete_upload))
+        .routes(routes!(datasets::abort_upload))
         .routes(routes!(tables::list_table_config))
+        .routes(routes!(auth::list_users))
+        .routes(routes!(auth::list_roles))
         .split_for_parts();
 
     (admin_router, admin_api)

--- a/beacon-api/src/axum/admin_datasets_http_tests.rs
+++ b/beacon-api/src/axum/admin_datasets_http_tests.rs
@@ -1,0 +1,365 @@
+//! HTTP-transport integration tests for the admin dataset file-management
+//! endpoints (upload / download / delete), driven through the real router with
+//! `tower::ServiceExt::oneshot`. Storage is rooted at a temp directory so the
+//! tests never touch the developer's `./data`.
+
+use std::sync::Arc;
+
+use ::axum::{
+    body::{to_bytes, Body},
+    http::{header, Request, StatusCode},
+    Router,
+};
+use base64::{engine::general_purpose, Engine as _};
+use beacon_core::runtime::Runtime;
+use tower::ServiceExt;
+
+use super::setup_router;
+
+/// Config rooted at `dir`, with a deliberately small upload cap so the `413`
+/// path is exercisable, and filesystem events off (no watcher on the temp dir).
+fn temp_config(dir: &std::path::Path, max_upload_bytes: u64) -> Arc<beacon_config::Config> {
+    let mut config = beacon_config::Config::load().expect("load config");
+    config.auth.anonymous_enabled = true;
+    config.sql.enable = true;
+    config.storage.data_dir = dir.to_path_buf();
+    config.storage.datasets_dir = dir.join("datasets");
+    config.storage.tables_dir = dir.join("tables");
+    config.storage.tmp_dir = dir.join("tmp");
+    config.storage.enable_fs_events = false;
+    config.storage.max_upload_bytes = max_upload_bytes;
+    // The local object stores canonicalize their root, so the directories must
+    // exist before the runtime builds them.
+    for sub in ["datasets", "tables", "tmp"] {
+        std::fs::create_dir_all(dir.join(sub)).expect("create storage dir");
+    }
+    Arc::new(config)
+}
+
+async fn runtime(config: Arc<beacon_config::Config>) -> Arc<Runtime> {
+    Arc::new(
+        Runtime::new_with_in_memory_auth(config)
+            .await
+            .expect("runtime should start"),
+    )
+}
+
+fn basic(username: &str, password: &str) -> String {
+    format!(
+        "Basic {}",
+        general_purpose::STANDARD.encode(format!("{username}:{password}"))
+    )
+}
+
+fn request(method: &str, uri: &str, auth: Option<&str>, body: Body) -> Request<Body> {
+    let mut builder = Request::builder().method(method).uri(uri);
+    if let Some(auth) = auth {
+        builder = builder.header(header::AUTHORIZATION, auth);
+    }
+    builder.body(body).unwrap()
+}
+
+async fn send(router: &Router, req: Request<Body>) -> (StatusCode, Vec<u8>) {
+    let res = router.clone().oneshot(req).await.unwrap();
+    let status = res.status();
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    (status, bytes.to_vec())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upload_download_delete_round_trip_is_super_user_only() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let config = temp_config(dir.path(), 1024);
+    let runtime = runtime(config.clone()).await;
+    let router = setup_router(runtime, config.clone()).unwrap();
+    let admin = basic(&config.admin.username, &config.admin.password);
+
+    let upload_uri = "/api/admin/datasets/upload?path=ctd/a.parquet";
+
+    // No credentials → 401, and nothing is written.
+    let (status, _) = send(
+        &router,
+        request("POST", upload_uri, None, Body::from("hello world")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // Admin upload → 200 with the reported size.
+    let (status, body) = send(
+        &router,
+        request("POST", upload_uri, Some(&admin), Body::from("hello world")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(parsed["path"], "ctd/a.parquet");
+    assert_eq!(parsed["size"], 11);
+
+    // Re-upload without overwrite → 409.
+    let (status, _) = send(
+        &router,
+        request("POST", upload_uri, Some(&admin), Body::from("again")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+
+    // Overwrite succeeds.
+    let (status, _) = send(
+        &router,
+        request(
+            "POST",
+            "/api/admin/datasets/upload?path=ctd/a.parquet&overwrite=true",
+            Some(&admin),
+            Body::from("replaced!"),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Download returns the (replaced) bytes.
+    let (status, body) = send(
+        &router,
+        request(
+            "GET",
+            "/api/admin/datasets/download?path=ctd/a.parquet",
+            Some(&admin),
+            Body::empty(),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, b"replaced!");
+
+    // Delete → 204, then download → 404.
+    let (status, _) = send(
+        &router,
+        request(
+            "DELETE",
+            "/api/admin/datasets?path=ctd/a.parquet",
+            Some(&admin),
+            Body::empty(),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (status, _) = send(
+        &router,
+        request(
+            "GET",
+            "/api/admin/datasets/download?path=ctd/a.parquet",
+            Some(&admin),
+            Body::empty(),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upload_rejects_traversal_extension_and_oversize() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let config = temp_config(dir.path(), 8); // 8-byte cap
+    let runtime = runtime(config.clone()).await;
+    let router = setup_router(runtime, config.clone()).unwrap();
+    let admin = basic(&config.admin.username, &config.admin.password);
+
+    // Path traversal → 400.
+    let (status, _) = send(
+        &router,
+        request(
+            "POST",
+            "/api/admin/datasets/upload?path=../evil.parquet",
+            Some(&admin),
+            Body::from("x"),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // The Beacon-internal prefix is reserved → 400.
+    let (status, _) = send(
+        &router,
+        request(
+            "POST",
+            "/api/admin/datasets/upload?path=__beacon__/x.parquet",
+            Some(&admin),
+            Body::from("x"),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // Unsupported extension → 400.
+    let (status, _) = send(
+        &router,
+        request(
+            "POST",
+            "/api/admin/datasets/upload?path=a/b.exe",
+            Some(&admin),
+            Body::from("x"),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // Over the 8-byte cap → 413, and nothing is left behind.
+    let (status, _) = send(
+        &router,
+        request(
+            "POST",
+            "/api/admin/datasets/upload?path=big.parquet",
+            Some(&admin),
+            Body::from("way too many bytes"),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+
+    let (status, _) = send(
+        &router,
+        request(
+            "GET",
+            "/api/admin/datasets/download?path=big.parquet",
+            Some(&admin),
+            Body::empty(),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn chunked_upload_round_trip_and_download() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let config = temp_config(dir.path(), 1024);
+    let runtime = runtime(config.clone()).await;
+    let router = setup_router(runtime, config.clone()).unwrap();
+    let admin = basic(&config.admin.username, &config.admin.password);
+
+    // Initiate → 200 with an upload_id.
+    let (status, body) = send(
+        &router,
+        request(
+            "POST",
+            "/api/admin/datasets/upload/initiate?path=big/multi.parquet",
+            Some(&admin),
+            Body::empty(),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let initiated: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let upload_id = initiated["upload_id"].as_str().unwrap().to_string();
+    assert!(initiated["part_size"].as_u64().unwrap() >= 5 * 1024 * 1024);
+
+    // Two parts, in order.
+    for (n, payload) in [(1, "part-one-"), (2, "part-two")] {
+        let (status, _) = send(
+            &router,
+            request(
+                "PUT",
+                &format!(
+                    "/api/admin/datasets/upload/part?upload_id={upload_id}&part_number={n}"
+                ),
+                Some(&admin),
+                Body::from(payload),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+    }
+
+    // Complete → 200 with the assembled size.
+    let (status, body) = send(
+        &router,
+        request(
+            "POST",
+            &format!("/api/admin/datasets/upload/complete?upload_id={upload_id}"),
+            Some(&admin),
+            Body::empty(),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let completed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(completed["path"], "big/multi.parquet");
+    assert_eq!(completed["size"], "part-one-part-two".len());
+
+    // Download returns the concatenated parts.
+    let (status, body) = send(
+        &router,
+        request(
+            "GET",
+            "/api/admin/datasets/download?path=big/multi.parquet",
+            Some(&admin),
+            Body::empty(),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, b"part-one-part-two");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn chunked_upload_rejects_unknown_session_and_out_of_order() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let config = temp_config(dir.path(), 1024);
+    let runtime = runtime(config.clone()).await;
+    let router = setup_router(runtime, config.clone()).unwrap();
+    let admin = basic(&config.admin.username, &config.admin.password);
+
+    // A part for an unknown session → 404.
+    let bogus = uuid::Uuid::new_v4();
+    let (status, _) = send(
+        &router,
+        request(
+            "PUT",
+            &format!("/api/admin/datasets/upload/part?upload_id={bogus}&part_number=1"),
+            Some(&admin),
+            Body::from("x"),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // Initiate a real session, then skip a part → 409.
+    let (_, body) = send(
+        &router,
+        request(
+            "POST",
+            "/api/admin/datasets/upload/initiate?path=gap.parquet",
+            Some(&admin),
+            Body::empty(),
+        ),
+    )
+    .await;
+    let upload_id = serde_json::from_slice::<serde_json::Value>(&body).unwrap()["upload_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let (status, _) = send(
+        &router,
+        request(
+            "PUT",
+            &format!("/api/admin/datasets/upload/part?upload_id={upload_id}&part_number=2"),
+            Some(&admin),
+            Body::from("x"),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+
+    // Abort cleans it up → 204.
+    let (status, _) = send(
+        &router,
+        request(
+            "DELETE",
+            &format!("/api/admin/datasets/upload?upload_id={upload_id}"),
+            Some(&admin),
+            Body::empty(),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+}

--- a/beacon-api/src/axum/mod.rs
+++ b/beacon-api/src/axum/mod.rs
@@ -1,10 +1,14 @@
 //! Axum-based HTTP transport for the Beacon API.
 
 mod admin;
+#[cfg(test)]
+mod admin_datasets_http_tests;
 mod auth;
 #[cfg(test)]
 mod auth_http_tests;
 mod client;
+#[cfg(test)]
+mod rbac_http_tests;
 mod router;
 
 pub(crate) use router::setup_router;

--- a/beacon-api/src/axum/rbac_http_tests.rs
+++ b/beacon-api/src/axum/rbac_http_tests.rs
@@ -1,0 +1,334 @@
+//! HTTP integration tests for the RBAC surface, driven through the real router
+//! with `tower::ServiceExt::oneshot`:
+//! - the admin auth list endpoints (`/api/admin/auth/{users,roles}`) and their
+//!   super-user gate,
+//! - the SQL-driven user/role/grant lifecycle (create → grant/deny → assign →
+//!   revoke → drop) reflected in those endpoints,
+//! - the model guards (read-only roles, reserved super-user, protected anonymous
+//!   user, non-super users can't manage or enumerate auth),
+//! - with enforcement on, that grants allow and denies block query results.
+
+use std::sync::Arc;
+
+use ::axum::{
+    body::{to_bytes, Body},
+    http::{header, Request, StatusCode},
+    Router,
+};
+use base64::{engine::general_purpose, Engine as _};
+use beacon_core::runtime::Runtime;
+use futures::TryStreamExt;
+use serde_json::Value;
+use tower::ServiceExt;
+
+use super::setup_router;
+
+/// Config with explicit auth + SQL settings; everything else from the environment.
+fn config(enforce: bool) -> Arc<beacon_config::Config> {
+    let mut config = beacon_config::Config::load().expect("load config");
+    config.auth.enforce = enforce;
+    config.auth.anonymous_enabled = true;
+    config.sql.enable = true;
+    Arc::new(config)
+}
+
+async fn runtime(config: Arc<beacon_config::Config>) -> Arc<Runtime> {
+    Arc::new(
+        Runtime::new_with_in_memory_auth(config)
+            .await
+            .expect("runtime should start"),
+    )
+}
+
+fn basic(username: &str, password: &str) -> String {
+    format!(
+        "Basic {}",
+        general_purpose::STANDARD.encode(format!("{username}:{password}"))
+    )
+}
+
+/// A unique name so managed tables don't collide with leftovers from other tests
+/// (the tables store is shared across runtimes in this process).
+fn unique(prefix: &str) -> String {
+    format!("{prefix}_{}", uuid::Uuid::new_v4().simple())
+}
+
+fn get(uri: &str, auth: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder().method("GET").uri(uri);
+    if let Some(auth) = auth {
+        builder = builder.header(header::AUTHORIZATION, auth);
+    }
+    builder.body(Body::empty()).unwrap()
+}
+
+fn post_query(sql: &str, auth: Option<&str>) -> Request<Body> {
+    let body = serde_json::json!({ "sql": sql }).to_string();
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/api/query")
+        .header(header::CONTENT_TYPE, "application/json");
+    if let Some(auth) = auth {
+        builder = builder.header(header::AUTHORIZATION, auth);
+    }
+    builder.body(Body::from(body)).unwrap()
+}
+
+async fn send(router: &Router, req: Request<Body>) -> (StatusCode, Vec<u8>) {
+    let res = router.clone().oneshot(req).await.unwrap();
+    let status = res.status();
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    (status, bytes.to_vec())
+}
+
+/// Run a query as the super-user and assert it returns 200 (auth DDL yields no rows).
+async fn admin_ok(router: &Router, admin: &str, sql: &str) {
+    let (status, _) = send(router, post_query(sql, Some(admin))).await;
+    assert_eq!(status, StatusCode::OK, "expected 200 for: {sql}");
+}
+
+fn json(bytes: &[u8]) -> Value {
+    serde_json::from_slice(bytes).expect("response should be JSON")
+}
+
+/// Seed managed tables (as the system identity) so enforcement tests have data.
+async fn seed(runtime: &Runtime, sql: &str) {
+    runtime
+        .run_query(
+            beacon_core::query::Query::sql(sql.to_string()),
+            beacon_core::AuthIdentity::system(),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("seed failed: {sql}: {e}"))
+        .into_record_stream()
+        .unwrap()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap_or_else(|e| panic!("seed drain failed: {sql}: {e}"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_endpoints_gated_and_list_default_principals() {
+    let config = config(false);
+    let runtime = runtime(config.clone()).await;
+    let router = setup_router(runtime, config.clone()).unwrap();
+    let admin = basic(&config.admin.username, &config.admin.password);
+
+    // A stored, non-super user to exercise the 403 path.
+    admin_ok(&router, &admin, "CREATE USER alice WITH PASSWORD 'pw'").await;
+    let alice = basic("alice", "pw");
+
+    // No credentials → 401; non-super → 403; super → 200.
+    assert_eq!(
+        send(&router, get("/api/admin/auth/users", None)).await.0,
+        StatusCode::UNAUTHORIZED
+    );
+    assert_eq!(
+        send(&router, get("/api/admin/auth/users", Some(&alice))).await.0,
+        StatusCode::FORBIDDEN
+    );
+    let (status, body) = send(&router, get("/api/admin/auth/users", Some(&admin))).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let users = json(&body);
+    let arr = users.as_array().unwrap();
+    // The config super-user is flagged and present.
+    assert!(arr.iter().any(|u| {
+        u["username"] == config.admin.username.as_str() && u["is_super_user"] == Value::Bool(true)
+    }));
+    // The anonymous user is flagged.
+    assert!(arr
+        .iter()
+        .any(|u| u["username"] == "anonymous" && u["is_anonymous"] == Value::Bool(true)));
+    // alice is a plain user.
+    assert!(arr.iter().any(|u| {
+        u["username"] == "alice"
+            && u["is_super_user"] == Value::Bool(false)
+            && u["is_anonymous"] == Value::Bool(false)
+    }));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rbac_lifecycle_reflected_in_endpoints() {
+    let config = config(false);
+    let runtime = runtime(config.clone()).await;
+    let router = setup_router(runtime, config.clone()).unwrap();
+    let admin = basic(&config.admin.username, &config.admin.password);
+
+    // Create + grant + deny + assign.
+    admin_ok(&router, &admin, "CREATE ROLE reader").await;
+    admin_ok(&router, &admin, "GRANT SELECT ON TABLE observations TO ROLE reader").await;
+    admin_ok(&router, &admin, "GRANT SELECT ON PATH 'argo/**/*.nc' TO ROLE reader").await;
+    admin_ok(&router, &admin, "DENY SELECT ON TABLE secret TO ROLE reader").await;
+    admin_ok(&router, &admin, "CREATE USER alice WITH PASSWORD 'pw'").await;
+    admin_ok(&router, &admin, "GRANT ROLE reader TO USER alice").await;
+
+    // Roles endpoint reflects the grants and denies.
+    let roles = json(&send(&router, get("/api/admin/auth/roles", Some(&admin))).await.1);
+    let reader = roles
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["name"] == "reader")
+        .expect("reader role present");
+    let grants = reader["grants"].as_array().unwrap();
+    assert!(grants.iter().any(|g| {
+        g["privilege"] == "SELECT" && g["target_type"] == "table" && g["target_value"] == "observations"
+    }));
+    assert!(grants
+        .iter()
+        .any(|g| g["target_type"] == "path" && g["target_value"] == "argo/**/*.nc"));
+    let denies = reader["denies"].as_array().unwrap();
+    assert!(denies
+        .iter()
+        .any(|d| d["target_type"] == "table" && d["target_value"] == "secret"));
+
+    // Users endpoint reflects the role assignment.
+    let users = json(&send(&router, get("/api/admin/auth/users", Some(&admin))).await.1);
+    let alice = users
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|u| u["username"] == "alice")
+        .expect("alice present");
+    assert_eq!(alice["roles"], serde_json::json!(["reader"]));
+
+    // Revoke + drop, then confirm the state is gone.
+    admin_ok(&router, &admin, "REVOKE SELECT ON TABLE observations FROM ROLE reader").await;
+    admin_ok(&router, &admin, "REVOKE DENY SELECT ON TABLE secret FROM ROLE reader").await;
+    admin_ok(&router, &admin, "REVOKE ROLE reader FROM USER alice").await;
+    admin_ok(&router, &admin, "DROP USER alice").await;
+
+    let users = json(&send(&router, get("/api/admin/auth/users", Some(&admin))).await.1);
+    assert!(!users.as_array().unwrap().iter().any(|u| u["username"] == "alice"));
+
+    let roles = json(&send(&router, get("/api/admin/auth/roles", Some(&admin))).await.1);
+    let reader = roles
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["name"] == "reader")
+        .expect("reader still exists");
+    assert!(reader["grants"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|g| g["target_value"] != "observations"));
+    assert!(reader["denies"].as_array().unwrap().is_empty());
+
+    admin_ok(&router, &admin, "DROP ROLE reader").await;
+    let roles = json(&send(&router, get("/api/admin/auth/roles", Some(&admin))).await.1);
+    assert!(!roles.as_array().unwrap().iter().any(|r| r["name"] == "reader"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn model_guards_are_enforced() {
+    let config = config(false);
+    let runtime = runtime(config.clone()).await;
+    let router = setup_router(runtime, config.clone()).unwrap();
+    let admin = basic(&config.admin.username, &config.admin.password);
+    let admin_name = config.admin.username.clone();
+
+    admin_ok(&router, &admin, "CREATE ROLE reader").await;
+
+    // Roles are read-only: only SELECT may be granted.
+    let bad = send(&router, post_query("GRANT INSERT ON TABLE t TO ROLE reader", Some(&admin))).await;
+    assert_eq!(bad.0, StatusCode::BAD_REQUEST);
+
+    // The super-user username is reserved (can't be created or dropped via SQL).
+    assert_eq!(
+        send(&router, post_query(&format!("DROP USER {admin_name}"), Some(&admin))).await.0,
+        StatusCode::BAD_REQUEST
+    );
+    assert_eq!(
+        send(
+            &router,
+            post_query(&format!("CREATE USER {admin_name} WITH PASSWORD 'x'"), Some(&admin))
+        )
+        .await
+        .0,
+        StatusCode::BAD_REQUEST
+    );
+
+    // The anonymous user can't be deleted while anonymous access is enabled.
+    assert_eq!(
+        send(&router, post_query("DROP USER anonymous", Some(&admin))).await.0,
+        StatusCode::BAD_REQUEST
+    );
+    let users = json(&send(&router, get("/api/admin/auth/users", Some(&admin))).await.1);
+    assert!(users.as_array().unwrap().iter().any(|u| u["username"] == "anonymous"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn non_super_user_cannot_manage_or_enumerate_auth() {
+    let config = config(false);
+    let runtime = runtime(config.clone()).await;
+    let router = setup_router(runtime, config.clone()).unwrap();
+    let admin = basic(&config.admin.username, &config.admin.password);
+
+    admin_ok(&router, &admin, "CREATE USER bob WITH PASSWORD 'pw'").await;
+    let bob = basic("bob", "pw");
+
+    // Auth DDL requires the super-user → 400 for bob.
+    assert_eq!(
+        send(&router, post_query("CREATE ROLE hacker", Some(&bob))).await.0,
+        StatusCode::BAD_REQUEST
+    );
+    // The admin enumeration endpoints reject non-super principals → 403.
+    assert_eq!(
+        send(&router, get("/api/admin/auth/roles", Some(&bob))).await.0,
+        StatusCode::FORBIDDEN
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn enforcement_grants_allow_and_denies_block() {
+    let config = config(true);
+    let runtime = runtime(config.clone()).await;
+    let admin = basic(&config.admin.username, &config.admin.password);
+
+    // Two tables with a row each (unique names to avoid cross-test collisions).
+    let t1 = unique("t1");
+    let t2 = unique("t2");
+    seed(&runtime, &format!("CREATE TABLE {t1} (a BIGINT)")).await;
+    seed(&runtime, &format!("INSERT INTO {t1} VALUES (1)")).await;
+    seed(&runtime, &format!("CREATE TABLE {t2} (a BIGINT)")).await;
+    seed(&runtime, &format!("INSERT INTO {t2} VALUES (2)")).await;
+
+    let router = setup_router(runtime, config.clone()).unwrap();
+
+    // reader gets a global SELECT grant; alice gets the role.
+    admin_ok(&router, &admin, "CREATE ROLE reader").await;
+    admin_ok(&router, &admin, "GRANT SELECT TO ROLE reader").await;
+    admin_ok(&router, &admin, "CREATE USER alice WITH PASSWORD 'pw'").await;
+    admin_ok(&router, &admin, "GRANT ROLE reader TO USER alice").await;
+    let alice = basic("alice", "pw");
+
+    // The global grant lets alice read both tables.
+    assert_eq!(
+        send(&router, post_query(&format!("SELECT * FROM {t1}"), Some(&alice))).await.0,
+        StatusCode::OK
+    );
+    assert_eq!(
+        send(&router, post_query(&format!("SELECT * FROM {t2}"), Some(&alice))).await.0,
+        StatusCode::OK
+    );
+
+    // A deny on t1 wins over the grant; t2 is still readable.
+    admin_ok(&router, &admin, &format!("DENY SELECT ON TABLE {t1} TO ROLE reader")).await;
+    assert_eq!(
+        send(&router, post_query(&format!("SELECT * FROM {t1}"), Some(&alice))).await.0,
+        StatusCode::BAD_REQUEST
+    );
+    assert_eq!(
+        send(&router, post_query(&format!("SELECT * FROM {t2}"), Some(&alice))).await.0,
+        StatusCode::OK
+    );
+
+    // A user with no roles can't read at all.
+    admin_ok(&router, &admin, "CREATE USER mallory WITH PASSWORD 'pw'").await;
+    let mallory = basic("mallory", "pw");
+    assert_eq!(
+        send(&router, post_query(&format!("SELECT * FROM {t2}"), Some(&mallory))).await.0,
+        StatusCode::BAD_REQUEST
+    );
+}

--- a/beacon-auth/src/basic.rs
+++ b/beacon-auth/src/basic.rs
@@ -89,6 +89,23 @@ impl UserDirectory for InMemoryUserStore {
     fn user_exists(&self, username: &str) -> bool {
         self.users.read().contains_key(username)
     }
+
+    fn list_users(&self) -> anyhow::Result<Vec<crate::provider::UserRecord>> {
+        let users = self.users.read();
+        let mut out: Vec<crate::provider::UserRecord> = users
+            .iter()
+            .map(|(username, record)| {
+                let mut roles: Vec<String> = record.roles.iter().cloned().collect();
+                roles.sort();
+                crate::provider::UserRecord {
+                    username: username.clone(),
+                    roles,
+                }
+            })
+            .collect();
+        out.sort_by(|a, b| a.username.cmp(&b.username));
+        Ok(out)
+    }
 }
 
 /// Default authentication provider backed by an in-memory user store.

--- a/beacon-auth/src/context.rs
+++ b/beacon-auth/src/context.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use crate::{
     credential::Credential,
-    provider::AuthProvider,
-    role::{ConcreteTarget, Privilege, PrivilegeRule, RoleProvider},
+    provider::{AuthProvider, UserRecord},
+    role::{ConcreteTarget, Privilege, PrivilegeRule, Role, RoleProvider},
 };
 
 /// Default username of the built-in anonymous principal.
@@ -118,6 +118,11 @@ impl AuthContext {
         self.anonymous_user.is_some()
     }
 
+    /// The username resolving anonymous access, if enabled.
+    pub fn anonymous_username(&self) -> Option<&str> {
+        self.anonymous_user.as_deref()
+    }
+
     /// Resolves the anonymous principal's identity (empty password), erroring when disabled.
     pub async fn authenticate_anonymous(&self) -> anyhow::Result<AuthIdentity> {
         let username = self
@@ -125,6 +130,20 @@ impl AuthContext {
             .as_deref()
             .ok_or_else(|| anyhow::anyhow!("anonymous access is disabled"))?;
         self.authenticate(&Credential::basic(username, "")).await
+    }
+
+    /// Enumerate all stored local users with their assigned roles. Returns empty when the
+    /// authentication provider has no manageable user directory (e.g. an OIDC-only deployment).
+    pub fn list_users(&self) -> anyhow::Result<Vec<UserRecord>> {
+        match self.auth_provider.user_directory() {
+            Some(dir) => dir.list_users(),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// Snapshot of all roles with their grant/deny rules.
+    pub fn list_roles(&self) -> Vec<Role> {
+        self.role_provider.list_roles()
     }
 
     pub fn role_provider(&self) -> &RoleProvider {
@@ -236,6 +255,15 @@ impl AuthContext {
 
     pub fn drop_user(&self, username: &str) -> anyhow::Result<()> {
         self.ensure_not_super_user_name(username)?;
+        // The anonymous user is Beacon-managed: while anonymous access is enabled it
+        // must always exist, so it can't be deleted (disable it with
+        // BEACON_AUTH_ANONYMOUS_ENABLED=false instead).
+        if self.anonymous_user.as_deref() == Some(username) {
+            anyhow::bail!(
+                "'{username}' is the anonymous user and cannot be deleted while anonymous access \
+                 is enabled (set BEACON_AUTH_ANONYMOUS_ENABLED=false to disable it)"
+            );
+        }
         self.user_directory()?.drop_user(username)
     }
 
@@ -278,6 +306,26 @@ mod tests {
         let mut ctx = admin_context();
         ctx.set_super_user("root", "secret");
         ctx
+    }
+
+    #[test]
+    fn anonymous_user_cannot_be_dropped_while_enabled() {
+        let mut ctx = admin_context();
+        ctx.create_user("anonymous", "").unwrap();
+        ctx.create_user("alice", "pw").unwrap();
+        ctx.set_anonymous_user("anonymous");
+
+        // The anonymous user is protected; a regular user is not.
+        assert!(ctx.drop_user("anonymous").is_err());
+        assert!(ctx.user_exists("anonymous"));
+        ctx.drop_user("alice").unwrap();
+        assert!(!ctx.user_exists("alice"));
+
+        // With anonymous access disabled, the user is droppable again.
+        let mut ctx = admin_context();
+        ctx.create_user("anonymous", "").unwrap();
+        ctx.drop_user("anonymous").unwrap();
+        assert!(!ctx.user_exists("anonymous"));
     }
 
     #[tokio::test]

--- a/beacon-auth/src/lib.rs
+++ b/beacon-auth/src/lib.rs
@@ -25,7 +25,7 @@ pub use context::{AuthContext, AuthIdentity, ANONYMOUS_USERNAME};
 pub use credential::Credential;
 pub use oidc::{OidcAuthProvider, OidcConfig};
 pub use password::{hash_password, verify_password};
-pub use provider::{AuthProvider, Authenticated, UserDirectory};
+pub use provider::{AuthProvider, Authenticated, UserDirectory, UserRecord};
 pub use role::{
     ConcreteTarget, Privilege, PrivilegeRule, PrivilegeTarget, Role, RoleProvider, RoleStore,
 };

--- a/beacon-auth/src/provider.rs
+++ b/beacon-auth/src/provider.rs
@@ -35,6 +35,13 @@ pub trait AuthProvider: Send + Sync {
     }
 }
 
+/// A stored user and the roles assigned to it.
+#[derive(Debug, Clone)]
+pub struct UserRecord {
+    pub username: String,
+    pub roles: Vec<String>,
+}
+
 /// SQL-managed user lifecycle and role assignment, exposed by providers that own their user store.
 pub trait UserDirectory: Send + Sync {
     fn create_user(&self, username: &str, password: &str) -> anyhow::Result<()>;
@@ -43,4 +50,6 @@ pub trait UserDirectory: Send + Sync {
     fn revoke_role(&self, username: &str, role: &str) -> anyhow::Result<()>;
     /// Whether a user with `username` exists. Used for idempotent bootstrap.
     fn user_exists(&self, username: &str) -> bool;
+    /// Enumerate all stored users with their assigned roles.
+    fn list_users(&self) -> anyhow::Result<Vec<UserRecord>>;
 }

--- a/beacon-auth/src/role.rs
+++ b/beacon-auth/src/role.rs
@@ -238,6 +238,13 @@ impl RoleProvider {
         Ok(())
     }
 
+    /// Snapshot of all roles with their grant/deny rules, ordered by name.
+    pub fn list_roles(&self) -> Vec<Role> {
+        let mut roles: Vec<Role> = self.roles.read().values().cloned().collect();
+        roles.sort_by(|a, b| a.name.cmp(&b.name));
+        roles
+    }
+
     /// Whether any of the given roles grants a global `ALL` privilege (i.e. super-user).
     pub fn has_global_all_grant(&self, roles: &[String]) -> bool {
         let registry = self.roles.read();

--- a/beacon-auth/src/sqlite.rs
+++ b/beacon-auth/src/sqlite.rs
@@ -18,7 +18,7 @@ use rusqlite::{params, Connection, OptionalExtension};
 use crate::{
     credential::Credential,
     password::{hash_password, verify_password},
-    provider::{AuthProvider, Authenticated, UserDirectory},
+    provider::{AuthProvider, Authenticated, UserDirectory, UserRecord},
     role::{Privilege, PrivilegeRule, PrivilegeTarget, Role, RoleStore},
 };
 
@@ -184,6 +184,33 @@ impl UserDirectory for SqliteStore {
         .optional()
         .map(|row| row.is_some())
         .unwrap_or(false)
+    }
+
+    fn list_users(&self) -> anyhow::Result<Vec<UserRecord>> {
+        let conn = self.conn.lock();
+        let usernames = conn
+            .prepare("SELECT username FROM users ORDER BY username")?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        let pairs = conn
+            .prepare("SELECT username, role FROM user_roles")?
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<Result<Vec<(String, String)>, _>>()?;
+
+        let mut by_user: HashMap<String, Vec<String>> = HashMap::new();
+        for (username, role) in pairs {
+            by_user.entry(username).or_default().push(role);
+        }
+        Ok(usernames
+            .into_iter()
+            .map(|username| {
+                let mut roles = by_user.remove(&username).unwrap_or_default();
+                roles.sort();
+                UserRecord { username, roles }
+            })
+            .collect())
     }
 }
 

--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -326,12 +326,27 @@ struct RawConfig {
     aws_region: Option<String>,
     #[envconfig(from = "BEACON_S3_ALLOW_HTTP", default = "true")]
     s3_allow_http: bool,
-    // Filesystem change events are on by default for the local datasets store;
-    // set BEACON_ENABLE_FS_EVENTS=false to disable the watcher.
-    #[envconfig(from = "BEACON_ENABLE_FS_EVENTS", default = "true")]
+    // Filesystem change events for the local datasets store. Off by default: the
+    // OS watcher (notify/FSEvents) can lag or replay stale events, and listings now
+    // read straight through to the backing store, so the watcher-maintained cache
+    // is not needed for correctness. Enable (BEACON_ENABLE_FS_EVENTS=true) to get
+    // live auto-refresh of external tables and event-driven crawler triggering when
+    // files change on disk (crawlers otherwise still run on their interval).
+    #[envconfig(from = "BEACON_ENABLE_FS_EVENTS", default = "false")]
     enable_fs_events: bool,
     #[envconfig(from = "BEACON_ENABLE_S3_EVENTS", default = "false")]
     enable_s3_events: bool,
+    // Maximum size, in bytes, accepted for a single dataset upload through the
+    // admin API. `0` disables the cap. Default ~5 GiB.
+    #[envconfig(from = "BEACON_MAX_UPLOAD_BYTES", default = "5368709120")]
+    max_upload_bytes: u64,
+    // Part size advertised for chunked (resumable) uploads. Default 8 MiB (≥ S3's
+    // 5 MiB minimum part size).
+    #[envconfig(from = "BEACON_UPLOAD_PART_SIZE", default = "8388608")]
+    upload_part_size: usize,
+    // Idle timeout (seconds) before an abandoned chunked upload session is aborted.
+    #[envconfig(from = "BEACON_UPLOAD_SESSION_TTL_SECS", default = "3600")]
+    upload_session_ttl_secs: u64,
 
     // Others
     #[envconfig(from = "BEACON_ENABLE_SYS_INFO", default = "false")]
@@ -504,6 +519,9 @@ impl From<RawConfig> for Config {
                     data_dir: root,
                     enable_fs_events: raw.enable_fs_events,
                     enable_s3_events: raw.enable_s3_events,
+                    max_upload_bytes: raw.max_upload_bytes,
+                    upload_part_size: raw.upload_part_size,
+                    upload_session_ttl_secs: raw.upload_session_ttl_secs,
                     s3,
                 }
             },

--- a/beacon-core/Cargo.toml
+++ b/beacon-core/Cargo.toml
@@ -17,6 +17,8 @@ geodatafusion = { workspace=true }
 arrow = { workspace=true}
 tokio = { workspace = true }
 object_store = { workspace = true }
+bytes = { workspace = true }
+thiserror = { workspace = true }
 async-stream = {workspace = true}
 parking_lot = { workspace = true}
 sysinfo = {workspace = true}

--- a/beacon-core/src/api.rs
+++ b/beacon-core/src/api.rs
@@ -62,6 +62,10 @@ pub struct DatasetInfo {
     pub can_inspect: bool,
     /// Whether the file supports partial (predicate/column-pushdown) exploration.
     pub can_partial_explore: bool,
+    /// Size in bytes of the underlying object(s), when known.
+    pub size: Option<u64>,
+    /// Last-modified timestamp (RFC 3339), when known.
+    pub last_modified: Option<String>,
 }
 
 impl From<DatasetMetadata> for DatasetInfo {
@@ -71,6 +75,87 @@ impl From<DatasetMetadata> for DatasetInfo {
             format: value.format,
             can_inspect: value.can_inspect,
             can_partial_explore: value.can_partial_explore,
+            size: value.size,
+            last_modified: value.last_modified.map(|dt| dt.to_rfc3339()),
+        }
+    }
+}
+
+/// A user account and the roles assigned to it, for the admin Users page.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+pub struct AuthUserView {
+    pub username: String,
+    pub roles: Vec<String>,
+    /// True for the single config-defined super-user (not editable via SQL).
+    pub is_super_user: bool,
+    /// True for the Beacon-managed anonymous user, which can't be deleted while
+    /// anonymous access is enabled.
+    pub is_anonymous: bool,
+}
+
+impl From<beacon_auth::UserRecord> for AuthUserView {
+    fn from(value: beacon_auth::UserRecord) -> Self {
+        Self {
+            username: value.username,
+            roles: value.roles,
+            is_super_user: false,
+            is_anonymous: false,
+        }
+    }
+}
+
+/// A single grant/deny rule, flattened for the UI.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+pub struct AuthRuleView {
+    /// Privilege name, e.g. `SELECT`.
+    pub privilege: String,
+    /// Target kind: `table`, `path`, or `all` (every target).
+    pub target_type: String,
+    /// Table name or path glob; `None` when the target is `all`.
+    pub target_value: Option<String>,
+}
+
+impl From<&beacon_auth::PrivilegeRule> for AuthRuleView {
+    fn from(rule: &beacon_auth::PrivilegeRule) -> Self {
+        let (target_type, target_value) = match &rule.target {
+            None | Some(beacon_auth::PrivilegeTarget::All) => ("all".to_string(), None),
+            Some(beacon_auth::PrivilegeTarget::Table(t)) => ("table".to_string(), Some(t.clone())),
+            Some(beacon_auth::PrivilegeTarget::Path(p)) => ("path".to_string(), Some(p.clone())),
+        };
+        Self {
+            privilege: rule.privilege.to_string(),
+            target_type,
+            target_value,
+        }
+    }
+}
+
+/// A role with its grant and deny rules, for the admin Roles page.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+pub struct AuthRoleView {
+    pub name: String,
+    pub grants: Vec<AuthRuleView>,
+    pub denies: Vec<AuthRuleView>,
+}
+
+impl From<beacon_auth::Role> for AuthRoleView {
+    fn from(role: beacon_auth::Role) -> Self {
+        // Rules live in a HashSet; sort for a stable, readable order.
+        let to_sorted = |rules: &std::collections::HashSet<beacon_auth::PrivilegeRule>| {
+            let mut views: Vec<AuthRuleView> = rules.iter().map(AuthRuleView::from).collect();
+            views.sort_by(|a, b| {
+                (&a.privilege, &a.target_type, &a.target_value).cmp(&(
+                    &b.privilege,
+                    &b.target_type,
+                    &b.target_value,
+                ))
+            });
+            views
+        };
+        Self {
+            grants: to_sorted(&role.grants),
+            denies: to_sorted(&role.denies),
+            name: role.name,
         }
     }
 }

--- a/beacon-core/src/dataset_files.rs
+++ b/beacon-core/src/dataset_files.rs
@@ -1,0 +1,377 @@
+//! Admin dataset file management: path safety plus upload / download / delete
+//! over the datasets store.
+//!
+//! These operations let a super-user get files in and out of the datasets store
+//! through the admin API. File mutation is the highest-risk surface in the
+//! product, so the safety checks here are deliberately strict and auditable:
+//!
+//! - [`validate_dataset_path`] is the single anti-traversal gate. Every operation
+//!   routes its user-supplied path through it before touching the store.
+//! - Uploads are streamed (never buffered whole), size-capped, and confined to an
+//!   extension allowlist derived from the formats Beacon can actually read.
+//! - Nothing here can read, write, or delete under the Beacon-internal
+//!   [`DATASETS_WRITEABLE_PREFIX`]; that area is owned by Beacon's own machinery.
+//!
+//! The thin wrappers operate on a [`DatasetsStore`]; the runtime layers the
+//! catalog-aware delete dependency check on top (see [`crate::runtime`]).
+
+use beacon_object_storage::{DatasetsStore, DATASETS_WRITEABLE_PREFIX};
+use bytes::Bytes;
+use futures::{Stream, StreamExt};
+use object_store::{path::Path, GetResult, ObjectStoreExt, WriteMultipart};
+
+/// Failure modes for dataset file management, each mapping to a distinct HTTP
+/// status at the API boundary.
+#[derive(Debug, thiserror::Error)]
+pub enum FileError {
+    /// The supplied path was empty, absolute, contained `.`/`..` or other illegal
+    /// characters, or resolved into the Beacon-internal prefix. → 400.
+    #[error("invalid dataset path: {0}")]
+    InvalidPath(String),
+    /// The filename extension is not in the allowlist of readable formats. → 400.
+    #[error("unsupported file extension '{0}'")]
+    UnsupportedExtension(String),
+    /// A file already exists at the destination and `overwrite` was not set. → 409.
+    #[error("a file already exists at '{0}'; pass overwrite=true to replace it")]
+    AlreadyExists(String),
+    /// The streamed upload exceeded the configured size cap. → 413.
+    #[error("upload exceeds the maximum allowed size of {limit} bytes")]
+    TooLarge { limit: u64 },
+    /// No object exists at the requested path. → 404.
+    #[error("dataset not found: {0}")]
+    NotFound(String),
+    /// The dataset is referenced by one or more tables/crawlers. → 409.
+    #[error("dataset '{path}' is in use by: {}", dependents.join(", "))]
+    InUse {
+        path: String,
+        dependents: Vec<String>,
+    },
+    /// The referenced chunked-upload session does not exist (unknown id, or it
+    /// already completed/expired). → 404.
+    #[error("unknown or expired upload session: {0}")]
+    UnknownUpload(String),
+    /// A chunked-upload part arrived out of order (a gap relative to the next
+    /// expected part). → 409.
+    #[error("upload part {got} is out of order; expected part {expected}")]
+    PartOutOfOrder { got: u32, expected: u32 },
+    /// An error reading the request body stream. → 400.
+    #[error("error reading upload stream: {0}")]
+    Body(std::io::Error),
+    /// An underlying object-store failure. → 500.
+    #[error(transparent)]
+    Storage(#[from] object_store::Error),
+}
+
+/// Result of a successful upload.
+#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+pub struct UploadResult {
+    /// The normalized object key the file was written to.
+    pub path: String,
+    /// The number of bytes written.
+    pub size: u64,
+}
+
+/// Validate and normalize a user-supplied dataset path into an object-store key.
+///
+/// This is the anti-traversal gate. It rejects, before any normalization:
+/// - empty paths,
+/// - absolute paths (leading `/` or `\`),
+/// - NUL or backslash characters,
+/// - any `.` or `..` segment (object_store would percent-encode these into odd
+///   keys rather than error; we reject them outright for a clean, auditable
+///   failure and to forbid traversal-shaped input),
+/// - paths that resolve to the datasets root, and
+/// - anything under the Beacon-internal [`DATASETS_WRITEABLE_PREFIX`].
+pub fn validate_dataset_path(input: &str) -> Result<Path, FileError> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(FileError::InvalidPath("path is empty".into()));
+    }
+    if trimmed.starts_with('/') || trimmed.starts_with('\\') {
+        return Err(FileError::InvalidPath("path must be relative".into()));
+    }
+    if trimmed.contains('\0') || trimmed.contains('\\') {
+        return Err(FileError::InvalidPath(
+            "path contains illegal characters".into(),
+        ));
+    }
+    for segment in trimmed.split('/') {
+        // Tolerate accidental double slashes (empty segments) but never dot
+        // segments — those are the traversal vector.
+        if segment == "." || segment == ".." {
+            return Err(FileError::InvalidPath(
+                "path may not contain '.' or '..' segments".into(),
+            ));
+        }
+    }
+
+    // object_store applies its own per-segment validation (and would otherwise
+    // percent-encode anything surprising); a parse error here is a clean reject.
+    let path = Path::parse(trimmed).map_err(|e| FileError::InvalidPath(e.to_string()))?;
+
+    if path.parts().next().is_none() {
+        return Err(FileError::InvalidPath(
+            "path resolves to the datasets root".into(),
+        ));
+    }
+    if is_internal(&path) {
+        return Err(FileError::InvalidPath(format!(
+            "path '{path}' is reserved for Beacon internal use"
+        )));
+    }
+    Ok(path)
+}
+
+/// Whether the path's first segment is the Beacon-internal writeable prefix.
+fn is_internal(path: &Path) -> bool {
+    path.parts()
+        .next()
+        .is_some_and(|first| first.as_ref() == DATASETS_WRITEABLE_PREFIX)
+}
+
+/// Check the file's extension against an allowlist (case-insensitive).
+///
+/// `allowed` is the set of extensions Beacon's registered formats recognize, so
+/// an upload can only land if the engine could subsequently read it.
+pub fn validate_extension(path: &Path, allowed: &[String]) -> Result<(), FileError> {
+    let ext = path
+        .filename()
+        .and_then(|name| name.rsplit_once('.'))
+        .map(|(_, ext)| ext.to_ascii_lowercase());
+    match ext {
+        Some(ext) if allowed.iter().any(|a| a.eq_ignore_ascii_case(&ext)) => Ok(()),
+        Some(ext) => Err(FileError::UnsupportedExtension(ext)),
+        None => Err(FileError::UnsupportedExtension("(none)".into())),
+    }
+}
+
+/// Stream `body` into the datasets store at the (already validated) `path`.
+///
+/// The body is streamed through a multipart writer, so memory stays bounded
+/// regardless of file size. `max_bytes` caps the total (`0` = unlimited); on
+/// exceed the partial upload is aborted and [`FileError::TooLarge`] returned.
+/// When `overwrite` is false, an existing object at `path` is rejected rather
+/// than clobbered.
+pub async fn upload_dataset<S>(
+    store: &DatasetsStore,
+    path: &Path,
+    overwrite: bool,
+    max_bytes: u64,
+    mut body: S,
+) -> Result<UploadResult, FileError>
+where
+    S: Stream<Item = Result<Bytes, std::io::Error>> + Unpin,
+{
+    if !overwrite {
+        match store.head(path).await {
+            Ok(_) => return Err(FileError::AlreadyExists(path.to_string())),
+            Err(object_store::Error::NotFound { .. }) => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    let mut writer = WriteMultipart::new(store.put_multipart(path).await?);
+    let mut total: u64 = 0;
+    while let Some(chunk) = body.next().await {
+        let chunk = chunk.map_err(FileError::Body)?;
+        total += chunk.len() as u64;
+        if max_bytes != 0 && total > max_bytes {
+            // Best-effort cleanup of already-uploaded parts before failing.
+            let _ = writer.abort().await;
+            return Err(FileError::TooLarge { limit: max_bytes });
+        }
+        writer.put(chunk);
+    }
+    writer.finish().await?;
+
+    Ok(UploadResult {
+        path: path.to_string(),
+        size: total,
+    })
+}
+
+/// Open a streaming read of the dataset at the (already validated) `path`.
+///
+/// The caller streams the returned [`GetResult`] to the client. A missing object
+/// (including anything hidden under the internal prefix) maps to
+/// [`FileError::NotFound`].
+pub async fn download_dataset(store: &DatasetsStore, path: &Path) -> Result<GetResult, FileError> {
+    match store.get(path).await {
+        Ok(result) => Ok(result),
+        Err(object_store::Error::NotFound { .. }) => Err(FileError::NotFound(path.to_string())),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Delete the dataset at the (already validated) `path`.
+///
+/// Existence is checked first so a missing file is a clean [`FileError::NotFound`]
+/// rather than a silent success. The caller is responsible for any dependency
+/// check (e.g. tables backed by this file) before invoking this.
+pub async fn delete_dataset(store: &DatasetsStore, path: &Path) -> Result<(), FileError> {
+    match store.head(path).await {
+        Ok(_) => {}
+        Err(object_store::Error::NotFound { .. }) => {
+            return Err(FileError::NotFound(path.to_string()))
+        }
+        Err(e) => return Err(e.into()),
+    }
+    store.delete(path).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use beacon_object_storage::datasets_store::local_datasets_store;
+    use futures::stream;
+
+    #[test]
+    fn rejects_traversal_and_absolute_and_internal_paths() {
+        for bad in [
+            "",
+            "   ",
+            "/etc/passwd",
+            "\\windows\\system32",
+            "a/../b",
+            "../secret",
+            "./hidden",
+            "a/./b",
+            "foo\0bar",
+            "a\\b",
+            "__beacon__/iceberg/x",
+            "__beacon__",
+        ] {
+            assert!(
+                validate_dataset_path(bad).is_err(),
+                "expected rejection for {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_normal_nested_paths() {
+        let path = validate_dataset_path("ctd/cruise42/station1.nc").expect("valid");
+        assert_eq!(path.to_string(), "ctd/cruise42/station1.nc");
+        // A sibling of the internal prefix is fine — only an exact first segment
+        // match is reserved.
+        assert!(validate_dataset_path("__beacon__extra/data.parquet").is_ok());
+    }
+
+    #[test]
+    fn extension_allowlist_is_case_insensitive() {
+        let allowed = vec!["nc".to_string(), "parquet".to_string()];
+        let ok = validate_dataset_path("a/b.NC").unwrap();
+        assert!(validate_extension(&ok, &allowed).is_ok());
+        let bad = validate_dataset_path("a/b.exe").unwrap();
+        assert!(matches!(
+            validate_extension(&bad, &allowed),
+            Err(FileError::UnsupportedExtension(_))
+        ));
+        let none = validate_dataset_path("a/README").unwrap();
+        assert!(validate_extension(&none, &allowed).is_err());
+    }
+
+    #[tokio::test]
+    async fn upload_download_delete_round_trip() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = local_datasets_store(dir.path().to_path_buf())
+            .await
+            .expect("store");
+        let path = validate_dataset_path("a/b.parquet").unwrap();
+
+        let body = stream::iter(vec![
+            Ok(Bytes::from_static(b"hello ")),
+            Ok(Bytes::from_static(b"world")),
+        ]);
+        let res = upload_dataset(&store, &path, false, 0, body)
+            .await
+            .expect("upload");
+        assert_eq!(res.size, 11);
+        assert_eq!(res.path, "a/b.parquet");
+
+        let got = download_dataset(&store, &path)
+            .await
+            .expect("download")
+            .bytes()
+            .await
+            .expect("bytes");
+        assert_eq!(got.as_ref(), b"hello world");
+
+        delete_dataset(&store, &path).await.expect("delete");
+        assert!(matches!(
+            download_dataset(&store, &path).await,
+            Err(FileError::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn upload_rejects_existing_without_overwrite() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = local_datasets_store(dir.path().to_path_buf())
+            .await
+            .expect("store");
+        let path = validate_dataset_path("x.parquet").unwrap();
+
+        let first = stream::iter(vec![Ok(Bytes::from_static(b"one"))]);
+        upload_dataset(&store, &path, false, 0, first)
+            .await
+            .expect("first upload");
+
+        let second = stream::iter(vec![Ok(Bytes::from_static(b"two"))]);
+        assert!(matches!(
+            upload_dataset(&store, &path, false, 0, second).await,
+            Err(FileError::AlreadyExists(_))
+        ));
+
+        // With overwrite, it succeeds and replaces the content.
+        let third = stream::iter(vec![Ok(Bytes::from_static(b"three"))]);
+        upload_dataset(&store, &path, true, 0, third)
+            .await
+            .expect("overwrite upload");
+        let got = download_dataset(&store, &path)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert_eq!(got.as_ref(), b"three");
+    }
+
+    #[tokio::test]
+    async fn upload_enforces_size_cap() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = local_datasets_store(dir.path().to_path_buf())
+            .await
+            .expect("store");
+        let path = validate_dataset_path("big.parquet").unwrap();
+
+        let body = stream::iter(vec![
+            Ok(Bytes::from_static(b"aaaa")),
+            Ok(Bytes::from_static(b"bbbb")),
+        ]);
+        // Cap of 5 bytes, payload is 8.
+        assert!(matches!(
+            upload_dataset(&store, &path, false, 5, body).await,
+            Err(FileError::TooLarge { limit: 5 })
+        ));
+        // The aborted upload left nothing behind.
+        assert!(matches!(
+            download_dataset(&store, &path).await,
+            Err(FileError::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn delete_missing_is_not_found() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = local_datasets_store(dir.path().to_path_buf())
+            .await
+            .expect("store");
+        let path = validate_dataset_path("nope.parquet").unwrap();
+        assert!(matches!(
+            delete_dataset(&store, &path).await,
+            Err(FileError::NotFound(_))
+        ));
+    }
+}

--- a/beacon-core/src/dataset_uploads.rs
+++ b/beacon-core/src/dataset_uploads.rs
@@ -1,0 +1,342 @@
+//! Server-side state for chunked (resumable) dataset uploads.
+//!
+//! Large files are uploaded as a sequence of parts across separate HTTP requests
+//! (initiate → put part × N → complete), so a single request never has to carry a
+//! multi-gigabyte body and a dropped connection only loses the part in flight.
+//!
+//! [`UploadManager`] keeps one [`UploadSession`] per in-progress upload, keyed by
+//! an `upload_id`. Each session holds an object-store [`MultipartUpload`] handle;
+//! every client part is buffered in full by the transport and submitted as one
+//! atomic object-store part (so a part can be safely retried). Abandoned sessions
+//! are aborted by a background sweeper after an idle timeout, which also releases
+//! the underlying multipart upload on stores (S3/GCS) that need explicit cleanup.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Weak},
+    time::{Duration, Instant},
+};
+
+use beacon_object_storage::DatasetsStore;
+use bytes::Bytes;
+use object_store::{path::Path, MultipartUpload, ObjectStoreExt};
+use parking_lot::Mutex;
+use uuid::Uuid;
+
+use crate::dataset_files::{FileError, UploadResult};
+
+/// Built-in part size (8 MiB) used when the configured size is `0`. Kept at or
+/// above S3's 5 MiB minimum so every non-final part is individually valid.
+const DEFAULT_PART_SIZE: usize = 8 * 1024 * 1024;
+/// Built-in idle timeout (1 hour) used when the configured TTL is `0`.
+const DEFAULT_TTL: Duration = Duration::from_secs(3600);
+/// Lower bound on how often the sweeper runs, regardless of TTL.
+const MIN_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+
+/// A single in-progress chunked upload.
+struct UploadSession {
+    /// Destination key (already validated at initiate time).
+    path: Path,
+    /// The object-store multipart upload, taken on complete/abort.
+    upload: Option<Box<dyn MultipartUpload>>,
+    /// Bytes accepted so far across all parts.
+    total: u64,
+    /// Cumulative size cap (`0` = unlimited), carried from initiate.
+    max_bytes: u64,
+    /// Count of parts accepted so far; the next expected 1-based part number is
+    /// `accepted_parts + 1`. A resend of an already-accepted part is idempotent.
+    accepted_parts: u32,
+    /// Last time this session saw activity, for idle expiry.
+    last_active: Instant,
+}
+
+/// Owns and manages all in-progress chunked uploads for a runtime.
+pub struct UploadManager {
+    sessions: Mutex<HashMap<Uuid, Arc<tokio::sync::Mutex<UploadSession>>>>,
+    part_size: usize,
+    ttl: Duration,
+}
+
+impl UploadManager {
+    /// Build the manager and spawn its idle-session sweeper. `part_size` and
+    /// `ttl_secs` of `0` fall back to the built-in defaults.
+    pub fn new(part_size: usize, ttl_secs: u64) -> Arc<Self> {
+        let part_size = if part_size == 0 {
+            DEFAULT_PART_SIZE
+        } else {
+            part_size
+        };
+        let ttl = if ttl_secs == 0 {
+            DEFAULT_TTL
+        } else {
+            Duration::from_secs(ttl_secs)
+        };
+        let manager = Arc::new(Self {
+            sessions: Mutex::new(HashMap::new()),
+            part_size,
+            ttl,
+        });
+        Self::spawn_sweeper(Arc::downgrade(&manager), ttl);
+        manager
+    }
+
+    /// The part size clients should slice large files into.
+    pub fn part_size(&self) -> usize {
+        self.part_size
+    }
+
+    /// Open a new chunked upload for `path`, returning its session id. The caller
+    /// is responsible for validating `path` and the overwrite policy first.
+    pub async fn initiate(
+        &self,
+        store: &DatasetsStore,
+        path: Path,
+        max_bytes: u64,
+    ) -> Result<Uuid, FileError> {
+        let upload = store.put_multipart(&path).await?;
+        let id = Uuid::new_v4();
+        let session = UploadSession {
+            path,
+            upload: Some(upload),
+            total: 0,
+            max_bytes,
+            accepted_parts: 0,
+            last_active: Instant::now(),
+        };
+        self.sessions
+            .lock()
+            .insert(id, Arc::new(tokio::sync::Mutex::new(session)));
+        Ok(id)
+    }
+
+    /// Submit one part. `part_number` is 1-based and must be the next expected
+    /// part, or an already-accepted one (treated as an idempotent retry).
+    ///
+    /// On an object-store failure the whole session is aborted and removed, since
+    /// a partially-written multipart upload cannot be safely resumed; the client
+    /// must restart the upload.
+    pub async fn put_part(
+        &self,
+        id: Uuid,
+        part_number: u32,
+        data: Bytes,
+    ) -> Result<(), FileError> {
+        let session = self.session(id)?;
+        let mut guard = session.lock().await;
+
+        let expected = guard.accepted_parts + 1;
+        // A resend of an already-accepted part (e.g. a lost response) is a no-op.
+        if part_number <= guard.accepted_parts {
+            guard.last_active = Instant::now();
+            return Ok(());
+        }
+        if part_number != expected {
+            return Err(FileError::PartOutOfOrder {
+                got: part_number,
+                expected,
+            });
+        }
+
+        let new_total = guard.total + data.len() as u64;
+        if guard.max_bytes != 0 && new_total > guard.max_bytes {
+            let limit = guard.max_bytes;
+            drop(guard);
+            self.abort(id).await.ok();
+            return Err(FileError::TooLarge { limit });
+        }
+
+        let upload = guard
+            .upload
+            .as_mut()
+            .ok_or_else(|| FileError::UnknownUpload(id.to_string()))?;
+        if let Err(e) = upload.put_part(data.into()).await {
+            // The multipart upload is now in an indeterminate state; tear it down.
+            drop(guard);
+            self.abort(id).await.ok();
+            return Err(e.into());
+        }
+
+        guard.total = new_total;
+        guard.accepted_parts += 1;
+        guard.last_active = Instant::now();
+        Ok(())
+    }
+
+    /// Finalize the upload, returning the resulting object's key and size.
+    pub async fn complete(&self, id: Uuid) -> Result<UploadResult, FileError> {
+        let session = self.remove(id)?;
+        let mut guard = session.lock().await;
+        let mut upload = guard
+            .upload
+            .take()
+            .ok_or_else(|| FileError::UnknownUpload(id.to_string()))?;
+        upload.complete().await?;
+        Ok(UploadResult {
+            path: guard.path.to_string(),
+            size: guard.total,
+        })
+    }
+
+    /// Abort and discard an in-progress upload, cleaning up object-store state.
+    pub async fn abort(&self, id: Uuid) -> Result<(), FileError> {
+        let session = self.remove(id)?;
+        let mut guard = session.lock().await;
+        if let Some(mut upload) = guard.upload.take() {
+            upload.abort().await?;
+        }
+        Ok(())
+    }
+
+    fn session(&self, id: Uuid) -> Result<Arc<tokio::sync::Mutex<UploadSession>>, FileError> {
+        self.sessions
+            .lock()
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| FileError::UnknownUpload(id.to_string()))
+    }
+
+    fn remove(&self, id: Uuid) -> Result<Arc<tokio::sync::Mutex<UploadSession>>, FileError> {
+        self.sessions
+            .lock()
+            .remove(&id)
+            .ok_or_else(|| FileError::UnknownUpload(id.to_string()))
+    }
+
+    /// Spawn the background task that aborts sessions idle longer than `ttl`. It
+    /// stops once the manager is dropped (the `Weak` no longer upgrades).
+    fn spawn_sweeper(manager: Weak<UploadManager>, ttl: Duration) {
+        let interval = ttl.min(MIN_SWEEP_INTERVAL.max(ttl / 4)).max(MIN_SWEEP_INTERVAL);
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(interval).await;
+                let Some(manager) = manager.upgrade() else {
+                    return; // manager (and its runtime) is gone
+                };
+                manager.sweep_expired().await;
+            }
+        });
+    }
+
+    /// Abort every session whose last activity is older than the TTL.
+    async fn sweep_expired(&self) {
+        let now = Instant::now();
+        let expired: Vec<Uuid> = {
+            let sessions = self.sessions.lock();
+            let mut ids = Vec::new();
+            for (id, session) in sessions.iter() {
+                // try_lock avoids blocking on a session mid-part; a busy session is
+                // by definition active, so skipping it is correct.
+                if let Ok(guard) = session.try_lock() {
+                    if now.duration_since(guard.last_active) > self.ttl {
+                        ids.push(*id);
+                    }
+                }
+            }
+            ids
+        };
+        for id in expired {
+            if let Err(e) = self.abort(id).await {
+                tracing::debug!(%id, error = %e, "failed to abort expired upload session");
+            } else {
+                tracing::info!(%id, "aborted idle upload session");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use beacon_object_storage::datasets_store::local_datasets_store;
+
+    async fn store() -> (tempfile::TempDir, DatasetsStore) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = local_datasets_store(dir.path().to_path_buf())
+            .await
+            .expect("store");
+        (dir, store)
+    }
+
+    #[tokio::test]
+    async fn chunked_round_trip() {
+        let (_dir, store) = store().await;
+        let mgr = UploadManager::new(0, 0);
+        let path = Path::from("big/data.parquet");
+
+        let id = mgr.initiate(&store, path.clone(), 0).await.unwrap();
+        mgr.put_part(id, 1, Bytes::from_static(b"aaaa")).await.unwrap();
+        mgr.put_part(id, 2, Bytes::from_static(b"bbbb")).await.unwrap();
+        let res = mgr.complete(id).await.unwrap();
+        assert_eq!(res.size, 8);
+        assert_eq!(res.path, "big/data.parquet");
+
+        let got = store.get(&path).await.unwrap().bytes().await.unwrap();
+        assert_eq!(got.as_ref(), b"aaaabbbb");
+    }
+
+    #[tokio::test]
+    async fn resent_part_is_idempotent() {
+        let (_dir, store) = store().await;
+        let mgr = UploadManager::new(0, 0);
+        let id = mgr
+            .initiate(&store, Path::from("a.parquet"), 0)
+            .await
+            .unwrap();
+        mgr.put_part(id, 1, Bytes::from_static(b"one")).await.unwrap();
+        // Re-send part 1 (e.g. a lost response): accepted as a no-op.
+        mgr.put_part(id, 1, Bytes::from_static(b"one")).await.unwrap();
+        mgr.put_part(id, 2, Bytes::from_static(b"two")).await.unwrap();
+        let res = mgr.complete(id).await.unwrap();
+        assert_eq!(res.size, 6);
+    }
+
+    #[tokio::test]
+    async fn out_of_order_part_is_rejected() {
+        let (_dir, store) = store().await;
+        let mgr = UploadManager::new(0, 0);
+        let id = mgr
+            .initiate(&store, Path::from("a.parquet"), 0)
+            .await
+            .unwrap();
+        mgr.put_part(id, 1, Bytes::from_static(b"one")).await.unwrap();
+        // Skipping part 2 → 3 is a gap.
+        assert!(matches!(
+            mgr.put_part(id, 3, Bytes::from_static(b"three")).await,
+            Err(FileError::PartOutOfOrder { got: 3, expected: 2 })
+        ));
+    }
+
+    #[tokio::test]
+    async fn unknown_session_errors() {
+        let mgr = UploadManager::new(0, 0);
+        let id = Uuid::new_v4();
+        assert!(matches!(
+            mgr.put_part(id, 1, Bytes::from_static(b"x")).await,
+            Err(FileError::UnknownUpload(_))
+        ));
+        assert!(matches!(
+            mgr.complete(id).await,
+            Err(FileError::UnknownUpload(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn cap_is_enforced_across_parts() {
+        let (_dir, store) = store().await;
+        let mgr = UploadManager::new(0, 0);
+        let id = mgr
+            .initiate(&store, Path::from("a.parquet"), 5)
+            .await
+            .unwrap();
+        mgr.put_part(id, 1, Bytes::from_static(b"abc")).await.unwrap();
+        // 3 + 4 = 7 > cap of 5 → rejected, session torn down.
+        assert!(matches!(
+            mgr.put_part(id, 2, Bytes::from_static(b"defg")).await,
+            Err(FileError::TooLarge { .. })
+        ));
+        assert!(matches!(
+            mgr.complete(id).await,
+            Err(FileError::UnknownUpload(_))
+        ));
+    }
+}

--- a/beacon-core/src/lib.rs
+++ b/beacon-core/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod api;
+pub mod dataset_files;
+pub mod dataset_uploads;
 pub mod metrics;
 pub mod parser;
 pub mod query;

--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -51,6 +51,11 @@ pub struct Runtime {
     config: Arc<beacon_config::Config>,
     /// Authentication + authorization context (users, roles, grants). Shared, owned by the runtime.
     auth: Arc<beacon_auth::AuthContext>,
+    /// The datasets object store, retained so the admin file-management endpoints
+    /// (upload/download/delete) can operate on it directly.
+    datasets_store: Arc<beacon_object_storage::DatasetsStore>,
+    /// In-progress chunked (resumable) upload sessions for large files.
+    upload_manager: Arc<crate::dataset_uploads::UploadManager>,
 }
 
 impl Runtime {
@@ -87,6 +92,11 @@ impl Runtime {
         ));
 
         let object_stores = beacon_object_storage::ObjectStores::new(&config.storage).await?;
+        let datasets_store = object_stores.datasets.clone();
+        let upload_manager = crate::dataset_uploads::UploadManager::new(
+            config.storage.upload_part_size,
+            config.storage.upload_session_ttl_secs,
+        );
 
         // The crawler manager is built after the file formats are registered, so
         // register an empty handle now and fill it below — the same late-fill
@@ -200,6 +210,8 @@ impl Runtime {
             table_function_docs,
             config,
             auth,
+            datasets_store,
+            upload_manager,
         })
     }
 
@@ -302,6 +314,41 @@ impl Runtime {
         self.auth.anonymous_enabled()
     }
 
+    /// List all principals for the admin Users page: the config-defined super-user first (flagged,
+    /// not editable), then every stored local user with its roles. OIDC-only deployments have no
+    /// stored users, so only the super-user is returned.
+    pub fn list_auth_users(&self) -> anyhow::Result<Vec<crate::api::AuthUserView>> {
+        let super_username = self.config.admin.username.clone();
+        let anonymous_username = self.auth.anonymous_username().map(str::to_owned);
+        let mut views = vec![crate::api::AuthUserView {
+            username: super_username.clone(),
+            roles: Vec::new(),
+            is_super_user: true,
+            is_anonymous: false,
+        }];
+        for record in self.auth.list_users()? {
+            // The super-user is config-only, never stored; guard against a name clash anyway.
+            if record.username == super_username {
+                continue;
+            }
+            let is_anonymous = anonymous_username.as_deref() == Some(record.username.as_str());
+            views.push(crate::api::AuthUserView {
+                is_anonymous,
+                ..crate::api::AuthUserView::from(record)
+            });
+        }
+        Ok(views)
+    }
+
+    /// Snapshot of all roles with their grant/deny rules, for the admin Roles page.
+    pub fn list_auth_roles(&self) -> Vec<crate::api::AuthRoleView> {
+        self.auth
+            .list_roles()
+            .into_iter()
+            .map(crate::api::AuthRoleView::from)
+            .collect()
+    }
+
     fn init_ctx(
         memory_pool: Arc<FairSpillPool>,
         datasets_store: Arc<beacon_object_storage::DatasetsStore>,
@@ -358,6 +405,12 @@ impl Runtime {
             .with_cache_manager(
                 datafusion::execution::cache::cache_manager::CacheManagerConfig {
                     table_files_statistics_cache: Some(beacon_file_statistics_cache()),
+                    // Disable DataFusion's directory-listing cache. Its default
+                    // config installs one (non-zero `list_files_cache_limit`) with a
+                    // TTL, which serves stale listings — missing freshly written
+                    // files and retaining deleted ones — and broke read-after-write
+                    // for the datasets view (uploads invisible, deletes lingering).
+                    list_files_cache_limit: 0,
                     ..Default::default()
                 },
             )
@@ -815,10 +868,20 @@ impl Runtime {
         offset: Option<usize>,
         limit: Option<usize>,
     ) -> anyhow::Result<Vec<DatasetMetadata>> {
-        Ok(
-            beacon_data_lake::list_datasets(&self.session_ctx, &self.file_formats, offset, limit, pattern)
-                .await?,
+        // List against the datasets store's *backing* store (disk/S3 truth) rather
+        // than the cache-backed facade. The cache is kept warm asynchronously by
+        // the filesystem watcher, which on some platforms lags or replays stale
+        // events — so a freshly uploaded or just-deleted file would otherwise be
+        // missing from / lingering in the listing until the watcher caught up.
+        Ok(beacon_data_lake::list_datasets(
+            &self.session_ctx,
+            self.datasets_store.backing_store(),
+            &self.file_formats,
+            offset,
+            limit,
+            pattern,
         )
+        .await?)
     }
 
     pub async fn total_datasets(&self) -> anyhow::Result<usize> {
@@ -896,6 +959,153 @@ impl Runtime {
     fn parse_beacon_statement(sql: &str) -> anyhow::Result<BeaconStatement> {
         let mut parser = BeaconParser::new(sql)?;
         parser.parse_statement().map_err(Into::into)
+    }
+
+    /// The set of filename extensions an uploaded dataset may carry, derived from
+    /// the formats this runtime can actually read. Keeping the allowlist in sync
+    /// with the registry means an upload only succeeds if it could be queried.
+    pub fn dataset_upload_extensions(&self) -> Vec<String> {
+        let mut exts: Vec<String> = self
+            .file_formats
+            .iter()
+            .flat_map(|f| f.file_extensions())
+            .map(|e| e.trim_start_matches('.').to_ascii_lowercase())
+            .filter(|e| !e.is_empty())
+            .collect();
+        exts.sort();
+        exts.dedup();
+        exts
+    }
+
+    /// Stream an uploaded file into the datasets store. The path is validated
+    /// (anti-traversal, internal-prefix guard) and its extension checked against
+    /// [`Self::dataset_upload_extensions`] before any bytes are written. The size
+    /// cap comes from `BEACON_MAX_UPLOAD_BYTES`.
+    pub async fn upload_dataset<S>(
+        &self,
+        raw_path: &str,
+        overwrite: bool,
+        body: S,
+    ) -> Result<crate::dataset_files::UploadResult, crate::dataset_files::FileError>
+    where
+        S: futures::Stream<Item = Result<bytes::Bytes, std::io::Error>> + Unpin,
+    {
+        let path = crate::dataset_files::validate_dataset_path(raw_path)?;
+        crate::dataset_files::validate_extension(&path, &self.dataset_upload_extensions())?;
+        let max_bytes = self.config.storage.max_upload_bytes;
+        crate::dataset_files::upload_dataset(&self.datasets_store, &path, overwrite, max_bytes, body)
+            .await
+    }
+
+    /// Begin a chunked (resumable) upload for a large file. Validates the path and
+    /// extension and the overwrite policy, opens a multipart upload, and returns
+    /// the new session id plus the part size clients should slice the file into.
+    pub async fn initiate_dataset_upload(
+        &self,
+        raw_path: &str,
+        overwrite: bool,
+    ) -> Result<(uuid::Uuid, usize), crate::dataset_files::FileError> {
+        let path = crate::dataset_files::validate_dataset_path(raw_path)?;
+        crate::dataset_files::validate_extension(&path, &self.dataset_upload_extensions())?;
+
+        if !overwrite {
+            use object_store::ObjectStoreExt;
+            match self.datasets_store.head(&path).await {
+                Ok(_) => {
+                    return Err(crate::dataset_files::FileError::AlreadyExists(
+                        path.to_string(),
+                    ))
+                }
+                Err(object_store::Error::NotFound { .. }) => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        let max_bytes = self.config.storage.max_upload_bytes;
+        let id = self
+            .upload_manager
+            .initiate(&self.datasets_store, path, max_bytes)
+            .await?;
+        Ok((id, self.upload_manager.part_size()))
+    }
+
+    /// Submit one part of a chunked upload (1-based `part_number`, in order).
+    pub async fn upload_dataset_part(
+        &self,
+        upload_id: uuid::Uuid,
+        part_number: u32,
+        data: bytes::Bytes,
+    ) -> Result<(), crate::dataset_files::FileError> {
+        self.upload_manager
+            .put_part(upload_id, part_number, data)
+            .await
+    }
+
+    /// Finalize a chunked upload, returning the resulting object's key and size.
+    pub async fn complete_dataset_upload(
+        &self,
+        upload_id: uuid::Uuid,
+    ) -> Result<crate::dataset_files::UploadResult, crate::dataset_files::FileError> {
+        self.upload_manager.complete(upload_id).await
+    }
+
+    /// Abort and discard an in-progress chunked upload.
+    pub async fn abort_dataset_upload(
+        &self,
+        upload_id: uuid::Uuid,
+    ) -> Result<(), crate::dataset_files::FileError> {
+        self.upload_manager.abort(upload_id).await
+    }
+
+    /// Open a streaming read of a dataset file for download. The path is validated
+    /// before the store is touched.
+    pub async fn download_dataset(
+        &self,
+        raw_path: &str,
+    ) -> Result<object_store::GetResult, crate::dataset_files::FileError> {
+        let path = crate::dataset_files::validate_dataset_path(raw_path)?;
+        crate::dataset_files::download_dataset(&self.datasets_store, &path).await
+    }
+
+    /// Delete a dataset file. The path is validated, then a best-effort dependency
+    /// check refuses the delete (with [`crate::dataset_files::FileError::InUse`]) if
+    /// any registered table references the file, so a query is not silently broken.
+    pub async fn delete_dataset(
+        &self,
+        raw_path: &str,
+    ) -> Result<(), crate::dataset_files::FileError> {
+        let path = crate::dataset_files::validate_dataset_path(raw_path)?;
+
+        let dependents = self.dataset_dependents(path.as_ref()).await;
+        if !dependents.is_empty() {
+            return Err(crate::dataset_files::FileError::InUse {
+                path: path.to_string(),
+                dependents,
+            });
+        }
+
+        crate::dataset_files::delete_dataset(&self.datasets_store, &path).await
+    }
+
+    /// Best-effort discovery of registered tables that reference a dataset path.
+    ///
+    /// Each table's flattened config is serialized and scanned for the path
+    /// substring (the same shape exposed by the admin table-config endpoint). This
+    /// catches external tables pointed directly at a file or its parent directory;
+    /// it is intentionally conservative — a hit blocks the delete so the caller can
+    /// drop the table first.
+    async fn dataset_dependents(&self, path: &str) -> Vec<String> {
+        let mut dependents = Vec::new();
+        for table in self.list_tables() {
+            if let Some(view) = self.list_table_config(table.clone()).await {
+                if let Ok(json) = serde_json::to_string(&view.config) {
+                    if json.contains(path) {
+                        dependents.push(table);
+                    }
+                }
+            }
+        }
+        dependents
     }
 }
 

--- a/beacon-data-lake/src/crawler/engine.rs
+++ b/beacon-data-lake/src/crawler/engine.rs
@@ -68,9 +68,18 @@ impl CrawlEngine {
         };
 
         // 1. Scan + classify (reuses list_datasets + per-format discover_datasets).
+        // Crawlers run periodically, so the cache-backed registered store is fine.
         let pattern = scan_pattern(&def.target_prefix);
+        let object_store = self
+            .session_ctx
+            .runtime_env()
+            .object_store(&*DATASETS_OBJECT_STORE_URL)
+            .map_err(|e| {
+                anyhow::anyhow!("crawler '{}' could not resolve datasets store: {e}", def.name)
+            })?;
         let datasets = list_datasets(
             &self.session_ctx,
+            object_store,
             &self.file_formats,
             None,
             None,

--- a/beacon-data-lake/src/files/mod.rs
+++ b/beacon-data-lake/src/files/mod.rs
@@ -44,15 +44,13 @@ pub fn create_temp_output_file(tmp_dir: &Path, extension: &str) -> TempOutputFil
 /// object store, asking each registered file format which objects it owns.
 pub async fn list_datasets(
     session_ctx: &SessionContext,
+    object_store: Arc<dyn object_store::ObjectStore>,
     file_formats: &[Arc<dyn FileFormatFactoryExt>],
     offset: Option<usize>,
     limit: Option<usize>,
     pattern: Option<String>,
 ) -> datafusion::error::Result<Vec<DatasetMetadata>> {
     let state = session_ctx.state();
-    let object_store = session_ctx
-        .runtime_env()
-        .object_store(&*DATASETS_OBJECT_STORE_URL)?;
 
     let listing_url = create_listing_url(pattern.unwrap_or_else(|| "*".to_string()))?;
 
@@ -75,6 +73,36 @@ pub async fn list_datasets(
     for file_format in file_formats.iter() {
         let format_datasets = file_format.discover_datasets(&objects)?;
         datasets.extend(format_datasets);
+    }
+
+    // Enrich each dataset with size + last-modified from the object listing. A
+    // single-file dataset matches an object exactly; a directory-shaped dataset
+    // (e.g. Zarr) aggregates every object under its prefix (sum of sizes, newest
+    // mtime). Datasets with no matching object keep `None`.
+    let by_path: HashMap<&str, &object_store::ObjectMeta> =
+        objects.iter().map(|o| (o.location.as_ref(), o)).collect();
+    for ds in datasets.iter_mut() {
+        if let Some(obj) = by_path.get(ds.file_path.as_str()) {
+            ds.size = Some(obj.size);
+            ds.last_modified = Some(obj.last_modified);
+        } else {
+            let prefix = format!("{}/", ds.file_path);
+            let mut total = 0u64;
+            let mut latest = None;
+            for o in &objects {
+                if o.location.as_ref().starts_with(&prefix) {
+                    total += o.size;
+                    latest = Some(match latest {
+                        Some(l) if l >= o.last_modified => l,
+                        _ => o.last_modified,
+                    });
+                }
+            }
+            if latest.is_some() {
+                ds.size = Some(total);
+                ds.last_modified = latest;
+            }
+        }
     }
 
     // Keep current pagination semantics to avoid behavior regressions.

--- a/beacon-datafusion-ext/Cargo.toml
+++ b/beacon-datafusion-ext/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 datafusion = { workspace = true }
 datafusion-federation = { workspace = true }
+chrono = { workspace = true }
 arrow-flight = { workspace = true, features = ["flight-sql"] }
 tonic = { workspace = true }
 async-trait = { workspace = true }

--- a/beacon-datafusion-ext/src/format_ext.rs
+++ b/beacon-datafusion-ext/src/format_ext.rs
@@ -39,6 +39,12 @@ pub struct DatasetMetadata {
     pub format: String,
     pub can_inspect: bool,
     pub can_partial_explore: bool,
+    /// Total size in bytes of the underlying object(s), when known. Filled in by
+    /// `list_datasets` from the object listing; `None` for datasets whose size
+    /// can't be resolved (e.g. no matching object).
+    pub size: Option<u64>,
+    /// Last-modified time of the underlying object(s) (RFC 3339), when known.
+    pub last_modified: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl DatasetMetadata {
@@ -48,6 +54,8 @@ impl DatasetMetadata {
             format,
             can_inspect: false,
             can_partial_explore: false,
+            size: None,
+            last_modified: None,
         }
     }
 }

--- a/beacon-object-storage/src/config.rs
+++ b/beacon-object-storage/src/config.rs
@@ -26,6 +26,18 @@ pub struct StorageConfig {
     pub enable_fs_events: bool,
     /// Reserved: wire S3 change notifications into the event listener.
     pub enable_s3_events: bool,
+    /// Maximum size, in bytes, accepted for a single dataset upload through the
+    /// admin API. `0` means unlimited. Defaults to `0` so embedders and tests that
+    /// build a [`StorageConfig`] directly are not capped; `beacon-config` fills a
+    /// concrete default from `BEACON_MAX_UPLOAD_BYTES`.
+    pub max_upload_bytes: u64,
+    /// Part size, in bytes, advertised to clients for chunked (resumable) uploads.
+    /// Clients slice large files into parts of this size. `0` => the built-in
+    /// default (8 MiB). Kept ≥ 5 MiB so each part satisfies S3's minimum.
+    pub upload_part_size: usize,
+    /// Idle timeout, in seconds, after which an in-progress chunked upload session
+    /// is aborted and cleaned up. `0` => the built-in default (1 hour).
+    pub upload_session_ttl_secs: u64,
     /// S3 backing for the datasets store. `None` => local filesystem; `Some` =>
     /// the datasets store is backed by S3, configured from these settings.
     pub s3: Option<S3Config>,

--- a/clients/beacon-ts/src/admin.ts
+++ b/clients/beacon-ts/src/admin.ts
@@ -55,4 +55,294 @@ export class AdminClient {
   async createExternalTable(spec: ExternalTableSpec): Promise<void> {
     await this.http.fetchRaw("POST", "/api/admin/external-tables", { json: spec });
   }
+
+  // -- dataset files ----------------------------------------------------------
+
+  /**
+   * Uploads a file into the datasets store.
+   *
+   * `path` is the destination key relative to the datasets root (e.g.
+   * `ctd/cruise42/a.nc`). The server validates the path, checks the extension
+   * against the readable-format allowlist, and enforces `BEACON_MAX_UPLOAD_BYTES`.
+   * By default an existing file is rejected with `409`; pass `overwrite` to
+   * replace it.
+   *
+   * Files at or below `thresholdBytes` (default 50 MiB) are sent in a single
+   * streaming `POST /api/admin/datasets/upload`. Larger files switch to the
+   * chunked, resumable protocol (initiate → part × N → complete), slicing the
+   * file into server-advertised parts; a failed part is retried (the server
+   * treats a resent part as idempotent), and the session is aborted on giving up.
+   * The request timeout is disabled by default so large uploads are not cut short.
+   */
+  uploadDataset(
+    path: string,
+    data: Blob | ArrayBuffer | Uint8Array,
+    opts: UploadOptions = {},
+  ): Promise<UploadResult> {
+    const source = toUploadSource(data);
+    const threshold = opts.thresholdBytes ?? DEFAULT_UPLOAD_THRESHOLD;
+    if (source.size > threshold) {
+      return this.uploadDatasetChunked(path, source, opts);
+    }
+    return this.http.fetchJson<UploadResult>("POST", "/api/admin/datasets/upload", {
+      query: { path, overwrite: opts.overwrite ? "true" : undefined },
+      body: data as BodyInit,
+      headers: { "Content-Type": "application/octet-stream" },
+      signal: opts.signal,
+      timeoutMs: opts.timeoutMs ?? 0,
+    });
+  }
+
+  /** Chunked/resumable upload path; see {@link uploadDataset}. */
+  private async uploadDatasetChunked(
+    path: string,
+    source: UploadSource,
+    opts: UploadOptions,
+  ): Promise<UploadResult> {
+    const init = await this.http.fetchJson<{ upload_id: string; part_size: number }>(
+      "POST",
+      "/api/admin/datasets/upload/initiate",
+      { query: { path, overwrite: opts.overwrite ? "true" : undefined }, signal: opts.signal },
+    );
+    const partSize = init.part_size > 0 ? init.part_size : DEFAULT_UPLOAD_THRESHOLD;
+    const total = source.size;
+
+    try {
+      let partNumber = 1;
+      for (let offset = 0; offset < total; offset += partSize) {
+        const end = Math.min(offset + partSize, total);
+        await this.putPartWithRetry(init.upload_id, partNumber, source.slice(offset, end), opts);
+        opts.onProgress?.({ uploaded: end, total });
+        partNumber++;
+      }
+      return await this.http.fetchJson<UploadResult>(
+        "POST",
+        "/api/admin/datasets/upload/complete",
+        { query: { upload_id: init.upload_id }, signal: opts.signal, timeoutMs: opts.timeoutMs ?? 0 },
+      );
+    } catch (err) {
+      // Best-effort cleanup of the server-side session; swallow abort errors.
+      await this.http
+        .fetchRaw("DELETE", "/api/admin/datasets/upload", { query: { upload_id: init.upload_id } })
+        .catch(() => undefined);
+      throw err;
+    }
+  }
+
+  /**
+   * PUTs one part, retrying the same part number on transient failure. This is
+   * safe because the server accepts a resent part idempotently.
+   */
+  private async putPartWithRetry(
+    uploadId: string,
+    partNumber: number,
+    chunk: BodyInit,
+    opts: UploadOptions,
+  ): Promise<void> {
+    const retries = opts.partRetries ?? 3;
+    let lastErr: unknown;
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        await this.http.fetchRaw("PUT", "/api/admin/datasets/upload/part", {
+          query: { upload_id: uploadId, part_number: partNumber },
+          body: chunk,
+          headers: { "Content-Type": "application/octet-stream" },
+          signal: opts.signal,
+          timeoutMs: opts.timeoutMs ?? 0,
+        });
+        return;
+      } catch (err) {
+        lastErr = err;
+        if (opts.signal?.aborted) throw err;
+        await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)));
+      }
+    }
+    throw lastErr;
+  }
+
+  /**
+   * Downloads a dataset file (`GET /api/admin/datasets/download`), resolving to a
+   * `Blob`. The request timeout is disabled by default for large files.
+   */
+  async downloadDataset(
+    path: string,
+    opts: { signal?: AbortSignal; timeoutMs?: number } = {},
+  ): Promise<Blob> {
+    const res = await this.http.fetchRaw("GET", "/api/admin/datasets/download", {
+      query: { path },
+      signal: opts.signal,
+      timeoutMs: opts.timeoutMs ?? 0,
+    });
+    return await res.blob();
+  }
+
+  /**
+   * Deletes a dataset file (`DELETE /api/admin/datasets`). The server refuses with
+   * `409` if a registered table references the file.
+   */
+  async deleteDataset(path: string): Promise<void> {
+    await this.http.fetchRaw("DELETE", "/api/admin/datasets", { query: { path } });
+  }
+
+  // -- users & roles ----------------------------------------------------------
+
+  /** Lists all users (the super-user plus stored local users) with their roles. */
+  listAuthUsers(): Promise<AuthUser[]> {
+    return this.http.fetchJson<AuthUser[]>("GET", "/api/admin/auth/users");
+  }
+
+  /** Lists all roles with their grant/deny rules. */
+  listAuthRoles(): Promise<AuthRole[]> {
+    return this.http.fetchJson<AuthRole[]>("GET", "/api/admin/auth/roles");
+  }
+
+  /**
+   * Runs an auth-management statement through the SQL endpoint as the super-user.
+   * Auth DDL (CREATE/DROP USER/ROLE, GRANT, DENY, REVOKE) returns no rows.
+   */
+  private async runSql(sql: string): Promise<void> {
+    await this.http.fetchRaw("POST", "/api/query", { json: { sql } });
+  }
+
+  createRole(role: string): Promise<void> {
+    return this.runSql(`CREATE ROLE ${ident(role)}`);
+  }
+  dropRole(role: string): Promise<void> {
+    return this.runSql(`DROP ROLE ${ident(role)}`);
+  }
+  createUser(username: string, password: string): Promise<void> {
+    return this.runSql(`CREATE USER ${ident(username)} WITH PASSWORD ${lit(password)}`);
+  }
+  dropUser(username: string): Promise<void> {
+    return this.runSql(`DROP USER ${ident(username)}`);
+  }
+  grantRoleToUser(username: string, role: string): Promise<void> {
+    return this.runSql(`GRANT ROLE ${ident(role)} TO USER ${ident(username)}`);
+  }
+  revokeRoleFromUser(username: string, role: string): Promise<void> {
+    return this.runSql(`REVOKE ROLE ${ident(role)} FROM USER ${ident(username)}`);
+  }
+
+  /** Grant (or, with `deny`, deny) a privilege on a target to a role. */
+  grantPrivilege(role: string, target: PrivilegeTarget, deny = false): Promise<void> {
+    const verb = deny ? "DENY" : "GRANT";
+    return this.runSql(`${verb} SELECT${targetClause(target)} TO ROLE ${ident(role)}`);
+  }
+
+  /** Remove a grant (default) or, with `deny`, a deny rule from a role. */
+  revokePrivilege(role: string, target: PrivilegeTarget, deny = false): Promise<void> {
+    const kind = deny ? "REVOKE DENY" : "REVOKE";
+    return this.runSql(`${kind} SELECT${targetClause(target)} FROM ROLE ${ident(role)}`);
+  }
+}
+
+/** A privilege target: all targets, a named table, or a path glob. */
+export type PrivilegeTarget =
+  | { type: "all" }
+  | { type: "table"; value: string }
+  | { type: "path"; value: string };
+
+/** Build the `ON ...` clause for a privilege statement (empty for `all`). */
+function targetClause(target: PrivilegeTarget): string {
+  if (target.type === "table") return ` ON TABLE ${ident(target.value)}`;
+  if (target.type === "path") return ` ON PATH ${lit(target.value)}`;
+  return "";
+}
+
+/**
+ * Validate a SQL identifier (role/user/table name). Restricting to a safe
+ * character set is what keeps these statements injection-proof, since
+ * identifiers can't be parameterized.
+ */
+function ident(name: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(
+      `invalid identifier "${name}": use letters, digits, and underscores (not starting with a digit)`,
+    );
+  }
+  return name;
+}
+
+/** Render a single-quoted SQL string literal, escaping embedded quotes. */
+function lit(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+/** A user account and its assigned roles. */
+export interface AuthUser {
+  username: string;
+  roles: string[];
+  is_super_user: boolean;
+  /** Beacon-managed anonymous user; can't be deleted while anonymous access is on. */
+  is_anonymous: boolean;
+}
+
+/** A single grant/deny rule, flattened. */
+export interface AuthRule {
+  privilege: string;
+  target_type: "all" | "table" | "path";
+  target_value: string | null;
+}
+
+/** A role with its grant and deny rules. */
+export interface AuthRole {
+  name: string;
+  grants: AuthRule[];
+  denies: AuthRule[];
+}
+
+/** Result of a successful dataset upload. */
+export interface UploadResult {
+  /** The normalized object key the file was written to. */
+  path: string;
+  /** The number of bytes written. */
+  size: number;
+}
+
+/** Progress of a chunked upload. */
+export interface UploadProgress {
+  /** Bytes uploaded so far. */
+  uploaded: number;
+  /** Total bytes to upload. */
+  total: number;
+}
+
+/** Options for {@link AdminClient.uploadDataset}. */
+export interface UploadOptions {
+  /** Replace an existing file instead of failing with `409`. */
+  overwrite?: boolean;
+  /** Cancels the upload (including in-flight chunked parts). */
+  signal?: AbortSignal;
+  /** Per-request timeout in ms; defaults to 0 (disabled) for uploads. */
+  timeoutMs?: number;
+  /** Files larger than this switch to the chunked protocol. Default 50 MiB. */
+  thresholdBytes?: number;
+  /** Retry attempts per part on transient failure (chunked only). Default 3. */
+  partRetries?: number;
+  /** Called after each part completes (chunked only). */
+  onProgress?: (progress: UploadProgress) => void;
+}
+
+/** Default size above which {@link AdminClient.uploadDataset} chunks: 50 MiB. */
+const DEFAULT_UPLOAD_THRESHOLD = 50 * 1024 * 1024;
+
+/** A size-known, sliceable view over the upload payload. */
+interface UploadSource {
+  size: number;
+  slice: (start: number, end: number) => BodyInit;
+}
+
+/** Normalize the accepted upload inputs into a sliceable {@link UploadSource}. */
+function toUploadSource(data: Blob | ArrayBuffer | Uint8Array): UploadSource {
+  if (data instanceof Blob) {
+    return { size: data.size, slice: (start, end) => data.slice(start, end) };
+  }
+  if (data instanceof Uint8Array) {
+    return { size: data.byteLength, slice: (start, end) => data.subarray(start, end) };
+  }
+  // ArrayBuffer
+  return {
+    size: data.byteLength,
+    slice: (start, end) => new Uint8Array(data, start, end - start),
+  };
 }

--- a/clients/beacon-ts/src/http.ts
+++ b/clients/beacon-ts/src/http.ts
@@ -93,21 +93,33 @@ export class Http {
     init: {
       query?: Record<string, string | number | undefined>;
       json?: unknown;
+      /**
+       * A raw request body (e.g. a `Blob`/`ArrayBuffer`/`Uint8Array` for binary
+       * uploads). Mutually exclusive with `json`; set `Content-Type` via `headers`.
+       */
+      body?: BodyInit;
       headers?: Record<string, string>;
       signal?: AbortSignal;
+      /**
+       * Per-request timeout override in ms. Falls back to the client default.
+       * Set to 0 to disable (e.g. for large streaming uploads/downloads).
+       */
+      timeoutMs?: number;
     } = {},
   ): Promise<Response> {
     const url = this.buildUrl(path, init.query);
     const headers: Record<string, string> = { ...this.extraHeaders, ...init.headers };
     if (this.authHeader) headers["Authorization"] = this.authHeader;
 
-    let body: string | undefined;
+    let body: BodyInit | undefined;
     if (init.json !== undefined) {
       headers["Content-Type"] = "application/json";
       body = JSON.stringify(init.json);
+    } else if (init.body !== undefined) {
+      body = init.body;
     }
 
-    const { signal, cancel, timedOut } = this.withTimeout(init.signal);
+    const { signal, cancel, timedOut } = this.withTimeout(init.signal, init.timeoutMs);
     let res: Response;
     try {
       res = await this.fetchImpl(url, { method, headers, body, signal });
@@ -155,7 +167,10 @@ export class Http {
    * timeout abort apart from an external cancellation (the abort reason is not
    * reliably propagated across runtimes, so we track it explicitly).
    */
-  private withTimeout(external?: AbortSignal): {
+  private withTimeout(
+    external?: AbortSignal,
+    timeoutOverrideMs?: number,
+  ): {
     signal: AbortSignal;
     cancel: () => void;
     timedOut: () => boolean;
@@ -170,12 +185,13 @@ export class Http {
       else external.addEventListener("abort", onExternalAbort, { once: true });
     }
 
+    const timeoutMs = timeoutOverrideMs ?? this.timeoutMs;
     let timer: ReturnType<typeof setTimeout> | undefined;
-    if (this.timeoutMs > 0) {
+    if (timeoutMs > 0) {
       timer = setTimeout(() => {
         timedOut = true;
         controller.abort(new DOMException("Request timed out", "TimeoutError"));
-      }, this.timeoutMs);
+      }, timeoutMs);
     }
 
     const cancel = () => {

--- a/clients/beacon-ts/src/index.ts
+++ b/clients/beacon-ts/src/index.ts
@@ -3,6 +3,15 @@
 export { BeaconClient } from "./client.js";
 export type { QueryResult, QueryOptions } from "./client.js";
 export { AdminClient } from "./admin.js";
+export type {
+  UploadResult,
+  UploadProgress,
+  UploadOptions,
+  PrivilegeTarget,
+  AuthUser,
+  AuthRule,
+  AuthRole,
+} from "./admin.js";
 export { Http, basicAuthHeader } from "./http.js";
 export type { ClientOptions, FetchLike } from "./http.js";
 export { BeaconError, ApiError, ConnectionError, TimeoutError } from "./errors.js";

--- a/clients/beacon-ts/test/admin.test.ts
+++ b/clients/beacon-ts/test/admin.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { BeaconClient } from "../src/index.js";
+
+/** A fetch stub that routes by URL and records every call. */
+function routerFetch() {
+  const calls: { method: string; url: string; body: unknown }[] = [];
+  const fn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    const method = (init?.method ?? "GET").toUpperCase();
+    calls.push({ method, url: u, body: init?.body });
+
+    if (u.includes("/datasets/upload/initiate")) {
+      return new Response(JSON.stringify({ upload_id: "u1", part_size: 4 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (u.includes("/datasets/upload/part")) {
+      return new Response(null, { status: 204 });
+    }
+    if (u.includes("/datasets/upload/complete")) {
+      return new Response(JSON.stringify({ path: "a/big.parquet", size: 10 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    // single-shot upload
+    return new Response(JSON.stringify({ path: "a/small.parquet", size: 3 }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+  return { fn: fn as unknown as typeof fetch, calls };
+}
+
+function adminClient(fetchFn: typeof fetch) {
+  return new BeaconClient({
+    url: "http://beacon.test",
+    username: "admin",
+    password: "pw",
+    fetch: fetchFn,
+  });
+}
+
+describe("AdminClient.uploadDataset", () => {
+  it("uses a single request for files at or below the threshold", async () => {
+    const { fn, calls } = routerFetch();
+    const client = adminClient(fn);
+
+    const res = await client.admin.uploadDataset("a/small.parquet", new Uint8Array(3));
+
+    expect(res).toEqual({ path: "a/small.parquet", size: 3 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.url).toContain("/api/admin/datasets/upload?");
+    expect(calls[0]!.url).toContain("path=a%2Fsmall.parquet");
+  });
+
+  it("switches to the chunked protocol above the threshold", async () => {
+    const { fn, calls } = routerFetch();
+    const client = adminClient(fn);
+    const progress: number[] = [];
+
+    const res = await client.admin.uploadDataset("a/big.parquet", new Uint8Array(10), {
+      thresholdBytes: 4,
+      onProgress: (p) => progress.push(p.uploaded),
+    });
+
+    expect(res).toEqual({ path: "a/big.parquet", size: 10 });
+
+    // initiate, 3 parts (4 + 4 + 2 bytes), complete.
+    const kinds = calls.map((c) => `${c.method} ${new URL(c.url).pathname}`);
+    expect(kinds).toEqual([
+      "POST /api/admin/datasets/upload/initiate",
+      "PUT /api/admin/datasets/upload/part",
+      "PUT /api/admin/datasets/upload/part",
+      "PUT /api/admin/datasets/upload/part",
+      "POST /api/admin/datasets/upload/complete",
+    ]);
+    // Parts are numbered in order.
+    const parts = calls
+      .filter((c) => c.url.includes("/upload/part"))
+      .map((c) => new URL(c.url).searchParams.get("part_number"));
+    expect(parts).toEqual(["1", "2", "3"]);
+    // Progress reports cumulative bytes.
+    expect(progress).toEqual([4, 8, 10]);
+  });
+
+  it("aborts the session if a part fails", async () => {
+    const calls: string[] = [];
+    const fn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = (init?.method ?? "GET").toUpperCase();
+      calls.push(`${method} ${new URL(u).pathname}`);
+      if (u.includes("/upload/initiate")) {
+        return new Response(JSON.stringify({ upload_id: "u1", part_size: 4 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (u.includes("/upload/part")) {
+        return new Response("boom", { status: 500 });
+      }
+      return new Response(null, { status: 204 });
+    });
+    const client = adminClient(fn as unknown as typeof fetch);
+
+    await expect(
+      client.admin.uploadDataset("a/big.parquet", new Uint8Array(10), {
+        thresholdBytes: 4,
+        partRetries: 0,
+      }),
+    ).rejects.toThrow();
+
+    // Initiate, the failed part, then a best-effort DELETE to abort the session.
+    expect(calls).toContain("DELETE /api/admin/datasets/upload");
+  });
+});

--- a/clients/beacon-web/package.json
+++ b/clients/beacon-web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@beacon/client": "*",
+    "@codemirror/autocomplete": "6.20.3",
     "@codemirror/lang-sql": "6.8.0",
     "@radix-ui/react-dialog": "1.1.4",
     "@radix-ui/react-dropdown-menu": "2.1.4",

--- a/clients/beacon-web/src/App.tsx
+++ b/clients/beacon-web/src/App.tsx
@@ -7,6 +7,7 @@ import { WorkbenchPage } from "./pages/workbench";
 import { TablesPage } from "./pages/tables";
 import { DatasetsPage } from "./pages/datasets";
 import { CrawlersPage } from "./pages/crawlers";
+import { AccessPage } from "./pages/access";
 import { ServerInfoPage } from "./pages/server-info";
 
 export default function App() {
@@ -20,6 +21,7 @@ export default function App() {
           <Route path="/tables" element={<TablesPage />} />
           <Route path="/datasets" element={<DatasetsPage />} />
           <Route path="/crawlers" element={<CrawlersPage />} />
+          <Route path="/access" element={<AccessPage />} />
           <Route path="/server" element={<ServerInfoPage />} />
         </Route>
       </Route>

--- a/clients/beacon-web/src/components/app-shell.tsx
+++ b/clients/beacon-web/src/components/app-shell.tsx
@@ -8,6 +8,7 @@ import {
   LogOut,
   Radar,
   Server,
+  ShieldCheck,
   TableProperties,
   TerminalSquare,
 } from "lucide-react";
@@ -32,6 +33,7 @@ const NAV = [
   { to: "/tables", label: "Tables", icon: TableProperties },
   { to: "/datasets", label: "Datasets", icon: FileStack },
   { to: "/crawlers", label: "Crawlers", icon: Radar },
+  { to: "/access", label: "Users & roles", icon: ShieldCheck },
   { to: "/server", label: "Server", icon: Server },
 ];
 

--- a/clients/beacon-web/src/components/sql-editor.tsx
+++ b/clients/beacon-web/src/components/sql-editor.tsx
@@ -1,8 +1,8 @@
 import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
-import { sql } from "@codemirror/lang-sql";
 import { forwardRef } from "react";
 
 import { useTheme } from "@/lib/theme";
+import { useSqlCompletion } from "@/lib/sql-completion";
 
 interface SqlEditorProps {
   value: string;
@@ -10,17 +10,18 @@ interface SqlEditorProps {
   onRun?: () => void;
 }
 
-/** CodeMirror SQL editor. Cmd/Ctrl+Enter triggers `onRun`. */
+/** CodeMirror SQL editor with metadata-aware autocomplete. Cmd/Ctrl+Enter runs. */
 export const SqlEditor = forwardRef<ReactCodeMirrorRef, SqlEditorProps>(
   ({ value, onChange, onRun }, ref) => {
     const { resolved } = useTheme();
+    const completion = useSqlCompletion();
     return (
       <CodeMirror
         ref={ref}
         value={value}
         height="100%"
         theme={resolved}
-        extensions={[sql()]}
+        extensions={completion}
         onChange={onChange}
         basicSetup={{ lineNumbers: true, foldGutter: false, highlightActiveLine: false }}
         onKeyDown={(e) => {

--- a/clients/beacon-web/src/lib/sql-completion.ts
+++ b/clients/beacon-web/src/lib/sql-completion.ts
@@ -1,0 +1,181 @@
+import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { sql, type SQLNamespace } from "@codemirror/lang-sql";
+import type {
+  Completion,
+  CompletionContext,
+  CompletionResult,
+} from "@codemirror/autocomplete";
+
+import { useBeacon } from "@/lib/beacon-context";
+
+/** Shape of one entry from `GET /api/tables-with-schema`. */
+interface TableWithSchema {
+  table_name: string;
+  columns: { name: string; data_type?: string; nullable?: boolean }[];
+}
+
+/** Parsed function metadata used to build completions and their doc tooltips. */
+interface FnMeta {
+  name: string;
+  description?: string;
+  returnType?: string;
+  params: { name: string; dataType?: string; description?: string }[];
+}
+
+/** Pull a function name out of a metadata object (the API isn't uniform). */
+function fnName(o: Record<string, unknown>): string | undefined {
+  const v = o.function_name ?? o.name ?? o.function ?? o.id;
+  return typeof v === "string" ? v : undefined;
+}
+
+/** True for the API's placeholder text, which we don't want to render as docs. */
+function isPlaceholder(s: string | undefined): boolean {
+  return !s || /^No (documentation|description) available$/i.test(s);
+}
+
+/** Parse a raw `/api/functions` (or table-functions) entry into {@link FnMeta}. */
+function parseFn(o: Record<string, unknown>): FnMeta | null {
+  const name = fnName(o);
+  if (!name) return null;
+  const rawParams = Array.isArray(o.params) ? (o.params as Record<string, unknown>[]) : [];
+  return {
+    name,
+    description: typeof o.description === "string" ? o.description : undefined,
+    returnType: typeof o.return_type === "string" ? o.return_type : undefined,
+    params: rawParams.map((p) => ({
+      name: typeof p.name === "string" ? p.name : "",
+      dataType: typeof p.data_type === "string" ? p.data_type : undefined,
+      description: typeof p.description === "string" ? p.description : undefined,
+    })),
+  };
+}
+
+/** Build a documentation tooltip (signature + description + params) for a function. */
+function renderFnDoc(fn: FnMeta): HTMLElement {
+  const dom = document.createElement("div");
+  dom.style.maxWidth = "32rem";
+
+  const paramSig = fn.params
+    .map((p) => (p.dataType ? `${p.name}: ${p.dataType}` : p.name))
+    .join(", ");
+  const sig = document.createElement("div");
+  sig.style.fontFamily = "monospace";
+  sig.style.fontWeight = "600";
+  sig.textContent = `${fn.name}(${paramSig})${fn.returnType ? ` → ${fn.returnType}` : ""}`;
+  dom.appendChild(sig);
+
+  if (!isPlaceholder(fn.description)) {
+    const desc = document.createElement("div");
+    desc.style.marginTop = "4px";
+    desc.textContent = fn.description as string;
+    dom.appendChild(desc);
+  }
+
+  const documented = fn.params.filter((p) => p.name && !isPlaceholder(p.description));
+  if (documented.length > 0) {
+    const ul = document.createElement("ul");
+    ul.style.margin = "6px 0 0";
+    ul.style.paddingLeft = "1.1rem";
+    for (const p of documented) {
+      const li = document.createElement("li");
+      const code = document.createElement("code");
+      code.textContent = p.name;
+      li.appendChild(code);
+      li.appendChild(document.createTextNode(` — ${p.description}`));
+      ul.appendChild(li);
+    }
+    dom.appendChild(ul);
+  }
+  return dom;
+}
+
+/**
+ * CodeMirror SQL completion fed by the runtime's live metadata:
+ * - table names and their columns (from `tables-with-schema`) — including
+ *   `table.column` / `alias.column` completion, with each column's data type,
+ * - scalar/aggregate and table-valued function names (inserted with a `(`), each
+ *   with a documentation tooltip (signature, description, parameters),
+ * - SQL keywords (provided by `@codemirror/lang-sql` out of the box).
+ *
+ * Returns a CodeMirror extension that updates as the metadata loads.
+ */
+export function useSqlCompletion() {
+  const beacon = useBeacon();
+
+  const tablesQuery = useQuery({
+    queryKey: ["tables-with-schema"],
+    queryFn: () => beacon.tablesWithSchema<TableWithSchema[]>(),
+    staleTime: 60_000,
+  });
+
+  const fnQuery = useQuery({
+    queryKey: ["sql-function-docs"],
+    queryFn: async () => {
+      const [scalar, table] = await Promise.all([
+        beacon.functions<Record<string, unknown>[]>(),
+        beacon.tableFunctions<Record<string, unknown>[]>(),
+      ]);
+      const parse = (arr: Record<string, unknown>[]) => {
+        const seen = new Set<string>();
+        const out: FnMeta[] = [];
+        for (const o of arr) {
+          const fn = parseFn(o);
+          if (!fn || seen.has(fn.name)) continue;
+          seen.add(fn.name);
+          out.push(fn);
+        }
+        return out.sort((a, b) => a.name.localeCompare(b.name));
+      };
+      return { scalar: parse(scalar), table: parse(table) };
+    },
+    staleTime: 60_000,
+  });
+
+  return React.useMemo(() => {
+    // Build the table → columns namespace. Columns are Completion objects so the
+    // popup shows each column's data type (detail) and a small info tooltip.
+    const schema: SQLNamespace = {};
+    for (const t of tablesQuery.data ?? []) {
+      (schema as Record<string, Completion[]>)[t.table_name] = (t.columns ?? [])
+        .filter((c) => c.name)
+        .map((c) => ({
+          label: c.name,
+          type: "property",
+          detail: c.data_type,
+          info: c.data_type
+            ? `${t.table_name}.${c.name} — ${c.data_type}${c.nullable === false ? " (not null)" : ""}`
+            : undefined,
+        }));
+    }
+
+    // Function completions: insert `name(` and attach a doc tooltip. Scalar
+    // functions show their return type as detail; table functions are labelled.
+    const toOption = (f: FnMeta, detail: string | undefined): Completion => ({
+      label: f.name,
+      type: "function",
+      detail,
+      apply: `${f.name}(`,
+      info: () => renderFnDoc(f),
+    });
+    const fnOptions: Completion[] = [
+      ...(fnQuery.data?.scalar ?? []).map((f) => toOption(f, f.returnType)),
+      ...(fnQuery.data?.table ?? []).map((f) => toOption(f, "table function")),
+    ];
+
+    const lang = sql({ schema });
+    const fnSource = (ctx: CompletionContext): CompletionResult | null => {
+      if (fnOptions.length === 0) return null;
+      const word = ctx.matchBefore(/\w+/);
+      if (!word || (word.from === word.to && !ctx.explicit)) return null;
+      // Don't suggest functions in member-access position (after `table.`/`alias.`),
+      // where only the resolved table's columns — handled by the language's own
+      // source, including FROM-clause alias resolution — should appear.
+      if (word.from > 0 && ctx.state.sliceDoc(word.from - 1, word.from) === ".") return null;
+      return { from: word.from, options: fnOptions, validFor: /^\w*$/ };
+    };
+
+    // Merge our function source with the language's built-in (tables/columns/keywords).
+    return [lang, lang.language.data.of({ autocomplete: fnSource })];
+  }, [tablesQuery.data, fnQuery.data]);
+}

--- a/clients/beacon-web/src/pages/access.tsx
+++ b/clients/beacon-web/src/pages/access.tsx
@@ -1,0 +1,525 @@
+import * as React from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2, Plus, Shield, Trash2, UserPlus, X } from "lucide-react";
+
+import type { AuthRole, AuthRule, AuthUser, PrivilegeTarget } from "@beacon/client";
+import { useBeacon } from "@/lib/beacon-context";
+import { errorMessage } from "@/lib/errors";
+import { PageContainer } from "@/components/app-shell";
+import { InfoBanner } from "@/components/info-banner";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { NativeSelect } from "@/components/ui/native-select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+/** Render a rule's target as a readable label. */
+function targetLabel(rule: AuthRule): string {
+  if (rule.target_type === "table") return `TABLE ${rule.target_value}`;
+  if (rule.target_type === "path") return `PATH ${rule.target_value}`;
+  return "all targets";
+}
+
+/** Map a rule back to the SDK's PrivilegeTarget shape (for revoke). */
+function ruleTarget(rule: AuthRule): PrivilegeTarget {
+  if (rule.target_type === "table") return { type: "table", value: rule.target_value ?? "" };
+  if (rule.target_type === "path") return { type: "path", value: rule.target_value ?? "" };
+  return { type: "all" };
+}
+
+export function AccessPage() {
+  const beacon = useBeacon();
+  const qc = useQueryClient();
+  const [error, setError] = React.useState<string | null>(null);
+
+  const usersQuery = useQuery({ queryKey: ["auth-users"], queryFn: () => beacon.admin.listAuthUsers() });
+  const rolesQuery = useQuery({ queryKey: ["auth-roles"], queryFn: () => beacon.admin.listAuthRoles() });
+
+  // One mutation runner for every action: run the thunk, then refresh both lists.
+  const action = useMutation({
+    mutationFn: (fn: () => Promise<void>) => fn(),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["auth-users"] });
+      qc.invalidateQueries({ queryKey: ["auth-roles"] });
+      setError(null);
+    },
+    onError: (e) => setError(errorMessage(e)),
+  });
+  const run = (fn: () => Promise<void>) => action.mutate(fn);
+  const busy = action.isPending;
+
+  const users = usersQuery.data ?? [];
+  const roles = rolesQuery.data ?? [];
+  const roleNames = roles.map((r) => r.name);
+
+  return (
+    <PageContainer
+      title="Users & roles"
+      description="Manage users, roles, and read access (deny wins over grant)."
+    >
+      <InfoBanner>
+        Roles hold <strong>read</strong> grants only (write access is reserved to the super-user).
+        Grant <code>SELECT</code> on a table, a path glob, or all targets; a <strong>deny</strong>{" "}
+        always overrides a grant. Assign roles to users to give them access. The super-user is
+        defined by <code>BEACON_ADMIN_*</code> and can&rsquo;t be edited here.
+      </InfoBanner>
+
+      {error && (
+        <div className="mb-3 rounded-md border border-destructive/40 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <UsersCard
+        users={users}
+        loading={usersQuery.isLoading}
+        roleNames={roleNames}
+        busy={busy}
+        run={run}
+        onError={setError}
+      />
+
+      <div className="h-4" />
+
+      <RolesCard roles={roles} loading={rolesQuery.isLoading} busy={busy} run={run} />
+    </PageContainer>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Users
+// ---------------------------------------------------------------------------
+
+function UsersCard({
+  users,
+  loading,
+  roleNames,
+  busy,
+  run,
+  onError,
+}: {
+  users: AuthUser[];
+  loading: boolean;
+  roleNames: string[];
+  busy: boolean;
+  run: (fn: () => Promise<void>) => void;
+  onError: (msg: string) => void;
+}) {
+  const beacon = useBeacon();
+  const [open, setOpen] = React.useState(false);
+  const [username, setUsername] = React.useState("");
+  const [password, setPassword] = React.useState("");
+
+  function createUser() {
+    run(async () => {
+      await beacon.admin.createUser(username.trim(), password);
+      setOpen(false);
+      setUsername("");
+      setPassword("");
+    });
+  }
+
+  return (
+    <Card className="overflow-hidden">
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <h2 className="text-sm font-semibold">Users</h2>
+        <Button size="sm" className="gap-1.5" onClick={() => setOpen(true)}>
+          <UserPlus className="h-4 w-4" /> New user
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+        </div>
+      ) : (
+        <ul className="divide-y">
+          {users.map((u) => (
+            <li key={u.username} className="flex items-center gap-3 px-4 py-2.5 text-sm">
+              <span className="flex w-48 shrink-0 items-center gap-1.5 font-mono">
+                {u.is_super_user && <Shield className="h-3.5 w-3.5 text-primary" />}
+                {u.username}
+              </span>
+              {u.is_super_user ? (
+                <Badge variant="secondary">super-user · full access</Badge>
+              ) : (
+                <div className="flex flex-1 flex-wrap items-center gap-1.5">
+                  {u.roles.map((role) => (
+                    <Badge key={role} variant="muted" className="gap-1 pr-1">
+                      {role}
+                      <button
+                        title={`Remove role ${role}`}
+                        disabled={busy}
+                        className="rounded hover:text-destructive"
+                        onClick={() => run(() => beacon.admin.revokeRoleFromUser(u.username, role))}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </Badge>
+                  ))}
+                  {u.roles.length === 0 && (
+                    <span className="text-xs text-muted-foreground">no roles</span>
+                  )}
+                  <AddRoleControl
+                    options={roleNames.filter((r) => !u.roles.includes(r))}
+                    onAdd={(role) => run(() => beacon.admin.grantRoleToUser(u.username, role))}
+                    disabled={busy}
+                  />
+                  {u.is_anonymous && (
+                    <Badge variant="secondary" title="Disable with BEACON_AUTH_ANONYMOUS_ENABLED=false">
+                      anonymous · always on
+                    </Badge>
+                  )}
+                </div>
+              )}
+              {!u.is_super_user && !u.is_anonymous && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 shrink-0 p-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  title="Delete user"
+                  disabled={busy}
+                  onClick={() => {
+                    if (window.confirm(`Delete user "${u.username}"?`))
+                      run(() => beacon.admin.dropUser(u.username));
+                  }}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Dialog open={open} onOpenChange={(o) => !busy && setOpen(o)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New user</DialogTitle>
+            <DialogDescription>
+              Created users are read-only until you assign them roles.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="new-username">Username</Label>
+              <Input
+                id="new-username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder="alice"
+                autoComplete="off"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="new-password">Password</Label>
+              <Input
+                id="new-password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete="new-password"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setOpen(false)} disabled={busy}>
+              Cancel
+            </Button>
+            <Button
+              disabled={busy || !username.trim() || !password}
+              onClick={() => {
+                try {
+                  createUser();
+                } catch (e) {
+                  onError(errorMessage(e));
+                }
+              }}
+            >
+              {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Create user"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}
+
+/** A compact "add a role" select + button. */
+function AddRoleControl({
+  options,
+  onAdd,
+  disabled,
+}: {
+  options: string[];
+  onAdd: (role: string) => void;
+  disabled: boolean;
+}) {
+  const [value, setValue] = React.useState("");
+  if (options.length === 0) return null;
+  return (
+    <span className="flex items-center gap-1">
+      <NativeSelect
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="h-6 w-28 text-xs"
+        disabled={disabled}
+      >
+        <option value="">+ role…</option>
+        {options.map((r) => (
+          <option key={r} value={r}>
+            {r}
+          </option>
+        ))}
+      </NativeSelect>
+      {value && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-6 px-2 text-[11px]"
+          disabled={disabled}
+          onClick={() => {
+            onAdd(value);
+            setValue("");
+          }}
+        >
+          Add
+        </Button>
+      )}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Roles
+// ---------------------------------------------------------------------------
+
+function RolesCard({
+  roles,
+  loading,
+  busy,
+  run,
+}: {
+  roles: AuthRole[];
+  loading: boolean;
+  busy: boolean;
+  run: (fn: () => Promise<void>) => void;
+}) {
+  const beacon = useBeacon();
+  const [newRole, setNewRole] = React.useState("");
+
+  return (
+    <Card className="overflow-hidden">
+      <div className="flex items-center justify-between gap-3 border-b px-4 py-3">
+        <h2 className="text-sm font-semibold">Roles</h2>
+        <div className="flex items-center gap-2">
+          <Input
+            value={newRole}
+            onChange={(e) => setNewRole(e.target.value)}
+            placeholder="role name"
+            className="h-8 w-40"
+          />
+          <Button
+            size="sm"
+            className="gap-1.5"
+            disabled={busy || !newRole.trim()}
+            onClick={() =>
+              run(async () => {
+                await beacon.admin.createRole(newRole.trim());
+                setNewRole("");
+              })
+            }
+          >
+            <Plus className="h-4 w-4" /> Add role
+          </Button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+        </div>
+      ) : roles.length === 0 ? (
+        <div className="p-4 text-sm text-muted-foreground">No roles yet.</div>
+      ) : (
+        <ul className="divide-y">
+          {roles.map((role) => (
+            <RoleRow key={role.name} role={role} busy={busy} run={run} />
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+
+function RoleRow({
+  role,
+  busy,
+  run,
+}: {
+  role: AuthRole;
+  busy: boolean;
+  run: (fn: () => Promise<void>) => void;
+}) {
+  const beacon = useBeacon();
+  return (
+    <li className="px-4 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-mono text-sm font-medium">{role.name}</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1 px-2 text-[11px] text-destructive hover:bg-destructive/10 hover:text-destructive"
+          disabled={busy}
+          onClick={() => {
+            if (window.confirm(`Delete role "${role.name}"? Users lose any access it granted.`))
+              run(() => beacon.admin.dropRole(role.name));
+          }}
+        >
+          <Trash2 className="h-3.5 w-3.5" /> Delete role
+        </Button>
+      </div>
+
+      <div className="mt-2 space-y-1.5">
+        <RuleChips
+          label="Grants"
+          rules={role.grants}
+          tone="grant"
+          busy={busy}
+          onRevoke={(rule) => run(() => beacon.admin.revokePrivilege(role.name, ruleTarget(rule), false))}
+        />
+        <RuleChips
+          label="Denies"
+          rules={role.denies}
+          tone="deny"
+          busy={busy}
+          onRevoke={(rule) => run(() => beacon.admin.revokePrivilege(role.name, ruleTarget(rule), true))}
+        />
+      </div>
+
+      <AddRuleForm
+        busy={busy}
+        onAdd={(target, deny) => run(() => beacon.admin.grantPrivilege(role.name, target, deny))}
+      />
+    </li>
+  );
+}
+
+function RuleChips({
+  label,
+  rules,
+  tone,
+  busy,
+  onRevoke,
+}: {
+  label: string;
+  rules: AuthRule[];
+  tone: "grant" | "deny";
+  busy: boolean;
+  onRevoke: (rule: AuthRule) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 text-xs">
+      <span className="w-12 shrink-0 text-muted-foreground">{label}</span>
+      {rules.length === 0 && <span className="text-muted-foreground">—</span>}
+      {rules.map((rule, i) => (
+        <span
+          key={i}
+          className={
+            "flex items-center gap-1 rounded border px-1.5 py-0.5 font-mono " +
+            (tone === "deny"
+              ? "border-destructive/40 text-destructive"
+              : "border-emerald-600/40 text-emerald-700 dark:text-emerald-400")
+          }
+        >
+          {rule.privilege} · {targetLabel(rule)}
+          <button
+            title="Revoke"
+            disabled={busy}
+            className="hover:opacity-70"
+            onClick={() => onRevoke(rule)}
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** Inline form to add a grant/deny rule to a role. */
+function AddRuleForm({
+  busy,
+  onAdd,
+}: {
+  busy: boolean;
+  onAdd: (target: PrivilegeTarget, deny: boolean) => void;
+}) {
+  const [kind, setKind] = React.useState<"grant" | "deny">("grant");
+  const [targetType, setTargetType] = React.useState<"all" | "table" | "path">("all");
+  const [value, setValue] = React.useState("");
+
+  const needsValue = targetType !== "all";
+  const ready = !needsValue || value.trim().length > 0;
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-1.5">
+      <NativeSelect
+        value={kind}
+        onChange={(e) => setKind(e.target.value as "grant" | "deny")}
+        className="h-7 w-24 text-xs"
+        disabled={busy}
+      >
+        <option value="grant">Grant</option>
+        <option value="deny">Deny</option>
+      </NativeSelect>
+      <span className="text-xs text-muted-foreground">SELECT on</span>
+      <NativeSelect
+        value={targetType}
+        onChange={(e) => setTargetType(e.target.value as "all" | "table" | "path")}
+        className="h-7 w-28 text-xs"
+        disabled={busy}
+      >
+        <option value="all">all targets</option>
+        <option value="table">table</option>
+        <option value="path">path glob</option>
+      </NativeSelect>
+      {needsValue && (
+        <Input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={targetType === "table" ? "table name" : "argo/**/*.nc"}
+          className="h-7 w-44 font-mono text-xs"
+          disabled={busy}
+        />
+      )}
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 px-2 text-[11px]"
+        disabled={busy || !ready}
+        onClick={() => {
+          const target: PrivilegeTarget =
+            targetType === "all"
+              ? { type: "all" }
+              : { type: targetType, value: value.trim() };
+          onAdd(target, kind === "deny");
+          setValue("");
+          setTargetType("all");
+          setKind("grant");
+        }}
+      >
+        Add rule
+      </Button>
+    </div>
+  );
+}

--- a/clients/beacon-web/src/pages/datasets.tsx
+++ b/clients/beacon-web/src/pages/datasets.tsx
@@ -1,6 +1,25 @@
 import * as React from "react";
-import { useQuery } from "@tanstack/react-query";
-import { ChevronRight, CornerLeftUp, Eye, FileStack, Folder, Loader2, Search, Table2 } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowDown,
+  ArrowUp,
+  Check,
+  ChevronRight,
+  CornerLeftUp,
+  Download,
+  Eye,
+  FileStack,
+  Folder,
+  Loader2,
+  MoreHorizontal,
+  Search,
+  Table2,
+  Terminal,
+  Trash2,
+  Upload,
+  X,
+} from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { useBeacon } from "@/lib/beacon-context";
@@ -16,9 +35,20 @@ import { Badge } from "@/components/ui/badge";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Label } from "@/components/ui/label";
+import { CheckboxField } from "@/components/ui/checkbox-field";
+import { formatBytes } from "@/lib/format";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
@@ -28,6 +58,8 @@ const PREVIEW_ROWS = 10;
 interface DatasetItem {
   path: string;
   format?: string;
+  size?: number;
+  lastModified?: string;
 }
 
 /** Maps a dataset `format` id to the query DSL's `from` format key. */
@@ -35,6 +67,34 @@ function fromKey(format: string | undefined): string {
   if (!format) return "parquet";
   const map: Record<string, string> = { nc: "netcdf" };
   return map[format] ?? format;
+}
+
+/**
+ * Maps a dataset `format` id to the table function that reads it. Note the names
+ * are not always `read_<format>` (e.g. ODV's `txt` → `read_odv_ascii`).
+ */
+const READ_FUNCTIONS: Record<string, string> = {
+  nc: "read_netcdf",
+  parquet: "read_parquet",
+  csv: "read_csv",
+  arrow: "read_arrow",
+  zarr: "read_zarr",
+  geoparquet: "read_geoparquet",
+  txt: "read_odv_ascii",
+  tiff: "read_tiff",
+  bbf: "read_bbf",
+  atlas: "read_atlas",
+};
+
+/**
+ * Build a `SELECT * FROM read_<fmt>(['<path>']) LIMIT 100` query for a dataset
+ * file, escaping single quotes in the path. Falls back to `read_parquet` for an
+ * undetected format (consistent with the preview's default).
+ */
+function readQuery(item: DatasetItem): string {
+  const fn = (item.format && READ_FUNCTIONS[item.format]) ?? "read_parquet";
+  const escaped = item.path.replace(/'/g, "''");
+  return `SELECT *\nFROM ${fn}(['${escaped}'])\nLIMIT 100;`;
 }
 
 /** The dialog target: a dataset path/format and which tab to open. */
@@ -51,7 +111,9 @@ function normalize(raw: unknown): DatasetItem[] {
     const obj = item as Record<string, unknown>;
     const path = (obj.path ?? obj.file ?? obj.file_path ?? "") as string;
     const format = (obj.format ?? obj.file_format) as string | undefined;
-    return { path, format };
+    const size = typeof obj.size === "number" ? obj.size : undefined;
+    const lastModified = typeof obj.last_modified === "string" ? obj.last_modified : undefined;
+    return { path, format, size, lastModified };
   });
 }
 
@@ -98,11 +160,196 @@ function parentPrefix(p: string): string {
   return idx >= 0 ? trimmed.slice(0, idx + 1) : "";
 }
 
+/** One rendered row: the up (..) entry, a sub-folder, or a file. */
+type ListRow =
+  | { type: "up" }
+  | { type: "folder"; name: string; count: number }
+  | { type: "file"; item: DatasetItem; label: string };
+
+/** Fixed row height (px) and shared column grid — must match between header and rows. */
+const ROW_H = 40;
+const ROW_GRID =
+  "grid grid-cols-[minmax(0,1fr)_4rem_5rem_7rem_11rem] items-center gap-2";
+
+function rowKey(row: ListRow): React.Key {
+  if (row.type === "file") return row.item.path;
+  if (row.type === "folder") return "dir:" + row.name;
+  return "up";
+}
+
+/** Sortable columns and the active sort state. */
+type SortKey = "name" | "size" | "modified";
+interface SortState {
+  key: SortKey;
+  dir: "asc" | "desc";
+}
+
+/** Compact last-modified label, e.g. "Jun 28, 20:10". Empty when unknown. */
+function formatModified(iso: string | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/** Order two files by the active sort (folders are ordered separately, by name). */
+function compareFiles(a: DatasetItem, b: DatasetItem, sort: SortState): number {
+  let cmp: number;
+  if (sort.key === "size") cmp = (a.size ?? -1) - (b.size ?? -1);
+  else if (sort.key === "modified") cmp = (a.lastModified ?? "").localeCompare(b.lastModified ?? "");
+  else cmp = a.path.localeCompare(b.path);
+  return sort.dir === "asc" ? cmp : -cmp;
+}
+
+/**
+ * Minimal fixed-height window: renders only the rows overlapping the viewport
+ * (plus a small overscan), positioned inside a full-height spacer. Keeps the
+ * datasets list responsive even with tens of thousands of rows, without pulling
+ * in a virtualization dependency. Remount (via `key`) to reset scroll.
+ */
+function VirtualList<T>({
+  items,
+  rowHeight,
+  height,
+  getKey,
+  renderRow,
+}: {
+  items: T[];
+  rowHeight: number;
+  height: number;
+  getKey: (item: T) => React.Key;
+  renderRow: (item: T) => React.ReactNode;
+}) {
+  const [scrollTop, setScrollTop] = React.useState(0);
+  const overscan = 8;
+  const start = Math.max(0, Math.floor(scrollTop / rowHeight) - overscan);
+  const end = Math.min(items.length, start + Math.ceil(height / rowHeight) + overscan * 2);
+  return (
+    <div
+      className="overflow-auto"
+      style={{ height }}
+      onScroll={(e) => setScrollTop(e.currentTarget.scrollTop)}
+    >
+      <div style={{ height: items.length * rowHeight, position: "relative" }}>
+        <div style={{ transform: `translateY(${start * rowHeight}px)` }}>
+          {items.slice(start, end).map((item) => (
+            <div key={getKey(item)} style={{ height: rowHeight }}>
+              {renderRow(item)}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function DatasetsPage() {
   const beacon = useBeacon();
+  const qc = useQueryClient();
+  const navigate = useNavigate();
   const [path, setPath] = React.useState(""); // current folder prefix, "" = root, else ends with "/"
-  const [filter, setFilter] = React.useState("");
+  const [search, setSearch] = React.useState(""); // global path search; non-empty switches to flat results
+  const [sort, setSort] = React.useState<SortState>({ key: "name", dir: "asc" });
   const [dialog, setDialog] = React.useState<DialogTarget | null>(null);
+  const [banner, setBanner] = React.useState<{ kind: "error" | "info"; text: string } | null>(null);
+  const [uploadOpen, setUploadOpen] = React.useState(false);
+  const [droppedItems, setDroppedItems] = React.useState<UploadItem[]>([]);
+  const [dragging, setDragging] = React.useState(false);
+  // Depth counter so child elements firing dragenter/dragleave don't flicker the
+  // overlay; it only clears when we've truly left the drop zone.
+  const dragDepth = React.useRef(0);
+
+  const refreshDatasets = React.useCallback(() => {
+    qc.invalidateQueries({ queryKey: ["datasets-all"] });
+    qc.invalidateQueries({ queryKey: ["total-datasets"] });
+  }, [qc]);
+
+  const deleteMutation = useMutation({
+    mutationFn: (p: string) => beacon.admin.deleteDataset(p),
+    onSuccess: () => {
+      setBanner({ kind: "info", text: "File deleted." });
+      refreshDatasets();
+    },
+    onError: (e) => setBanner({ kind: "error", text: errorMessage(e) }),
+  });
+
+  async function download(p: string) {
+    setBanner(null);
+    try {
+      const blob = await beacon.admin.downloadDataset(p);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = baseName(p);
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setBanner({ kind: "error", text: errorMessage(e) });
+    }
+  }
+
+  // Open the query editor pre-filled with a table-function query for this file.
+  function openInQuery(item: DatasetItem) {
+    navigate("/query", { state: { sql: readQuery(item) } });
+  }
+
+  function openUpload(items: UploadItem[]) {
+    setDroppedItems(items);
+    setUploadOpen(true);
+  }
+
+  // Drag-and-drop: dropping files opens the upload dialog pre-loaded with them and
+  // the current folder as the destination (so you can still review before upload).
+  const isFileDrag = (e: React.DragEvent) => e.dataTransfer.types.includes("Files");
+  function onDragEnter(e: React.DragEvent) {
+    if (!isFileDrag(e)) return;
+    e.preventDefault();
+    dragDepth.current += 1;
+    setDragging(true);
+  }
+  function onDragOver(e: React.DragEvent) {
+    if (isFileDrag(e)) e.preventDefault(); // mark this a valid drop target
+  }
+  function onDragLeave() {
+    dragDepth.current = Math.max(0, dragDepth.current - 1);
+    if (dragDepth.current === 0) setDragging(false);
+  }
+  function onDrop(e: React.DragEvent) {
+    if (!isFileDrag(e)) return;
+    e.preventDefault();
+    dragDepth.current = 0;
+    setDragging(false);
+    // Expand folders (async) into a flat list of items; entries are read
+    // synchronously inside itemsFromDataTransfer before any await.
+    void itemsFromDataTransfer(e.dataTransfer).then((items) => {
+      if (items.length > 0) openUpload(items);
+    });
+  }
+
+  function onUploaded(folder: string, uploaded: number, failed: number) {
+    // Refresh the listing and move to the destination folder so the new files are
+    // visible behind the dialog. The dialog itself stays open (showing the per-file
+    // ✓/✗ status and summary) until the user dismisses it.
+    refreshDatasets();
+    goTo(folder);
+    setBanner(
+      failed > 0
+        ? {
+            kind: "error",
+            text: `${failed} file${failed === 1 ? "" : "s"} failed to upload${
+              uploaded > 0 ? `, ${uploaded} succeeded` : ""
+            } — see the list for details.`,
+          }
+        : { kind: "info", text: `Uploaded ${uploaded} file${uploaded === 1 ? "" : "s"}.` },
+    );
+  }
 
   const totalQuery = useQuery({ queryKey: ["total-datasets"], queryFn: () => beacon.totalDatasets() });
   const datasetsQuery = useQuery({
@@ -111,16 +358,166 @@ export function DatasetsPage() {
   });
 
   const items = datasetsQuery.data ?? [];
-  const { folders, files } = React.useMemo(() => browse(items, path, filter), [items, path, filter]);
+  const searching = search.trim().length > 0;
   const crumbs = path ? path.replace(/\/$/, "").split("/") : [];
+
+  // Unified, virtualizable row list. A non-empty search switches to a flat list
+  // of all matching files (by full path) across every folder; otherwise it's the
+  // current folder's sub-folders and files.
+  const rows = React.useMemo<ListRow[]>(() => {
+    if (searching) {
+      const q = search.trim().toLowerCase();
+      return items
+        .filter((it) => it.path.toLowerCase().includes(q))
+        .sort((a, b) => compareFiles(a, b, sort))
+        .map((item) => ({ type: "file", item, label: item.path }));
+    }
+    const { folders, files } = browse(items, path, "");
+    const list: ListRow[] = [];
+    if (path) list.push({ type: "up" });
+    // Folders stay grouped on top (name-ordered); files follow the active sort.
+    for (const f of folders) list.push({ type: "folder", name: f.name, count: f.count });
+    for (const file of [...files].sort((a, b) => compareFiles(a, b, sort)))
+      list.push({ type: "file", item: file, label: baseName(file.path) });
+    return list;
+  }, [items, path, search, searching, sort]);
+
+  function toggleSort(key: SortKey) {
+    setSort((s) => (s.key === key ? { key, dir: s.dir === "asc" ? "desc" : "asc" } : { key, dir: "asc" }));
+  }
+
+  function sortHeader(label: string, col: SortKey, align: "left" | "right" = "left") {
+    const active = sort.key === col;
+    return (
+      <button
+        onClick={() => toggleSort(col)}
+        className={cn(
+          "flex items-center gap-1 hover:text-foreground",
+          align === "right" && "justify-end",
+        )}
+      >
+        {label}
+        {active &&
+          (sort.dir === "asc" ? (
+            <ArrowUp className="h-3 w-3" />
+          ) : (
+            <ArrowDown className="h-3 w-3" />
+          ))}
+      </button>
+    );
+  }
 
   function enter(folder: string) {
     setPath(path + folder + "/");
-    setFilter("");
+    setSearch("");
   }
   function goTo(prefix: string) {
     setPath(prefix);
-    setFilter("");
+    setSearch("");
+  }
+
+  function renderRow(row: ListRow): React.ReactNode {
+    const rowClass = ROW_GRID + " h-full w-full border-b px-3 text-xs hover:bg-muted/50";
+    if (row.type === "up") {
+      return (
+        <button onClick={() => goTo(parentPrefix(path))} className={rowClass + " text-left"}>
+          <span className="flex items-center gap-1.5 font-mono text-muted-foreground">
+            <CornerLeftUp className="h-3.5 w-3.5 shrink-0" /> ..
+          </span>
+          <span />
+          <span />
+          <span />
+          <span />
+        </button>
+      );
+    }
+    if (row.type === "folder") {
+      return (
+        <button onClick={() => enter(row.name)} className={rowClass + " text-left"}>
+          <span className="flex min-w-0 items-center gap-1.5 font-mono">
+            <Folder className="h-3.5 w-3.5 shrink-0 text-primary" />
+            <span className="truncate">{row.name}</span>
+          </span>
+          <span className="text-muted-foreground">
+            {row.count} item{row.count === 1 ? "" : "s"}
+          </span>
+          <span />
+          <span />
+          <span />
+        </button>
+      );
+    }
+    const d = row.item;
+    return (
+      <div className={rowClass}>
+        <button
+          className="flex min-w-0 items-center gap-1.5 text-left font-mono hover:text-primary hover:underline"
+          onClick={() => setDialog({ path: d.path, format: d.format, tab: "preview" })}
+          title={d.path}
+        >
+          <FileStack className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span className="truncate">{row.label}</span>
+        </button>
+        <span className="min-w-0 truncate">
+          {d.format ? <Badge variant="muted">{d.format}</Badge> : "—"}
+        </span>
+        <span className="truncate text-right tabular-nums text-muted-foreground">
+          {typeof d.size === "number" ? formatBytes(d.size) : "—"}
+        </span>
+        <span className="truncate text-muted-foreground" title={d.lastModified}>
+          {formatModified(d.lastModified)}
+        </span>
+        <div className="flex justify-end gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-6 gap-1 px-2 text-[11px]"
+            onClick={() => setDialog({ path: d.path, format: d.format, tab: "preview" })}
+          >
+            <Eye className="h-3 w-3" /> Preview
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-6 gap-1 px-2 text-[11px]"
+            onClick={() => setDialog({ path: d.path, format: d.format, tab: "schema" })}
+          >
+            <Table2 className="h-3 w-3" /> Schema
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-6 w-6 p-0" title="More actions">
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => openInQuery(d)}>
+                <Terminal className="mr-2 h-3.5 w-3.5" /> Query
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => download(d.path)}>
+                <Download className="mr-2 h-3.5 w-3.5" /> Download
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-destructive focus:text-destructive"
+                disabled={deleteMutation.isPending}
+                onClick={() => {
+                  if (
+                    window.confirm(
+                      `Delete "${baseName(d.path)}"? This permanently removes the file from the datasets store.`,
+                    )
+                  ) {
+                    setBanner(null);
+                    deleteMutation.mutate(d.path);
+                  }
+                }}
+              >
+                <Trash2 className="mr-2 h-3.5 w-3.5" /> Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -128,16 +525,38 @@ export function DatasetsPage() {
       title="Datasets"
       description="Browse the datasets store. Preview rows or inspect a file's schema."
       actions={
-        typeof totalQuery.data === "number" ? (
-          <Badge variant="secondary">{totalQuery.data} total</Badge>
-        ) : undefined
+        <div className="flex items-center gap-2">
+          {typeof totalQuery.data === "number" && (
+            <Badge variant="secondary">{totalQuery.data} total</Badge>
+          )}
+          <Button size="sm" className="gap-1.5" onClick={() => openUpload([])}>
+            <Upload className="h-4 w-4" />
+            Upload
+          </Button>
+        </div>
       }
     >
       <InfoBanner>
         Datasets are the raw files discovered in the datasets store. Browse folders, preview the
-        first rows, or inspect a file&rsquo;s schema. To make them queryable, register a table from
-        the <strong>Tables</strong> page (External table) or via a Crawler.
+        first rows, or inspect a file&rsquo;s schema. To query a file, hit <strong>Query</strong> to
+        open the editor on a table function (e.g.{" "}
+        <span className="font-mono">read_netcdf(&hellip;)</span>), or register a reusable table from
+        the <strong>Tables</strong> page (External table) or via a Crawler. <strong>Upload</strong>{" "}
+        adds files at any path you choose &mdash; type a destination folder to drop them into an
+        existing folder or create a new one.
       </InfoBanner>
+      {banner && (
+        <div
+          className={cn(
+            "mb-3 rounded-md border px-3 py-2 text-sm",
+            banner.kind === "error"
+              ? "border-destructive/40 text-destructive"
+              : "border-border text-muted-foreground",
+          )}
+        >
+          {banner.text}
+        </div>
+      )}
       <div className="mb-3 flex items-center gap-3">
         <nav className="flex flex-wrap items-center gap-1 text-sm">
           <button
@@ -161,108 +580,72 @@ export function DatasetsPage() {
             </span>
           ))}
         </nav>
-        <div className="relative ml-auto w-64">
+        <div className="relative ml-auto w-72">
           <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-            placeholder="Filter this folder"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search all files by path…"
             className="h-8 pl-8"
           />
         </div>
       </div>
 
-      <Card className="overflow-hidden">
-        {datasetsQuery.isLoading && (
-          <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" /> Loading datasets…
+      <div
+        className="relative"
+        onDragEnter={onDragEnter}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+      >
+        {dragging && (
+          <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-lg border-2 border-dashed border-primary bg-primary/5 text-sm font-medium text-primary">
+            <span className="flex items-center gap-2">
+              <Upload className="h-4 w-4" />
+              Drop to upload to {path || "the datasets root"}
+            </span>
           </div>
         )}
+        <Card className="overflow-hidden">
+          {datasetsQuery.isLoading && (
+            <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" /> Loading datasets…
+            </div>
+          )}
         {datasetsQuery.isError && (
           <div className="p-4 text-sm text-destructive">{errorMessage(datasetsQuery.error)}</div>
         )}
-        {datasetsQuery.data && folders.length === 0 && files.length === 0 && (
+        {datasetsQuery.data && rows.length === 0 && (
           <div className="p-4 text-sm text-muted-foreground">
-            {filter ? "Nothing matches in this folder." : "This folder is empty."}
+            {searching ? `No files match “${search.trim()}”.` : "This folder is empty."}
           </div>
         )}
-        {datasetsQuery.data && (folders.length > 0 || files.length > 0) && (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead className="w-28">Format</TableHead>
-                <TableHead className="w-56 text-right">Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {path !== "" && (
-                <TableRow className="cursor-pointer" onClick={() => goTo(parentPrefix(path))}>
-                  <TableCell className="font-mono text-xs">
-                    <span className="flex items-center gap-1.5 text-muted-foreground">
-                      <CornerLeftUp className="h-3.5 w-3.5 shrink-0" /> ..
-                    </span>
-                  </TableCell>
-                  <TableCell />
-                  <TableCell />
-                </TableRow>
-              )}
-              {folders.map((d) => (
-                <TableRow key={"dir:" + d.name} className="cursor-pointer" onClick={() => enter(d.name)}>
-                  <TableCell className="font-mono text-xs">
-                    <span className="flex items-center gap-1.5">
-                      <Folder className="h-3.5 w-3.5 shrink-0 text-primary" />
-                      {d.name}
-                    </span>
-                  </TableCell>
-                  <TableCell className="text-xs text-muted-foreground">
-                    {d.count} item{d.count === 1 ? "" : "s"}
-                  </TableCell>
-                  <TableCell />
-                </TableRow>
-              ))}
-              {files.map((d) => (
-                <TableRow key={d.path}>
-
-                  <TableCell className="font-mono text-xs">
-                    <button
-                      className="flex items-center gap-1.5 text-left hover:text-primary hover:underline"
-                      onClick={() => setDialog({ path: d.path, format: d.format, tab: "preview" })}
-                      title="Preview rows"
-                    >
-                      <FileStack className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                      {baseName(d.path)}
-                    </button>
-                  </TableCell>
-                  <TableCell className="py-0">
-                    {d.format ? <Badge variant="muted">{d.format}</Badge> : "—"}
-                  </TableCell>
-                  <TableCell className="py-0 text-right">
-                    <div className="flex justify-end gap-2">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-6 gap-1 px-2 text-[11px]"
-                        onClick={() => setDialog({ path: d.path, format: d.format, tab: "preview" })}
-                      >
-                        <Eye className="h-3 w-3" /> Preview
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-6 gap-1 px-2 text-[11px]"
-                        onClick={() => setDialog({ path: d.path, format: d.format, tab: "schema" })}
-                      >
-                        <Table2 className="h-3 w-3" /> Schema
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+        {datasetsQuery.data && rows.length > 0 && (
+          <>
+            {searching && (
+              <div className="border-b px-3 py-1.5 text-xs text-muted-foreground">
+                {rows.length.toLocaleString()} match{rows.length === 1 ? "" : "es"} across all folders
+              </div>
+            )}
+            <div className={ROW_GRID + " border-b bg-muted/30 px-3 py-2 text-xs font-medium text-muted-foreground"}>
+              {sortHeader("Name", "name")}
+              <span>Format</span>
+              {sortHeader("Size", "size", "right")}
+              {sortHeader("Modified", "modified")}
+              <span className="text-right">Actions</span>
+            </div>
+            <VirtualList
+              key={searching ? "search:" + search.trim() : "path:" + path}
+              items={rows}
+              rowHeight={ROW_H}
+              height={Math.min(rows.length * ROW_H, 560)}
+              getKey={rowKey}
+              renderRow={renderRow}
+            />
+          </>
         )}
-      </Card>
+        </Card>
+      </div>
 
       <Dialog open={dialog !== null} onOpenChange={(o) => !o && setDialog(null)}>
         <DialogContent className="max-w-4xl grid-cols-1">
@@ -285,7 +668,400 @@ export function DatasetsPage() {
           )}
         </DialogContent>
       </Dialog>
+
+      <UploadDialog
+        open={uploadOpen}
+        onOpenChange={setUploadOpen}
+        initialFolder={path}
+        initialItems={droppedItems}
+        onUploaded={onUploaded}
+        onError={(text) => setBanner({ kind: "error", text })}
+      />
     </PageContainer>
+  );
+}
+
+/** A file plus its path relative to the destination, preserving dropped/picked folder structure. */
+interface UploadItem {
+  file: File;
+  relPath: string;
+}
+
+/** Per-file upload status, keyed by `relPath`, shown in the dialog's file list. */
+interface ItemStatus {
+  state: "uploading" | "done" | "error";
+  error?: string;
+}
+
+const totalBytes = (items: UploadItem[]) => items.reduce((sum, it) => sum + it.file.size, 0);
+
+/** Map a flat FileList to upload items, honoring `webkitRelativePath` (set when a folder is picked). */
+function itemsFromFileList(list: FileList): UploadItem[] {
+  return Array.from(list).map((file) => ({ file, relPath: file.webkitRelativePath || file.name }));
+}
+
+/** Recursively expand a dropped file-system entry into upload items under `prefix`. */
+async function expandEntry(entry: FileSystemEntry, prefix: string): Promise<UploadItem[]> {
+  if (entry.isFile) {
+    const file = await new Promise<File>((resolve, reject) =>
+      (entry as FileSystemFileEntry).file(resolve, reject),
+    );
+    return [{ file, relPath: prefix + entry.name }];
+  }
+  const reader = (entry as FileSystemDirectoryEntry).createReader();
+  // readEntries returns the directory in batches; call until it yields none.
+  const readBatch = () =>
+    new Promise<FileSystemEntry[]>((resolve, reject) => reader.readEntries(resolve, reject));
+  const items: UploadItem[] = [];
+  for (let batch = await readBatch(); batch.length > 0; batch = await readBatch()) {
+    for (const child of batch) {
+      items.push(...(await expandEntry(child, `${prefix}${entry.name}/`)));
+    }
+  }
+  return items;
+}
+
+/**
+ * Turn a drop's `DataTransfer` into upload items, expanding any dropped folders.
+ * Entries are only valid during the drop event, so they must be captured
+ * synchronously (the loop below) before the async directory traversal.
+ */
+async function itemsFromDataTransfer(dt: DataTransfer): Promise<UploadItem[]> {
+  const entries: FileSystemEntry[] = [];
+  const looseFiles: File[] = [];
+  for (const item of Array.from(dt.items)) {
+    if (item.kind !== "file") continue;
+    const entry = item.webkitGetAsEntry?.();
+    if (entry) entries.push(entry);
+    else {
+      const file = item.getAsFile();
+      if (file) looseFiles.push(file);
+    }
+  }
+  const nested = (await Promise.all(entries.map((entry) => expandEntry(entry, "")))).flat();
+  return [...nested, ...looseFiles.map((file) => ({ file, relPath: file.name }))];
+}
+
+/**
+ * Normalize a user-typed destination folder into an object-store key prefix:
+ * trims, drops leading slashes, collapses repeats, and ensures a single trailing
+ * slash. "" means the datasets root.
+ */
+function normalizeFolder(input: string): string {
+  const p = input.trim().replace(/^\/+/, "").replace(/\/{2,}/g, "/");
+  if (!p) return "";
+  return p.endsWith("/") ? p : p + "/";
+}
+
+/**
+ * Upload dialog: pick files and choose the destination folder. Files are written
+ * to `<folder><filename>`, so typing a new (possibly nested) folder is how you
+ * create one — object storage has no empty folders. Large files use the SDK's
+ * resumable chunked path automatically; a per-file progress bar is shown.
+ */
+function UploadDialog({
+  open,
+  onOpenChange,
+  initialFolder,
+  initialItems,
+  onUploaded,
+  onError,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialFolder: string;
+  initialItems?: UploadItem[];
+  onUploaded: (folder: string, uploaded: number, failed: number) => void;
+  onError: (message: string) => void;
+}) {
+  const beacon = useBeacon();
+  const [folder, setFolder] = React.useState(initialFolder);
+  const [overwrite, setOverwrite] = React.useState(false);
+  const [selected, setSelected] = React.useState<UploadItem[]>([]);
+  const [progress, setProgress] = React.useState<{
+    name: string;
+    index: number;
+    count: number;
+    pct: number;
+  } | null>(null);
+  const [statuses, setStatuses] = React.useState<Record<string, ItemStatus>>({});
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const folderInputRef = React.useRef<HTMLInputElement | null>(null);
+
+  // Seed the folder/items from the props ONLY when the dialog opens. Keying this
+  // on `open` alone (not initialFolder/initialItems) is deliberate: after a
+  // successful upload the page navigates to the destination folder, which changes
+  // `initialFolder` — if that re-ran the reset, it would wipe the just-finished
+  // ✓/✗ status while the dialog is still open. The dialog must persist its result
+  // until the user dismisses it.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  React.useEffect(() => {
+    if (open) {
+      setFolder(initialFolder);
+      setSelected(initialItems ?? []);
+      setStatuses({});
+      setOverwrite(false);
+      setProgress(null);
+    }
+  }, [open]);
+
+  // `webkitdirectory` is not a typed React prop, so set it via a callback ref the
+  // moment the element mounts — more reliable than an effect, which can run before
+  // the (portal-mounted) input is attached. With it set, the second picker selects
+  // a whole folder; files keep their relative paths via `webkitRelativePath`.
+  const folderInputCallbackRef = React.useCallback((el: HTMLInputElement | null) => {
+    folderInputRef.current = el;
+    if (el) {
+      el.setAttribute("webkitdirectory", "");
+      el.setAttribute("directory", "");
+    }
+  }, []);
+
+  const dest = normalizeFolder(folder);
+  const bytes = totalBytes(selected);
+
+  const hasErrors = Object.values(statuses).some((s) => s.state === "error");
+
+  // Live tally for the summary line, by per-file status.
+  const counts = selected.reduce(
+    (acc, it) => {
+      const state = statuses[it.relPath]?.state;
+      if (state === "done") acc.done += 1;
+      else if (state === "error") acc.failed += 1;
+      else if (state === "uploading") acc.uploading += 1;
+      else acc.pending += 1;
+      return acc;
+    },
+    { done: 0, failed: 0, uploading: 0, pending: 0 },
+  );
+  const started = counts.done + counts.failed + counts.uploading > 0;
+  const allDone = selected.length > 0 && counts.done === selected.length;
+
+  const upload = useMutation({
+    // Upload each file independently: a failure marks just that file and the run
+    // continues, so one bad file in a big folder doesn't abort the rest. Overall
+    // progress is completed bytes plus the current file's reported bytes, over the
+    // grand total. Files already uploaded in a prior attempt are skipped (so the
+    // Upload button doubles as "retry the failed ones").
+    mutationFn: async () => {
+      let bytesDone = 0;
+      let uploaded = 0;
+      let failed = 0;
+      for (const [index, item] of selected.entries()) {
+        if (statuses[item.relPath]?.state === "done") {
+          bytesDone += item.file.size;
+          uploaded += 1;
+          continue;
+        }
+        const update = (extra: number) =>
+          setProgress({
+            name: item.relPath,
+            index,
+            count: selected.length,
+            pct: bytes > 0 ? Math.round(((bytesDone + extra) / bytes) * 100) : 100,
+          });
+        update(0); // mark the file started — small (single-shot) files emit no onProgress
+        setStatuses((s) => ({ ...s, [item.relPath]: { state: "uploading" } }));
+        try {
+          await beacon.admin.uploadDataset(dest + item.relPath, item.file, {
+            overwrite,
+            onProgress: ({ uploaded: u }) => update(u),
+          });
+          setStatuses((s) => ({ ...s, [item.relPath]: { state: "done" } }));
+          uploaded += 1;
+        } catch (e) {
+          setStatuses((s) => ({ ...s, [item.relPath]: { state: "error", error: errorMessage(e) } }));
+          failed += 1;
+        }
+        bytesDone += item.file.size;
+      }
+      return { uploaded, failed };
+    },
+    // Per-file errors are caught above, so this resolves even on partial failure;
+    // the page decides whether to close the dialog (only on a fully clean run).
+    onSuccess: ({ uploaded, failed }) => onUploaded(dest, uploaded, failed),
+    onError: (e) => onError(errorMessage(e)),
+    onSettled: () => setProgress(null),
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !upload.isPending && onOpenChange(o)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Upload files</DialogTitle>
+          <DialogDescription>
+            Files are written into the destination folder, keeping the structure of any folders you
+            add. A new folder is created automatically when the first file lands in it.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="upload-dest">Destination folder</Label>
+            <Input
+              id="upload-dest"
+              value={folder}
+              placeholder="(datasets root)"
+              onChange={(e) => setFolder(e.target.value)}
+              className="font-mono text-xs"
+            />
+            <p className="text-xs text-muted-foreground">
+              Use <span className="font-mono">/</span> to nest, e.g.{" "}
+              <span className="font-mono">ctd/cruise42/</span>. Leave empty for the root.
+            </p>
+          </div>
+
+          <div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={(e) => {
+                if (e.target.files) setSelected(itemsFromFileList(e.target.files));
+                e.target.value = "";
+              }}
+            />
+            <input
+              ref={folderInputCallbackRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={(e) => {
+                if (e.target.files) setSelected(itemsFromFileList(e.target.files));
+                e.target.value = "";
+              }}
+            />
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                Choose files…
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => folderInputRef.current?.click()}
+              >
+                Choose folder…
+              </Button>
+              <span className="text-xs text-muted-foreground">
+                or drag &amp; drop files/folders onto the list
+              </span>
+            </div>
+            {selected.length > 0 && (
+              <>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {selected.length} file{selected.length === 1 ? "" : "s"} · {formatBytes(bytes)}
+                  {started && (
+                    <>
+                      {" — "}
+                      <span className="text-emerald-600">{counts.done} done</span>
+                      {" · "}
+                      <span className={counts.failed > 0 ? "text-destructive" : undefined}>
+                        {counts.failed} failed
+                      </span>
+                      {counts.uploading > 0 && <>{` · ${counts.uploading} uploading`}</>}
+                      {" · "}
+                      {counts.pending} pending
+                    </>
+                  )}
+                </p>
+                <ul className="mt-1 max-h-44 space-y-1 overflow-auto rounded-md border p-2 text-xs">
+                  {selected.map((it) => {
+                    const st = statuses[it.relPath];
+                    return (
+                      <li
+                        key={it.relPath}
+                        className="flex items-center justify-between gap-3 font-mono"
+                      >
+                        <span className="flex min-w-0 items-center gap-1.5">
+                          {st?.state === "uploading" && (
+                            <Loader2 className="h-3 w-3 shrink-0 animate-spin text-muted-foreground" />
+                          )}
+                          {st?.state === "done" && (
+                            <Check className="h-3 w-3 shrink-0 text-emerald-500" />
+                          )}
+                          {st?.state === "error" && (
+                            <X className="h-3 w-3 shrink-0 text-destructive" />
+                          )}
+                          <span className="truncate" title={dest + it.relPath}>
+                            {dest}
+                            {it.relPath}
+                          </span>
+                        </span>
+                        <span className="shrink-0 text-muted-foreground">
+                          {st?.state === "error" ? (
+                            <span className="text-destructive" title={st.error}>
+                              failed
+                            </span>
+                          ) : (
+                            formatBytes(it.file.size)
+                          )}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            )}
+          </div>
+
+          <CheckboxField
+            checked={overwrite}
+            onChange={setOverwrite}
+            label="Overwrite existing files"
+            hint="Replace a file if one already exists at the same path (otherwise the upload fails)."
+          />
+
+          {progress && (
+            <div className="rounded-md border border-border px-3 py-2">
+              <div className="mb-1 flex items-center justify-between gap-2 text-xs text-muted-foreground">
+                <span className="truncate font-mono">
+                  Uploading {Math.min(progress.index + 1, progress.count)} of {progress.count}:{" "}
+                  {progress.name}
+                </span>
+                <span className="tabular-nums">{progress.pct}%</span>
+              </div>
+              <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full bg-primary transition-[width] duration-200"
+                  style={{ width: `${progress.pct}%` }}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={upload.isPending}>
+            {started && !upload.isPending ? "Close" : "Cancel"}
+          </Button>
+          <Button
+            className="gap-1.5"
+            disabled={selected.length === 0 || upload.isPending || allDone}
+            onClick={() => upload.mutate()}
+          >
+            {upload.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : allDone ? (
+              <Check className="h-4 w-4" />
+            ) : (
+              <Upload className="h-4 w-4" />
+            )}
+            {allDone
+              ? "Uploaded"
+              : hasErrors
+                ? "Retry failed"
+                : `Upload${selected.length > 0 ? ` ${selected.length} file${selected.length === 1 ? "" : "s"}` : ""}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/clients/beacon-web/src/pages/workbench.tsx
+++ b/clients/beacon-web/src/pages/workbench.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useLocation } from "react-router-dom";
 import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import type { ArrowTable, Row } from "@beacon/client";
 import {
@@ -70,8 +71,12 @@ const STARTER_SQL = "SELECT 1 AS n";
 
 export function WorkbenchPage() {
   const beacon = useBeacon();
+  const location = useLocation();
   const editorRef = React.useRef<ReactCodeMirrorRef>(null);
-  const [sql, setSql] = React.useState(STARTER_SQL);
+  // Another page (e.g. Datasets → "Query") can open the editor pre-filled by
+  // navigating to `/query` with `{ state: { sql } }`.
+  const initialSql = (location.state as { sql?: string } | null)?.sql;
+  const [sql, setSql] = React.useState(initialSql ?? STARTER_SQL);
   const [running, setRunning] = React.useState(false);
   const [explaining, setExplaining] = React.useState(false);
   const [analyzing, setAnalyzing] = React.useState(false);

--- a/design/ui-file-management.md
+++ b/design/ui-file-management.md
@@ -1,0 +1,285 @@
+# Design: Dataset file management through the admin UI
+
+**Status:** v1 implemented (upload + download + delete, super-user-only)
+**Author:** (design discussion)
+**Scope:** Let super-users upload, download, and delete dataset files from the
+beacon-web admin UI, backed by new authenticated `/api/admin/datasets/*`
+endpoints over the existing object-storage layer.
+
+## Implementation status (v1)
+
+Shipped on this branch:
+
+- **Core** ([beacon-core/src/dataset_files.rs](../beacon-core/src/dataset_files.rs)) —
+  `validate_dataset_path` (anti-traversal + internal-prefix guard), extension
+  allowlist, and streamed `upload`/`download`/`delete` over the datasets store,
+  with unit tests. Runtime methods (`upload_dataset`/`download_dataset`/
+  `delete_dataset`) wire in the allowlist (from the format registry), the
+  `BEACON_MAX_UPLOAD_BYTES` cap, and a best-effort delete dependency check
+  against registered tables.
+- **API** ([beacon-api/src/axum/admin/datasets.rs](../beacon-api/src/axum/admin/datasets.rs)) —
+  `POST /api/admin/datasets/upload` (streaming), `GET …/datasets/download`,
+  `DELETE …/datasets`, behind the existing super-user `basic_auth` gate, with
+  status mapping (400/404/409/413) and end-to-end HTTP tests.
+- **Config** — `BEACON_MAX_UPLOAD_BYTES` (default 5 GiB; `0` = unlimited).
+- **Chunked / resumable upload** for large files — `UploadManager`
+  ([beacon-core/src/dataset_uploads.rs](../beacon-core/src/dataset_uploads.rs))
+  keeps one session per upload (object-store `MultipartUpload` handle), accepts
+  atomic, in-order, idempotently-retryable parts, enforces the cumulative cap,
+  and a background sweeper aborts idle sessions. Endpoints:
+  `POST …/datasets/upload/initiate`, `PUT …/upload/part`, `POST …/upload/complete`,
+  `DELETE …/upload`. Config: `BEACON_UPLOAD_PART_SIZE` (default 8 MiB),
+  `BEACON_UPLOAD_SESSION_TTL_SECS` (default 1 h).
+- **SDK** ([clients/beacon-ts/src/admin.ts](../clients/beacon-ts/src/admin.ts)) —
+  `uploadDataset` (auto **threshold switch**: single-shot ≤ 50 MiB, chunked above,
+  with per-part retry + `onProgress`) / `downloadDataset` / `deleteDataset`.
+- **Web UI** ([clients/beacon-web/src/pages/datasets.tsx](../clients/beacon-web/src/pages/datasets.tsx)) —
+  Upload button (uploads into the browsed folder, with a progress bar) + per-file
+  Download/Delete.
+
+Deferred to later iterations (see §7): soft-delete/trash, audit log, per-deployment
+quota, Zarr-directory upload, rename/move, and per-path RBAC enforcement. Note
+v1 already includes delete (with the dependency check) rather than holding it to
+v2 as originally staged.
+
+---
+
+## 1. Motivation
+
+Beacon discovers data files passively from the datasets store
+(`DatasetsStore`, local FS or S3). There is currently **no in-product way to get
+a file in or out**: operators must `scp` / `aws s3 cp` into the mounted volume
+out of band. The web UI's [datasets page](../clients/beacon-web/src/pages/datasets.tsx)
+is read-only browse + schema preview.
+
+This is the missing first step of the core self-service loop the UI already
+half-supports: *drop a file → `CREATE EXTERNAL TABLE` over it → query it*. The
+external-table dialog and query editor already exist; only the "drop a file"
+(and its inverse, "get a result file out") steps are missing.
+
+Goals:
+
+- **Upload** one or more dataset files into the datasets store from the UI.
+- **Download** an existing dataset file from the UI.
+- **Delete** a dataset file from the UI, safely.
+
+Non-goals (this iteration):
+
+- Folder rename/move, multi-file archive download, drag-and-drop reorganization.
+- Editing file contents in place.
+- Exposing these operations to non-super-user roles (see §6 — the privilege
+  vocabulary is designed to allow it later, but enforcement stays super-user-only
+  for v1).
+- Managing the internal writeable prefix (`__beacon__`) — that stays hidden.
+
+---
+
+## 2. Current state (what we build on)
+
+| Piece | Location | Relevance |
+|---|---|---|
+| `ObjectStores { datasets, tables, tmp }` | [beacon-object-storage/src/lib.rs](../beacon-object-storage/src/lib.rs) | `datasets` is an `Arc<DatasetsStore>` wrapping `object_store` (local or S3). `put`/`get`/`delete` are native to `object_store`. |
+| `DatasetsStore` | [beacon-object-storage/src/datasets_store.rs](../beacon-object-storage/src/datasets_store.rs) | Lists/caches/watches files; hides Beacon-internal objects; has `DATASETS_WRITEABLE_PREFIX = "__beacon__"` for internal writeable objects and `is_*_writeable_prefix` guards. |
+| Admin router | [beacon-api/src/axum/admin/mod.rs](../beacon-api/src/axum/admin/mod.rs) | `/api/admin/*`, gated by `basic_auth` middleware. New resource slots in next to crawlers/external-tables. |
+| `basic_auth` middleware | [beacon-api/src/axum/auth.rs](../beacon-api/src/axum/auth.rs) | Rejects non-super-user (`identity.is_super_user`) with 403; 401 if no/invalid creds. |
+| Privilege model | [beacon-auth/src/role.rs](../beacon-auth/src/role.rs) | `Privilege::{Read, Insert, Delete, …}` × `PrivilegeTarget` (tables **and** path-globs). Vocabulary to extend later. |
+| Datasets page | [clients/beacon-web/src/pages/datasets.tsx](../clients/beacon-web/src/pages/datasets.tsx) | Folder tree, preview, schema. Host for upload/download/delete controls. |
+| TS SDK admin client | [clients/beacon-ts/src/admin.ts](../clients/beacon-ts/src/admin.ts) | `admin.createCrawler()` etc. New `admin.uploadDataset()` / `downloadDataset()` / `deleteDataset()` land here. |
+
+Key existing affordance: the object store already distinguishes a
+Beacon-internal writeable prefix from user-visible datasets. User uploads must
+land in the **user-visible** area, never under `__beacon__`, and the internal
+prefix must remain rejected for all three operations.
+
+---
+
+## 3. API design
+
+All endpoints live under the existing super-user-gated admin router and return
+the admin error shape (`bad_request` → 400 with text). Paths are relative to the
+datasets-store root and always validated (see §4).
+
+### 3.1 Upload
+
+```
+POST /api/admin/datasets/upload?path=<dir/relative/path>
+Content-Type: application/octet-stream   (single-file, streaming body)
+```
+
+- `path` is the **destination key** (directory + filename) relative to the
+  datasets root, e.g. `ctd/cruise42/station1.nc`.
+- Body is streamed straight into `datasets.put_multipart` / chunked `put` — never
+  buffered whole in memory (scientific NetCDF/Zarr files are large).
+- **Overwrite policy:** reject if key exists unless `?overwrite=true`. Default is
+  reject, to avoid silently clobbering a file backing a live table.
+- Response `201`: `{ "path": "...", "size": <bytes>, "etag": "..." }`.
+
+> Multipart/form-data is an acceptable alternative if the frontend upload library
+> needs it; the streaming raw-body form is preferred to keep memory flat. Pick
+> one and keep the SDK consistent.
+
+For Zarr (a directory of many files) the v1 answer is: upload a **zipped** Zarr
+and unpack server-side into a directory key, OR require per-object uploads.
+Recommend deferring Zarr-directory upload to a follow-up and documenting the
+limitation; single-file formats (NetCDF, Parquet, CSV, Arrow, GeoTIFF) cover the
+common case.
+
+### 3.2 Download
+
+```
+GET /api/admin/datasets/download?path=<relative/path>
+```
+
+- Streams `datasets.get(path)` body back with
+  `Content-Disposition: attachment; filename="<basename>"` and a best-effort
+  `Content-Type`.
+- 404 if the key does not exist or resolves under a hidden/internal prefix.
+
+### 3.3 Delete
+
+```
+DELETE /api/admin/datasets?path=<relative/path>
+```
+
+- **Dependency check first** (see §4.3): refuse with `409 Conflict` and a list of
+  dependents if any table or crawler references the file/path.
+- On success: `datasets.delete(path)`, invalidate the listing cache for the
+  prefix, return `200` with `{ "path": "...", "deleted": true }`.
+- **Soft-delete option (recommended):** move into a `__trash__` area under the
+  internal writeable prefix instead of hard-deleting, with a TTL sweep. Lets an
+  operator recover from a mistaken delete. If we skip this for v1, the dependency
+  check and confirmation dialog become mandatory, not optional.
+
+### 3.4 (Reuse) Listing
+
+The existing `GET /api/list-datasets` already powers the folder tree; no new list
+endpoint is needed. After a mutation the frontend re-fetches it. Server must
+invalidate the `DatasetsStore` listing cache on upload/delete so the new state is
+visible immediately (the FS watcher handles eventual consistency for
+out-of-band changes, but a UI mutation should reflect instantly).
+
+---
+
+## 4. Safety / security (the part that matters most)
+
+File mutation is the highest-risk surface in the product. Each control below is a
+hard requirement, not a nice-to-have.
+
+### 4.1 Path confinement (anti-traversal)
+
+- Reject any `path` containing `..`, a leading `/`, a drive/UNC prefix, or NUL.
+- Normalize to a relative `object_store::path::Path` (which itself rejects
+  `..` segments) and verify the canonical result is still under the datasets
+  root. Never join user input onto a filesystem path with `PathBuf::push` before
+  this check.
+- Reject any path resolving under `DATASETS_WRITEABLE_PREFIX` (`__beacon__`) or
+  any other hidden/internal prefix — these are Beacon-owned.
+- On **S3** there is no real filesystem to traverse, but the same key
+  normalization applies so behavior is identical across backends (and so a
+  symlink on local FS can't escape — `object_store`'s local backend should be
+  configured to not follow symlinks out of root).
+
+### 4.2 Upload validation
+
+- **Extension/format allowlist:** only accept extensions beacon can actually read
+  (`.nc`, `.parquet`, `.csv`, `.arrow`/`.ipc`, `.tif`/`.tiff`, `.zip` for zarr,
+  etc.). Derive from the format registry, not a hardcoded list, so it stays in
+  sync with supported readers.
+- **Size cap:** configurable `BEACON_MAX_UPLOAD_BYTES` (sensible default, e.g.
+  some GB), enforced by counting streamed bytes and aborting + cleaning up the
+  partial object on exceed.
+- **Content-type is advisory only** — never trust it for authorization or routing.
+
+### 4.3 Delete dependency check
+
+Before deleting, resolve whether the file is referenced by:
+
+- A registered **external table** (its location/glob covers the path).
+- A **crawler**'s discovery pattern (deleting matched files mid-crawl is
+  surprising; at minimum warn).
+
+If referenced, return `409` with the dependent names so the UI can show
+"`station1.nc` backs table `ctd_station1` — drop the table first." This requires
+a lookup against the table catalog in [beacon-data-lake](../beacon-data-lake);
+scope this lookup carefully so it's cheap.
+
+### 4.4 AuthZ
+
+- v1: all three endpoints require `is_super_user` (existing `basic_auth`
+  middleware). No code change to authz needed beyond mounting under the admin
+  router.
+- Download in particular is **data exfiltration** — keep it super-user-only even
+  though reads elsewhere may be granted to lesser roles.
+
+### 4.5 Audit
+
+Every successful (and rejected) mutation should emit an audit record:
+principal, operation, path, size, result. Beacon already has a query
+observability registry + Activity page — extend that surface rather than
+inventing a new one. This is near-mandatory once delete exists.
+
+---
+
+## 5. Frontend (beacon-web)
+
+On the [datasets page](../clients/beacon-web/src/pages/datasets.tsx):
+
+- **Upload:** an "Upload" button per folder → file picker (multi-select), with a
+  progress bar driven by the streaming upload. Show per-file success/failure;
+  surface allowlist/size/overwrite errors inline.
+- **Download:** a download icon on each file row → hits the download endpoint.
+- **Delete:** a delete action on each file row → confirmation dialog that
+  **shows the dependency-check result** (disabled/blocked with explanation if the
+  file backs a table). Never a bare "are you sure".
+- After any mutation, invalidate the dataset listing query (TanStack Query or
+  equivalent) to refresh the tree.
+
+SDK additions in [clients/beacon-ts/src/admin.ts](../clients/beacon-ts/src/admin.ts):
+`uploadDataset(path, blob, { overwrite })`, `downloadDataset(path) → Blob/stream`,
+`deleteDataset(path)`. Mirror the existing admin-method conventions (Basic auth
+header, error decoding).
+
+---
+
+## 6. Future-proofing for RBAC
+
+The auth model already has `Privilege::{Read, Insert, Delete}` over path-glob
+targets ([beacon-auth/src/role.rs](../beacon-auth/src/role.rs)). The clean future
+mapping is:
+
+| Operation | Privilege | Target |
+|---|---|---|
+| Download | `Read` | path-glob |
+| Upload | `Insert` | path-glob |
+| Delete | `Delete` | path-glob |
+
+So a later change can swap the blanket `is_super_user` gate for a per-path
+privilege check **without changing the endpoint contracts**. v1 should still
+enforce super-user-only, but write the handler so the authz decision is a single
+call that's easy to replace.
+
+---
+
+## 7. Rollout plan
+
+1. **v1 — Upload + Download (super-user).** Streaming upload (path-confined,
+   allowlisted, size-capped) + download. Highest value, lowest risk. No delete.
+2. **v2 — Delete with safety.** Dependency check + confirmation + soft-delete to
+   trash. Audit records for all three operations.
+3. **v3 — Hardening.** Per-deployment storage quota, Zarr-directory upload,
+   optional per-path RBAC enforcement (§6), rename/move.
+
+---
+
+## 8. Open questions
+
+1. **Streaming raw body vs multipart/form-data** for upload — pick based on the
+   chosen frontend upload lib; keep SDK + endpoint consistent.
+2. **Soft-delete vs hard-delete** for v2 — recommend soft-delete; needs a trash
+   area + TTL sweep. Decide before building delete.
+3. **Zarr (directory-shaped) uploads** — zip-and-unpack vs defer. Recommend defer
+   + document.
+4. **Overwrite semantics** — default reject; is `?overwrite=true` enough, or do we
+   want a versioned write? Recommend reject-by-default for v1.
+5. **Cache invalidation contract** — confirm `DatasetsStore` exposes a way to
+   invalidate a prefix's cached listing synchronously after a mutation.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -47,6 +47,7 @@ pytest -v
 | Env var | Default | Effect |
 | ------- | ------- | ------ |
 | `BEACON_IMAGE` | _(unset)_ | If set, run this image instead of building the local `Dockerfile`. Use `ghcr.io/maris-development/beacon:latest` for fast reruns. |
+| `BEACON_BASE_URL` | _(unset)_ | If set, the RBAC tests (`test_rbac.py`) run against this already-running Beacon instead of Docker — handy for iterating against a local debug build. Also reads `BEACON_ADMIN_USERNAME`/`BEACON_ADMIN_PASSWORD` (default `admin`/`securepassword`). Set `BEACON_AUTH_ENFORCE=true` to also run the enforcement test (it must match the server's config). |
 
 > **Note:** The published image will **fail** the external- and managed-table tests
 > until the HTTP write-path change in `beacon-api` (admin basic-auth → super-user on

--- a/integration-tests/test_rbac.py
+++ b/integration-tests/test_rbac.py
@@ -25,6 +25,11 @@ from beacon_client import BeaconHTTPClient
 ADMIN_USER = os.environ.get("BEACON_ADMIN_USERNAME", "admin")
 ADMIN_PW = os.environ.get("BEACON_ADMIN_PASSWORD", "securepassword")
 
+# Whether the server under test applies query-time authorization. Mirror the
+# server's BEACON_AUTH_ENFORCE so the enforce-on / enforce-off tests each run
+# against the matching configuration (off is the default).
+ENFORCE = os.environ.get("BEACON_AUTH_ENFORCE", "").lower() == "true"
+
 ROLE = "rbac_reader"
 USER = "rbac_alice"
 USER2 = "rbac_bob"
@@ -159,10 +164,7 @@ def test_non_super_user_cannot_manage_or_enumerate(admin, base_url, clean):
     assert bob.admin_get("/api/admin/auth/roles").status_code == 403
 
 
-@pytest.mark.skipif(
-    os.environ.get("BEACON_AUTH_ENFORCE", "").lower() != "true",
-    reason="requires the server to run with BEACON_AUTH_ENFORCE=true",
-)
+@pytest.mark.skipif(not ENFORCE, reason="requires the server to run with BEACON_AUTH_ENFORCE=true")
 def test_enforcement_grant_allows_deny_blocks(admin, base_url, clean):
     admin.execute(f"CREATE TABLE {TABLE} (a BIGINT)", admin=True)
     admin.execute(f"INSERT INTO {TABLE} VALUES (1)", admin=True)
@@ -183,3 +185,30 @@ def test_enforcement_grant_allows_deny_blocks(admin, base_url, clean):
     admin.execute(f"CREATE USER {USER2} WITH PASSWORD 'pw'", admin=True)
     mallory = BeaconHTTPClient(base_url, USER2, "pw")
     assert mallory.raw({"sql": f"SELECT * FROM {TABLE}"}, admin=True).status_code == 400
+
+
+@pytest.mark.skipif(ENFORCE, reason="requires the server's default BEACON_AUTH_ENFORCE=false")
+def test_no_enforcement_reads_not_gated(admin, base_url, clean):
+    """With enforcement off, the role model is managed but not applied to reads:
+    grants/denies and role membership don't gate queries (the super-user DDL gate
+    still applies — covered by the guard tests above)."""
+    admin.execute(f"CREATE TABLE {TABLE} (a BIGINT)", admin=True)
+    admin.execute(f"INSERT INTO {TABLE} VALUES (1)", admin=True)
+
+    # A role that explicitly DENIES the table, assigned to alice.
+    admin.execute(f"CREATE ROLE {ROLE}", admin=True)
+    admin.execute(f"DENY SELECT ON TABLE {TABLE} TO ROLE {ROLE}", admin=True)
+    admin.execute(f"CREATE USER {USER} WITH PASSWORD 'pw'", admin=True)
+    admin.execute(f"GRANT ROLE {ROLE} TO USER {USER}", admin=True)
+    alice = BeaconHTTPClient(base_url, USER, "pw")
+
+    # The deny is not applied: alice can still read.
+    assert alice.raw({"sql": f"SELECT * FROM {TABLE}"}, admin=True).status_code == 200
+
+    # A user with no roles can also read.
+    admin.execute(f"CREATE USER {USER2} WITH PASSWORD 'pw'", admin=True)
+    mallory = BeaconHTTPClient(base_url, USER2, "pw")
+    assert mallory.raw({"sql": f"SELECT * FROM {TABLE}"}, admin=True).status_code == 200
+
+    # An unauthenticated (anonymous) request can read too.
+    assert admin.raw({"sql": f"SELECT * FROM {TABLE}"}, admin=False).status_code == 200

--- a/integration-tests/test_rbac.py
+++ b/integration-tests/test_rbac.py
@@ -1,0 +1,185 @@
+"""RBAC integration tests over the HTTP API.
+
+Covers the admin auth list endpoints (``/api/admin/auth/{users,roles}``), the
+SQL-driven user/role/grant lifecycle, the model guards (read-only roles, reserved
+super-user, protected anonymous user, non-super users can't manage or enumerate),
+and — when the server runs with enforcement on — that grants allow and denies
+block query results.
+
+Connection: by default these use the Docker-managed container like the rest of
+the suite. Set ``BEACON_BASE_URL`` (and optionally ``BEACON_ADMIN_USERNAME`` /
+``BEACON_ADMIN_PASSWORD``) to run against an already-running Beacon instead — no
+Docker required. The enforcement test only runs when ``BEACON_AUTH_ENFORCE=true``
+is set in the test environment (matching the server's configuration).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import requests
+
+from beacon_client import BeaconHTTPClient
+
+ADMIN_USER = os.environ.get("BEACON_ADMIN_USERNAME", "admin")
+ADMIN_PW = os.environ.get("BEACON_ADMIN_PASSWORD", "securepassword")
+
+ROLE = "rbac_reader"
+USER = "rbac_alice"
+USER2 = "rbac_bob"
+TABLE = "rbac_obs"
+
+
+@pytest.fixture(scope="module")
+def base_url(request) -> str:
+    """An external server (``BEACON_BASE_URL``) or the suite's Docker container.
+
+    Resolving the Docker container lazily means setting ``BEACON_BASE_URL`` skips
+    Docker entirely (no image build, network, or container).
+    """
+    url = os.environ.get("BEACON_BASE_URL")
+    if url:
+        return url.rstrip("/")
+    return request.getfixturevalue("beacon_container")
+
+
+@pytest.fixture(scope="module")
+def admin(base_url) -> BeaconHTTPClient:
+    return BeaconHTTPClient(base_url, ADMIN_USER, ADMIN_PW)
+
+
+@pytest.fixture
+def clean(admin):
+    """Drop the test users/roles/table before and after, so reruns start clean."""
+
+    def _drop():
+        for sql in (
+            f"REVOKE ROLE {ROLE} FROM USER {USER}",
+            f"DROP USER {USER}",
+            f"DROP USER {USER2}",
+            f"DROP ROLE {ROLE}",
+            f"DROP TABLE IF EXISTS {TABLE}",
+        ):
+            admin.raw({"sql": sql}, admin=True)  # ignore failures (may not exist)
+
+    _drop()
+    yield
+    _drop()
+
+
+def _users(admin: BeaconHTTPClient) -> list[dict]:
+    resp = admin.admin_get("/api/admin/auth/users")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _roles(admin: BeaconHTTPClient) -> list[dict]:
+    resp = admin.admin_get("/api/admin/auth/roles")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def test_list_flags_super_user_and_anonymous(admin):
+    users = _users(admin)
+    su = next(u for u in users if u["username"] == ADMIN_USER)
+    assert su["is_super_user"] is True
+    anon = next(u for u in users if u["username"] == "anonymous")
+    assert anon["is_anonymous"] is True
+    assert anon["is_super_user"] is False
+
+
+def test_admin_auth_endpoints_require_super_user(admin, base_url, clean):
+    # No credentials -> 401.
+    assert admin.admin_get("/api/admin/auth/users", admin=False).status_code == 401
+    assert requests.get(f"{base_url}/api/admin/auth/roles").status_code == 401
+
+    # A valid but non-super user -> 403.
+    admin.execute(f"CREATE USER {USER2} WITH PASSWORD 'pw'", admin=True)
+    bob = BeaconHTTPClient(base_url, USER2, "pw")
+    assert bob.admin_get("/api/admin/auth/users").status_code == 403
+
+
+def test_rbac_lifecycle_reflected_in_endpoints(admin, clean):
+    admin.execute(f"CREATE ROLE {ROLE}", admin=True)
+    admin.execute(f"GRANT SELECT ON TABLE observations TO ROLE {ROLE}", admin=True)
+    admin.execute(f"GRANT SELECT ON PATH 'argo/**/*.nc' TO ROLE {ROLE}", admin=True)
+    admin.execute(f"DENY SELECT ON TABLE secret TO ROLE {ROLE}", admin=True)
+    admin.execute(f"CREATE USER {USER} WITH PASSWORD 'pw'", admin=True)
+    admin.execute(f"GRANT ROLE {ROLE} TO USER {USER}", admin=True)
+
+    role = next(r for r in _roles(admin) if r["name"] == ROLE)
+    grants = role["grants"]
+    assert any(g["target_type"] == "table" and g["target_value"] == "observations" for g in grants)
+    assert any(g["target_type"] == "path" and g["target_value"] == "argo/**/*.nc" for g in grants)
+    assert any(d["target_type"] == "table" and d["target_value"] == "secret" for d in role["denies"])
+
+    user = next(u for u in _users(admin) if u["username"] == USER)
+    assert user["roles"] == [ROLE]
+
+    # Revoke + drop, then confirm the state is gone.
+    admin.execute(f"REVOKE SELECT ON TABLE observations FROM ROLE {ROLE}", admin=True)
+    admin.execute(f"REVOKE DENY SELECT ON TABLE secret FROM ROLE {ROLE}", admin=True)
+    admin.execute(f"REVOKE ROLE {ROLE} FROM USER {USER}", admin=True)
+    admin.execute(f"DROP USER {USER}", admin=True)
+    assert all(u["username"] != USER for u in _users(admin))
+
+    role = next(r for r in _roles(admin) if r["name"] == ROLE)
+    assert all(g["target_value"] != "observations" for g in role["grants"])
+    assert role["denies"] == []
+
+    admin.execute(f"DROP ROLE {ROLE}", admin=True)
+    assert all(r["name"] != ROLE for r in _roles(admin))
+
+
+def test_model_guards(admin, clean):
+    admin.execute(f"CREATE ROLE {ROLE}", admin=True)
+
+    # Roles are read-only: only SELECT may be granted.
+    assert admin.raw({"sql": f"GRANT INSERT ON TABLE t TO ROLE {ROLE}"}, admin=True).status_code == 400
+
+    # The super-user username is reserved and cannot be created or dropped.
+    assert admin.raw({"sql": f"DROP USER {ADMIN_USER}"}, admin=True).status_code == 400
+    assert admin.raw(
+        {"sql": f"CREATE USER {ADMIN_USER} WITH PASSWORD 'x'"}, admin=True
+    ).status_code == 400
+
+    # The anonymous user can't be deleted while anonymous access is enabled.
+    assert admin.raw({"sql": "DROP USER anonymous"}, admin=True).status_code == 400
+    assert any(u["username"] == "anonymous" for u in _users(admin))
+
+
+def test_non_super_user_cannot_manage_or_enumerate(admin, base_url, clean):
+    admin.execute(f"CREATE USER {USER2} WITH PASSWORD 'pw'", admin=True)
+    bob = BeaconHTTPClient(base_url, USER2, "pw")
+
+    # Auth DDL requires the super-user -> 400.
+    assert bob.raw({"sql": "CREATE ROLE hacker"}, admin=True).status_code == 400
+    # The enumeration endpoints reject non-super principals -> 403.
+    assert bob.admin_get("/api/admin/auth/roles").status_code == 403
+
+
+@pytest.mark.skipif(
+    os.environ.get("BEACON_AUTH_ENFORCE", "").lower() != "true",
+    reason="requires the server to run with BEACON_AUTH_ENFORCE=true",
+)
+def test_enforcement_grant_allows_deny_blocks(admin, base_url, clean):
+    admin.execute(f"CREATE TABLE {TABLE} (a BIGINT)", admin=True)
+    admin.execute(f"INSERT INTO {TABLE} VALUES (1)", admin=True)
+    admin.execute(f"CREATE ROLE {ROLE}", admin=True)
+    admin.execute(f"GRANT SELECT TO ROLE {ROLE}", admin=True)
+    admin.execute(f"CREATE USER {USER} WITH PASSWORD 'pw'", admin=True)
+    admin.execute(f"GRANT ROLE {ROLE} TO USER {USER}", admin=True)
+    alice = BeaconHTTPClient(base_url, USER, "pw")
+
+    # The global grant lets alice read.
+    assert alice.raw({"sql": f"SELECT * FROM {TABLE}"}, admin=True).status_code == 200
+
+    # A deny wins over the grant.
+    admin.execute(f"DENY SELECT ON TABLE {TABLE} TO ROLE {ROLE}", admin=True)
+    assert alice.raw({"sql": f"SELECT * FROM {TABLE}"}, admin=True).status_code == 400
+
+    # A user with no roles can't read at all.
+    admin.execute(f"CREATE USER {USER2} WITH PASSWORD 'pw'", admin=True)
+    mallory = BeaconHTTPClient(base_url, USER2, "pw")
+    assert mallory.raw({"sql": f"SELECT * FROM {TABLE}"}, admin=True).status_code == 400


### PR DESCRIPTION
Admin/web features built on top of the auth & RBAC backend.

## Dataset file management (super-user)
- Streaming **upload / download / delete** via `/api/admin/datasets/*` with path-safety (anti-traversal, internal-prefix guard), an extension allowlist, and `BEACON_MAX_UPLOAD_BYTES`.
- **Resumable chunked upload** for large files (session manager + `initiate`/`part`/`complete`/`abort`); the SDK auto-switches above a size threshold with per-part retry and progress.
- **Datasets page**: drag-and-drop (incl. folders, recursive, structure preserved), editable destination folder, overall progress + per-file ✓/✗ status with retry, global path search, virtualized list, **Size/Modified** columns (sortable), an overflow action menu, a **Query** action (opens the editor on a table function), and **register-as-external-table**.

## Read-after-write listing fix
- Disabled DataFusion's default list-files cache and list datasets through the backing store; **`BEACON_ENABLE_FS_EVENTS` now defaults to `false`** (the OS watcher was unreliable). Uploads and deletes are now immediately visible without a reload.

## Users & roles (RBAC) management UI
- Auth **enumeration** (`UserDirectory::list_users`, `RoleProvider::list_roles`, `AuthContext` helpers) + read endpoints `GET /api/admin/auth/{users,roles}`.
- New **`/access`** page: create/drop users & roles, assign roles, grant/deny/revoke `SELECT` on table / path glob / all. The super-user is flagged and non-editable; the **anonymous user is protected from deletion** while anonymous access is enabled (enforced in the backend).

## SQL editor autocomplete
- Metadata-aware completion: tables, columns (with data types), `alias.column`, and functions with **documentation tooltips** (signature, description, parameters).

## Tests
- `beacon-auth` (anonymous-delete guard), `beacon-object-storage`, `beacon-core` (`dataset_files`/`dataset_uploads`), `beacon-api` HTTP integration suites (`admin_datasets_http_tests`, `rbac_http_tests`), and SDK vitest for chunked upload.

## Notes
- Most mutations are performed as the super-user via the SQL query endpoint; the admin endpoints added here are read-only listing + the dataset file operations.
- RBAC enforcement still requires `BEACON_AUTH_ENFORCE=true` (backward-compatible default off).