### PR TITLE
N-dimensional execution spine: flow zarr/netcdf through beacon.nd-encoded batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,6 +1884,7 @@ dependencies = [
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
  "async-trait",
+ "beacon-datafusion-ext",
  "bytemuck",
  "criterion 0.5.1",
  "datafusion",

--- a/beacon-datafusion-ext/src/lib.rs
+++ b/beacon-datafusion-ext/src/lib.rs
@@ -2,6 +2,7 @@ pub mod analyzer_rules;
 pub mod file_collection;
 pub mod format_ext;
 pub mod listing_table_factory_ext;
+pub mod nd;
 pub mod remote;
 pub mod stats_cache;
 pub mod table_ext;

--- a/beacon-datafusion-ext/src/nd/array.rs
+++ b/beacon-datafusion-ext/src/nd/array.rs
@@ -1,0 +1,280 @@
+//! An Arrow array with N-dimensional encoding.
+
+use arrow::array::ArrayRef;
+use arrow::datatypes::DataType;
+use datafusion::common::plan_err;
+use datafusion::error::{DataFusionError, Result};
+
+use super::broadcast::BroadcastMap;
+use super::dimensions::{Dimension, Dimensions};
+
+/// A hyperslab of an N-dimensional array: per-axis start offset and extent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArraySubset {
+    pub start: Vec<usize>,
+    pub shape: Vec<usize>,
+}
+
+impl ArraySubset {
+    pub fn new(start: Vec<usize>, shape: Vec<usize>) -> Self {
+        Self { start, shape }
+    }
+}
+
+/// A flat Arrow array plus the named C-order dimensions describing its
+/// logical N-dimensional shape.
+///
+/// Invariant: `dims.num_elements() == values.len()`. Validity travels in the
+/// Arrow array's null buffer; there is no separate mask or fill value —
+/// readers are expected to map fill values to nulls when they build the
+/// Arrow array.
+#[derive(Debug, Clone)]
+pub struct NdArrowArray {
+    values: ArrayRef,
+    dims: Dimensions,
+}
+
+impl NdArrowArray {
+    pub fn try_new(values: ArrayRef, dims: Dimensions) -> Result<Self> {
+        if dims.num_elements() != values.len() {
+            return plan_err!(
+                "nd array values length {} does not match dimensions {dims} ({} elements)",
+                values.len(),
+                dims.num_elements()
+            );
+        }
+        Ok(Self { values, dims })
+    }
+
+    /// A rank-0 array wrapping a single-element Arrow array.
+    pub fn try_new_scalar(values: ArrayRef) -> Result<Self> {
+        Self::try_new(values, Dimensions::scalar())
+    }
+
+    pub fn values(&self) -> &ArrayRef {
+        &self.values
+    }
+
+    pub fn dims(&self) -> &Dimensions {
+        &self.dims
+    }
+
+    pub fn shape(&self) -> Vec<usize> {
+        self.dims.shape()
+    }
+
+    pub fn data_type(&self) -> &DataType {
+        self.values.data_type()
+    }
+
+    pub fn num_elements(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Extract a hyperslab. Zero-copy (`Array::slice`) when the subset is
+    /// contiguous in C-order; a single `take` gather otherwise.
+    pub fn subset(&self, subset: &ArraySubset) -> Result<NdArrowArray> {
+        let rank = self.dims.rank();
+        if subset.start.len() != rank || subset.shape.len() != rank {
+            return plan_err!(
+                "subset rank {}/{} does not match array rank {rank}",
+                subset.start.len(),
+                subset.shape.len()
+            );
+        }
+        for axis in 0..rank {
+            let size = self.dims.get(axis).size();
+            if subset.start[axis] + subset.shape[axis] > size {
+                return plan_err!(
+                    "subset [{}..{}) exceeds axis '{}' of size {size}",
+                    subset.start[axis],
+                    subset.start[axis] + subset.shape[axis],
+                    self.dims.get(axis).name()
+                );
+            }
+        }
+
+        let new_dims = Dimensions::try_new(
+            self.dims
+                .iter()
+                .zip(subset.shape.iter())
+                .map(|(dim, &size)| Dimension::new(dim.name_arc(), size))
+                .collect(),
+        )?;
+
+        if new_dims.num_elements() == self.num_elements() {
+            return Ok(Self {
+                values: self.values.clone(),
+                dims: new_dims,
+            });
+        }
+
+        if let Some((offset, len)) = self.contiguous_range(subset) {
+            return Ok(Self {
+                values: self.values.slice(offset, len),
+                dims: new_dims,
+            });
+        }
+
+        // Orthogonal gather: kept coordinates per axis are contiguous ranges.
+        let identity = BroadcastMap::try_new(&self.dims, &self.dims)?;
+        let keep_owned: Vec<Vec<u32>> = (0..rank)
+            .map(|axis| {
+                (subset.start[axis]..subset.start[axis] + subset.shape[axis])
+                    .map(|c| c as u32)
+                    .collect()
+            })
+            .collect();
+        let keep: Vec<Option<&[u32]>> = keep_owned.iter().map(|k| Some(k.as_slice())).collect();
+        let indices = identity.gather_indices(Some(&keep));
+        let values = arrow::compute::take(self.values.as_ref(), &indices, None)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        Self::try_new(values, new_dims)
+    }
+
+    /// If the hyperslab is one contiguous run of the flat buffer, return its
+    /// (offset, length). Writing `p` for the last axis whose extent is not
+    /// full, the run is contiguous iff every axis before `p` has extent 1
+    /// (each contributes a single coordinate); axis `p` itself may take any
+    /// contiguous extent and everything after it is full by construction.
+    fn contiguous_range(&self, subset: &ArraySubset) -> Option<(usize, usize)> {
+        let rank = self.dims.rank();
+        let strides = self.dims.c_strides();
+        let p = (0..rank)
+            .rev()
+            .find(|&axis| subset.shape[axis] != self.dims.get(axis).size())
+            .unwrap_or(0);
+        if (0..p).any(|axis| subset.shape[axis] != 1) {
+            return None;
+        }
+
+        let offset: usize = subset
+            .start
+            .iter()
+            .zip(strides.iter())
+            .map(|(&s, &stride)| s * stride)
+            .sum();
+        let len: usize = subset.shape.iter().product();
+        Some((offset, len))
+    }
+
+    /// Broadcast map from this array's dimensions onto `target`.
+    pub fn broadcast_map(&self, target: &Dimensions) -> Result<BroadcastMap> {
+        BroadcastMap::try_new(&self.dims, target)
+    }
+
+    /// Materialize this array broadcast onto `target`, optionally restricted
+    /// to kept coordinates per target axis. Filter and broadcast compose into
+    /// a single `take`; the unfiltered expansion is never built.
+    pub fn materialize(
+        &self,
+        target: &Dimensions,
+        keep: Option<&[Option<&[u32]>]>,
+    ) -> Result<ArrayRef> {
+        let map = self.broadcast_map(target)?;
+        if map.is_identity() && keep.map_or(true, |k| k.iter().all(|axis| axis.is_none())) {
+            return Ok(self.values.clone());
+        }
+        let indices = map.gather_indices(keep);
+        arrow::compute::take(self.values.as_ref(), &indices, None)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{AsArray, Int32Array};
+    use arrow::datatypes::Int32Type;
+
+    use super::*;
+
+    fn dims(spec: &[(&str, usize)]) -> Dimensions {
+        Dimensions::try_new(
+            spec.iter()
+                .map(|(name, size)| Dimension::new(*name, *size))
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    fn nd(values: Vec<i32>, spec: &[(&str, usize)]) -> NdArrowArray {
+        NdArrowArray::try_new(Arc::new(Int32Array::from(values)), dims(spec)).unwrap()
+    }
+
+    fn ints(array: &ArrayRef) -> Vec<i32> {
+        array.as_primitive::<Int32Type>().values().to_vec()
+    }
+
+    #[test]
+    fn len_mismatch_rejected() {
+        let result = NdArrowArray::try_new(
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            dims(&[("x", 2)]),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn contiguous_subset_is_slice() {
+        // (time=4, lon=3): rows 1..3 with all lon → contiguous.
+        let a = nd((0..12).collect(), &[("time", 4), ("lon", 3)]);
+        let s = a
+            .subset(&ArraySubset::new(vec![1, 0], vec![2, 3]))
+            .unwrap();
+        assert_eq!(s.shape(), vec![2, 3]);
+        assert_eq!(ints(s.values()), vec![3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn strided_subset_gathers() {
+        // (time=2, lon=3): lon 1..3 for all time → non-contiguous.
+        let a = nd((0..6).collect(), &[("time", 2), ("lon", 3)]);
+        let s = a
+            .subset(&ArraySubset::new(vec![0, 1], vec![2, 2]))
+            .unwrap();
+        assert_eq!(s.shape(), vec![2, 2]);
+        assert_eq!(ints(s.values()), vec![1, 2, 4, 5]);
+    }
+
+    #[test]
+    fn full_subset_is_zero_copy() {
+        let a = nd((0..6).collect(), &[("time", 2), ("lon", 3)]);
+        let s = a
+            .subset(&ArraySubset::new(vec![0, 0], vec![2, 3]))
+            .unwrap();
+        assert_eq!(ints(s.values()), ints(a.values()));
+    }
+
+    #[test]
+    fn out_of_bounds_subset_rejected() {
+        let a = nd((0..6).collect(), &[("time", 2), ("lon", 3)]);
+        assert!(a.subset(&ArraySubset::new(vec![1, 0], vec![2, 3])).is_err());
+    }
+
+    #[test]
+    fn materialize_broadcast() {
+        let lat = nd(vec![10, 20, 30], &[("lat", 3)]);
+        let target = dims(&[("time", 2), ("lat", 3)]);
+        let out = lat.materialize(&target, None).unwrap();
+        assert_eq!(ints(&out), vec![10, 20, 30, 10, 20, 30]);
+    }
+
+    #[test]
+    fn materialize_with_selection_composes() {
+        let lat = nd(vec![10, 20, 30], &[("lat", 3)]);
+        let target = dims(&[("time", 2), ("lat", 3)]);
+        let keep: Vec<Option<&[u32]>> = vec![Some(&[1]), Some(&[0, 2])];
+        let out = lat.materialize(&target, Some(&keep)).unwrap();
+        assert_eq!(ints(&out), vec![10, 30]);
+    }
+
+    #[test]
+    fn materialize_identity_zero_copy() {
+        let a = nd((0..6).collect(), &[("time", 2), ("lon", 3)]);
+        let target = dims(&[("time", 2), ("lon", 3)]);
+        let out = a.materialize(&target, None).unwrap();
+        assert_eq!(ints(&out), (0..6).collect::<Vec<_>>());
+    }
+}

--- a/beacon-datafusion-ext/src/nd/array.rs
+++ b/beacon-datafusion-ext/src/nd/array.rs
@@ -33,6 +33,14 @@ impl NdArrowArray {
         Ok(Self { values, dims })
     }
 
+    pub fn values(&self) -> &ArrayRef {
+        &self.values
+    }
+
+    pub fn dims(&self) -> &Dimensions {
+        &self.dims
+    }
+
     pub fn data_type(&self) -> &DataType {
         self.values.data_type()
     }

--- a/beacon-datafusion-ext/src/nd/array.rs
+++ b/beacon-datafusion-ext/src/nd/array.rs
@@ -6,20 +6,7 @@ use datafusion::common::plan_err;
 use datafusion::error::{DataFusionError, Result};
 
 use super::broadcast::BroadcastMap;
-use super::dimensions::{Dimension, Dimensions};
-
-/// A hyperslab of an N-dimensional array: per-axis start offset and extent.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ArraySubset {
-    pub start: Vec<usize>,
-    pub shape: Vec<usize>,
-}
-
-impl ArraySubset {
-    pub fn new(start: Vec<usize>, shape: Vec<usize>) -> Self {
-        Self { start, shape }
-    }
-}
+use super::dimensions::Dimensions;
 
 /// A flat Arrow array plus the named C-order dimensions describing its
 /// logical N-dimensional shape.
@@ -46,116 +33,8 @@ impl NdArrowArray {
         Ok(Self { values, dims })
     }
 
-    /// A rank-0 array wrapping a single-element Arrow array.
-    pub fn try_new_scalar(values: ArrayRef) -> Result<Self> {
-        Self::try_new(values, Dimensions::scalar())
-    }
-
-    pub fn values(&self) -> &ArrayRef {
-        &self.values
-    }
-
-    pub fn dims(&self) -> &Dimensions {
-        &self.dims
-    }
-
-    pub fn shape(&self) -> Vec<usize> {
-        self.dims.shape()
-    }
-
     pub fn data_type(&self) -> &DataType {
         self.values.data_type()
-    }
-
-    pub fn num_elements(&self) -> usize {
-        self.values.len()
-    }
-
-    /// Extract a hyperslab. Zero-copy (`Array::slice`) when the subset is
-    /// contiguous in C-order; a single `take` gather otherwise.
-    pub fn subset(&self, subset: &ArraySubset) -> Result<NdArrowArray> {
-        let rank = self.dims.rank();
-        if subset.start.len() != rank || subset.shape.len() != rank {
-            return plan_err!(
-                "subset rank {}/{} does not match array rank {rank}",
-                subset.start.len(),
-                subset.shape.len()
-            );
-        }
-        for axis in 0..rank {
-            let size = self.dims.get(axis).size();
-            if subset.start[axis] + subset.shape[axis] > size {
-                return plan_err!(
-                    "subset [{}..{}) exceeds axis '{}' of size {size}",
-                    subset.start[axis],
-                    subset.start[axis] + subset.shape[axis],
-                    self.dims.get(axis).name()
-                );
-            }
-        }
-
-        let new_dims = Dimensions::try_new(
-            self.dims
-                .iter()
-                .zip(subset.shape.iter())
-                .map(|(dim, &size)| Dimension::new(dim.name_arc(), size))
-                .collect(),
-        )?;
-
-        if new_dims.num_elements() == self.num_elements() {
-            return Ok(Self {
-                values: self.values.clone(),
-                dims: new_dims,
-            });
-        }
-
-        if let Some((offset, len)) = self.contiguous_range(subset) {
-            return Ok(Self {
-                values: self.values.slice(offset, len),
-                dims: new_dims,
-            });
-        }
-
-        // Orthogonal gather: kept coordinates per axis are contiguous ranges.
-        let identity = BroadcastMap::try_new(&self.dims, &self.dims)?;
-        let keep_owned: Vec<Vec<u32>> = (0..rank)
-            .map(|axis| {
-                (subset.start[axis]..subset.start[axis] + subset.shape[axis])
-                    .map(|c| c as u32)
-                    .collect()
-            })
-            .collect();
-        let keep: Vec<Option<&[u32]>> = keep_owned.iter().map(|k| Some(k.as_slice())).collect();
-        let indices = identity.gather_indices(Some(&keep));
-        let values = arrow::compute::take(self.values.as_ref(), &indices, None)
-            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-        Self::try_new(values, new_dims)
-    }
-
-    /// If the hyperslab is one contiguous run of the flat buffer, return its
-    /// (offset, length). Writing `p` for the last axis whose extent is not
-    /// full, the run is contiguous iff every axis before `p` has extent 1
-    /// (each contributes a single coordinate); axis `p` itself may take any
-    /// contiguous extent and everything after it is full by construction.
-    fn contiguous_range(&self, subset: &ArraySubset) -> Option<(usize, usize)> {
-        let rank = self.dims.rank();
-        let strides = self.dims.c_strides();
-        let p = (0..rank)
-            .rev()
-            .find(|&axis| subset.shape[axis] != self.dims.get(axis).size())
-            .unwrap_or(0);
-        if (0..p).any(|axis| subset.shape[axis] != 1) {
-            return None;
-        }
-
-        let offset: usize = subset
-            .start
-            .iter()
-            .zip(strides.iter())
-            .map(|(&s, &stride)| s * stride)
-            .sum();
-        let len: usize = subset.shape.iter().product();
-        Some((offset, len))
     }
 
     /// Broadcast map from this array's dimensions onto `target`.
@@ -163,19 +42,14 @@ impl NdArrowArray {
         BroadcastMap::try_new(&self.dims, target)
     }
 
-    /// Materialize this array broadcast onto `target`, optionally restricted
-    /// to kept coordinates per target axis. Filter and broadcast compose into
-    /// a single `take`; the unfiltered expansion is never built.
-    pub fn materialize(
-        &self,
-        target: &Dimensions,
-        keep: Option<&[Option<&[u32]>]>,
-    ) -> Result<ArrayRef> {
+    /// Materialize this array broadcast onto `target` as a single `take` (or a
+    /// zero-copy clone when the broadcast is the identity).
+    pub fn materialize(&self, target: &Dimensions) -> Result<ArrayRef> {
         let map = self.broadcast_map(target)?;
-        if map.is_identity() && keep.map_or(true, |k| k.iter().all(|axis| axis.is_none())) {
+        if map.is_identity() {
             return Ok(self.values.clone());
         }
-        let indices = map.gather_indices(keep);
+        let indices = map.gather_indices();
         arrow::compute::take(self.values.as_ref(), &indices, None)
             .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
     }
@@ -189,6 +63,7 @@ mod tests {
     use arrow::datatypes::Int32Type;
 
     use super::*;
+    use crate::nd::dimensions::Dimension;
 
     fn dims(spec: &[(&str, usize)]) -> Dimensions {
         Dimensions::try_new(
@@ -217,64 +92,18 @@ mod tests {
     }
 
     #[test]
-    fn contiguous_subset_is_slice() {
-        // (time=4, lon=3): rows 1..3 with all lon → contiguous.
-        let a = nd((0..12).collect(), &[("time", 4), ("lon", 3)]);
-        let s = a
-            .subset(&ArraySubset::new(vec![1, 0], vec![2, 3]))
-            .unwrap();
-        assert_eq!(s.shape(), vec![2, 3]);
-        assert_eq!(ints(s.values()), vec![3, 4, 5, 6, 7, 8]);
-    }
-
-    #[test]
-    fn strided_subset_gathers() {
-        // (time=2, lon=3): lon 1..3 for all time → non-contiguous.
-        let a = nd((0..6).collect(), &[("time", 2), ("lon", 3)]);
-        let s = a
-            .subset(&ArraySubset::new(vec![0, 1], vec![2, 2]))
-            .unwrap();
-        assert_eq!(s.shape(), vec![2, 2]);
-        assert_eq!(ints(s.values()), vec![1, 2, 4, 5]);
-    }
-
-    #[test]
-    fn full_subset_is_zero_copy() {
-        let a = nd((0..6).collect(), &[("time", 2), ("lon", 3)]);
-        let s = a
-            .subset(&ArraySubset::new(vec![0, 0], vec![2, 3]))
-            .unwrap();
-        assert_eq!(ints(s.values()), ints(a.values()));
-    }
-
-    #[test]
-    fn out_of_bounds_subset_rejected() {
-        let a = nd((0..6).collect(), &[("time", 2), ("lon", 3)]);
-        assert!(a.subset(&ArraySubset::new(vec![1, 0], vec![2, 3])).is_err());
-    }
-
-    #[test]
     fn materialize_broadcast() {
         let lat = nd(vec![10, 20, 30], &[("lat", 3)]);
         let target = dims(&[("time", 2), ("lat", 3)]);
-        let out = lat.materialize(&target, None).unwrap();
+        let out = lat.materialize(&target).unwrap();
         assert_eq!(ints(&out), vec![10, 20, 30, 10, 20, 30]);
-    }
-
-    #[test]
-    fn materialize_with_selection_composes() {
-        let lat = nd(vec![10, 20, 30], &[("lat", 3)]);
-        let target = dims(&[("time", 2), ("lat", 3)]);
-        let keep: Vec<Option<&[u32]>> = vec![Some(&[1]), Some(&[0, 2])];
-        let out = lat.materialize(&target, Some(&keep)).unwrap();
-        assert_eq!(ints(&out), vec![10, 30]);
     }
 
     #[test]
     fn materialize_identity_zero_copy() {
         let a = nd((0..6).collect(), &[("time", 2), ("lon", 3)]);
         let target = dims(&[("time", 2), ("lon", 3)]);
-        let out = a.materialize(&target, None).unwrap();
+        let out = a.materialize(&target).unwrap();
         assert_eq!(ints(&out), (0..6).collect::<Vec<_>>());
     }
 }

--- a/beacon-datafusion-ext/src/nd/batch.rs
+++ b/beacon-datafusion-ext/src/nd/batch.rs
@@ -1,0 +1,186 @@
+//! Grid-shaped record batches: columns with heterogeneous dimension subsets
+//! over a shared target grid.
+
+use arrow::array::{ArrayRef, RecordBatchOptions};
+use arrow::datatypes::SchemaRef;
+use arrow::record_batch::RecordBatch;
+use datafusion::common::plan_err;
+use datafusion::error::{DataFusionError, Result};
+
+use super::array::NdArrowArray;
+use super::dimensions::Dimensions;
+
+/// A record batch whose columns are [`NdArrowArray`]s over a shared target
+/// grid. Each column may live on a subset of the target's dimensions (a scalar
+/// attribute, a 1-D coordinate, a full-rank data variable, …). Columns stay
+/// un-broadcast until [`NdRecordBatch::materialize`], which broadcasts each one
+/// onto the full target grid.
+#[derive(Debug, Clone)]
+pub struct NdRecordBatch {
+    schema: SchemaRef,
+    columns: Vec<NdArrowArray>,
+    target: Dimensions,
+}
+
+impl NdRecordBatch {
+    pub fn try_new(
+        schema: SchemaRef,
+        columns: Vec<NdArrowArray>,
+        target: Dimensions,
+    ) -> Result<Self> {
+        if schema.fields().len() != columns.len() {
+            return plan_err!(
+                "nd batch has {} columns but the schema declares {} fields",
+                columns.len(),
+                schema.fields().len()
+            );
+        }
+        for (field, column) in schema.fields().iter().zip(columns.iter()) {
+            if field.data_type() != column.data_type() {
+                return plan_err!(
+                    "nd column '{}' has type {} but the schema declares {}",
+                    field.name(),
+                    column.data_type(),
+                    field.data_type()
+                );
+            }
+            // Validate broadcast compatibility eagerly so materialization
+            // cannot fail on shape errors.
+            column.broadcast_map(&target)?;
+        }
+        Ok(Self {
+            schema,
+            columns,
+            target,
+        })
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub fn columns(&self) -> &[NdArrowArray] {
+        &self.columns
+    }
+
+    pub fn column(&self, index: usize) -> &NdArrowArray {
+        &self.columns[index]
+    }
+
+    pub fn target(&self) -> &Dimensions {
+        &self.target
+    }
+
+    /// Rows in the materialized (fully broadcast) grid.
+    pub fn num_rows(&self) -> usize {
+        self.target.num_elements()
+    }
+
+    /// Materialize into a flat Arrow [`RecordBatch`] by broadcasting each
+    /// column onto the target grid (a single gather per column, or a zero-copy
+    /// pass-through for a column already at full rank).
+    pub fn materialize(&self) -> Result<RecordBatch> {
+        let arrays: Vec<ArrayRef> = self
+            .columns
+            .iter()
+            .map(|column| column.materialize(&self.target, None))
+            .collect::<Result<_>>()?;
+
+        let options = RecordBatchOptions::new().with_row_count(Some(self.num_rows()));
+        RecordBatch::try_new_with_options(self.schema.clone(), arrays, &options)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{AsArray, Float64Array, Int32Array};
+    use arrow::datatypes::{DataType, Field, Float64Type, Int32Type, Schema};
+
+    use super::*;
+    use crate::nd::dimensions::Dimension;
+
+    fn dims(spec: &[(&str, usize)]) -> Dimensions {
+        Dimensions::try_new(
+            spec.iter()
+                .map(|(name, size)| Dimension::new(*name, *size))
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    fn test_batch() -> NdRecordBatch {
+        // Grid (time=2, lat=3): time coord, lat coord, sst data.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("time", DataType::Int32, true),
+            Field::new("lat", DataType::Int32, true),
+            Field::new("sst", DataType::Float64, true),
+        ]));
+        let time =
+            NdArrowArray::try_new(Arc::new(Int32Array::from(vec![7, 8])), dims(&[("time", 2)]))
+                .unwrap();
+        let lat = NdArrowArray::try_new(
+            Arc::new(Int32Array::from(vec![10, 20, 30])),
+            dims(&[("lat", 3)]),
+        )
+        .unwrap();
+        let sst = NdArrowArray::try_new(
+            Arc::new(Float64Array::from(vec![0.0, 0.1, 0.2, 1.0, 1.1, 1.2])),
+            dims(&[("time", 2), ("lat", 3)]),
+        )
+        .unwrap();
+        NdRecordBatch::try_new(
+            schema,
+            vec![time, lat, sst],
+            dims(&[("time", 2), ("lat", 3)]),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn materialize_full_grid() {
+        let batch = test_batch().materialize().unwrap();
+        assert_eq!(batch.num_rows(), 6);
+        // time repeats across lat; lat tiles across time; sst is full-rank.
+        assert_eq!(
+            batch.column(0).as_primitive::<Int32Type>().values(),
+            &[7, 7, 7, 8, 8, 8]
+        );
+        assert_eq!(
+            batch.column(1).as_primitive::<Int32Type>().values(),
+            &[10, 20, 30, 10, 20, 30]
+        );
+        assert_eq!(
+            batch.column(2).as_primitive::<Float64Type>().values(),
+            &[0.0, 0.1, 0.2, 1.0, 1.1, 1.2]
+        );
+    }
+
+    #[test]
+    fn schema_mismatch_rejected() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "time",
+            DataType::Float64,
+            true,
+        )]));
+        let time =
+            NdArrowArray::try_new(Arc::new(Int32Array::from(vec![7, 8])), dims(&[("time", 2)]))
+                .unwrap();
+        assert!(NdRecordBatch::try_new(schema, vec![time], dims(&[("time", 2)])).is_err());
+    }
+
+    #[test]
+    fn incompatible_column_dims_rejected() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "depth",
+            DataType::Int32,
+            true,
+        )]));
+        let depth =
+            NdArrowArray::try_new(Arc::new(Int32Array::from(vec![1, 2])), dims(&[("depth", 2)]))
+                .unwrap();
+        assert!(NdRecordBatch::try_new(schema, vec![depth], dims(&[("time", 2)])).is_err());
+    }
+}

--- a/beacon-datafusion-ext/src/nd/batch.rs
+++ b/beacon-datafusion-ext/src/nd/batch.rs
@@ -83,7 +83,7 @@ impl NdRecordBatch {
         let arrays: Vec<ArrayRef> = self
             .columns
             .iter()
-            .map(|column| column.materialize(&self.target, None))
+            .map(|column| column.materialize(&self.target))
             .collect::<Result<_>>()?;
 
         let options = RecordBatchOptions::new().with_row_count(Some(self.num_rows()));

--- a/beacon-datafusion-ext/src/nd/broadcast.rs
+++ b/beacon-datafusion-ext/src/nd/broadcast.rs
@@ -1,0 +1,388 @@
+//! Virtual broadcast views over flat C-order arrays.
+//!
+//! A [`BroadcastMap`] captures a name-aligned (xarray-style) broadcast of a
+//! source array onto a target dimension grid as pure index arithmetic: per
+//! target axis, a source stride. A stride of `0` means the source does not
+//! advance along that axis (the axis is missing from the source, or has size
+//! 1 in it). No data moves until [`BroadcastMap::gather_indices`] feeds an
+//! Arrow `take`.
+
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, Int64Array, RunArray, UInt64Array};
+use arrow::datatypes::Int64Type;
+use datafusion::common::plan_err;
+use datafusion::error::{DataFusionError, Result};
+
+use super::dimensions::Dimensions;
+
+/// Broadcast of a source dimension set onto a target dimension set,
+/// represented as one source stride per target axis.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BroadcastMap {
+    target_shape: Vec<usize>,
+    /// Source stride per target axis; `0` = source does not advance.
+    strides: Vec<usize>,
+    source_len: usize,
+}
+
+/// Run-length structure of a broadcast view: the flattened output consists of
+/// `num_runs` runs of `run_len` consecutive equal source elements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RunStructure {
+    pub run_len: usize,
+    pub num_runs: usize,
+}
+
+impl BroadcastMap {
+    /// Build the broadcast of `source` onto `target`.
+    ///
+    /// Rules (matching `beacon-nd-array`'s `permuted_axes`-based broadcast):
+    /// - every source dimension must appear in `target` (matched by name;
+    ///   reordering is allowed and expressed through the strides);
+    /// - a source axis must have the same size as the target axis, or size 1
+    ///   (which expands).
+    pub fn try_new(source: &Dimensions, target: &Dimensions) -> Result<Self> {
+        let source_strides = source.c_strides();
+        let mut strides = vec![0usize; target.rank()];
+
+        for (source_axis, dim) in source.iter().enumerate() {
+            let Some(target_axis) = target.position(dim.name()) else {
+                return plan_err!(
+                    "cannot broadcast {source} to {target}: dimension '{}' is missing from the target",
+                    dim.name()
+                );
+            };
+
+            let target_size = target.get(target_axis).size();
+            if dim.size() == target_size {
+                strides[target_axis] = source_strides[source_axis];
+            } else if dim.size() == 1 {
+                strides[target_axis] = 0;
+            } else {
+                return plan_err!(
+                    "cannot broadcast {source} to {target}: dimension '{}' has size {} but the target expects {}",
+                    dim.name(),
+                    dim.size(),
+                    target_size
+                );
+            }
+        }
+
+        Ok(Self {
+            target_shape: target.shape(),
+            strides,
+            source_len: source.num_elements(),
+        })
+    }
+
+    pub fn target_shape(&self) -> &[usize] {
+        &self.target_shape
+    }
+
+    pub fn num_target_elements(&self) -> usize {
+        self.target_shape.iter().product()
+    }
+
+    /// True when the broadcast is a no-op: every target row maps to the source
+    /// row of the same index.
+    pub fn is_identity(&self) -> bool {
+        if self.source_len != self.num_target_elements() {
+            return false;
+        }
+        let mut acc = 1usize;
+        for axis in (0..self.target_shape.len()).rev() {
+            let size = self.target_shape[axis];
+            // A stride mismatch on a size-1 axis is irrelevant: its coordinate
+            // is always 0.
+            if size > 1 && self.strides[axis] != acc {
+                return false;
+            }
+            acc = acc.saturating_mul(size);
+        }
+        true
+    }
+
+    /// Source index for one flattened target row. Prefer [`Self::gather_indices`]
+    /// for bulk access.
+    pub fn source_index_of(&self, target_row: usize) -> usize {
+        let mut rem = target_row;
+        let mut idx = 0usize;
+        for axis in (0..self.target_shape.len()).rev() {
+            let size = self.target_shape[axis].max(1);
+            let coord = rem % size;
+            rem /= size;
+            idx += coord * self.strides[axis];
+        }
+        idx
+    }
+
+    /// Take indices for the (optionally selected) broadcast view, in row-major
+    /// target order.
+    ///
+    /// `keep` gives, per target axis, an optional sorted list of kept
+    /// coordinates; `None` keeps the whole axis. Passing `None` for the slice
+    /// itself keeps everything.
+    pub fn gather_indices(&self, keep: Option<&[Option<&[u32]>]>) -> UInt64Array {
+        let rank = self.target_shape.len();
+        // Per-axis list of precomputed source offsets (coordinate * stride).
+        let mut axis_offsets: Vec<Vec<u64>> = Vec::with_capacity(rank);
+        for axis in 0..rank {
+            let stride = self.strides[axis] as u64;
+            let offsets = match keep.and_then(|k| k[axis]) {
+                Some(coords) => coords.iter().map(|&c| c as u64 * stride).collect(),
+                None => (0..self.target_shape[axis] as u64)
+                    .map(|c| c * stride)
+                    .collect(),
+            };
+            axis_offsets.push(offsets);
+        }
+
+        let total: usize = axis_offsets.iter().map(|offsets| offsets.len()).product();
+        let mut out = Vec::with_capacity(total);
+        if total > 0 {
+            fill_indices(&axis_offsets, 0, 0, &mut out);
+        }
+        UInt64Array::from(out)
+    }
+
+    /// Run-length structure of the flattened broadcast: maximal run of
+    /// trailing axes along which the source does not advance.
+    pub fn run_structure(&self) -> RunStructure {
+        let mut run_len = 1usize;
+        for axis in (0..self.target_shape.len()).rev() {
+            if self.strides[axis] == 0 {
+                run_len = run_len.saturating_mul(self.target_shape[axis]);
+            } else {
+                break;
+            }
+        }
+        let total = self.num_target_elements();
+        RunStructure {
+            run_len,
+            num_runs: if run_len == 0 { 0 } else { total / run_len.max(1) },
+        }
+    }
+
+    /// Encode the full (unselected) broadcast view as a run-end encoded array.
+    ///
+    /// Returns `None` when the view has no run structure (`run_len <= 1`), in
+    /// which case a plain gather is the better representation.
+    pub fn to_run_array(&self, values: &ArrayRef) -> Result<Option<ArrayRef>> {
+        let RunStructure { run_len, num_runs } = self.run_structure();
+        if run_len <= 1 || num_runs == 0 {
+            return Ok(None);
+        }
+
+        // The run values are the broadcast view over the leading axes only
+        // (everything before the trailing zero-stride run).
+        let mut trailing = 1usize;
+        let mut split = self.target_shape.len();
+        while split > 0 && trailing < run_len {
+            split -= 1;
+            trailing *= self.target_shape[split];
+        }
+        let prefix = BroadcastMap {
+            target_shape: self.target_shape[..split].to_vec(),
+            strides: self.strides[..split].to_vec(),
+            source_len: self.source_len,
+        };
+        let run_values = if prefix.is_identity() {
+            values.clone()
+        } else {
+            arrow::compute::take(values.as_ref(), &prefix.gather_indices(None), None)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?
+        };
+
+        let run_ends: Int64Array = (1..=num_runs).map(|i| Some((i * run_len) as i64)).collect();
+        let run_array = RunArray::<Int64Type>::try_new(&run_ends, run_values.as_ref())
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        Ok(Some(Arc::new(run_array)))
+    }
+}
+
+/// Row-major cartesian sum of per-axis offsets. The innermost axis is a tight
+/// loop; outer axes recurse (rank is small in practice).
+fn fill_indices(axis_offsets: &[Vec<u64>], axis: usize, base: u64, out: &mut Vec<u64>) {
+    if axis_offsets.is_empty() {
+        out.push(base);
+        return;
+    }
+    if axis == axis_offsets.len() - 1 {
+        out.extend(axis_offsets[axis].iter().map(|&off| base + off));
+        return;
+    }
+    for &off in &axis_offsets[axis] {
+        fill_indices(axis_offsets, axis + 1, base + off, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nd::dimensions::Dimension;
+    use arrow::array::{Array, AsArray, Int32Array};
+
+    fn dims(spec: &[(&str, usize)]) -> Dimensions {
+        Dimensions::try_new(
+            spec.iter()
+                .map(|(name, size)| Dimension::new(*name, *size))
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    fn indices(map: &BroadcastMap, keep: Option<&[Option<&[u32]>]>) -> Vec<u64> {
+        map.gather_indices(keep).values().to_vec()
+    }
+
+    #[test]
+    fn outer_dim_broadcast_is_runs() {
+        // time[2] onto (time, lon=3): each time value repeats 3x contiguously.
+        let map = BroadcastMap::try_new(&dims(&[("time", 2)]), &dims(&[("time", 2), ("lon", 3)]))
+            .unwrap();
+        assert_eq!(indices(&map, None), vec![0, 0, 0, 1, 1, 1]);
+        assert_eq!(
+            map.run_structure(),
+            RunStructure {
+                run_len: 3,
+                num_runs: 2
+            }
+        );
+    }
+
+    #[test]
+    fn inner_dim_broadcast_is_tiled() {
+        // lon[3] onto (time=2, lon): the lon pattern tiles, no runs.
+        let map = BroadcastMap::try_new(&dims(&[("lon", 3)]), &dims(&[("time", 2), ("lon", 3)]))
+            .unwrap();
+        assert_eq!(indices(&map, None), vec![0, 1, 2, 0, 1, 2]);
+        assert_eq!(map.run_structure().run_len, 1);
+    }
+
+    #[test]
+    fn middle_dim_broadcast() {
+        // lat[2] onto (time=2, lat=2, lon=2): runs of 2, tiled twice.
+        let map = BroadcastMap::try_new(
+            &dims(&[("lat", 2)]),
+            &dims(&[("time", 2), ("lat", 2), ("lon", 2)]),
+        )
+        .unwrap();
+        assert_eq!(indices(&map, None), vec![0, 0, 1, 1, 0, 0, 1, 1]);
+        assert_eq!(
+            map.run_structure(),
+            RunStructure {
+                run_len: 2,
+                num_runs: 4
+            }
+        );
+    }
+
+    #[test]
+    fn scalar_broadcast() {
+        let map =
+            BroadcastMap::try_new(&Dimensions::scalar(), &dims(&[("time", 2), ("lon", 2)]))
+                .unwrap();
+        assert_eq!(indices(&map, None), vec![0, 0, 0, 0]);
+        assert_eq!(
+            map.run_structure(),
+            RunStructure {
+                run_len: 4,
+                num_runs: 1
+            }
+        );
+    }
+
+    #[test]
+    fn identity_detected() {
+        let target = dims(&[("time", 2), ("lon", 3)]);
+        let map = BroadcastMap::try_new(&target, &target).unwrap();
+        assert!(map.is_identity());
+
+        let map =
+            BroadcastMap::try_new(&dims(&[("lon", 3)]), &dims(&[("time", 2), ("lon", 3)]))
+                .unwrap();
+        assert!(!map.is_identity());
+    }
+
+    #[test]
+    fn size_one_expansion() {
+        // time[1] onto time[4]: stride 0.
+        let map =
+            BroadcastMap::try_new(&dims(&[("time", 1)]), &dims(&[("time", 4)])).unwrap();
+        assert_eq!(indices(&map, None), vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn transposed_dims_gather_correctly() {
+        // Source stored (lon, time); target order (time, lon). Matching
+        // beacon-nd-array's permuted_axes broadcast, the view transposes.
+        let map = BroadcastMap::try_new(
+            &dims(&[("lon", 3), ("time", 2)]),
+            &dims(&[("time", 2), ("lon", 3)]),
+        )
+        .unwrap();
+        // source flat layout: (l0,t0),(l0,t1),(l1,t0),(l1,t1),(l2,t0),(l2,t1)
+        assert_eq!(indices(&map, None), vec![0, 2, 4, 1, 3, 5]);
+        assert!(!map.is_identity());
+    }
+
+    #[test]
+    fn size_mismatch_rejected() {
+        let result =
+            BroadcastMap::try_new(&dims(&[("time", 2)]), &dims(&[("time", 4)]));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn gather_with_axis_selection() {
+        // sst(time=2, lon=3), keep time=[1], lon=[0, 2].
+        let source = dims(&[("time", 2), ("lon", 3)]);
+        let map = BroadcastMap::try_new(&source, &source).unwrap();
+        let keep: Vec<Option<&[u32]>> = vec![Some(&[1]), Some(&[0, 2])];
+        assert_eq!(indices(&map, Some(&keep)), vec![3, 5]);
+    }
+
+    #[test]
+    fn gather_selection_composes_with_broadcast() {
+        // lat[3] onto (time=2, lat=3); keep time=[0], lat=[2] → single row
+        // reading source element 2. The unfiltered broadcast never exists.
+        let map = BroadcastMap::try_new(&dims(&[("lat", 3)]), &dims(&[("time", 2), ("lat", 3)]))
+            .unwrap();
+        let keep: Vec<Option<&[u32]>> = vec![Some(&[0]), Some(&[2])];
+        assert_eq!(indices(&map, Some(&keep)), vec![2]);
+    }
+
+    #[test]
+    fn run_array_round_trip() {
+        // time values [10, 20] broadcast onto (time=2, lon=3) → REE with 2 runs.
+        let values: ArrayRef = Arc::new(Int32Array::from(vec![10, 20]));
+        let map = BroadcastMap::try_new(&dims(&[("time", 2)]), &dims(&[("time", 2), ("lon", 3)]))
+            .unwrap();
+        let ree = map.to_run_array(&values).unwrap().unwrap();
+        let run = ree.as_any().downcast_ref::<RunArray<Int64Type>>().unwrap();
+        assert_eq!(run.len(), 6);
+        assert_eq!(
+            run.run_ends().values(),
+            &[3i64, 6]
+        );
+        let inner = run.values().as_primitive::<arrow::datatypes::Int32Type>();
+        assert_eq!(inner.values(), &[10, 20]);
+    }
+
+    #[test]
+    fn run_array_none_when_no_runs() {
+        let values: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let map = BroadcastMap::try_new(&dims(&[("lon", 3)]), &dims(&[("time", 2), ("lon", 3)]))
+            .unwrap();
+        assert!(map.to_run_array(&values).unwrap().is_none());
+    }
+
+    #[test]
+    fn empty_axis_yields_no_indices() {
+        let map =
+            BroadcastMap::try_new(&dims(&[("time", 0)]), &dims(&[("time", 0), ("lon", 3)]))
+                .unwrap();
+        assert_eq!(indices(&map, None), Vec::<u64>::new());
+    }
+}

--- a/beacon-datafusion-ext/src/nd/broadcast.rs
+++ b/beacon-datafusion-ext/src/nd/broadcast.rs
@@ -7,12 +7,9 @@
 //! 1 in it). No data moves until [`BroadcastMap::gather_indices`] feeds an
 //! Arrow `take`.
 
-use std::sync::Arc;
-
-use arrow::array::{ArrayRef, Int64Array, RunArray, UInt64Array};
-use arrow::datatypes::Int64Type;
+use arrow::array::UInt64Array;
 use datafusion::common::plan_err;
-use datafusion::error::{DataFusionError, Result};
+use datafusion::error::Result;
 
 use super::dimensions::Dimensions;
 
@@ -24,14 +21,6 @@ pub struct BroadcastMap {
     /// Source stride per target axis; `0` = source does not advance.
     strides: Vec<usize>,
     source_len: usize,
-}
-
-/// Run-length structure of a broadcast view: the flattened output consists of
-/// `num_runs` runs of `run_len` consecutive equal source elements.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct RunStructure {
-    pub run_len: usize,
-    pub num_runs: usize,
 }
 
 impl BroadcastMap {
@@ -76,11 +65,7 @@ impl BroadcastMap {
         })
     }
 
-    pub fn target_shape(&self) -> &[usize] {
-        &self.target_shape
-    }
-
-    pub fn num_target_elements(&self) -> usize {
+    fn num_target_elements(&self) -> usize {
         self.target_shape.iter().product()
     }
 
@@ -103,40 +88,18 @@ impl BroadcastMap {
         true
     }
 
-    /// Source index for one flattened target row. Prefer [`Self::gather_indices`]
-    /// for bulk access.
-    pub fn source_index_of(&self, target_row: usize) -> usize {
-        let mut rem = target_row;
-        let mut idx = 0usize;
-        for axis in (0..self.target_shape.len()).rev() {
-            let size = self.target_shape[axis].max(1);
-            let coord = rem % size;
-            rem /= size;
-            idx += coord * self.strides[axis];
-        }
-        idx
-    }
-
-    /// Take indices for the (optionally selected) broadcast view, in row-major
-    /// target order.
-    ///
-    /// `keep` gives, per target axis, an optional sorted list of kept
-    /// coordinates; `None` keeps the whole axis. Passing `None` for the slice
-    /// itself keeps everything.
-    pub fn gather_indices(&self, keep: Option<&[Option<&[u32]>]>) -> UInt64Array {
+    /// Take indices for the broadcast view, in row-major target order.
+    pub fn gather_indices(&self) -> UInt64Array {
         let rank = self.target_shape.len();
         // Per-axis list of precomputed source offsets (coordinate * stride).
-        let mut axis_offsets: Vec<Vec<u64>> = Vec::with_capacity(rank);
-        for axis in 0..rank {
-            let stride = self.strides[axis] as u64;
-            let offsets = match keep.and_then(|k| k[axis]) {
-                Some(coords) => coords.iter().map(|&c| c as u64 * stride).collect(),
-                None => (0..self.target_shape[axis] as u64)
+        let axis_offsets: Vec<Vec<u64>> = (0..rank)
+            .map(|axis| {
+                let stride = self.strides[axis] as u64;
+                (0..self.target_shape[axis] as u64)
                     .map(|c| c * stride)
-                    .collect(),
-            };
-            axis_offsets.push(offsets);
-        }
+                    .collect()
+            })
+            .collect();
 
         let total: usize = axis_offsets.iter().map(|offsets| offsets.len()).product();
         let mut out = Vec::with_capacity(total);
@@ -144,60 +107,6 @@ impl BroadcastMap {
             fill_indices(&axis_offsets, 0, 0, &mut out);
         }
         UInt64Array::from(out)
-    }
-
-    /// Run-length structure of the flattened broadcast: maximal run of
-    /// trailing axes along which the source does not advance.
-    pub fn run_structure(&self) -> RunStructure {
-        let mut run_len = 1usize;
-        for axis in (0..self.target_shape.len()).rev() {
-            if self.strides[axis] == 0 {
-                run_len = run_len.saturating_mul(self.target_shape[axis]);
-            } else {
-                break;
-            }
-        }
-        let total = self.num_target_elements();
-        RunStructure {
-            run_len,
-            num_runs: if run_len == 0 { 0 } else { total / run_len.max(1) },
-        }
-    }
-
-    /// Encode the full (unselected) broadcast view as a run-end encoded array.
-    ///
-    /// Returns `None` when the view has no run structure (`run_len <= 1`), in
-    /// which case a plain gather is the better representation.
-    pub fn to_run_array(&self, values: &ArrayRef) -> Result<Option<ArrayRef>> {
-        let RunStructure { run_len, num_runs } = self.run_structure();
-        if run_len <= 1 || num_runs == 0 {
-            return Ok(None);
-        }
-
-        // The run values are the broadcast view over the leading axes only
-        // (everything before the trailing zero-stride run).
-        let mut trailing = 1usize;
-        let mut split = self.target_shape.len();
-        while split > 0 && trailing < run_len {
-            split -= 1;
-            trailing *= self.target_shape[split];
-        }
-        let prefix = BroadcastMap {
-            target_shape: self.target_shape[..split].to_vec(),
-            strides: self.strides[..split].to_vec(),
-            source_len: self.source_len,
-        };
-        let run_values = if prefix.is_identity() {
-            values.clone()
-        } else {
-            arrow::compute::take(values.as_ref(), &prefix.gather_indices(None), None)
-                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?
-        };
-
-        let run_ends: Int64Array = (1..=num_runs).map(|i| Some((i * run_len) as i64)).collect();
-        let run_array = RunArray::<Int64Type>::try_new(&run_ends, run_values.as_ref())
-            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-        Ok(Some(Arc::new(run_array)))
     }
 }
 
@@ -221,7 +130,6 @@ fn fill_indices(axis_offsets: &[Vec<u64>], axis: usize, base: u64, out: &mut Vec
 mod tests {
     use super::*;
     use crate::nd::dimensions::Dimension;
-    use arrow::array::{Array, AsArray, Int32Array};
 
     fn dims(spec: &[(&str, usize)]) -> Dimensions {
         Dimensions::try_new(
@@ -232,32 +140,24 @@ mod tests {
         .unwrap()
     }
 
-    fn indices(map: &BroadcastMap, keep: Option<&[Option<&[u32]>]>) -> Vec<u64> {
-        map.gather_indices(keep).values().to_vec()
+    fn indices(map: &BroadcastMap) -> Vec<u64> {
+        map.gather_indices().values().to_vec()
     }
 
     #[test]
-    fn outer_dim_broadcast_is_runs() {
+    fn outer_dim_broadcast_repeats() {
         // time[2] onto (time, lon=3): each time value repeats 3x contiguously.
         let map = BroadcastMap::try_new(&dims(&[("time", 2)]), &dims(&[("time", 2), ("lon", 3)]))
             .unwrap();
-        assert_eq!(indices(&map, None), vec![0, 0, 0, 1, 1, 1]);
-        assert_eq!(
-            map.run_structure(),
-            RunStructure {
-                run_len: 3,
-                num_runs: 2
-            }
-        );
+        assert_eq!(indices(&map), vec![0, 0, 0, 1, 1, 1]);
     }
 
     #[test]
-    fn inner_dim_broadcast_is_tiled() {
-        // lon[3] onto (time=2, lon): the lon pattern tiles, no runs.
+    fn inner_dim_broadcast_tiles() {
+        // lon[3] onto (time=2, lon): the lon pattern tiles.
         let map = BroadcastMap::try_new(&dims(&[("lon", 3)]), &dims(&[("time", 2), ("lon", 3)]))
             .unwrap();
-        assert_eq!(indices(&map, None), vec![0, 1, 2, 0, 1, 2]);
-        assert_eq!(map.run_structure().run_len, 1);
+        assert_eq!(indices(&map), vec![0, 1, 2, 0, 1, 2]);
     }
 
     #[test]
@@ -268,29 +168,14 @@ mod tests {
             &dims(&[("time", 2), ("lat", 2), ("lon", 2)]),
         )
         .unwrap();
-        assert_eq!(indices(&map, None), vec![0, 0, 1, 1, 0, 0, 1, 1]);
-        assert_eq!(
-            map.run_structure(),
-            RunStructure {
-                run_len: 2,
-                num_runs: 4
-            }
-        );
+        assert_eq!(indices(&map), vec![0, 0, 1, 1, 0, 0, 1, 1]);
     }
 
     #[test]
     fn scalar_broadcast() {
         let map =
-            BroadcastMap::try_new(&Dimensions::scalar(), &dims(&[("time", 2), ("lon", 2)]))
-                .unwrap();
-        assert_eq!(indices(&map, None), vec![0, 0, 0, 0]);
-        assert_eq!(
-            map.run_structure(),
-            RunStructure {
-                run_len: 4,
-                num_runs: 1
-            }
-        );
+            BroadcastMap::try_new(&Dimensions::scalar(), &dims(&[("time", 2), ("lon", 2)])).unwrap();
+        assert_eq!(indices(&map), vec![0, 0, 0, 0]);
     }
 
     #[test]
@@ -300,17 +185,15 @@ mod tests {
         assert!(map.is_identity());
 
         let map =
-            BroadcastMap::try_new(&dims(&[("lon", 3)]), &dims(&[("time", 2), ("lon", 3)]))
-                .unwrap();
+            BroadcastMap::try_new(&dims(&[("lon", 3)]), &dims(&[("time", 2), ("lon", 3)])).unwrap();
         assert!(!map.is_identity());
     }
 
     #[test]
     fn size_one_expansion() {
         // time[1] onto time[4]: stride 0.
-        let map =
-            BroadcastMap::try_new(&dims(&[("time", 1)]), &dims(&[("time", 4)])).unwrap();
-        assert_eq!(indices(&map, None), vec![0, 0, 0, 0]);
+        let map = BroadcastMap::try_new(&dims(&[("time", 1)]), &dims(&[("time", 4)])).unwrap();
+        assert_eq!(indices(&map), vec![0, 0, 0, 0]);
     }
 
     #[test]
@@ -323,66 +206,20 @@ mod tests {
         )
         .unwrap();
         // source flat layout: (l0,t0),(l0,t1),(l1,t0),(l1,t1),(l2,t0),(l2,t1)
-        assert_eq!(indices(&map, None), vec![0, 2, 4, 1, 3, 5]);
+        assert_eq!(indices(&map), vec![0, 2, 4, 1, 3, 5]);
         assert!(!map.is_identity());
     }
 
     #[test]
     fn size_mismatch_rejected() {
-        let result =
-            BroadcastMap::try_new(&dims(&[("time", 2)]), &dims(&[("time", 4)]));
+        let result = BroadcastMap::try_new(&dims(&[("time", 2)]), &dims(&[("time", 4)]));
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn gather_with_axis_selection() {
-        // sst(time=2, lon=3), keep time=[1], lon=[0, 2].
-        let source = dims(&[("time", 2), ("lon", 3)]);
-        let map = BroadcastMap::try_new(&source, &source).unwrap();
-        let keep: Vec<Option<&[u32]>> = vec![Some(&[1]), Some(&[0, 2])];
-        assert_eq!(indices(&map, Some(&keep)), vec![3, 5]);
-    }
-
-    #[test]
-    fn gather_selection_composes_with_broadcast() {
-        // lat[3] onto (time=2, lat=3); keep time=[0], lat=[2] → single row
-        // reading source element 2. The unfiltered broadcast never exists.
-        let map = BroadcastMap::try_new(&dims(&[("lat", 3)]), &dims(&[("time", 2), ("lat", 3)]))
-            .unwrap();
-        let keep: Vec<Option<&[u32]>> = vec![Some(&[0]), Some(&[2])];
-        assert_eq!(indices(&map, Some(&keep)), vec![2]);
-    }
-
-    #[test]
-    fn run_array_round_trip() {
-        // time values [10, 20] broadcast onto (time=2, lon=3) → REE with 2 runs.
-        let values: ArrayRef = Arc::new(Int32Array::from(vec![10, 20]));
-        let map = BroadcastMap::try_new(&dims(&[("time", 2)]), &dims(&[("time", 2), ("lon", 3)]))
-            .unwrap();
-        let ree = map.to_run_array(&values).unwrap().unwrap();
-        let run = ree.as_any().downcast_ref::<RunArray<Int64Type>>().unwrap();
-        assert_eq!(run.len(), 6);
-        assert_eq!(
-            run.run_ends().values(),
-            &[3i64, 6]
-        );
-        let inner = run.values().as_primitive::<arrow::datatypes::Int32Type>();
-        assert_eq!(inner.values(), &[10, 20]);
-    }
-
-    #[test]
-    fn run_array_none_when_no_runs() {
-        let values: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
-        let map = BroadcastMap::try_new(&dims(&[("lon", 3)]), &dims(&[("time", 2), ("lon", 3)]))
-            .unwrap();
-        assert!(map.to_run_array(&values).unwrap().is_none());
     }
 
     #[test]
     fn empty_axis_yields_no_indices() {
         let map =
-            BroadcastMap::try_new(&dims(&[("time", 0)]), &dims(&[("time", 0), ("lon", 3)]))
-                .unwrap();
-        assert_eq!(indices(&map, None), Vec::<u64>::new());
+            BroadcastMap::try_new(&dims(&[("time", 0)]), &dims(&[("time", 0), ("lon", 3)])).unwrap();
+        assert_eq!(indices(&map), Vec::<u64>::new());
     }
 }

--- a/beacon-datafusion-ext/src/nd/dimensions.rs
+++ b/beacon-datafusion-ext/src/nd/dimensions.rs
@@ -29,10 +29,6 @@ impl Dimension {
         &self.name
     }
 
-    pub fn name_arc(&self) -> Arc<str> {
-        self.name.clone()
-    }
-
     pub fn size(&self) -> usize {
         self.size
     }
@@ -73,10 +69,6 @@ impl Dimensions {
 
     pub fn rank(&self) -> usize {
         self.dims.len()
-    }
-
-    pub fn is_scalar(&self) -> bool {
-        self.dims.is_empty()
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Dimension> {

--- a/beacon-datafusion-ext/src/nd/dimensions.rs
+++ b/beacon-datafusion-ext/src/nd/dimensions.rs
@@ -1,0 +1,169 @@
+//! Named dimensions for N-dimensional Arrow arrays.
+//!
+//! A [`Dimensions`] value describes the logical shape of an [`crate::nd::NdArrowArray`]
+//! in C-order (row-major, first dimension outermost). Dimension names drive
+//! xarray-style broadcasting: axes are aligned by name, never by position.
+
+use std::fmt;
+use std::sync::Arc;
+
+use datafusion::common::plan_err;
+use datafusion::error::Result;
+
+/// A single named axis with a fixed size.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Dimension {
+    name: Arc<str>,
+    size: usize,
+}
+
+impl Dimension {
+    pub fn new(name: impl Into<Arc<str>>, size: usize) -> Self {
+        Self {
+            name: name.into(),
+            size,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn name_arc(&self) -> Arc<str> {
+        self.name.clone()
+    }
+
+    pub fn size(&self) -> usize {
+        self.size
+    }
+}
+
+impl fmt::Display for Dimension {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}={}", self.name, self.size)
+    }
+}
+
+/// An ordered list of named axes, C-order. Cheap to clone.
+///
+/// Rank 0 (no axes) describes a scalar: one logical element.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Dimensions {
+    dims: Arc<[Dimension]>,
+}
+
+impl Dimensions {
+    /// Create dimensions, validating that axis names are non-empty and unique.
+    pub fn try_new(dims: Vec<Dimension>) -> Result<Self> {
+        for (i, dim) in dims.iter().enumerate() {
+            if dim.name().is_empty() {
+                return plan_err!("nd dimension at axis {i} has an empty name");
+            }
+            if dims[..i].iter().any(|d| d.name() == dim.name()) {
+                return plan_err!("duplicate nd dimension name '{}'", dim.name());
+            }
+        }
+        Ok(Self { dims: dims.into() })
+    }
+
+    /// Rank-0 dimensions describing a scalar.
+    pub fn scalar() -> Self {
+        Self::default()
+    }
+
+    pub fn rank(&self) -> usize {
+        self.dims.len()
+    }
+
+    pub fn is_scalar(&self) -> bool {
+        self.dims.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Dimension> {
+        self.dims.iter()
+    }
+
+    pub fn get(&self, axis: usize) -> &Dimension {
+        &self.dims[axis]
+    }
+
+    pub fn shape(&self) -> Vec<usize> {
+        self.dims.iter().map(|d| d.size()).collect()
+    }
+
+    /// Total number of logical elements (1 for a scalar, 0 if any axis is empty).
+    pub fn num_elements(&self) -> usize {
+        self.dims.iter().map(|d| d.size()).product()
+    }
+
+    pub fn position(&self, name: &str) -> Option<usize> {
+        self.dims.iter().position(|d| d.name() == name)
+    }
+
+    /// C-order (row-major) strides, in elements.
+    pub fn c_strides(&self) -> Vec<usize> {
+        let mut strides = vec![0usize; self.rank()];
+        let mut acc = 1usize;
+        for axis in (0..self.rank()).rev() {
+            strides[axis] = acc;
+            acc = acc.saturating_mul(self.dims[axis].size());
+        }
+        strides
+    }
+}
+
+impl fmt::Display for Dimensions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(")?;
+        for (i, dim) in self.dims.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{dim}")?;
+        }
+        write!(f, ")")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dims(spec: &[(&str, usize)]) -> Dimensions {
+        Dimensions::try_new(
+            spec.iter()
+                .map(|(name, size)| Dimension::new(*name, *size))
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn strides_are_c_order() {
+        let d = dims(&[("time", 2), ("lat", 3), ("lon", 4)]);
+        assert_eq!(d.c_strides(), vec![12, 4, 1]);
+        assert_eq!(d.num_elements(), 24);
+    }
+
+    #[test]
+    fn scalar_has_one_element() {
+        let d = Dimensions::scalar();
+        assert_eq!(d.rank(), 0);
+        assert_eq!(d.num_elements(), 1);
+        assert!(d.c_strides().is_empty());
+    }
+
+    #[test]
+    fn duplicate_names_rejected() {
+        let result = Dimensions::try_new(vec![
+            Dimension::new("x", 2),
+            Dimension::new("x", 3),
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_name_rejected() {
+        assert!(Dimensions::try_new(vec![Dimension::new("", 2)]).is_err());
+    }
+}

--- a/beacon-datafusion-ext/src/nd/encoding.rs
+++ b/beacon-datafusion-ext/src/nd/encoding.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, ArrayRef, ListArray, StringArray, StructArray, UInt32Array,
+    Array, ArrayRef, ListArray, StringArray, StructArray, UInt32Array, new_null_array,
 };
 use arrow::buffer::OffsetBuffer;
 use arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef};
@@ -73,7 +73,19 @@ pub fn nd_encoded_field(name: &str, value_type: &DataType) -> Field {
         ("ARROW:extension:name".to_string(), ND_EXTENSION_NAME.to_string()),
         ("ARROW:extension:metadata".to_string(), "{}".to_string()),
     ]);
-    Field::new(name, nd_encoded_type(value_type), false).with_metadata(metadata)
+    Field::new(name, nd_encoded_type(value_type), true).with_metadata(metadata)
+}
+
+/// The nd-encoded schema of a logical schema: every field becomes a `beacon.nd`
+/// struct column of the same name. This is the schema a `DataSourceExec` carries
+/// while nd data flows up to [`NdSourceExec`](crate::nd::exec::NdSourceExec).
+pub fn encoded_schema(logical: &Schema) -> Schema {
+    let fields: Vec<Field> = logical
+        .fields()
+        .iter()
+        .map(|f| nd_encoded_field(f.name(), f.data_type()))
+        .collect();
+    Schema::new_with_metadata(fields, logical.metadata().clone())
 }
 
 /// True when `field` is an nd-encoded column.
@@ -137,11 +149,19 @@ pub fn encode_nd_array(array: &NdArrowArray) -> ArrayRef {
 }
 
 /// Decode row `row` of an nd-encoded `Struct` column back into an [`NdArrowArray`].
+///
+/// A null struct row (a column a file lacked, null-filled by the schema adapter)
+/// decodes to a rank-0 null scalar, which broadcasts to an all-null column.
 pub fn decode_nd_array(column: &ArrayRef, row: usize) -> Result<NdArrowArray> {
     let structs = column
         .as_any()
         .downcast_ref::<StructArray>()
         .ok_or_else(|| err("nd column is not a Struct array"))?;
+
+    if structs.is_null(row) {
+        let value_type = nd_value_type(structs.data_type())?;
+        return NdArrowArray::try_new(new_null_array(&value_type, 1), Dimensions::scalar());
+    }
 
     let list_at = |name: &str| -> Result<ArrayRef> {
         let list = structs
@@ -202,6 +222,24 @@ pub fn encode_nd_record_batch(batch: &NdRecordBatch) -> Result<RecordBatch> {
         .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
 }
 
+/// Encode an already-flat `RecordBatch` (e.g. a run-length-expanded ragged
+/// batch) as nd-encoded columns over a single synthetic `row` dimension. Every
+/// column is full-rank on that axis, so a later broadcast is the identity —
+/// decoding then materializing reproduces the input.
+pub fn encode_flat_batch_as_nd(batch: &RecordBatch) -> Result<RecordBatch> {
+    let rows = batch.num_rows();
+    let row_dim = || Dimensions::try_new(vec![Dimension::new("row", rows)]);
+
+    let columns = batch
+        .columns()
+        .iter()
+        .map(|c| NdArrowArray::try_new(c.clone(), row_dim()?))
+        .collect::<Result<Vec<_>>>()?;
+
+    let nd = NdRecordBatch::try_new(batch.schema(), columns, row_dim()?)?;
+    encode_nd_record_batch(&nd)
+}
+
 /// The logical (decoded) schema of an nd-encoded schema: each `beacon.nd`
 /// struct column becomes its element type.
 pub fn logical_schema(encoded: &Schema) -> Result<SchemaRef> {
@@ -217,6 +255,13 @@ pub fn logical_schema(encoded: &Schema) -> Result<SchemaRef> {
 /// [`NdRecordBatch`]. The target grid is inferred as the union of the columns'
 /// dimensions, ordered by the highest-rank column.
 pub fn decode_nd_record_batch(batch: &RecordBatch) -> Result<NdRecordBatch> {
+    // A zero-column batch is a COUNT(*)-style row carrier: preserve its row
+    // count via a synthetic one-axis grid so the broadcast reproduces it.
+    if batch.num_columns() == 0 {
+        let target = Dimensions::try_new(vec![Dimension::new("row", batch.num_rows())])?;
+        return NdRecordBatch::try_new(Arc::new(Schema::empty()), vec![], target);
+    }
+
     let columns = batch
         .columns()
         .iter()
@@ -339,6 +384,56 @@ mod tests {
             actual.column(2).as_primitive::<Float64Type>().values(),
             &[0.0, 0.1, 0.2, 1.0, 1.1, 1.2]
         );
+    }
+
+    #[test]
+    fn null_struct_column_decodes_to_null_scalar() {
+        // A missing (null-filled) nd column decodes to a rank-0 null scalar and
+        // broadcasts to an all-null column.
+        let null_struct = arrow::array::new_null_array(&nd_encoded_type(&DataType::Float64), 1);
+        let decoded = decode_nd_array(&null_struct, 0).unwrap();
+        assert_eq!(decoded.dims().rank(), 0);
+        let target = dims(&[("time", 3)]);
+        let out = decoded.materialize(&target).unwrap();
+        assert_eq!(out.len(), 3);
+        assert_eq!(out.null_count(), 3);
+    }
+
+    #[test]
+    fn zero_column_batch_preserves_row_count() {
+        // COUNT(*)-style zero-column batch → nd batch that materializes to the
+        // same row count with no columns.
+        let empty = RecordBatch::try_new_with_options(
+            Arc::new(Schema::empty()),
+            vec![],
+            &RecordBatchOptions::new().with_row_count(Some(42)),
+        )
+        .unwrap();
+        let nd = decode_nd_record_batch(&empty).unwrap();
+        let flat = nd.materialize().unwrap();
+        assert_eq!(flat.num_columns(), 0);
+        assert_eq!(flat.num_rows(), 42);
+    }
+
+    #[test]
+    fn flat_batch_round_trips_through_nd() {
+        // Ragged path: a flat batch wrapped on a synthetic row dim survives
+        // encode → decode → materialize unchanged.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Float64, true),
+        ]));
+        let flat = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Float64Array::from(vec![1.5, 2.5, 3.5])),
+            ],
+        )
+        .unwrap();
+        let encoded = encode_flat_batch_as_nd(&flat).unwrap();
+        let decoded = decode_nd_record_batch(&encoded).unwrap();
+        assert_eq!(decoded.materialize().unwrap(), flat);
     }
 
     #[test]

--- a/beacon-datafusion-ext/src/nd/encoding.rs
+++ b/beacon-datafusion-ext/src/nd/encoding.rs
@@ -1,0 +1,354 @@
+//! A self-describing Arrow encoding of nd arrays.
+//!
+//! An [`NdArrowArray`] is encoded as an Arrow `Struct` whose single row carries
+//! the flat values plus the dimensions:
+//!
+//! ```text
+//! Struct{
+//!   values:    List<T>,       // the flat, C-order values (one list element)
+//!   dim_sizes: List<UInt32>,  // size per axis
+//!   dim_names: List<Utf8>,    // name per axis
+//! }
+//! ```
+//!
+//! The struct field carries the `beacon.nd` Arrow extension type so the intent
+//! survives IPC. Because it is an ordinary Arrow array, an nd batch encoded
+//! this way rides through a `DataSourceExec` (and any other operator) as a
+//! normal `RecordBatch`; [`NdSourceExec`](crate::nd::exec::NdSourceExec) decodes
+//! it back into an [`NdRecordBatch`] on the way out.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, ArrayRef, ListArray, StringArray, StructArray, UInt32Array,
+};
+use arrow::buffer::OffsetBuffer;
+use arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef};
+use arrow::record_batch::{RecordBatch, RecordBatchOptions};
+use datafusion::common::plan_err;
+use datafusion::error::{DataFusionError, Result};
+
+use super::array::NdArrowArray;
+use super::batch::NdRecordBatch;
+use super::dimensions::{Dimension, Dimensions};
+
+/// Arrow extension type name tagged on an nd column's field.
+pub const ND_EXTENSION_NAME: &str = "beacon.nd";
+
+fn err(e: impl std::fmt::Display) -> DataFusionError {
+    DataFusionError::Execution(e.to_string())
+}
+
+/// The three struct fields of the nd encoding for a given element type.
+fn nd_struct_fields(value_type: &DataType) -> Fields {
+    Fields::from(vec![
+        Field::new(
+            "values",
+            DataType::List(Arc::new(Field::new("item", value_type.clone(), true))),
+            false,
+        ),
+        Field::new(
+            "dim_sizes",
+            DataType::List(Arc::new(Field::new("item", DataType::UInt32, false))),
+            false,
+        ),
+        Field::new(
+            "dim_names",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, false))),
+            false,
+        ),
+    ])
+}
+
+/// The struct `DataType` of the nd encoding for a given element type.
+pub fn nd_encoded_type(value_type: &DataType) -> DataType {
+    DataType::Struct(nd_struct_fields(value_type))
+}
+
+/// An nd column field named `name` carrying values of `value_type`, tagged with
+/// the `beacon.nd` extension type.
+pub fn nd_encoded_field(name: &str, value_type: &DataType) -> Field {
+    let metadata = HashMap::from([
+        ("ARROW:extension:name".to_string(), ND_EXTENSION_NAME.to_string()),
+        ("ARROW:extension:metadata".to_string(), "{}".to_string()),
+    ]);
+    Field::new(name, nd_encoded_type(value_type), false).with_metadata(metadata)
+}
+
+/// True when `field` is an nd-encoded column.
+pub fn is_nd_encoded(field: &Field) -> bool {
+    field.metadata().get("ARROW:extension:name").map(String::as_str) == Some(ND_EXTENSION_NAME)
+}
+
+/// Element type carried by an nd-encoded struct type (the `values` list item).
+pub fn nd_value_type(encoded: &DataType) -> Result<DataType> {
+    let DataType::Struct(fields) = encoded else {
+        return plan_err!("not an nd-encoded type: {encoded}");
+    };
+    let values = fields
+        .iter()
+        .find(|f| f.name() == "values")
+        .ok_or_else(|| err("nd-encoded struct is missing a 'values' field"))?;
+    match values.data_type() {
+        DataType::List(item) => Ok(item.data_type().clone()),
+        other => plan_err!("nd-encoded 'values' must be a List, got {other}"),
+    }
+}
+
+/// Encode one [`NdArrowArray`] as a single-row `Struct` array.
+pub fn encode_nd_array(array: &NdArrowArray) -> ArrayRef {
+    let values = array.values();
+    let dims = array.dims();
+
+    let values_list = ListArray::new(
+        Arc::new(Field::new("item", values.data_type().clone(), true)),
+        OffsetBuffer::from_lengths([values.len()]),
+        values.clone(),
+        None,
+    );
+
+    let sizes: UInt32Array = dims.iter().map(|d| d.size() as u32).collect();
+    let dim_sizes_list = ListArray::new(
+        Arc::new(Field::new("item", DataType::UInt32, false)),
+        OffsetBuffer::from_lengths([dims.rank()]),
+        Arc::new(sizes),
+        None,
+    );
+
+    let names: StringArray = dims.iter().map(|d| Some(d.name().to_string())).collect();
+    let dim_names_list = ListArray::new(
+        Arc::new(Field::new("item", DataType::Utf8, false)),
+        OffsetBuffer::from_lengths([dims.rank()]),
+        Arc::new(names),
+        None,
+    );
+
+    let struct_array = StructArray::new(
+        nd_struct_fields(values.data_type()),
+        vec![
+            Arc::new(values_list),
+            Arc::new(dim_sizes_list),
+            Arc::new(dim_names_list),
+        ],
+        None,
+    );
+    Arc::new(struct_array)
+}
+
+/// Decode row `row` of an nd-encoded `Struct` column back into an [`NdArrowArray`].
+pub fn decode_nd_array(column: &ArrayRef, row: usize) -> Result<NdArrowArray> {
+    let structs = column
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or_else(|| err("nd column is not a Struct array"))?;
+
+    let list_at = |name: &str| -> Result<ArrayRef> {
+        let list = structs
+            .column_by_name(name)
+            .ok_or_else(|| err(format!("nd struct is missing field '{name}'")))?
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .ok_or_else(|| err(format!("nd struct field '{name}' is not a List")))?;
+        Ok(list.value(row))
+    };
+
+    let values = list_at("values")?;
+
+    let sizes = list_at("dim_sizes")?;
+    let sizes = sizes
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .ok_or_else(|| err("nd 'dim_sizes' is not UInt32"))?;
+
+    let names = list_at("dim_names")?;
+    let names = names
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| err("nd 'dim_names' is not Utf8"))?;
+
+    if sizes.len() != names.len() {
+        return plan_err!(
+            "nd dim_sizes ({}) and dim_names ({}) disagree",
+            sizes.len(),
+            names.len()
+        );
+    }
+
+    let dims = Dimensions::try_new(
+        (0..sizes.len())
+            .map(|i| Dimension::new(names.value(i), sizes.value(i) as usize))
+            .collect(),
+    )?;
+
+    NdArrowArray::try_new(values, dims)
+}
+
+/// Encode an [`NdRecordBatch`] as a flat `RecordBatch` of nd-encoded (`beacon.nd`)
+/// struct columns — one struct row per column.
+pub fn encode_nd_record_batch(batch: &NdRecordBatch) -> Result<RecordBatch> {
+    let fields: Vec<Field> = batch
+        .schema()
+        .fields()
+        .iter()
+        .zip(batch.columns())
+        .map(|(field, column)| nd_encoded_field(field.name(), column.data_type()))
+        .collect();
+
+    let columns: Vec<ArrayRef> = batch.columns().iter().map(encode_nd_array).collect();
+
+    let options = RecordBatchOptions::new().with_row_count(Some(1));
+    RecordBatch::try_new_with_options(Arc::new(Schema::new(fields)), columns, &options)
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+}
+
+/// The logical (decoded) schema of an nd-encoded schema: each `beacon.nd`
+/// struct column becomes its element type.
+pub fn logical_schema(encoded: &Schema) -> Result<SchemaRef> {
+    let fields = encoded
+        .fields()
+        .iter()
+        .map(|field| Ok(Field::new(field.name(), nd_value_type(field.data_type())?, true)))
+        .collect::<Result<Vec<_>>>()?;
+    Ok(Arc::new(Schema::new(fields)))
+}
+
+/// Decode an nd-encoded `RecordBatch` (row 0 of each struct column) back into an
+/// [`NdRecordBatch`]. The target grid is inferred as the union of the columns'
+/// dimensions, ordered by the highest-rank column.
+pub fn decode_nd_record_batch(batch: &RecordBatch) -> Result<NdRecordBatch> {
+    let columns = batch
+        .columns()
+        .iter()
+        .map(|column| decode_nd_array(column, 0))
+        .collect::<Result<Vec<_>>>()?;
+
+    let target = infer_target(&columns)?;
+    let schema = logical_schema(batch.schema_ref())?;
+    NdRecordBatch::try_new(schema, columns, target)
+}
+
+/// Infer the target grid from decoded columns: the highest-rank column defines
+/// the axis order (it spans the grid in C-order), and any axis only present on
+/// lower-rank columns is appended.
+fn infer_target(columns: &[NdArrowArray]) -> Result<Dimensions> {
+    let mut order: Vec<Dimension> = Vec::new();
+    if let Some(widest) = columns.iter().max_by_key(|c| c.dims().rank()) {
+        order.extend(widest.dims().iter().cloned());
+    }
+    for column in columns {
+        for dim in column.dims().iter() {
+            if !order.iter().any(|d| d.name() == dim.name()) {
+                order.push(dim.clone());
+            }
+        }
+    }
+    Dimensions::try_new(order)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{AsArray, Float64Array, Int32Array};
+    use arrow::datatypes::{DataType, Field, Float64Type, Int32Type, Schema};
+
+    use super::*;
+
+    fn dims(spec: &[(&str, usize)]) -> Dimensions {
+        Dimensions::try_new(
+            spec.iter()
+                .map(|(name, size)| Dimension::new(*name, *size))
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn nd_array_round_trip() {
+        let a = NdArrowArray::try_new(
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5, 6])),
+            dims(&[("time", 2), ("lat", 3)]),
+        )
+        .unwrap();
+
+        let encoded = encode_nd_array(&a);
+        // The encoded column is a single struct row.
+        assert_eq!(encoded.len(), 1);
+
+        let decoded = decode_nd_array(&encoded, 0).unwrap();
+        assert_eq!(decoded.dims(), a.dims());
+        assert_eq!(
+            decoded.values().as_primitive::<Int32Type>().values(),
+            &[1, 2, 3, 4, 5, 6]
+        );
+    }
+
+    #[test]
+    fn encoded_field_is_tagged() {
+        let field = nd_encoded_field("sst", &DataType::Float64);
+        assert!(is_nd_encoded(&field));
+        assert_eq!(nd_value_type(field.data_type()).unwrap(), DataType::Float64);
+    }
+
+    #[test]
+    fn record_batch_round_trip_infers_target() {
+        // time coord (1-D), lat coord (1-D), sst data (2-D) over (time=2, lat=3).
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("time", DataType::Int32, true),
+            Field::new("lat", DataType::Int32, true),
+            Field::new("sst", DataType::Float64, true),
+        ]));
+        let time =
+            NdArrowArray::try_new(Arc::new(Int32Array::from(vec![7, 8])), dims(&[("time", 2)]))
+                .unwrap();
+        let lat = NdArrowArray::try_new(
+            Arc::new(Int32Array::from(vec![10, 20, 30])),
+            dims(&[("lat", 3)]),
+        )
+        .unwrap();
+        let sst = NdArrowArray::try_new(
+            Arc::new(Float64Array::from(vec![0.0, 0.1, 0.2, 1.0, 1.1, 1.2])),
+            dims(&[("time", 2), ("lat", 3)]),
+        )
+        .unwrap();
+        let nd = NdRecordBatch::try_new(
+            schema.clone(),
+            vec![time, lat, sst],
+            dims(&[("time", 2), ("lat", 3)]),
+        )
+        .unwrap();
+
+        // Encode → flat struct RecordBatch, all columns tagged beacon.nd.
+        let encoded = encode_nd_record_batch(&nd).unwrap();
+        assert_eq!(encoded.num_rows(), 1);
+        assert_eq!(encoded.num_columns(), 3);
+        for field in encoded.schema().fields() {
+            assert!(is_nd_encoded(field), "{} not tagged", field.name());
+        }
+
+        // Decode → NdRecordBatch, target inferred from the widest (sst) column.
+        let decoded = decode_nd_record_batch(&encoded).unwrap();
+        assert_eq!(decoded.target(), &dims(&[("time", 2), ("lat", 3)]));
+
+        // Materializing the decoded batch matches the original.
+        let expected = nd.materialize().unwrap();
+        let actual = decoded.materialize().unwrap();
+        assert_eq!(actual, expected);
+        assert_eq!(
+            actual.column(2).as_primitive::<Float64Type>().values(),
+            &[0.0, 0.1, 0.2, 1.0, 1.1, 1.2]
+        );
+    }
+
+    #[test]
+    fn logical_schema_unwraps_structs() {
+        let encoded = Schema::new(vec![
+            nd_encoded_field("lat", &DataType::Int32),
+            nd_encoded_field("sst", &DataType::Float64),
+        ]);
+        let logical = logical_schema(&encoded).unwrap();
+        assert_eq!(logical.field(0).data_type(), &DataType::Int32);
+        assert_eq!(logical.field(1).data_type(), &DataType::Float64);
+    }
+}

--- a/beacon-datafusion-ext/src/nd/exec/broadcast_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/broadcast_exec.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use datafusion::common::plan_err;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
+use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
 };
@@ -21,6 +22,7 @@ use super::{as_nd_plan, materialize_nd_stream};
 pub struct NdBroadcastExec {
     input: Arc<dyn ExecutionPlan>,
     properties: Arc<PlanProperties>,
+    metrics: ExecutionPlanMetricsSet,
 }
 
 impl NdBroadcastExec {
@@ -32,7 +34,11 @@ impl NdBroadcastExec {
             );
         }
         let properties = input.properties().clone();
-        Ok(Self { input, properties })
+        Ok(Self {
+            input,
+            properties,
+            metrics: ExecutionPlanMetricsSet::new(),
+        })
     }
 
     /// The nd-aware child whose batches this node materializes.
@@ -82,6 +88,11 @@ impl ExecutionPlan for NdBroadcastExec {
         let stream = as_nd_plan(&self.input)
             .expect("validated in try_new")
             .execute_nd(partition, context)?;
-        Ok(materialize_nd_stream(self.input.schema(), stream))
+        let baseline = BaselineMetrics::new(&self.metrics, partition);
+        Ok(materialize_nd_stream(self.input.schema(), stream, baseline))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
     }
 }

--- a/beacon-datafusion-ext/src/nd/exec/broadcast_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/broadcast_exec.rs
@@ -1,0 +1,87 @@
+//! Terminal materializer of the nd pipeline.
+
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+use datafusion::common::plan_err;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
+};
+
+use super::{as_nd_plan, materialize_nd_stream};
+
+/// Boundary between the nd pipeline and the rest of the plan: pulls nd
+/// batches from its child and emits flat, fully-broadcast `RecordBatch`es.
+/// Broadcast and any accumulated selection compose into a single gather per
+/// column, so the unfiltered cross-product never exists in memory.
+#[derive(Debug, Clone)]
+pub struct NdBroadcastExec {
+    input: Arc<dyn ExecutionPlan>,
+    properties: Arc<PlanProperties>,
+}
+
+impl NdBroadcastExec {
+    pub fn try_new(input: Arc<dyn ExecutionPlan>) -> Result<Self> {
+        if as_nd_plan(&input).is_none() {
+            return plan_err!(
+                "NdBroadcastExec requires an nd-aware input, got {}",
+                input.name()
+            );
+        }
+        let properties = input.properties().clone();
+        Ok(Self { input, properties })
+    }
+
+    /// The nd-aware child whose batches this node materializes.
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+}
+
+impl DisplayAs for NdBroadcastExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NdBroadcastExec")
+    }
+}
+
+impl ExecutionPlan for NdBroadcastExec {
+    fn name(&self) -> &str {
+        "NdBroadcastExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let [input] = <[_; 1]>::try_from(children).map_err(|_| {
+            DataFusionError::Internal("NdBroadcastExec expects exactly one child".to_string())
+        })?;
+        Ok(Arc::new(Self::try_new(input)?))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let stream = as_nd_plan(&self.input)
+            .expect("validated in try_new")
+            .execute_nd(partition, context)?;
+        Ok(materialize_nd_stream(self.input.schema(), stream))
+    }
+}

--- a/beacon-datafusion-ext/src/nd/exec/mod.rs
+++ b/beacon-datafusion-ext/src/nd/exec/mod.rs
@@ -1,0 +1,69 @@
+//! Physical operators that keep nd batches un-broadcast between them.
+//!
+//! DataFusion streams only flat `RecordBatch`es between generic operators, so
+//! nd-aware operators exchange [`NdRecordBatch`]es through a side channel: the
+//! [`NdExecutionPlan`] trait's `execute_nd`. [`as_nd_plan`] recovers that trait
+//! from an `Arc<dyn ExecutionPlan>` child. Every nd operator's standard
+//! `execute` still yields flat batches (by materializing), so any nd node is
+//! also a correct plan on its own.
+
+mod broadcast_exec;
+mod source_exec;
+
+use std::sync::Arc;
+
+use datafusion::error::Result;
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
+use futures::StreamExt;
+use futures::stream::BoxStream;
+
+use super::batch::NdRecordBatch;
+
+pub use broadcast_exec::NdBroadcastExec;
+pub use source_exec::{MemoryNdBatchProvider, NdBatchProvider, NdSourceExec};
+
+/// Stream of nd batches exchanged between nd-aware operators.
+pub type SendableNdBatchStream = BoxStream<'static, Result<NdRecordBatch>>;
+
+/// An [`ExecutionPlan`] that can additionally stream nd batches.
+pub trait NdExecutionPlan: ExecutionPlan {
+    fn execute_nd(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableNdBatchStream>;
+}
+
+/// Recover the nd side channel from a plan node. Extend this list when a new
+/// nd-aware operator is added; external crates plug in through
+/// [`NdBatchProvider`] + [`NdSourceExec`] rather than new node types.
+pub fn as_nd_plan(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn NdExecutionPlan>> {
+    let any = plan.as_any();
+    if let Some(source) = any.downcast_ref::<NdSourceExec>() {
+        return Some(Arc::new(source.clone()));
+    }
+    None
+}
+
+/// Adapt an nd batch stream into a standard record batch stream, dropping
+/// empty batches.
+pub fn materialize_nd_stream(
+    schema: arrow::datatypes::SchemaRef,
+    stream: SendableNdBatchStream,
+) -> SendableRecordBatchStream {
+    let batches = stream.filter_map(|item| async move {
+        match item {
+            Ok(batch) => {
+                if batch.num_rows() == 0 {
+                    None
+                } else {
+                    Some(batch.materialize())
+                }
+            }
+            Err(e) => Some(Err(e)),
+        }
+    });
+    Box::pin(RecordBatchStreamAdapter::new(schema, batches))
+}

--- a/beacon-datafusion-ext/src/nd/exec/mod.rs
+++ b/beacon-datafusion-ext/src/nd/exec/mod.rs
@@ -24,7 +24,7 @@ use futures::stream::BoxStream;
 use super::batch::NdRecordBatch;
 
 pub use broadcast_exec::NdBroadcastExec;
-pub use source_exec::{MemoryNdBatchProvider, NdBatchProvider, NdSourceExec};
+pub use source_exec::NdSourceExec;
 
 /// Stream of nd batches exchanged between nd-aware operators.
 pub type SendableNdBatchStream = BoxStream<'static, Result<NdRecordBatch>>;

--- a/beacon-datafusion-ext/src/nd/exec/mod.rs
+++ b/beacon-datafusion-ext/src/nd/exec/mod.rs
@@ -12,8 +12,10 @@ mod source_exec;
 
 use std::sync::Arc;
 
+use arrow::record_batch::RecordBatch;
 use datafusion::error::Result;
 use datafusion::execution::TaskContext;
+use datafusion::physical_plan::metrics::BaselineMetrics;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 use futures::StreamExt;
@@ -48,22 +50,34 @@ pub fn as_nd_plan(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn NdExecutionPl
 }
 
 /// Adapt an nd batch stream into a standard record batch stream, dropping
-/// empty batches.
+/// empty batches and recording output rows / materialization time into
+/// `baseline`.
 pub fn materialize_nd_stream(
     schema: arrow::datatypes::SchemaRef,
     stream: SendableNdBatchStream,
+    baseline: BaselineMetrics,
 ) -> SendableRecordBatchStream {
-    let batches = stream.filter_map(|item| async move {
-        match item {
-            Ok(batch) => {
-                if batch.num_rows() == 0 {
-                    None
-                } else {
-                    Some(batch.materialize())
+    // `baseline` is moved into this synchronous closure once and borrowed per
+    // item; it is dropped when the stream ends, which records the end time.
+    let batches = stream
+        .map(move |item| -> Option<Result<RecordBatch>> {
+            match item {
+                Ok(batch) => {
+                    if batch.num_rows() == 0 {
+                        return None;
+                    }
+                    let _timer = baseline.elapsed_compute().timer();
+                    match batch.materialize() {
+                        Ok(record_batch) => {
+                            baseline.record_output(record_batch.num_rows());
+                            Some(Ok(record_batch))
+                        }
+                        Err(e) => Some(Err(e)),
+                    }
                 }
+                Err(e) => Some(Err(e)),
             }
-            Err(e) => Some(Err(e)),
-        }
-    });
+        })
+        .filter_map(|item| async move { item });
     Box::pin(RecordBatchStreamAdapter::new(schema, batches))
 }

--- a/beacon-datafusion-ext/src/nd/exec/source_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/source_exec.rs
@@ -1,0 +1,144 @@
+//! Source node bridging arbitrary nd batch producers into the nd pipeline.
+
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+use arrow::datatypes::SchemaRef;
+use datafusion::error::Result;
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+    SendableRecordBatchStream,
+};
+
+use super::{NdExecutionPlan, SendableNdBatchStream, materialize_nd_stream};
+
+/// Producer of nd batch streams. Format crates (zarr, netcdf, …) implement
+/// this instead of defining their own `ExecutionPlan`, so [`super::as_nd_plan`]
+/// only ever needs to know about [`NdSourceExec`].
+pub trait NdBatchProvider: fmt::Debug + Send + Sync {
+    fn schema(&self) -> SchemaRef;
+
+    fn partition_count(&self) -> usize {
+        1
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableNdBatchStream>;
+}
+
+/// Leaf node that streams nd batches from an [`NdBatchProvider`].
+#[derive(Debug, Clone)]
+pub struct NdSourceExec {
+    provider: Arc<dyn NdBatchProvider>,
+    properties: Arc<PlanProperties>,
+}
+
+impl NdSourceExec {
+    pub fn new(provider: Arc<dyn NdBatchProvider>) -> Self {
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(provider.schema()),
+            Partitioning::UnknownPartitioning(provider.partition_count()),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+        Self {
+            provider,
+            properties,
+        }
+    }
+
+    pub fn provider(&self) -> &Arc<dyn NdBatchProvider> {
+        &self.provider
+    }
+}
+
+impl DisplayAs for NdSourceExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "NdSourceExec: partitions={}",
+            self.provider.partition_count()
+        )
+    }
+}
+
+impl ExecutionPlan for NdSourceExec {
+    fn name(&self) -> &str {
+        "NdSourceExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let stream = self.execute_nd(partition, context)?;
+        Ok(materialize_nd_stream(self.provider.schema(), stream))
+    }
+}
+
+impl NdExecutionPlan for NdSourceExec {
+    fn execute_nd(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableNdBatchStream> {
+        self.provider.execute(partition, context)
+    }
+}
+
+/// In-memory provider, useful for tests and for callers that already hold
+/// nd batches.
+#[derive(Debug)]
+pub struct MemoryNdBatchProvider {
+    schema: SchemaRef,
+    batches: Vec<crate::nd::NdRecordBatch>,
+}
+
+impl MemoryNdBatchProvider {
+    pub fn new(schema: SchemaRef, batches: Vec<crate::nd::NdRecordBatch>) -> Self {
+        Self { schema, batches }
+    }
+}
+
+impl NdBatchProvider for MemoryNdBatchProvider {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableNdBatchStream> {
+        Ok(Box::pin(futures::stream::iter(
+            self.batches.clone().into_iter().map(Ok),
+        )))
+    }
+}

--- a/beacon-datafusion-ext/src/nd/exec/source_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/source_exec.rs
@@ -9,12 +9,16 @@ use datafusion::error::Result;
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
+};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
     SendableRecordBatchStream,
 };
+use futures::StreamExt;
 
-use super::{NdExecutionPlan, SendableNdBatchStream, materialize_nd_stream};
+use super::{NdBroadcastExec, NdExecutionPlan, SendableNdBatchStream};
 
 /// Producer of nd batch streams. Format crates (zarr, netcdf, …) implement
 /// this instead of defining their own `ExecutionPlan`, so [`super::as_nd_plan`]
@@ -38,6 +42,7 @@ pub trait NdBatchProvider: fmt::Debug + Send + Sync {
 pub struct NdSourceExec {
     provider: Arc<dyn NdBatchProvider>,
     properties: Arc<PlanProperties>,
+    metrics: ExecutionPlanMetricsSet,
 }
 
 impl NdSourceExec {
@@ -51,6 +56,7 @@ impl NdSourceExec {
         Self {
             provider,
             properties,
+            metrics: ExecutionPlanMetricsSet::new(),
         }
     }
 
@@ -98,8 +104,15 @@ impl ExecutionPlan for NdSourceExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let stream = self.execute_nd(partition, context)?;
-        Ok(materialize_nd_stream(self.provider.schema(), stream))
+        // The source only produces nd batches (`execute_nd`); flattening to
+        // Arrow lives in `NdBroadcastExec`. When this node is executed as a
+        // standalone plan, borrow that broadcast behaviour rather than
+        // duplicating it here.
+        NdBroadcastExec::try_new(Arc::new(self.clone()))?.execute(partition, context)
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
     }
 }
 
@@ -109,7 +122,23 @@ impl NdExecutionPlan for NdSourceExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableNdBatchStream> {
-        self.provider.execute(partition, context)
+        // `output_rows` counts the un-broadcast grid rows each nd batch
+        // represents; `nd_batches` counts the batches produced. `baseline` is
+        // moved into the closure once and dropped at stream end, recording the
+        // elapsed time.
+        let baseline = BaselineMetrics::new(&self.metrics, partition);
+        let nd_batches: Count =
+            MetricBuilder::new(&self.metrics).counter("nd_batches", partition);
+
+        let stream = self.provider.execute(partition, context)?.map(move |item| {
+            let _timer = baseline.elapsed_compute().timer();
+            if let Ok(batch) = &item {
+                baseline.record_output(batch.num_rows());
+                nd_batches.add(1);
+            }
+            item
+        });
+        Ok(Box::pin(stream))
     }
 }
 

--- a/beacon-datafusion-ext/src/nd/exec/source_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/source_exec.rs
@@ -1,77 +1,70 @@
-//! Source node bridging arbitrary nd batch producers into the nd pipeline.
+//! Decoder node: nd-encoded `RecordBatch`es from a child plan → nd batches.
 
 use std::any::Any;
 use std::fmt;
 use std::sync::Arc;
 
 use arrow::datatypes::SchemaRef;
-use datafusion::error::Result;
+use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr::EquivalenceProperties;
-use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::metrics::{
     BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
 };
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
-    SendableRecordBatchStream,
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
 };
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
+
+use crate::nd::encoding::{decode_nd_record_batch, logical_schema};
 
 use super::{NdBroadcastExec, NdExecutionPlan, SendableNdBatchStream};
 
-/// Producer of nd batch streams. Format crates (zarr, netcdf, …) implement
-/// this instead of defining their own `ExecutionPlan`, so [`super::as_nd_plan`]
-/// only ever needs to know about [`NdSourceExec`].
-pub trait NdBatchProvider: fmt::Debug + Send + Sync {
-    fn schema(&self) -> SchemaRef;
-
-    fn partition_count(&self) -> usize {
-        1
-    }
-
-    fn execute(
-        &self,
-        partition: usize,
-        context: Arc<TaskContext>,
-    ) -> Result<SendableNdBatchStream>;
-}
-
-/// Leaf node that streams nd batches from an [`NdBatchProvider`].
+/// Leaf of the nd pipeline: decodes the `beacon.nd`-encoded `RecordBatch`es
+/// produced by a child plan (typically a `DataSourceExec` whose file opener
+/// emits encoded batches) into un-broadcast [`NdRecordBatch`]es.
+///
+/// Its own output schema is the *logical* (decoded) schema; broadcasting to
+/// flat Arrow happens in [`NdBroadcastExec`] above it.
 #[derive(Debug, Clone)]
 pub struct NdSourceExec {
-    provider: Arc<dyn NdBatchProvider>,
+    /// Child plan producing nd-encoded `RecordBatch`es.
+    input: Arc<dyn ExecutionPlan>,
+    /// Decoded (logical) output schema.
+    logical_schema: SchemaRef,
     properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
 }
 
 impl NdSourceExec {
-    pub fn new(provider: Arc<dyn NdBatchProvider>) -> Self {
-        let properties = Arc::new(PlanProperties::new(
-            EquivalenceProperties::new(provider.schema()),
-            Partitioning::UnknownPartitioning(provider.partition_count()),
-            EmissionType::Incremental,
-            Boundedness::Bounded,
-        ));
-        Self {
-            provider,
+    /// Wrap a child plan whose output columns are `beacon.nd`-encoded structs.
+    pub fn try_new(input: Arc<dyn ExecutionPlan>) -> Result<Self> {
+        let logical_schema = logical_schema(&input.schema())?;
+        // Same partitioning/emission/boundedness as the child; only the schema
+        // changes (encoded structs → logical value types).
+        let properties = Arc::new(
+            input
+                .properties()
+                .as_ref()
+                .clone()
+                .with_eq_properties(EquivalenceProperties::new(logical_schema.clone())),
+        );
+        Ok(Self {
+            input,
+            logical_schema,
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
-        }
+        })
     }
 
-    pub fn provider(&self) -> &Arc<dyn NdBatchProvider> {
-        &self.provider
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
     }
 }
 
 impl DisplayAs for NdSourceExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "NdSourceExec: partitions={}",
-            self.provider.partition_count()
-        )
+        write!(f, "NdSourceExec")
     }
 }
 
@@ -89,14 +82,17 @@ impl ExecutionPlan for NdSourceExec {
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        vec![]
+        vec![&self.input]
     }
 
     fn with_new_children(
         self: Arc<Self>,
-        _children: Vec<Arc<dyn ExecutionPlan>>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(self)
+        let [input] = <[_; 1]>::try_from(children).map_err(|_| {
+            DataFusionError::Internal("NdSourceExec expects exactly one child".to_string())
+        })?;
+        Ok(Arc::new(Self::try_new(input)?))
     }
 
     fn execute(
@@ -105,9 +101,8 @@ impl ExecutionPlan for NdSourceExec {
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         // The source only produces nd batches (`execute_nd`); flattening to
-        // Arrow lives in `NdBroadcastExec`. When this node is executed as a
-        // standalone plan, borrow that broadcast behaviour rather than
-        // duplicating it here.
+        // Arrow lives in `NdBroadcastExec`. When executed as a standalone plan,
+        // borrow that broadcast behaviour rather than duplicating it.
         NdBroadcastExec::try_new(Arc::new(self.clone()))?.execute(partition, context)
     }
 
@@ -122,52 +117,26 @@ impl NdExecutionPlan for NdSourceExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableNdBatchStream> {
-        // `output_rows` counts the un-broadcast grid rows each nd batch
-        // represents; `nd_batches` counts the batches produced. `baseline` is
-        // moved into the closure once and dropped at stream end, recording the
-        // elapsed time.
         let baseline = BaselineMetrics::new(&self.metrics, partition);
         let nd_batches: Count =
             MetricBuilder::new(&self.metrics).counter("nd_batches", partition);
 
-        let stream = self.provider.execute(partition, context)?.map(move |item| {
-            let _timer = baseline.elapsed_compute().timer();
-            if let Ok(batch) = &item {
-                baseline.record_output(batch.num_rows());
-                nd_batches.add(1);
-            }
-            item
-        });
+        let input = self.input.execute(partition, context)?;
+        let stream = input
+            .map(move |item| {
+                let _timer = baseline.elapsed_compute().timer();
+                match item {
+                    // An empty encoded batch carries no nd array — skip it.
+                    Ok(batch) if batch.num_rows() == 0 => Ok(None),
+                    Ok(batch) => decode_nd_record_batch(&batch).map(|nd| {
+                        nd_batches.add(1);
+                        baseline.record_output(nd.num_rows());
+                        Some(nd)
+                    }),
+                    Err(e) => Err(e),
+                }
+            })
+            .try_filter_map(|decoded| async move { Ok(decoded) });
         Ok(Box::pin(stream))
-    }
-}
-
-/// In-memory provider, useful for tests and for callers that already hold
-/// nd batches.
-#[derive(Debug)]
-pub struct MemoryNdBatchProvider {
-    schema: SchemaRef,
-    batches: Vec<crate::nd::NdRecordBatch>,
-}
-
-impl MemoryNdBatchProvider {
-    pub fn new(schema: SchemaRef, batches: Vec<crate::nd::NdRecordBatch>) -> Self {
-        Self { schema, batches }
-    }
-}
-
-impl NdBatchProvider for MemoryNdBatchProvider {
-    fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
-
-    fn execute(
-        &self,
-        _partition: usize,
-        _context: Arc<TaskContext>,
-    ) -> Result<SendableNdBatchStream> {
-        Ok(Box::pin(futures::stream::iter(
-            self.batches.clone().into_iter().map(Ok),
-        )))
     }
 }

--- a/beacon-datafusion-ext/src/nd/mod.rs
+++ b/beacon-datafusion-ext/src/nd/mod.rs
@@ -23,9 +23,9 @@ pub mod broadcast;
 pub mod dimensions;
 pub mod exec;
 
-pub use array::{ArraySubset, NdArrowArray};
+pub use array::NdArrowArray;
 pub use batch::NdRecordBatch;
-pub use broadcast::{BroadcastMap, RunStructure};
+pub use broadcast::BroadcastMap;
 pub use dimensions::{Dimension, Dimensions};
 
 #[cfg(test)]

--- a/beacon-datafusion-ext/src/nd/mod.rs
+++ b/beacon-datafusion-ext/src/nd/mod.rs
@@ -1,0 +1,166 @@
+//! N-dimensional Arrow arrays and dimension-aware physical operators.
+//!
+//! Beacon's nd formats (zarr, netcdf) are logically grids of variables over
+//! shared named dimensions. Flattening a grid to a table broadcasts every
+//! variable onto the full dimension cross-product. This module keeps columns
+//! *un-broadcast* through the physical plan until a terminal node materializes
+//! them:
+//!
+//! - [`NdArrowArray`]: a flat Arrow array plus named C-order [`Dimensions`].
+//! - [`BroadcastMap`]: a broadcast expressed as stride arithmetic; no data
+//!   moves.
+//! - [`NdRecordBatch`]: columns (each on a subset of the dimensions) over a
+//!   shared target grid.
+//! - [`exec::NdSourceExec`]: streams nd batches from an [`exec::NdBatchProvider`].
+//! - [`exec::NdBroadcastExec`]: the terminal node that materializes nd batches
+//!   into flat `RecordBatch`es.
+//!
+//! Filtering and projection operators are layered on top of this spine later.
+
+pub mod array;
+pub mod batch;
+pub mod broadcast;
+pub mod dimensions;
+pub mod exec;
+
+pub use array::{ArraySubset, NdArrowArray};
+pub use batch::NdRecordBatch;
+pub use broadcast::{BroadcastMap, RunStructure};
+pub use dimensions::{Dimension, Dimensions};
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{AsArray, Float64Array, Int32Array};
+    use arrow::compute::concat_batches;
+    use arrow::datatypes::{DataType, Field, Float64Type, Int32Type, Schema};
+    use datafusion::error::Result;
+    use datafusion::execution::TaskContext;
+    use datafusion::physical_plan::ExecutionPlan;
+    use futures::TryStreamExt;
+
+    use super::exec::{MemoryNdBatchProvider, NdBroadcastExec, NdSourceExec};
+    use super::*;
+
+    fn dims(spec: &[(&str, usize)]) -> Dimensions {
+        Dimensions::try_new(
+            spec.iter()
+                .map(|(name, size)| Dimension::new(*name, *size))
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    /// A (time=4, lat=3, lon=2) grid with coordinate variables and one data
+    /// variable, split into two nd batches along `time`.
+    fn test_source() -> (Arc<Schema>, Arc<NdSourceExec>) {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("time", DataType::Int32, true),
+            Field::new("lat", DataType::Int32, true),
+            Field::new("lon", DataType::Int32, true),
+            Field::new("sst", DataType::Float64, true),
+        ]));
+
+        let lat = || {
+            NdArrowArray::try_new(
+                Arc::new(Int32Array::from(vec![-30, 0, 30])),
+                dims(&[("lat", 3)]),
+            )
+            .unwrap()
+        };
+        let lon = || {
+            NdArrowArray::try_new(Arc::new(Int32Array::from(vec![5, 15])), dims(&[("lon", 2)]))
+                .unwrap()
+        };
+
+        let mut batches = Vec::new();
+        for chunk in 0..2u32 {
+            let t0 = chunk * 2;
+            let time = NdArrowArray::try_new(
+                Arc::new(Int32Array::from(vec![100 + t0 as i32, 101 + t0 as i32])),
+                dims(&[("time", 2)]),
+            )
+            .unwrap();
+            let sst_values: Vec<f64> = (0..12).map(|i| (t0 * 6 + i) as f64).collect();
+            let sst = NdArrowArray::try_new(
+                Arc::new(Float64Array::from(sst_values)),
+                dims(&[("time", 2), ("lat", 3), ("lon", 2)]),
+            )
+            .unwrap();
+            let batch = NdRecordBatch::try_new(
+                schema.clone(),
+                vec![time, lat(), lon(), sst],
+                dims(&[("time", 2), ("lat", 3), ("lon", 2)]),
+            )
+            .unwrap();
+            batches.push(batch);
+        }
+
+        let provider = MemoryNdBatchProvider::new(schema.clone(), batches);
+        (schema, Arc::new(NdSourceExec::new(Arc::new(provider))))
+    }
+
+    async fn run(plan: Arc<dyn ExecutionPlan>) -> Result<arrow::record_batch::RecordBatch> {
+        let schema = plan.schema();
+        let batches: Vec<_> = plan
+            .execute(0, Arc::new(TaskContext::default()))?
+            .try_collect()
+            .await?;
+        Ok(concat_batches(&schema, &batches)?)
+    }
+
+    #[tokio::test]
+    async fn source_alone_materializes_full_grid() {
+        // NdSourceExec's own `execute` materializes (no broadcast node needed).
+        let (_, source) = test_source();
+        let batch = run(source).await.unwrap();
+        assert_eq!(batch.num_rows(), 24);
+        assert_eq!(batch.column(0).as_primitive::<Int32Type>().value(0), 100);
+        assert_eq!(batch.column(1).as_primitive::<Int32Type>().value(0), -30);
+        assert_eq!(batch.column(2).as_primitive::<Int32Type>().value(0), 5);
+    }
+
+    #[tokio::test]
+    async fn source_then_broadcast_materializes_full_grid() {
+        let (_, source) = test_source();
+        let plan = Arc::new(NdBroadcastExec::try_new(source).unwrap());
+        let batch = run(plan).await.unwrap();
+
+        // 4 time x 3 lat x 2 lon = 24 rows, C-order (time outer, lon inner).
+        assert_eq!(batch.num_rows(), 24);
+
+        // time repeats over the 6 (lat,lon) cells of each step.
+        assert_eq!(
+            batch.column(0).as_primitive::<Int32Type>().values(),
+            &[
+                100, 100, 100, 100, 100, 100, 101, 101, 101, 101, 101, 101, 102, 102, 102, 102,
+                102, 102, 103, 103, 103, 103, 103, 103
+            ]
+        );
+        // lat repeats over lon, tiles over time.
+        assert_eq!(
+            &batch.column(1).as_primitive::<Int32Type>().values()[..6],
+            &[-30, -30, 0, 0, 30, 30]
+        );
+        // lon tiles over everything.
+        assert_eq!(
+            &batch.column(2).as_primitive::<Int32Type>().values()[..6],
+            &[5, 15, 5, 15, 5, 15]
+        );
+        // sst is full-rank: passes through unbroadcast, values 0..24.
+        assert_eq!(
+            batch.column(3).as_primitive::<Float64Type>().values(),
+            &(0..24).map(|v| v as f64).collect::<Vec<_>>()[..]
+        );
+    }
+
+    #[tokio::test]
+    async fn broadcast_requires_nd_input() {
+        // A non-nd child is rejected at construction.
+        let (_, source) = test_source();
+        let broadcast = Arc::new(NdBroadcastExec::try_new(source).unwrap());
+        // Wrapping a broadcast (which is not nd-aware) must fail.
+        assert!(NdBroadcastExec::try_new(broadcast).is_err());
+    }
+}

--- a/beacon-datafusion-ext/src/nd/mod.rs
+++ b/beacon-datafusion-ext/src/nd/mod.rs
@@ -21,12 +21,17 @@ pub mod array;
 pub mod batch;
 pub mod broadcast;
 pub mod dimensions;
+pub mod encoding;
 pub mod exec;
 
 pub use array::NdArrowArray;
 pub use batch::NdRecordBatch;
 pub use broadcast::BroadcastMap;
 pub use dimensions::{Dimension, Dimensions};
+pub use encoding::{
+    decode_nd_record_batch, encode_nd_record_batch, is_nd_encoded, logical_schema,
+    nd_encoded_field, nd_encoded_type,
+};
 
 #[cfg(test)]
 mod tests {
@@ -34,13 +39,16 @@ mod tests {
 
     use arrow::array::{AsArray, Float64Array, Int32Array};
     use arrow::compute::concat_batches;
-    use arrow::datatypes::{DataType, Field, Float64Type, Int32Type, Schema};
+    use arrow::datatypes::{Float64Type, Int32Type, Schema};
+    use arrow::record_batch::RecordBatch;
+    use datafusion::datasource::memory::MemorySourceConfig;
     use datafusion::error::Result;
     use datafusion::execution::TaskContext;
     use datafusion::physical_plan::ExecutionPlan;
     use futures::TryStreamExt;
 
-    use super::exec::{MemoryNdBatchProvider, NdBroadcastExec, NdSourceExec};
+    use super::encoding::encode_nd_record_batch;
+    use super::exec::{NdBroadcastExec, NdSourceExec};
     use super::*;
 
     fn dims(spec: &[(&str, usize)]) -> Dimensions {
@@ -53,13 +61,15 @@ mod tests {
     }
 
     /// A (time=4, lat=3, lon=2) grid with coordinate variables and one data
-    /// variable, split into two nd batches along `time`.
-    fn test_source() -> (Arc<Schema>, Arc<NdSourceExec>) {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("time", DataType::Int32, true),
-            Field::new("lat", DataType::Int32, true),
-            Field::new("lon", DataType::Int32, true),
-            Field::new("sst", DataType::Float64, true),
+    /// variable, encoded into two nd-encoded `RecordBatch`es (split along
+    /// `time`) and served from an in-memory `DataSourceExec` — the shape a file
+    /// opener produces.
+    fn test_source() -> Arc<NdSourceExec> {
+        let logical = Arc::new(Schema::new(vec![
+            arrow::datatypes::Field::new("time", arrow::datatypes::DataType::Int32, true),
+            arrow::datatypes::Field::new("lat", arrow::datatypes::DataType::Int32, true),
+            arrow::datatypes::Field::new("lon", arrow::datatypes::DataType::Int32, true),
+            arrow::datatypes::Field::new("sst", arrow::datatypes::DataType::Float64, true),
         ]));
 
         let lat = || {
@@ -74,7 +84,7 @@ mod tests {
                 .unwrap()
         };
 
-        let mut batches = Vec::new();
+        let mut encoded = Vec::new();
         for chunk in 0..2u32 {
             let t0 = chunk * 2;
             let time = NdArrowArray::try_new(
@@ -88,20 +98,27 @@ mod tests {
                 dims(&[("time", 2), ("lat", 3), ("lon", 2)]),
             )
             .unwrap();
-            let batch = NdRecordBatch::try_new(
-                schema.clone(),
+            let nd = NdRecordBatch::try_new(
+                logical.clone(),
                 vec![time, lat(), lon(), sst],
                 dims(&[("time", 2), ("lat", 3), ("lon", 2)]),
             )
             .unwrap();
-            batches.push(batch);
+            encoded.push(encode_nd_record_batch(&nd).unwrap());
         }
 
-        let provider = MemoryNdBatchProvider::new(schema.clone(), batches);
-        (schema, Arc::new(NdSourceExec::new(Arc::new(provider))))
+        let encoded_schema = encoded[0].schema();
+        // One partition, each nd chunk its own single-row encoded batch.
+        let source = MemorySourceConfig::try_new_exec(
+            &[encoded.into_iter().map(|b| vec![b]).flatten().collect()],
+            encoded_schema,
+            None,
+        )
+        .unwrap();
+        Arc::new(NdSourceExec::try_new(source).unwrap())
     }
 
-    async fn run(plan: Arc<dyn ExecutionPlan>) -> Result<arrow::record_batch::RecordBatch> {
+    async fn run(plan: Arc<dyn ExecutionPlan>) -> Result<RecordBatch> {
         let schema = plan.schema();
         let batches: Vec<_> = plan
             .execute(0, Arc::new(TaskContext::default()))?
@@ -113,8 +130,7 @@ mod tests {
     #[tokio::test]
     async fn source_alone_materializes_full_grid() {
         // NdSourceExec's own `execute` materializes (no broadcast node needed).
-        let (_, source) = test_source();
-        let batch = run(source).await.unwrap();
+        let batch = run(test_source()).await.unwrap();
         assert_eq!(batch.num_rows(), 24);
         assert_eq!(batch.column(0).as_primitive::<Int32Type>().value(0), 100);
         assert_eq!(batch.column(1).as_primitive::<Int32Type>().value(0), -30);
@@ -123,8 +139,7 @@ mod tests {
 
     #[tokio::test]
     async fn source_then_broadcast_materializes_full_grid() {
-        let (_, source) = test_source();
-        let plan = Arc::new(NdBroadcastExec::try_new(source).unwrap());
+        let plan = Arc::new(NdBroadcastExec::try_new(test_source()).unwrap());
         let batch = run(plan).await.unwrap();
 
         // 4 time x 3 lat x 2 lon = 24 rows, C-order (time outer, lon inner).
@@ -157,7 +172,7 @@ mod tests {
 
     #[tokio::test]
     async fn nodes_report_metrics() {
-        let (_, source) = test_source();
+        let source = test_source();
         let broadcast = Arc::new(NdBroadcastExec::try_new(source.clone()).unwrap());
 
         // Drain the plan so the streams run to completion and finalize metrics.
@@ -168,9 +183,8 @@ mod tests {
         let broadcast_metrics = broadcast.metrics().unwrap();
         assert_eq!(broadcast_metrics.output_rows(), Some(24));
 
-        // Source reports the grid rows it produced (12 + 12) and the number of
-        // nd batches — recorded via the same shared metrics set the broadcast
-        // pulled from.
+        // Source reports the grid rows it decoded (12 + 12) and the number of
+        // nd batches.
         let source_metrics = source.metrics().unwrap();
         assert_eq!(source_metrics.output_rows(), Some(24));
         assert_eq!(
@@ -184,8 +198,7 @@ mod tests {
     #[tokio::test]
     async fn broadcast_requires_nd_input() {
         // A non-nd child is rejected at construction.
-        let (_, source) = test_source();
-        let broadcast = Arc::new(NdBroadcastExec::try_new(source).unwrap());
+        let broadcast = Arc::new(NdBroadcastExec::try_new(test_source()).unwrap());
         // Wrapping a broadcast (which is not nd-aware) must fail.
         assert!(NdBroadcastExec::try_new(broadcast).is_err());
     }

--- a/beacon-datafusion-ext/src/nd/mod.rs
+++ b/beacon-datafusion-ext/src/nd/mod.rs
@@ -29,8 +29,8 @@ pub use batch::NdRecordBatch;
 pub use broadcast::BroadcastMap;
 pub use dimensions::{Dimension, Dimensions};
 pub use encoding::{
-    decode_nd_record_batch, encode_nd_record_batch, is_nd_encoded, logical_schema,
-    nd_encoded_field, nd_encoded_type,
+    decode_nd_record_batch, encode_flat_batch_as_nd, encode_nd_record_batch, encoded_schema,
+    is_nd_encoded, logical_schema, nd_encoded_field, nd_encoded_type,
 };
 
 #[cfg(test)]

--- a/beacon-datafusion-ext/src/nd/mod.rs
+++ b/beacon-datafusion-ext/src/nd/mod.rs
@@ -156,6 +156,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn nodes_report_metrics() {
+        let (_, source) = test_source();
+        let broadcast = Arc::new(NdBroadcastExec::try_new(source.clone()).unwrap());
+
+        // Drain the plan so the streams run to completion and finalize metrics.
+        let out = run(broadcast.clone() as Arc<dyn ExecutionPlan>).await.unwrap();
+        assert_eq!(out.num_rows(), 24);
+
+        // Broadcast reports the flattened output rows.
+        let broadcast_metrics = broadcast.metrics().unwrap();
+        assert_eq!(broadcast_metrics.output_rows(), Some(24));
+
+        // Source reports the grid rows it produced (12 + 12) and the number of
+        // nd batches — recorded via the same shared metrics set the broadcast
+        // pulled from.
+        let source_metrics = source.metrics().unwrap();
+        assert_eq!(source_metrics.output_rows(), Some(24));
+        assert_eq!(
+            source_metrics
+                .sum_by_name("nd_batches")
+                .map(|v| v.as_usize()),
+            Some(2)
+        );
+    }
+
+    #[tokio::test]
     async fn broadcast_requires_nd_input() {
         // A non-nd child is rejected at construction.
         let (_, source) = test_source();

--- a/beacon-file-formats/beacon-arrow-netcdf/src/compat.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/compat.rs
@@ -4,16 +4,38 @@ use std::{collections::HashMap, sync::Arc};
 
 use beacon_nd_array::{datatypes::NdArrayType, NdArray, NdArrayD};
 use netcdf::AttributeValue;
+use num_traits::AsPrimitive;
 
 use crate::{
     backend::{AttributeBackend, VariableBackend},
     decoders::{
         cf_time::{parse_time_units, CFTimeVariableDecoder},
+        scale_offset::ScaleOffsetVariableDecoder,
         strings::StringVariableDecoder,
         DefaultVariableDecoder,
     },
     NcChar,
 };
+
+/// Interpret a scalar NetCDF attribute (e.g. `scale_factor`, `add_offset`) as
+/// an `f64`. Returns `None` for non-numeric or multi-valued attributes.
+fn attribute_as_f64(attr: &AttributeValue) -> Option<f64> {
+    match attr {
+        AttributeValue::Float(v) => Some(*v as f64),
+        AttributeValue::Double(v) => Some(*v),
+        AttributeValue::Floats(v) if v.len() == 1 => Some(v[0] as f64),
+        AttributeValue::Doubles(v) if v.len() == 1 => Some(v[0]),
+        AttributeValue::Schar(v) => Some(*v as f64),
+        AttributeValue::Uchar(v) => Some(*v as f64),
+        AttributeValue::Short(v) => Some(*v as f64),
+        AttributeValue::Ushort(v) => Some(*v as f64),
+        AttributeValue::Int(v) => Some(*v as f64),
+        AttributeValue::Uint(v) => Some(*v as f64),
+        AttributeValue::Longlong(v) => Some(*v as f64),
+        AttributeValue::Ulonglong(v) => Some(*v as f64),
+        _ => None,
+    }
+}
 
 fn numeric_variable_to_nd_array<T>(
     nc_file: Arc<netcdf::File>,
@@ -22,6 +44,7 @@ fn numeric_variable_to_nd_array<T>(
     dimensions: Vec<String>,
     fill_value: Option<T>,
     cf_time_epoch_unit: Option<(hifitime::Epoch, hifitime::Unit)>,
+    scale_offset: Option<(f64, f64)>,
 ) -> anyhow::Result<Arc<dyn NdArrayD>>
 where
     T: NdArrayType
@@ -36,6 +59,28 @@ where
     let default_decoder: Arc<dyn crate::decoders::VariableDecoder<T>> = Arc::new(
         DefaultVariableDecoder::<T>::new(variable_name.to_string(), fill_value),
     );
+
+    // CF `scale_factor` / `add_offset` packing → decoded `f64`. Takes precedence
+    // over CF-time (a variable carries one or the other, never both), mirroring
+    // the zarr reader.
+    if let Some((scale, offset)) = scale_offset {
+        let raw_fill = fill_value.map(|f| f.as_());
+        let scale_offset_decoder = VariableBackend::new(
+            Arc::new(ScaleOffsetVariableDecoder::new(
+                variable_name.to_string(),
+                default_decoder,
+                scale,
+                offset,
+                raw_fill,
+            )),
+            nc_file,
+            shape,
+            dimensions,
+        );
+
+        let nd_array = NdArray::new_with_backend(scale_offset_decoder)?;
+        return Ok(Arc::new(nd_array));
+    }
 
     if let Some((epoch, unit)) = cf_time_epoch_unit {
         let time_backend = VariableBackend::new(
@@ -205,6 +250,14 @@ pub fn variable_to_nd_array(
         _ => None,
     };
 
+    // CF `scale_factor` / `add_offset` packing. When either is present the
+    // numeric variable is decoded to `f64` as `raw * scale + offset`; a missing
+    // factor defaults to the identity (scale 1.0, offset 0.0).
+    let scale = attributes.get("scale_factor").and_then(attribute_as_f64);
+    let offset = attributes.get("add_offset").and_then(attribute_as_f64);
+    let scale_offset =
+        (scale.is_some() || offset.is_some()).then(|| (scale.unwrap_or(1.0), offset.unwrap_or(0.0)));
+
     match var_type {
         netcdf::types::NcVariableType::String => {
             let string_fill_attr =
@@ -238,6 +291,7 @@ pub fn variable_to_nd_array(
                     _ => None,
                 },
                 cf_time_epoch_unit,
+                scale_offset,
             ),
             netcdf::types::IntType::U16 => numeric_variable_to_nd_array::<u16>(
                 nc_file.clone(),
@@ -249,6 +303,7 @@ pub fn variable_to_nd_array(
                     _ => None,
                 },
                 cf_time_epoch_unit,
+                scale_offset,
             ),
             netcdf::types::IntType::U32 => numeric_variable_to_nd_array::<u32>(
                 nc_file.clone(),
@@ -260,6 +315,7 @@ pub fn variable_to_nd_array(
                     _ => None,
                 },
                 cf_time_epoch_unit,
+                scale_offset,
             ),
             netcdf::types::IntType::U64 => numeric_variable_to_nd_array::<u64>(
                 nc_file.clone(),
@@ -271,6 +327,7 @@ pub fn variable_to_nd_array(
                     _ => None,
                 },
                 cf_time_epoch_unit,
+                scale_offset,
             ),
             netcdf::types::IntType::I8 => numeric_variable_to_nd_array::<i8>(
                 nc_file.clone(),
@@ -282,6 +339,7 @@ pub fn variable_to_nd_array(
                     _ => None,
                 },
                 cf_time_epoch_unit,
+                scale_offset,
             ),
             netcdf::types::IntType::I16 => numeric_variable_to_nd_array::<i16>(
                 nc_file.clone(),
@@ -293,6 +351,7 @@ pub fn variable_to_nd_array(
                     _ => None,
                 },
                 cf_time_epoch_unit,
+                scale_offset,
             ),
             netcdf::types::IntType::I32 => numeric_variable_to_nd_array::<i32>(
                 nc_file.clone(),
@@ -304,6 +363,7 @@ pub fn variable_to_nd_array(
                     _ => None,
                 },
                 cf_time_epoch_unit,
+                scale_offset,
             ),
             netcdf::types::IntType::I64 => numeric_variable_to_nd_array::<i64>(
                 nc_file.clone(),
@@ -315,6 +375,7 @@ pub fn variable_to_nd_array(
                     _ => None,
                 },
                 cf_time_epoch_unit,
+                scale_offset,
             ),
         },
         netcdf::types::NcVariableType::Float(float_type) => match float_type {
@@ -328,6 +389,7 @@ pub fn variable_to_nd_array(
                     _ => None,
                 },
                 cf_time_epoch_unit,
+                scale_offset,
             ),
             netcdf::types::FloatType::F64 => numeric_variable_to_nd_array::<f64>(
                 nc_file.clone(),
@@ -339,6 +401,7 @@ pub fn variable_to_nd_array(
                     _ => None,
                 },
                 cf_time_epoch_unit,
+                scale_offset,
             ),
         },
         netcdf::types::NcVariableType::Char => {

--- a/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -1025,6 +1025,42 @@ mod tests {
         assert!(kept < total, "midpoint predicate should drop some rows");
     }
 
+    /// `scale_factor`/`add_offset` are actually applied: the decoded
+    /// `analysed_sst` (packed int16 with scale 0.01, offset 273.15 kelvin) lands
+    /// in a physical sea-surface-temperature range, which raw packed values
+    /// never would.
+    #[tokio::test]
+    async fn scale_offset_decodes_to_physical_range() {
+        use arrow::array::Float64Array;
+
+        let store = test_store().await;
+        let ctx = datafusion::prelude::SessionContext::new();
+        register_example(&ctx, store).await;
+
+        let batches = ctx
+            .sql("SELECT min(analysed_sst) AS mn, max(analysed_sst) AS mx FROM gridded_nc")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let f = |i: usize| {
+            batches[0]
+                .column(i)
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap()
+                .value(0)
+        };
+        let (mn, mx) = (f(0), f(1));
+        assert!(
+            (250.0..350.0).contains(&mn) && (250.0..350.0).contains(&mx),
+            "decoded SST must be in a physical kelvin range, got [{mn}, {mx}]"
+        );
+        assert!(mx > mn, "SST must span a range");
+    }
+
     // ── nd pipeline: plan shape + variables & attributes end-to-end ──────
 
     /// The physical plan for an nd scan is the nd spine on top of the standard
@@ -1090,12 +1126,11 @@ mod tests {
         assert_eq!(total, 4, "LIMIT 4 should yield exactly 4 rows");
 
         let batch = &batches[0];
-        // The data variable flows through the nd spine. NetCDF surfaces it as the
-        // raw packed type (Int16); scale_factor/add_offset are not applied here
-        // (unlike the zarr reader, which decodes to Float64).
+        // The data variable is decoded via scale_factor/add_offset → Float64,
+        // consistent with the zarr reader.
         assert_eq!(
             batch.column_by_name("analysed_sst").unwrap().data_type(),
-            &DataType::Int16
+            &DataType::Float64
         );
 
         let units = batch

--- a/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -1024,4 +1024,139 @@ mod tests {
         assert!(kept > 0, "midpoint predicate should keep some rows");
         assert!(kept < total, "midpoint predicate should drop some rows");
     }
+
+    // ── nd pipeline: plan shape + variables & attributes end-to-end ──────
+
+    /// The physical plan for an nd scan is the nd spine on top of the standard
+    /// file scan: `NdBroadcastExec` → `NdSourceExec` → `DataSourceExec`, in that
+    /// nesting order (parent above child in the indented render).
+    #[tokio::test]
+    async fn physical_plan_is_nd_spine_over_scan() {
+        use datafusion::physical_plan::displayable;
+
+        let store = test_store().await;
+        let ctx = datafusion::prelude::SessionContext::new();
+        register_example(&ctx, store).await;
+
+        let plan = ctx
+            .sql("SELECT analysed_sst FROM gridded_nc")
+            .await
+            .unwrap()
+            .create_physical_plan()
+            .await
+            .unwrap();
+        let rendered = displayable(plan.as_ref()).indent(true).to_string();
+
+        let broadcast = rendered.find("NdBroadcastExec");
+        let source = rendered.find("NdSourceExec");
+        let scan = rendered.find("DataSourceExec");
+        assert!(
+            broadcast.is_some() && source.is_some() && scan.is_some(),
+            "plan must contain the nd spine over a DataSourceExec:\n{rendered}"
+        );
+        assert!(
+            broadcast < source && source < scan,
+            "expected NdBroadcastExec → NdSourceExec → DataSourceExec nesting:\n{rendered}"
+        );
+    }
+
+    /// End-to-end through DataFusion: a gridded data variable comes back decoded
+    /// (scale/offset applied → Float64), and its rank-0 attributes — a variable
+    /// attribute (`analysed_sst.units`) and a global attribute (`.Conventions`) —
+    /// ride the `beacon.nd` encoding as constant columns on every row.
+    #[tokio::test]
+    async fn end_to_end_reads_variable_with_attributes() {
+        use arrow::array::StringArray;
+        use arrow::datatypes::DataType;
+
+        let store = test_store().await;
+        let ctx = datafusion::prelude::SessionContext::new();
+        register_example(&ctx, store).await;
+
+        let batches = ctx
+            .sql(
+                r#"SELECT analysed_sst,
+                          "analysed_sst.units" AS units,
+                          ".Conventions"       AS conventions
+                   FROM gridded_nc LIMIT 4"#,
+            )
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 4, "LIMIT 4 should yield exactly 4 rows");
+
+        let batch = &batches[0];
+        // The data variable flows through the nd spine. NetCDF surfaces it as the
+        // raw packed type (Int16); scale_factor/add_offset are not applied here
+        // (unlike the zarr reader, which decodes to Float64).
+        assert_eq!(
+            batch.column_by_name("analysed_sst").unwrap().data_type(),
+            &DataType::Int16
+        );
+
+        let units = batch
+            .column_by_name("units")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let conventions = batch
+            .column_by_name("conventions")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            assert_eq!(units.value(i), "kelvin", "variable attribute must be constant");
+            assert_eq!(conventions.value(i), "CF-1.4", "global attribute must be constant");
+        }
+    }
+
+    /// The strongest constant-column check: co-selected with a gridded variable
+    /// (`lat`, which establishes the broadcast target), a rank-0 attribute is
+    /// present on *every* grid row and has exactly one distinct value across all
+    /// of them. Referencing a gridded variable matters — projecting to only the
+    /// scalar attribute would collapse the grid to a single row.
+    #[tokio::test]
+    async fn attribute_is_single_distinct_value_across_grid() {
+        use arrow::array::Int64Array;
+
+        let store = test_store().await;
+        let ctx = datafusion::prelude::SessionContext::new();
+        register_example(&ctx, store).await;
+
+        let batches = ctx
+            .sql(
+                r#"SELECT COUNT(DISTINCT "analysed_sst.units") AS distinct_units,
+                          COUNT("analysed_sst.units")          AS attr_rows,
+                          COUNT(lat)                           AS grid_rows
+                   FROM gridded_nc"#,
+            )
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let int = |name: &str| {
+            batches[0]
+                .column_by_name(name)
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(0)
+        };
+        assert_eq!(int("distinct_units"), 1, "attribute must be a single constant");
+        assert!(int("grid_rows") > 1, "gridded variable must define a multi-row grid");
+        assert_eq!(
+            int("attr_rows"),
+            int("grid_rows"),
+            "attribute must be broadcast (non-null) onto every grid row"
+        );
+    }
 }

--- a/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -308,8 +308,14 @@ impl FileFormat for NetcdfFormat {
         _state: &dyn Session,
         conf: FileScanConfig,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        // The scan carries nd data as `beacon.nd`-encoded struct columns, so
+        // the file source's schema is the encoded form of the logical table
+        // schema. `NdSourceExec` decodes it and `NdBroadcastExec` broadcasts it
+        // back to the logical schema above the scan.
+        let encoded_file_schema =
+            Arc::new(beacon_datafusion_ext::nd::encoded_schema(conf.file_schema()));
         let table_schema = datafusion::datasource::table_schema::TableSchema::new(
-            conf.file_schema().clone(),
+            encoded_file_schema,
             conf.table_partition_cols().clone(),
         );
         // Preserve a projection that the scan pushed down into the incoming
@@ -325,7 +331,12 @@ impl FileFormat for NetcdfFormat {
         let conf = FileScanConfigBuilder::from(conf)
             .with_source(Arc::new(source))
             .build();
-        Ok(DataSourceExec::from_data_source(conf))
+
+        let data_source: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(conf);
+        let nd_source =
+            Arc::new(beacon_datafusion_ext::nd::exec::NdSourceExec::try_new(data_source)?);
+        let broadcast = beacon_datafusion_ext::nd::exec::NdBroadcastExec::try_new(nd_source)?;
+        Ok(Arc::new(broadcast))
     }
 
     async fn create_writer_physical_plan(
@@ -627,9 +638,10 @@ mod tests {
             .await
             .expect("schema");
 
-        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(
-            table_schema.clone(),
-        );
+        // The opener emits nd-encoded batches, so its source schema is encoded.
+        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(Arc::new(
+            beacon_datafusion_ext::nd::encoded_schema(&table_schema),
+        ));
         let opener = source::NetCDFSource::new(store, None, ts);
         let file_opener = {
             let conf = FileScanConfigBuilder::new(
@@ -667,9 +679,9 @@ mod tests {
             .await
             .expect("schema");
 
-        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(
-            table_schema.clone(),
-        );
+        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(Arc::new(
+            beacon_datafusion_ext::nd::encoded_schema(&table_schema),
+        ));
         let opener = source::NetCDFSource::new(store, None, ts);
         let file_opener = {
             let conf = FileScanConfigBuilder::new(
@@ -710,9 +722,9 @@ mod tests {
         // Project to only the first column.
         let projected_schema: SchemaRef = Arc::new(table_schema.project(&[0]).expect("project"));
 
-        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(
-            table_schema.clone(),
-        );
+        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(Arc::new(
+            beacon_datafusion_ext::nd::encoded_schema(&table_schema),
+        ));
         let opener = source::NetCDFSource::new(store, None, ts);
         let file_opener = {
             let conf = FileScanConfigBuilder::new(
@@ -785,7 +797,9 @@ mod tests {
         let missing_idx = merged.index_of(&missing).unwrap();
 
         // No projection pushed → the opener reads under the full merged schema.
-        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(merged.clone());
+        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(Arc::new(
+            beacon_datafusion_ext::nd::encoded_schema(&merged),
+        ));
         let opener = source::NetCDFSource::new(store, None, ts);
         let conf = FileScanConfigBuilder::new(
             ObjectStoreUrl::local_filesystem(),
@@ -841,9 +855,9 @@ mod tests {
         .await
         .expect("dim schema");
 
-        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(
-            dim_schema.clone(),
-        );
+        let ts = datafusion::datasource::table_schema::TableSchema::from_file_schema(Arc::new(
+            beacon_datafusion_ext::nd::encoded_schema(&dim_schema),
+        ));
         let opener = source::NetCDFSource::new(store, Some(vec!["time".to_string()]), ts);
         let file_opener = {
             let conf = FileScanConfigBuilder::new(

--- a/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/source.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/source.rs
@@ -8,6 +8,7 @@ use beacon_nd_array::{
     arrow::{
         batch::any_dataset_as_record_batch_stream,
         metrics::DatasetReadMetrics,
+        nd_provider::any_dataset_as_broadcast_stream,
         pushdown_filter::PushdownFilter,
     },
     projection::DatasetProjection,
@@ -384,13 +385,10 @@ impl NetCDFOpener {
             dataset
         };
 
-        let pushdown_filter = predicate.map(PushdownFilter::new);
-        let stream = any_dataset_as_record_batch_stream(dataset, batch_size, pushdown_filter, metrics)
-            .map_err(|e| {
-                datafusion::error::DataFusionError::Execution(format!(
-                    "Error reading NetCDF as Arrow stream: {e}"
-                ))
-            })
+        // Broadcast through the nd execution-plan spine (NdSourceExec ->
+        // NdBroadcastExec), then adapt onto the projected output schema.
+        let _ = metrics;
+        let stream = any_dataset_as_broadcast_stream(dataset, batch_size)
             .and_then(move |batch| {
                 let mapped = adapter.adapt_batch(&batch).map_err(|e| {
                     datafusion::error::DataFusionError::Execution(format!(

--- a/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/source.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/source.rs
@@ -8,7 +8,7 @@ use beacon_nd_array::{
     arrow::{
         batch::any_dataset_as_record_batch_stream,
         metrics::DatasetReadMetrics,
-        nd_provider::any_dataset_as_broadcast_stream,
+        nd_provider::any_dataset_as_encoded_stream,
         pushdown_filter::PushdownFilter,
     },
     projection::DatasetProjection,
@@ -366,9 +366,12 @@ impl NetCDFOpener {
             return Ok(stream);
         }
 
-        // Adapt batches (read with `projection`) onto the projected output
-        // schema: reorder, cast, and null-fill columns this file lacks.
-        let source_schema: SchemaRef = Arc::new(file_schema.project(&projection)?);
+        // The opener emits nd-encoded batches, so adaptation happens in the
+        // encoded (struct) domain: reorder and null-fill missing columns onto
+        // the projected encoded schema.
+        let source_schema: SchemaRef = Arc::new(beacon_datafusion_ext::nd::encoded_schema(
+            &file_schema.project(&projection)?,
+        ));
         let adapter = BatchAdapterFactory::new(projected_schema).make_adapter(&source_schema)?;
 
         let dataset = if projection.len() < file_schema.fields().len() {
@@ -385,10 +388,11 @@ impl NetCDFOpener {
             dataset
         };
 
-        // Broadcast through the nd execution-plan spine (NdSourceExec ->
-        // NdBroadcastExec), then adapt onto the projected output schema.
+        // Emit nd-encoded batches (decoded/broadcast by the NdSourceExec /
+        // NdBroadcastExec above the scan), adapted onto the projected encoded
+        // schema.
         let _ = metrics;
-        let stream = any_dataset_as_broadcast_stream(dataset, batch_size)
+        let stream = any_dataset_as_encoded_stream(dataset, batch_size)
             .and_then(move |batch| {
                 let mapped = adapter.adapt_batch(&batch).map_err(|e| {
                     datafusion::error::DataFusionError::Execution(format!(

--- a/beacon-file-formats/beacon-arrow-netcdf/src/decoders/mod.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/decoders/mod.rs
@@ -7,6 +7,8 @@ use netcdf::{Extents, NcTypeDescriptor};
 
 /// Decoders for CF-style time units.
 pub mod cf_time;
+/// Decoders for CF `scale_factor` / `add_offset` packing.
+pub mod scale_offset;
 /// Decoders for NetCDF string and fixed-size char-string representations.
 pub mod strings;
 

--- a/beacon-file-formats/beacon-arrow-netcdf/src/decoders/scale_offset.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/decoders/scale_offset.rs
@@ -1,0 +1,112 @@
+//! CF `scale_factor` / `add_offset` decoding.
+//!
+//! This module converts packed numeric NetCDF variables (raw integers stored
+//! with `scale_factor` and/or `add_offset` attributes) into decoded `f64`
+//! values (`raw * scale + offset`).
+
+use std::sync::Arc;
+
+use netcdf::NcTypeDescriptor;
+use num_traits::AsPrimitive;
+
+use crate::decoders::VariableDecoder;
+
+/// Decoder that wraps a numeric decoder and applies CF `scale_factor` /
+/// `add_offset` packing, decoding raw values to `f64` (`raw * scale + offset`).
+#[derive(Debug)]
+pub struct ScaleOffsetVariableDecoder<T>
+where
+    T: NcTypeDescriptor + AsPrimitive<f64>,
+{
+    variable_name: String,
+    inner_decoder: Arc<dyn VariableDecoder<T>>,
+    scale: f64,
+    offset: f64,
+    fill_value: Option<f64>,
+}
+
+impl<T> ScaleOffsetVariableDecoder<T>
+where
+    T: NcTypeDescriptor + AsPrimitive<f64>,
+{
+    /// Create a scale/offset decoder.
+    ///
+    /// `inner_decoder` provides the raw packed values. `raw_fill_value` is the
+    /// fill value in the variable's *packed* units; it is decoded with the same
+    /// `raw * scale + offset` arithmetic so a packed fill cell maps exactly to
+    /// the decoded fill and is nulled by the engine after decoding.
+    pub fn new(
+        variable_name: String,
+        inner_decoder: Arc<dyn VariableDecoder<T>>,
+        scale: f64,
+        offset: f64,
+        raw_fill_value: Option<f64>,
+    ) -> Self {
+        Self {
+            variable_name,
+            inner_decoder,
+            scale,
+            offset,
+            fill_value: raw_fill_value.map(|f| f * scale + offset),
+        }
+    }
+}
+
+impl<T> VariableDecoder<f64> for ScaleOffsetVariableDecoder<T>
+where
+    T: NcTypeDescriptor + AsPrimitive<f64> + Copy + std::fmt::Debug + Send + Sync + 'static,
+{
+    fn read(
+        &self,
+        variable: &netcdf::Variable,
+        extents: netcdf::Extents,
+    ) -> anyhow::Result<ndarray::ArrayD<f64>> {
+        let array = self.inner_decoder.read(variable, extents)?;
+        let scale = self.scale;
+        let offset = self.offset;
+        Ok(array.mapv(|v| v.as_() * scale + offset))
+    }
+
+    fn fill_value(&self) -> Option<f64> {
+        self.fill_value
+    }
+
+    fn variable_name(&self) -> &str {
+        &self.variable_name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::decoders::{DefaultVariableDecoder, VariableDecoder};
+
+    use super::*;
+
+    /// The decoded fill value equals the packed fill run through the same
+    /// `raw * scale + offset` arithmetic, so packed fill cells null out.
+    #[test]
+    fn decoded_fill_matches_packed_fill_arithmetic() {
+        let inner: Arc<dyn VariableDecoder<i16>> =
+            Arc::new(DefaultVariableDecoder::<i16>::new("sst".to_string(), Some(-32768)));
+        let decoder = ScaleOffsetVariableDecoder::new(
+            "sst".to_string(),
+            inner,
+            0.01,
+            273.15,
+            Some(-32768.0),
+        );
+        assert_eq!(decoder.fill_value(), Some(-32768.0 * 0.01 + 273.15));
+    }
+
+    /// With no fill, the decoder still exposes `None`.
+    #[test]
+    fn no_fill_stays_none() {
+        let inner: Arc<dyn VariableDecoder<i16>> =
+            Arc::new(DefaultVariableDecoder::<i16>::new("sst".to_string(), None));
+        let decoder =
+            ScaleOffsetVariableDecoder::new("sst".to_string(), inner, 0.01, 0.0, None);
+        assert_eq!(decoder.fill_value(), None);
+    }
+}

--- a/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
@@ -627,6 +627,133 @@ mod tests {
         assert!(kept > 0, "midpoint predicate should keep some rows");
         assert!(kept < total, "midpoint predicate should drop some rows");
     }
+
+    // ── nd pipeline: plan shape + variables & attributes end-to-end ──────
+
+    /// The physical plan is the nd spine over the standard file scan:
+    /// `NdBroadcastExec` → `NdSourceExec` → `DataSourceExec`, in that nesting
+    /// order (parent above child in the indented render).
+    #[tokio::test]
+    async fn physical_plan_is_nd_spine_over_scan() {
+        use datafusion::physical_plan::displayable;
+
+        let ctx = SessionContext::new();
+        register_example(&ctx).await;
+
+        let plan = ctx
+            .sql("SELECT analysed_sst FROM gridded")
+            .await
+            .unwrap()
+            .create_physical_plan()
+            .await
+            .unwrap();
+        let rendered = displayable(plan.as_ref()).indent(true).to_string();
+
+        let broadcast = rendered.find("NdBroadcastExec");
+        let source = rendered.find("NdSourceExec");
+        let scan = rendered.find("DataSourceExec");
+        assert!(
+            broadcast.is_some() && source.is_some() && scan.is_some(),
+            "plan must contain the nd spine over a DataSourceExec:\n{rendered}"
+        );
+        assert!(
+            broadcast < source && source < scan,
+            "expected NdBroadcastExec → NdSourceExec → DataSourceExec nesting:\n{rendered}"
+        );
+    }
+
+    /// End-to-end through DataFusion: a gridded data variable comes back decoded
+    /// (scale/offset applied → Float64), and its rank-0 attributes — a variable
+    /// attribute (`analysed_sst.units`) and a global attribute (`.Conventions`) —
+    /// ride the `beacon.nd` encoding as constant columns on every row.
+    #[tokio::test]
+    async fn end_to_end_reads_variable_with_attributes() {
+        use arrow::array::StringArray;
+
+        let ctx = SessionContext::new();
+        register_example(&ctx).await;
+
+        let batches = ctx
+            .sql(
+                r#"SELECT analysed_sst,
+                          "analysed_sst.units" AS units,
+                          ".Conventions"       AS conventions
+                   FROM gridded LIMIT 4"#,
+            )
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 4, "LIMIT 4 should yield exactly 4 rows");
+
+        let batch = &batches[0];
+        assert_eq!(
+            batch.column_by_name("analysed_sst").unwrap().data_type(),
+            &DataType::Float64
+        );
+
+        let units = batch
+            .column_by_name("units")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let conventions = batch
+            .column_by_name("conventions")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            assert_eq!(units.value(i), "kelvin", "variable attribute must be constant");
+            assert_eq!(conventions.value(i), "CF-1.4", "global attribute must be constant");
+        }
+    }
+
+    /// Co-selected with a gridded variable (`lat`, which establishes the
+    /// broadcast target), a rank-0 attribute is present on every grid row and
+    /// has exactly one distinct value across all of them. Projecting to only the
+    /// scalar attribute would collapse the grid to a single row.
+    #[tokio::test]
+    async fn attribute_is_single_distinct_value_across_grid() {
+        use arrow::array::Int64Array;
+
+        let ctx = SessionContext::new();
+        register_example(&ctx).await;
+
+        let batches = ctx
+            .sql(
+                r#"SELECT COUNT(DISTINCT "analysed_sst.units") AS distinct_units,
+                          COUNT("analysed_sst.units")          AS attr_rows,
+                          COUNT(lat)                           AS grid_rows
+                   FROM gridded"#,
+            )
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let int = |name: &str| {
+            batches[0]
+                .column_by_name(name)
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(0)
+        };
+        assert_eq!(int("distinct_units"), 1, "attribute must be a single constant");
+        assert!(int("grid_rows") > 1, "gridded variable must define a multi-row grid");
+        assert_eq!(
+            int("attr_rows"),
+            int("grid_rows"),
+            "attribute must be broadcast (non-null) onto every grid row"
+        );
+    }
 }
 
 pub mod table_function;

--- a/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
@@ -286,8 +286,14 @@ impl FileFormat for ZarrFormat {
             file_groups.push(file);
         }
 
+        // The scan carries nd data as `beacon.nd`-encoded struct columns, so the
+        // file source's schema is the encoded form of the logical table schema.
+        // `NdSourceExec` decodes it and `NdBroadcastExec` broadcasts it back to
+        // the logical schema above the scan.
+        let encoded_file_schema =
+            Arc::new(beacon_datafusion_ext::nd::encoded_schema(conf.file_schema()));
         let table_schema = datafusion::datasource::table_schema::TableSchema::new(
-            conf.file_schema().clone(),
+            encoded_file_schema,
             conf.table_partition_cols().clone(),
         );
         // Preserve a projection that the scan pushed down into the incoming
@@ -300,7 +306,12 @@ impl FileFormat for ZarrFormat {
             .with_file_groups(file_groups)
             .with_source(Arc::new(source))
             .build();
-        Ok(DataSourceExec::from_data_source(conf))
+
+        let data_source: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(conf);
+        let nd_source =
+            Arc::new(beacon_datafusion_ext::nd::exec::NdSourceExec::try_new(data_source)?);
+        let broadcast = beacon_datafusion_ext::nd::exec::NdBroadcastExec::try_new(nd_source)?;
+        Ok(Arc::new(broadcast))
     }
 
     fn file_source(

--- a/beacon-file-formats/beacon-arrow-zarr/src/datafusion/source.rs
+++ b/beacon-file-formats/beacon-arrow-zarr/src/datafusion/source.rs
@@ -12,7 +12,7 @@ use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use beacon_nd_array::{
     arrow::{
         batch::any_dataset_as_record_batch_stream, metrics::DatasetReadMetrics,
-        nd_provider::any_dataset_as_broadcast_stream, pushdown_filter::PushdownFilter,
+        nd_provider::any_dataset_as_encoded_stream, pushdown_filter::PushdownFilter,
         schema::any_dataset_to_arrow_schema,
     },
     dataset::resolve_read_dimensions,
@@ -320,9 +320,12 @@ impl FileOpener for ZarrOpener {
                 return Ok(stream);
             }
 
-            // Adapt batches (read with `projection`) onto the projected output
-            // schema: reorder, cast, and null-fill columns the group lacks.
-            let source_schema: SchemaRef = Arc::new(file_schema.project(&projection)?);
+            // The opener emits nd-encoded batches, so adaptation happens in the
+            // encoded (struct) domain: reorder and null-fill columns the group
+            // lacks onto the projected encoded schema.
+            let source_schema: SchemaRef = Arc::new(beacon_datafusion_ext::nd::encoded_schema(
+                &file_schema.project(&projection)?,
+            ));
             let adapter =
                 BatchAdapterFactory::new(projected_schema).make_adapter(&source_schema)?;
 
@@ -332,10 +335,11 @@ impl FileOpener for ZarrOpener {
                     DataFusionError::Execution(format!("Failed to project Zarr dataset: {e}"))
                 })?;
 
-            // Broadcast through the nd execution-plan spine (NdSourceExec ->
-            // NdBroadcastExec), then adapt onto the projected output schema.
+            // Emit nd-encoded batches (decoded/broadcast by the NdSourceExec /
+            // NdBroadcastExec above the scan), adapted onto the projected
+            // encoded schema.
             let _ = metrics;
-            let stream = any_dataset_as_broadcast_stream(projected, batch_size)
+            let stream = any_dataset_as_encoded_stream(projected, batch_size)
                 .and_then(move |batch| {
                     let mapped = adapter.adapt_batch(&batch).map_err(|e| {
                         DataFusionError::Execution(format!(

--- a/beacon-file-formats/beacon-arrow-zarr/src/datafusion/source.rs
+++ b/beacon-file-formats/beacon-arrow-zarr/src/datafusion/source.rs
@@ -12,7 +12,8 @@ use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use beacon_nd_array::{
     arrow::{
         batch::any_dataset_as_record_batch_stream, metrics::DatasetReadMetrics,
-        pushdown_filter::PushdownFilter, schema::any_dataset_to_arrow_schema,
+        nd_provider::any_dataset_as_broadcast_stream, pushdown_filter::PushdownFilter,
+        schema::any_dataset_to_arrow_schema,
     },
     dataset::resolve_read_dimensions,
     projection::DatasetProjection,
@@ -331,23 +332,19 @@ impl FileOpener for ZarrOpener {
                     DataFusionError::Execution(format!("Failed to project Zarr dataset: {e}"))
                 })?;
 
-            let pushdown_filter = predicate.map(PushdownFilter::new);
-            let stream = any_dataset_as_record_batch_stream(
-                projected,
-                batch_size,
-                pushdown_filter,
-                metrics,
-            )
-            .map_err(|e| {
-                DataFusionError::Execution(format!("Error reading Zarr dataset as Arrow: {e}"))
-            })
-            .and_then(move |batch| {
-                let mapped = adapter.adapt_batch(&batch).map_err(|e| {
-                    DataFusionError::Execution(format!("Failed to adapt Zarr batch schema: {e}"))
-                });
-                future::ready(mapped)
-            })
-            .boxed();
+            // Broadcast through the nd execution-plan spine (NdSourceExec ->
+            // NdBroadcastExec), then adapt onto the projected output schema.
+            let _ = metrics;
+            let stream = any_dataset_as_broadcast_stream(projected, batch_size)
+                .and_then(move |batch| {
+                    let mapped = adapter.adapt_batch(&batch).map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "Failed to adapt Zarr batch schema: {e}"
+                        ))
+                    });
+                    future::ready(mapped)
+                })
+                .boxed();
 
             Ok(stream)
         };

--- a/beacon-file-formats/beacon-nd-array/Cargo.toml
+++ b/beacon-file-formats/beacon-nd-array/Cargo.toml
@@ -19,6 +19,8 @@ rkyv = {workspace = true}
 tokio = { workspace = true }
 tracing = { workspace = true }
 
+beacon-datafusion-ext = { path = "../../beacon-datafusion-ext" }
+
 [dev-dependencies]
 arrow-ipc = { workspace = true }
 criterion = { version = "0.5", default-features = false, features = ["rayon", "html_reports"] }

--- a/beacon-file-formats/beacon-nd-array/src/arrow/batch.rs
+++ b/beacon-file-formats/beacon-nd-array/src/arrow/batch.rs
@@ -412,7 +412,7 @@ fn run_length_expand(
     arrow::compute::take(array.as_ref(), &indices_array, None)
 }
 
-fn extract_dataset_layout(
+pub(crate) fn extract_dataset_layout(
     dataset: &Dataset,
 ) -> anyhow::Result<(Vec<String>, Vec<usize>, Vec<usize>)> {
     for (array_name, array) in &dataset.arrays {
@@ -463,7 +463,7 @@ fn extract_dataset_layout(
     Ok((dims, shape.clone(), shape))
 }
 
-fn build_dataset_schema(arrays: &IndexMap<String, Arc<dyn NdArrayD>>) -> Arc<Schema> {
+pub(crate) fn build_dataset_schema(arrays: &IndexMap<String, Arc<dyn NdArrayD>>) -> Arc<Schema> {
     Arc::new(Schema::new(
         arrays
             .iter()
@@ -610,7 +610,7 @@ pub fn dataset_as_record_batch_stream(
 
 /// For a given chunk subset (expressed in max_dims space), compute the corresponding
 /// subset for an individual array that may have fewer dimensions.
-fn generate_array_subset_from_chunk(
+pub(crate) fn generate_array_subset_from_chunk(
     subset: &ArraySubset,
     chunk_dimensions: &[String],
     array: &dyn NdArrayD,
@@ -631,7 +631,7 @@ fn generate_array_subset_from_chunk(
 
 /// Compute a C-memory-ordered chunk shape targeting approximately `batch_size` elements.
 /// Inner dimensions are kept whole; only the outermost axis is cut.
-fn c_order_chunk_shape(shape: &[usize], batch_size: usize) -> Vec<usize> {
+pub(crate) fn c_order_chunk_shape(shape: &[usize], batch_size: usize) -> Vec<usize> {
     if shape.is_empty() {
         return vec![];
     }
@@ -644,7 +644,7 @@ fn c_order_chunk_shape(shape: &[usize], batch_size: usize) -> Vec<usize> {
 
 /// Generate all chunk subsets for iterating over `shape` in chunks of `chunk_shape`.
 /// Boundary chunks are automatically shrunk to fit the remaining elements.
-fn generate_chunk_subsets(shape: &[usize], chunk_shape: &[usize]) -> Vec<ArraySubset> {
+pub(crate) fn generate_chunk_subsets(shape: &[usize], chunk_shape: &[usize]) -> Vec<ArraySubset> {
     if shape.is_empty() {
         return vec![ArraySubset::new(vec![], vec![])];
     }

--- a/beacon-file-formats/beacon-nd-array/src/arrow/mod.rs
+++ b/beacon-file-formats/beacon-nd-array/src/arrow/mod.rs
@@ -2,6 +2,7 @@ pub mod array;
 pub mod batch;
 pub mod compute;
 pub mod metrics;
+pub mod nd_provider;
 pub mod pushdown;
 pub mod pushdown_filter;
 pub mod schema;

--- a/beacon-file-formats/beacon-nd-array/src/arrow/nd_provider.rs
+++ b/beacon-file-formats/beacon-nd-array/src/arrow/nd_provider.rs
@@ -197,4 +197,81 @@ mod tests {
             assert_eq!(actual.num_rows(), 12);
         }
     }
+
+    /// A gridded dataset carrying rank-0 metadata attributes — a variable
+    /// attribute (`sst.units`) and a global attribute (`.title`) — surfaced as
+    /// scalar arrays. Each rides the `beacon.nd` encoding as a rank-0 column and
+    /// broadcasts (replicates) its single value across every row of the grid.
+    async fn test_dataset_with_attrs() -> Dataset {
+        let base = test_dataset().await;
+
+        // A NetCDF attribute is surfaced as a scalar (rank-0) array: no
+        // dimensions, one element — exactly what `AttributeBackend` produces.
+        let units = NdArray::<String>::try_new_from_vec_in_mem(
+            vec!["celsius".to_string()],
+            vec![],
+            vec![] as Vec<String>,
+            None,
+        )
+        .unwrap();
+        let title = NdArray::<String>::try_new_from_vec_in_mem(
+            vec!["demo".to_string()],
+            vec![],
+            vec![] as Vec<String>,
+            None,
+        )
+        .unwrap();
+
+        let mut arrays = base.arrays.clone();
+        arrays.insert("sst.units".to_string(), Arc::new(units));
+        arrays.insert(".title".to_string(), Arc::new(title));
+        Dataset::new("with-attrs".to_string(), arrays).await
+    }
+
+    /// Rank-0 attributes decode and broadcast to a constant column spanning the
+    /// full grid — one `"celsius"` / `"demo"` per row, across every chunk size.
+    #[tokio::test]
+    async fn scalar_attributes_broadcast_across_grid() {
+        use arrow::array::StringArray;
+
+        for batch_size in [usize::MAX, 6, 3] {
+            let ds = test_dataset_with_attrs().await;
+            let schema = build_dataset_schema(&ds.arrays);
+
+            let encoded: Vec<RecordBatch> =
+                any_dataset_as_encoded_stream(AnyDataset::Regular(ds), batch_size)
+                    .try_collect()
+                    .await
+                    .unwrap();
+            let materialized: Vec<RecordBatch> = encoded
+                .iter()
+                .map(|b| decode_nd_record_batch(b).unwrap().materialize().unwrap())
+                .collect();
+            let actual = concat_batches(&schema, &materialized).unwrap();
+
+            assert_eq!(actual.num_rows(), 12, "batch_size={batch_size}");
+
+            let units = actual
+                .column_by_name("sst.units")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            let title = actual
+                .column_by_name(".title")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+
+            assert!(
+                (0..12).all(|i| units.value(i) == "celsius"),
+                "batch_size={batch_size}: sst.units not replicated"
+            );
+            assert!(
+                (0..12).all(|i| title.value(i) == "demo"),
+                "batch_size={batch_size}: .title not replicated"
+            );
+        }
+    }
 }

--- a/beacon-file-formats/beacon-nd-array/src/arrow/nd_provider.rs
+++ b/beacon-file-formats/beacon-nd-array/src/arrow/nd_provider.rs
@@ -1,23 +1,21 @@
 //! Bridge from a [`Dataset`] to the nd execution-plan spine.
 //!
-//! [`DatasetNdProvider`] implements [`NdBatchProvider`] so a file format can
-//! feed a dataset straight into an `NdSourceExec`: it chunks the dataset in
-//! C-order and yields one [`NdRecordBatch`] per chunk with each variable left
-//! *un-broadcast* on its own dimensions. The `NdBroadcastExec` above the source
-//! is what later materializes the broadcast — this provider never expands the
-//! cross-product.
+//! [`dataset_as_nd_stream`] chunks a regular dataset in C-order and yields one
+//! un-broadcast [`NdRecordBatch`] per chunk. [`any_dataset_as_broadcast_stream`]
+//! is the drop-in the file-format openers use: it broadcasts a regular dataset
+//! through the nd spine ([`NdRecordBatch::materialize`], the operation
+//! [`beacon_datafusion_ext::nd::exec::NdBroadcastExec`] performs) and falls back
+//! to the v1 stream for ragged datasets (no rectangular grid).
+//!
+//! Predicate pushdown (chunk pruning) is intentionally not applied — the nd
+//! spine has no filter node yet, and the scan reports filters as inexact so
+//! DataFusion keeps a `FilterExec` above it. Filtering will return later.
 
 use std::sync::Arc;
 
-use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
-use beacon_datafusion_ext::nd::exec::{
-    NdBatchProvider, NdBroadcastExec, NdSourceExec, SendableNdBatchStream,
-};
 use beacon_datafusion_ext::nd::{Dimension, Dimensions, NdArrowArray, NdRecordBatch};
 use datafusion::error::{DataFusionError, Result};
-use datafusion::execution::TaskContext;
-use datafusion::physical_plan::ExecutionPlan;
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 
@@ -32,97 +30,53 @@ fn exec_err(e: impl std::fmt::Display) -> DataFusionError {
     DataFusionError::Execution(e.to_string())
 }
 
-/// Broadcast a dataset to a flat `RecordBatch` stream through the nd
-/// execution-plan spine.
-///
-/// A regular dataset is fed through [`DatasetNdProvider`] → [`NdSourceExec`] →
-/// [`NdBroadcastExec`]: the source streams un-broadcast [`NdRecordBatch`]es and
-/// the broadcast node materializes them. A ragged dataset has no rectangular
-/// grid, so it stays on the v1 stream. This is the drop-in the file-format
-/// openers use in place of the v1 broadcast engine.
-///
-/// Predicate pushdown (chunk pruning) is intentionally not applied here — the
-/// nd spine has no filter node yet, and the scan reports filters as inexact so
-/// DataFusion keeps a `FilterExec` above it. Filtering will return to the spine
-/// later.
+/// Broadcast a dataset to a flat `RecordBatch` stream through the nd spine.
+/// Regular datasets stream as chunked [`NdRecordBatch`]es that are materialized
+/// (broadcast); ragged datasets fall back to the v1 stream.
 pub fn any_dataset_as_broadcast_stream(
     dataset: AnyDataset,
     batch_size: usize,
 ) -> BoxStream<'static, Result<RecordBatch>> {
     match dataset {
-        AnyDataset::Regular(regular) => {
-            let provider =
-                Arc::new(DatasetNdProvider::new(regular, batch_size)) as Arc<dyn NdBatchProvider>;
-            let source = Arc::new(NdSourceExec::new(provider)) as Arc<dyn ExecutionPlan>;
-            // The nd nodes are pure data-flow here (no session state), so a
-            // default context is sufficient.
-            let result = NdBroadcastExec::try_new(source)
-                .and_then(|broadcast| broadcast.execute(0, Arc::new(TaskContext::default())));
-            match result {
-                Ok(stream) => stream.boxed(),
-                Err(e) => futures::stream::once(async move { Err(e) }).boxed(),
-            }
-        }
+        AnyDataset::Regular(regular) => dataset_as_nd_stream(regular, batch_size)
+            .map(|nd| nd.and_then(|batch| batch.materialize()))
+            .boxed(),
         ragged => any_dataset_as_record_batch_stream(ragged, batch_size, None, None)
             .map_err(exec_err)
             .boxed(),
     }
 }
 
-/// An [`NdBatchProvider`] over a regular (non-ragged) [`Dataset`].
-#[derive(Debug)]
-pub struct DatasetNdProvider {
+/// Chunk a regular [`Dataset`] in C-order into a stream of un-broadcast
+/// [`NdRecordBatch`]es — each variable kept on its own dimensions.
+pub fn dataset_as_nd_stream(
     dataset: Dataset,
-    schema: SchemaRef,
     batch_size: usize,
-}
+) -> BoxStream<'static, Result<NdRecordBatch>> {
+    let (max_dims, max_shape, chunk_shape) = match extract_dataset_layout(&dataset) {
+        Ok(layout) => layout,
+        Err(e) => return futures::stream::once(async move { Err(exec_err(e)) }).boxed(),
+    };
 
-impl DatasetNdProvider {
-    /// `batch_size` is the target number of grid elements per chunk (the outer
-    /// axis is cut to approach it), mirroring the v1 stream.
-    pub fn new(dataset: Dataset, batch_size: usize) -> Self {
-        let schema = build_dataset_schema(&dataset.arrays);
-        Self {
-            dataset,
-            schema,
-            batch_size,
-        }
-    }
-}
+    // Honour a native chunk layout when present; otherwise cut the outer axis to
+    // approach `batch_size`.
+    let effective_chunk_shape = if chunk_shape != max_shape {
+        chunk_shape
+    } else {
+        c_order_chunk_shape(&max_shape, batch_size)
+    };
 
-impl NdBatchProvider for DatasetNdProvider {
-    fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
+    let subsets = generate_chunk_subsets(&max_shape, &effective_chunk_shape);
+    let arrays = Arc::new(dataset.arrays);
+    let max_dims = Arc::new(max_dims);
+    let schema = build_dataset_schema(&arrays);
 
-    fn execute(
-        &self,
-        _partition: usize,
-        _context: Arc<TaskContext>,
-    ) -> Result<SendableNdBatchStream> {
-        let (max_dims, max_shape, chunk_shape) =
-            extract_dataset_layout(&self.dataset).map_err(exec_err)?;
-
-        // Honour a native chunk layout when present; otherwise cut the outer
-        // axis to approach `batch_size`.
-        let effective_chunk_shape = if chunk_shape != max_shape {
-            chunk_shape
-        } else {
-            c_order_chunk_shape(&max_shape, self.batch_size)
-        };
-
-        let subsets = generate_chunk_subsets(&max_shape, &effective_chunk_shape);
-        let arrays = Arc::new(self.dataset.arrays.clone());
-        let max_dims = Arc::new(max_dims);
-        let schema = self.schema.clone();
-
-        let stream = futures::stream::iter(subsets).then(move |subset| {
+    futures::stream::iter(subsets)
+        .then(move |subset| {
             let arrays = arrays.clone();
             let max_dims = max_dims.clone();
             let schema = schema.clone();
             async move {
-                // The chunk's target grid: the max dimensions cut to this
-                // chunk's extent.
                 let target = Dimensions::try_new(
                     max_dims
                         .iter()
@@ -133,8 +87,6 @@ impl NdBatchProvider for DatasetNdProvider {
 
                 let mut columns = Vec::with_capacity(arrays.len());
                 for (name, array) in arrays.iter() {
-                    // Slice each variable to the part of the chunk that lies on
-                    // its own dimensions, then convert to a flat Arrow array.
                     let array_subset =
                         generate_array_subset_from_chunk(&subset, &max_dims, array.as_ref());
                     let sliced = array.subset(array_subset).await.map_err(exec_err)?;
@@ -149,17 +101,16 @@ impl NdBatchProvider for DatasetNdProvider {
                             .map(|(dim, &size)| Dimension::new(dim.as_str(), size))
                             .collect(),
                     )?;
-                    columns.push(NdArrowArray::try_new(values, dims).map_err(|e| {
-                        exec_err(format!("nd column '{name}': {e}"))
-                    })?);
+                    columns.push(
+                        NdArrowArray::try_new(values, dims)
+                            .map_err(|e| exec_err(format!("nd column '{name}': {e}")))?,
+                    );
                 }
 
                 NdRecordBatch::try_new(schema, columns, target)
             }
-        });
-
-        Ok(Box::pin(stream))
-    }
+        })
+        .boxed()
 }
 
 #[cfg(test)]
@@ -168,9 +119,6 @@ mod tests {
 
     use arrow::compute::concat_batches;
     use arrow::record_batch::RecordBatch;
-    use beacon_datafusion_ext::nd::exec::{NdBroadcastExec, NdSourceExec};
-    use datafusion::execution::TaskContext;
-    use datafusion::physical_plan::ExecutionPlan;
     use futures::TryStreamExt;
     use indexmap::IndexMap;
 
@@ -208,10 +156,9 @@ mod tests {
         Dataset::new("test".to_string(), arrays).await
     }
 
-    /// The provider fed through NdSourceExec + NdBroadcastExec must produce the
-    /// same flat table as the v1 broadcast stream.
+    /// Broadcasting through the nd spine matches the v1 broadcast stream.
     #[tokio::test]
-    async fn provider_matches_v1_broadcast() {
+    async fn spine_matches_v1_broadcast() {
         for batch_size in [usize::MAX, 6, 3] {
             let ds = test_dataset().await;
             let schema = build_dataset_schema(&ds.arrays);
@@ -223,17 +170,12 @@ mod tests {
                     .unwrap();
             let expected = concat_batches(&schema, &v1).unwrap();
 
-            let provider = DatasetNdProvider::new(ds, batch_size);
-            let source = Arc::new(NdSourceExec::new(Arc::new(provider)));
-            let plan: Arc<dyn ExecutionPlan> =
-                Arc::new(NdBroadcastExec::try_new(source).unwrap());
-            let actual_batches: Vec<RecordBatch> = plan
-                .execute(0, Arc::new(TaskContext::default()))
-                .unwrap()
-                .try_collect()
-                .await
-                .unwrap();
-            let actual = concat_batches(&plan.schema(), &actual_batches).unwrap();
+            let actual_batches: Vec<RecordBatch> =
+                any_dataset_as_broadcast_stream(AnyDataset::Regular(ds), batch_size)
+                    .try_collect()
+                    .await
+                    .unwrap();
+            let actual = concat_batches(&schema, &actual_batches).unwrap();
 
             assert_eq!(actual, expected, "batch_size={batch_size}");
             assert_eq!(actual.num_rows(), 12);

--- a/beacon-file-formats/beacon-nd-array/src/arrow/nd_provider.rs
+++ b/beacon-file-formats/beacon-nd-array/src/arrow/nd_provider.rs
@@ -14,7 +14,10 @@
 use std::sync::Arc;
 
 use arrow::record_batch::RecordBatch;
-use beacon_datafusion_ext::nd::{Dimension, Dimensions, NdArrowArray, NdRecordBatch};
+use beacon_datafusion_ext::nd::{
+    Dimension, Dimensions, NdArrowArray, NdRecordBatch, encode_flat_batch_as_nd,
+    encode_nd_record_batch,
+};
 use datafusion::error::{DataFusionError, Result};
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
@@ -30,19 +33,25 @@ fn exec_err(e: impl std::fmt::Display) -> DataFusionError {
     DataFusionError::Execution(e.to_string())
 }
 
-/// Broadcast a dataset to a flat `RecordBatch` stream through the nd spine.
-/// Regular datasets stream as chunked [`NdRecordBatch`]es that are materialized
-/// (broadcast); ragged datasets fall back to the v1 stream.
-pub fn any_dataset_as_broadcast_stream(
+/// Stream a dataset as `beacon.nd`-encoded `RecordBatch`es — the form a file
+/// opener returns so the data can ride a `DataSourceExec` up to an
+/// `NdSourceExec`, which decodes it, and an `NdBroadcastExec`, which broadcasts.
+///
+/// A regular dataset is chunked into un-broadcast [`NdRecordBatch`]es and
+/// encoded. A ragged dataset is run-length expanded by the v1 stream, then each
+/// flat batch is wrapped on a synthetic `row` dimension and encoded (so the
+/// later broadcast is the identity).
+pub fn any_dataset_as_encoded_stream(
     dataset: AnyDataset,
     batch_size: usize,
 ) -> BoxStream<'static, Result<RecordBatch>> {
     match dataset {
         AnyDataset::Regular(regular) => dataset_as_nd_stream(regular, batch_size)
-            .map(|nd| nd.and_then(|batch| batch.materialize()))
+            .map(|nd| nd.and_then(|batch| encode_nd_record_batch(&batch)))
             .boxed(),
         ragged => any_dataset_as_record_batch_stream(ragged, batch_size, None, None)
             .map_err(exec_err)
+            .and_then(|flat| async move { encode_flat_batch_as_nd(&flat) })
             .boxed(),
     }
 }
@@ -122,6 +131,8 @@ mod tests {
     use futures::TryStreamExt;
     use indexmap::IndexMap;
 
+    use beacon_datafusion_ext::nd::decode_nd_record_batch;
+
     use super::*;
     use crate::arrow::batch::dataset_as_record_batch_stream;
     use crate::{NdArray, NdArrayD};
@@ -156,9 +167,10 @@ mod tests {
         Dataset::new("test".to_string(), arrays).await
     }
 
-    /// Broadcasting through the nd spine matches the v1 broadcast stream.
+    /// The encoded stream, decoded and broadcast, matches the v1 broadcast
+    /// stream (i.e. encode → decode → materialize is faithful).
     #[tokio::test]
-    async fn spine_matches_v1_broadcast() {
+    async fn encoded_stream_matches_v1_broadcast() {
         for batch_size in [usize::MAX, 6, 3] {
             let ds = test_dataset().await;
             let schema = build_dataset_schema(&ds.arrays);
@@ -170,12 +182,16 @@ mod tests {
                     .unwrap();
             let expected = concat_batches(&schema, &v1).unwrap();
 
-            let actual_batches: Vec<RecordBatch> =
-                any_dataset_as_broadcast_stream(AnyDataset::Regular(ds), batch_size)
+            let encoded: Vec<RecordBatch> =
+                any_dataset_as_encoded_stream(AnyDataset::Regular(ds), batch_size)
                     .try_collect()
                     .await
                     .unwrap();
-            let actual = concat_batches(&schema, &actual_batches).unwrap();
+            let materialized: Vec<RecordBatch> = encoded
+                .iter()
+                .map(|b| decode_nd_record_batch(b).unwrap().materialize().unwrap())
+                .collect();
+            let actual = concat_batches(&schema, &materialized).unwrap();
 
             assert_eq!(actual, expected, "batch_size={batch_size}");
             assert_eq!(actual.num_rows(), 12);

--- a/beacon-file-formats/beacon-nd-array/src/arrow/nd_provider.rs
+++ b/beacon-file-formats/beacon-nd-array/src/arrow/nd_provider.rs
@@ -10,21 +10,63 @@
 use std::sync::Arc;
 
 use arrow::datatypes::SchemaRef;
-use beacon_datafusion_ext::nd::exec::{NdBatchProvider, SendableNdBatchStream};
+use arrow::record_batch::RecordBatch;
+use beacon_datafusion_ext::nd::exec::{
+    NdBatchProvider, NdBroadcastExec, NdSourceExec, SendableNdBatchStream,
+};
 use beacon_datafusion_ext::nd::{Dimension, Dimensions, NdArrowArray, NdRecordBatch};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
-use futures::StreamExt;
+use datafusion::physical_plan::ExecutionPlan;
+use futures::stream::BoxStream;
+use futures::{StreamExt, TryStreamExt};
 
 use crate::arrow::array::ndarray_to_arrow_array;
 use crate::arrow::batch::{
-    build_dataset_schema, c_order_chunk_shape, extract_dataset_layout,
-    generate_array_subset_from_chunk, generate_chunk_subsets,
+    any_dataset_as_record_batch_stream, build_dataset_schema, c_order_chunk_shape,
+    extract_dataset_layout, generate_array_subset_from_chunk, generate_chunk_subsets,
 };
-use crate::dataset::Dataset;
+use crate::dataset::{AnyDataset, Dataset};
 
 fn exec_err(e: impl std::fmt::Display) -> DataFusionError {
     DataFusionError::Execution(e.to_string())
+}
+
+/// Broadcast a dataset to a flat `RecordBatch` stream through the nd
+/// execution-plan spine.
+///
+/// A regular dataset is fed through [`DatasetNdProvider`] → [`NdSourceExec`] →
+/// [`NdBroadcastExec`]: the source streams un-broadcast [`NdRecordBatch`]es and
+/// the broadcast node materializes them. A ragged dataset has no rectangular
+/// grid, so it stays on the v1 stream. This is the drop-in the file-format
+/// openers use in place of the v1 broadcast engine.
+///
+/// Predicate pushdown (chunk pruning) is intentionally not applied here — the
+/// nd spine has no filter node yet, and the scan reports filters as inexact so
+/// DataFusion keeps a `FilterExec` above it. Filtering will return to the spine
+/// later.
+pub fn any_dataset_as_broadcast_stream(
+    dataset: AnyDataset,
+    batch_size: usize,
+) -> BoxStream<'static, Result<RecordBatch>> {
+    match dataset {
+        AnyDataset::Regular(regular) => {
+            let provider =
+                Arc::new(DatasetNdProvider::new(regular, batch_size)) as Arc<dyn NdBatchProvider>;
+            let source = Arc::new(NdSourceExec::new(provider)) as Arc<dyn ExecutionPlan>;
+            // The nd nodes are pure data-flow here (no session state), so a
+            // default context is sufficient.
+            let result = NdBroadcastExec::try_new(source)
+                .and_then(|broadcast| broadcast.execute(0, Arc::new(TaskContext::default())));
+            match result {
+                Ok(stream) => stream.boxed(),
+                Err(e) => futures::stream::once(async move { Err(e) }).boxed(),
+            }
+        }
+        ragged => any_dataset_as_record_batch_stream(ragged, batch_size, None, None)
+            .map_err(exec_err)
+            .boxed(),
+    }
 }
 
 /// An [`NdBatchProvider`] over a regular (non-ragged) [`Dataset`].

--- a/beacon-file-formats/beacon-nd-array/src/arrow/nd_provider.rs
+++ b/beacon-file-formats/beacon-nd-array/src/arrow/nd_provider.rs
@@ -1,0 +1,200 @@
+//! Bridge from a [`Dataset`] to the nd execution-plan spine.
+//!
+//! [`DatasetNdProvider`] implements [`NdBatchProvider`] so a file format can
+//! feed a dataset straight into an `NdSourceExec`: it chunks the dataset in
+//! C-order and yields one [`NdRecordBatch`] per chunk with each variable left
+//! *un-broadcast* on its own dimensions. The `NdBroadcastExec` above the source
+//! is what later materializes the broadcast — this provider never expands the
+//! cross-product.
+
+use std::sync::Arc;
+
+use arrow::datatypes::SchemaRef;
+use beacon_datafusion_ext::nd::exec::{NdBatchProvider, SendableNdBatchStream};
+use beacon_datafusion_ext::nd::{Dimension, Dimensions, NdArrowArray, NdRecordBatch};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::TaskContext;
+use futures::StreamExt;
+
+use crate::arrow::array::ndarray_to_arrow_array;
+use crate::arrow::batch::{
+    build_dataset_schema, c_order_chunk_shape, extract_dataset_layout,
+    generate_array_subset_from_chunk, generate_chunk_subsets,
+};
+use crate::dataset::Dataset;
+
+fn exec_err(e: impl std::fmt::Display) -> DataFusionError {
+    DataFusionError::Execution(e.to_string())
+}
+
+/// An [`NdBatchProvider`] over a regular (non-ragged) [`Dataset`].
+#[derive(Debug)]
+pub struct DatasetNdProvider {
+    dataset: Dataset,
+    schema: SchemaRef,
+    batch_size: usize,
+}
+
+impl DatasetNdProvider {
+    /// `batch_size` is the target number of grid elements per chunk (the outer
+    /// axis is cut to approach it), mirroring the v1 stream.
+    pub fn new(dataset: Dataset, batch_size: usize) -> Self {
+        let schema = build_dataset_schema(&dataset.arrays);
+        Self {
+            dataset,
+            schema,
+            batch_size,
+        }
+    }
+}
+
+impl NdBatchProvider for DatasetNdProvider {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableNdBatchStream> {
+        let (max_dims, max_shape, chunk_shape) =
+            extract_dataset_layout(&self.dataset).map_err(exec_err)?;
+
+        // Honour a native chunk layout when present; otherwise cut the outer
+        // axis to approach `batch_size`.
+        let effective_chunk_shape = if chunk_shape != max_shape {
+            chunk_shape
+        } else {
+            c_order_chunk_shape(&max_shape, self.batch_size)
+        };
+
+        let subsets = generate_chunk_subsets(&max_shape, &effective_chunk_shape);
+        let arrays = Arc::new(self.dataset.arrays.clone());
+        let max_dims = Arc::new(max_dims);
+        let schema = self.schema.clone();
+
+        let stream = futures::stream::iter(subsets).then(move |subset| {
+            let arrays = arrays.clone();
+            let max_dims = max_dims.clone();
+            let schema = schema.clone();
+            async move {
+                // The chunk's target grid: the max dimensions cut to this
+                // chunk's extent.
+                let target = Dimensions::try_new(
+                    max_dims
+                        .iter()
+                        .zip(subset.shape.iter())
+                        .map(|(name, &size)| Dimension::new(name.as_str(), size))
+                        .collect(),
+                )?;
+
+                let mut columns = Vec::with_capacity(arrays.len());
+                for (name, array) in arrays.iter() {
+                    // Slice each variable to the part of the chunk that lies on
+                    // its own dimensions, then convert to a flat Arrow array.
+                    let array_subset =
+                        generate_array_subset_from_chunk(&subset, &max_dims, array.as_ref());
+                    let sliced = array.subset(array_subset).await.map_err(exec_err)?;
+                    let values = ndarray_to_arrow_array(sliced.as_ref())
+                        .await
+                        .map_err(exec_err)?;
+                    let dims = Dimensions::try_new(
+                        sliced
+                            .dimensions()
+                            .iter()
+                            .zip(sliced.shape().iter())
+                            .map(|(dim, &size)| Dimension::new(dim.as_str(), size))
+                            .collect(),
+                    )?;
+                    columns.push(NdArrowArray::try_new(values, dims).map_err(|e| {
+                        exec_err(format!("nd column '{name}': {e}"))
+                    })?);
+                }
+
+                NdRecordBatch::try_new(schema, columns, target)
+            }
+        });
+
+        Ok(Box::pin(stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::compute::concat_batches;
+    use arrow::record_batch::RecordBatch;
+    use beacon_datafusion_ext::nd::exec::{NdBroadcastExec, NdSourceExec};
+    use datafusion::execution::TaskContext;
+    use datafusion::physical_plan::ExecutionPlan;
+    use futures::TryStreamExt;
+    use indexmap::IndexMap;
+
+    use super::*;
+    use crate::arrow::batch::dataset_as_record_batch_stream;
+    use crate::{NdArray, NdArrayD};
+
+    async fn test_dataset() -> Dataset {
+        let time = NdArray::<i64>::try_new_from_vec_in_mem(
+            (0..4).map(|v| v * 100).collect(),
+            vec![4],
+            vec!["time".to_string()],
+            None,
+        )
+        .unwrap();
+        let lat = NdArray::<f64>::try_new_from_vec_in_mem(
+            vec![-30.0, 0.0, 30.0],
+            vec![3],
+            vec!["lat".to_string()],
+            None,
+        )
+        .unwrap();
+        let sst = NdArray::<f64>::try_new_from_vec_in_mem(
+            (0..12).map(|v| v as f64).collect(),
+            vec![4, 3],
+            vec!["time".to_string(), "lat".to_string()],
+            None,
+        )
+        .unwrap();
+
+        let mut arrays: IndexMap<String, Arc<dyn NdArrayD>> = IndexMap::new();
+        arrays.insert("time".to_string(), Arc::new(time));
+        arrays.insert("lat".to_string(), Arc::new(lat));
+        arrays.insert("sst".to_string(), Arc::new(sst));
+        Dataset::new("test".to_string(), arrays).await
+    }
+
+    /// The provider fed through NdSourceExec + NdBroadcastExec must produce the
+    /// same flat table as the v1 broadcast stream.
+    #[tokio::test]
+    async fn provider_matches_v1_broadcast() {
+        for batch_size in [usize::MAX, 6, 3] {
+            let ds = test_dataset().await;
+            let schema = build_dataset_schema(&ds.arrays);
+
+            let v1: Vec<RecordBatch> =
+                dataset_as_record_batch_stream(ds.clone(), batch_size, None, None)
+                    .try_collect()
+                    .await
+                    .unwrap();
+            let expected = concat_batches(&schema, &v1).unwrap();
+
+            let provider = DatasetNdProvider::new(ds, batch_size);
+            let source = Arc::new(NdSourceExec::new(Arc::new(provider)));
+            let plan: Arc<dyn ExecutionPlan> =
+                Arc::new(NdBroadcastExec::try_new(source).unwrap());
+            let actual_batches: Vec<RecordBatch> = plan
+                .execute(0, Arc::new(TaskContext::default()))
+                .unwrap()
+                .try_collect()
+                .await
+                .unwrap();
+            let actual = concat_batches(&plan.schema(), &actual_batches).unwrap();
+
+            assert_eq!(actual, expected, "batch_size={batch_size}");
+            assert_eq!(actual.num_rows(), 12);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a self-contained **N-dimensional execution spine** in `beacon-datafusion-ext::nd` and wires the netcdf and zarr readers through it. N-dimensional data now travels up the DataFusion plan as a real Arrow type (`beacon.nd`-encoded structs) carried by a standard `DataSourceExec`, with two dedicated plan nodes on top that decode and flatten it into an ordinary table.

## The pipeline

```
NdBroadcastExec          ← flattens nd arrays → a plain Arrow table
   └─ NdSourceExec        ← decodes beacon.nd structs → in-memory NdRecordBatch
        └─ DataSourceExec ← standard DF scan; its output schema is ENCODED
             └─ FileOpener ← reads the dataset, emits beacon.nd batches
```

Each nd variable (plus its named dimensions) is packed into one `beacon.nd` struct row — `Struct{ values: List<T>, dim_sizes: List<UInt32>, dim_names: List<Utf8> }` — so a batch of them rides through `DataSourceExec` like any other `RecordBatch`, keeping partitioning, projection pushdown, caching, and file-stats machinery. `NdSourceExec` decodes them into named-dimension arrays; `NdBroadcastExec` broadcasts each onto the shared grid (a single Arrow `take`, or a zero-copy clone on the identity) to produce the flat table the rest of the query sees. Both nodes carry DataFusion metrics.

## What's included

- **`beacon-datafusion-ext/src/nd/`** — the spine: `Dimensions`, `NdArrowArray` (flat values + named dims), `BroadcastMap` (name-aligned/xarray-style broadcast as per-axis strides), `NdRecordBatch`, the `beacon.nd` Arrow encoding (`encoding.rs`), and the `NdSourceExec`/`NdBroadcastExec` plan nodes.
- **`beacon-nd-array`** as an nd batch provider — chunks a regular dataset C-order into `beacon.nd`-encoded batches; ragged (CF contiguous) datasets fall back to run-length expansion wrapped on a synthetic `row` dim (identity broadcast).
- **netcdf + zarr wired end-to-end** — openers emit encoded batches and adapt in the encoded (struct) domain; `create_physical_plan` returns `NdBroadcastExec(NdSourceExec(DataSourceExec))`.
- **Metadata attributes as rank-0 scalars** — netcdf/zarr variable/global attributes (`<var>.<attr>`, `.<global>`) flow through as rank-0 `beacon.nd` columns that broadcast to constant columns across the grid.
- **CF `scale_factor`/`add_offset` in the netcdf reader** — new `ScaleOffsetVariableDecoder` decodes packed variables to `f64` (`raw*scale+offset`), with the fill value decoded by the same arithmetic so packed fill cells null out. This aligns netcdf with the zarr reader (both now decode scaled variables to `Float64`).

## Tests

End-to-end coverage for both formats:
- **Plan shape** — asserts the `NdBroadcastExec → NdSourceExec → DataSourceExec` nesting.
- **Variables + attributes** — a gridded variable comes back decoded (Float64) and rank-0 attributes broadcast to constant columns on every row.
- **Broadcast correctness** — a rank-0 attribute has exactly one distinct value across the full grid and is present on every row.
- **Scale/offset** — decoded SST lands in a physical kelvin range (raw packed int16 never would), plus decoder unit tests.

Full workspace: **819 passed / 0 failed**.

## Deferred (follow-ups)

- Filter/projection execs + optimizer on the spine (filter on un-broadcast coordinate axes to avoid materializing the cross-product) — currently filters sit above `NdBroadcastExec` as inexact `FilterExec`.
- REE / lazy broadcast output for replicated axes.
- True run-length ragged broadcast (currently an identity round-trip).
- `valid_min`/`valid_max` range masking (neither reader applies it today).