### PR TITLE
nd projection pushdown: evaluate element-wise projections before the broadcast

### DIFF
--- a/beacon-config/src/lib.rs
+++ b/beacon-config/src/lib.rs
@@ -99,6 +99,12 @@ pub struct SqlConfig {
     pub enable: bool,
     pub default_table: String,
     pub enable_pushdown_projection: bool,
+    /// Enable the N-dimensional pipeline optimizer: the physical rule that
+    /// replaces plan nodes above the nd broadcast (e.g. sinking element-wise
+    /// projections into an `NdProjectionExec`) when it can. The base nd pipeline
+    /// (`NdSourceExec` → `NdBroadcastExec`) always runs regardless; this only
+    /// gates the node-rewriting optimizations.
+    pub enable_nd_pipeline: bool,
     pub stream_coalesce: SqlStreamCoalesceConfig,
     /// Storage engine used for managed `CREATE TABLE` when the statement does not
     /// override it (via `SET beacon.table_engine = '…'`).
@@ -375,6 +381,8 @@ struct RawConfig {
     max_age: u64,
     #[envconfig(from = "BEACON_ENABLE_PUSHDOWN_PROJECTION", default = "true")]
     enable_pushdown_projection: bool,
+    #[envconfig(from = "BEACON_ENABLE_ND_PIPELINE", default = "false")]
+    enable_nd_pipeline: bool,
 
     /// Root directory for Beacon's local data (datasets, tables, tmp, etc.).
     #[envconfig(from = "BEACON_DATA_DIR", default = "./data")]
@@ -475,6 +483,7 @@ impl From<RawConfig> for Config {
                 enable: raw.enable_sql,
                 default_table: raw.default_table,
                 enable_pushdown_projection: raw.enable_pushdown_projection,
+                enable_nd_pipeline: raw.enable_nd_pipeline,
                 stream_coalesce: SqlStreamCoalesceConfig {
                     enabled: raw.sql_stream_coalesce_enabled,
                     target_rows: raw.sql_stream_coalesce_target_rows,

--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -363,6 +363,9 @@ impl Runtime {
         // (always-local) one used for each table's `table.json`.
         let lance_warehouse = Arc::new(beacon_lance::LanceWarehouse::new(tables_store));
 
+        // Captured before `app_config` is moved into the session config below.
+        let enable_nd_pipeline = app_config.sql.enable_nd_pipeline;
+
         let mut config = SessionConfig::new()
             .with_batch_size(app_config.runtime.batch_size)
             .with_coalesce_batches(true)
@@ -424,7 +427,7 @@ impl Runtime {
         // the state is built, so it is created with an empty cell that is filled
         // immediately afterwards (a `Weak`, to avoid a reference cycle).
         let session_cell = crate::statement_plan::new_session_cell();
-        let session_state = SessionStateBuilder::new()
+        let mut state_builder = SessionStateBuilder::new()
             .with_config(config)
             .with_runtime_env(runtime_env)
             .with_default_features()
@@ -432,14 +435,22 @@ impl Runtime {
             // optimizer rule set with the `FederationOptimizerRule` inserted, so
             // sub-plans rooted at remote tables get pushed down. The matching
             // `FederatedPlanner` lives in `BeaconQueryPlanner`'s extension planners.
-            .with_optimizer_rules(datafusion_federation::default_optimizer_rules())
-            // Sink element-wise projections below the nd broadcast so they run
-            // on un-broadcast coordinate axes instead of the full grid. Appended
-            // after the default physical rules, so it sees the planned
-            // `ProjectionExec` above `NdBroadcastExec`.
-            .with_physical_optimizer_rule(Arc::new(
+            .with_optimizer_rules(datafusion_federation::default_optimizer_rules());
+
+        // Opt-in nd-pipeline optimizer (BEACON_ENABLE_ND_PIPELINE): sink
+        // element-wise projections below the nd broadcast so they run on
+        // un-broadcast coordinate axes instead of the full grid. Appended after
+        // the default physical rules, so it sees the planned `ProjectionExec`
+        // above `NdBroadcastExec`. The base pipeline (`NdSourceExec` →
+        // `NdBroadcastExec`) is emitted by the formats and always runs; only this
+        // node-rewriting rule is gated.
+        if enable_nd_pipeline {
+            state_builder = state_builder.with_physical_optimizer_rule(Arc::new(
                 beacon_datafusion_ext::nd::NdProjectionPushdown::new(),
-            ))
+            ));
+        }
+
+        let session_state = state_builder
             .with_query_planner(Arc::new(crate::statement_plan::BeaconQueryPlanner::new(
                 session_cell.clone(),
             )))

--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -433,6 +433,13 @@ impl Runtime {
             // sub-plans rooted at remote tables get pushed down. The matching
             // `FederatedPlanner` lives in `BeaconQueryPlanner`'s extension planners.
             .with_optimizer_rules(datafusion_federation::default_optimizer_rules())
+            // Sink element-wise projections below the nd broadcast so they run
+            // on un-broadcast coordinate axes instead of the full grid. Appended
+            // after the default physical rules, so it sees the planned
+            // `ProjectionExec` above `NdBroadcastExec`.
+            .with_physical_optimizer_rule(Arc::new(
+                beacon_datafusion_ext::nd::NdProjectionPushdown::new(),
+            ))
             .with_query_planner(Arc::new(crate::statement_plan::BeaconQueryPlanner::new(
                 session_cell.clone(),
             )))

--- a/beacon-datafusion-ext/src/nd/array.rs
+++ b/beacon-datafusion-ext/src/nd/array.rs
@@ -54,6 +54,14 @@ impl NdArrowArray {
     /// zero-copy clone when the broadcast is the identity).
     pub fn materialize(&self, target: &Dimensions) -> Result<ArrayRef> {
         let map = self.broadcast_map(target)?;
+        self.materialize_with_map(&map)
+    }
+
+    /// Materialize using a precomputed [`BroadcastMap`] (from
+    /// [`broadcast_map`](Self::broadcast_map)). Zero-copy when the map is the
+    /// identity; otherwise a single gather. Lets callers inspect the map first
+    /// (e.g. to count implicit broadcasts) without recomputing it.
+    pub fn materialize_with_map(&self, map: &BroadcastMap) -> Result<ArrayRef> {
         if map.is_identity() {
             return Ok(self.values.clone());
         }

--- a/beacon-datafusion-ext/src/nd/batch.rs
+++ b/beacon-datafusion-ext/src/nd/batch.rs
@@ -80,15 +80,34 @@ impl NdRecordBatch {
     /// column onto the target grid (a single gather per column, or a zero-copy
     /// pass-through for a column already at full rank).
     pub fn materialize(&self) -> Result<RecordBatch> {
+        Ok(self.materialize_with_stats()?.0)
+    }
+
+    /// Like [`materialize`](Self::materialize), but also returns how many columns
+    /// required an actual broadcast gather versus passed through zero-copy (an
+    /// identity broadcast, i.e. already at full rank). Used to report implicit
+    /// broadcasts as plan metrics.
+    pub fn materialize_with_stats(&self) -> Result<(RecordBatch, usize, usize)> {
+        let mut broadcasts = 0usize;
+        let mut passthroughs = 0usize;
         let arrays: Vec<ArrayRef> = self
             .columns
             .iter()
-            .map(|column| column.materialize(&self.target))
+            .map(|column| {
+                let map = column.broadcast_map(&self.target)?;
+                if map.is_identity() {
+                    passthroughs += 1;
+                } else {
+                    broadcasts += 1;
+                }
+                column.materialize_with_map(&map)
+            })
             .collect::<Result<_>>()?;
 
         let options = RecordBatchOptions::new().with_row_count(Some(self.num_rows()));
-        RecordBatch::try_new_with_options(self.schema.clone(), arrays, &options)
-            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+        let batch = RecordBatch::try_new_with_options(self.schema.clone(), arrays, &options)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        Ok((batch, broadcasts, passthroughs))
     }
 }
 

--- a/beacon-datafusion-ext/src/nd/exec/broadcast_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/broadcast_exec.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 use datafusion::common::plan_err;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
-use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
+};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
 };
@@ -89,7 +91,19 @@ impl ExecutionPlan for NdBroadcastExec {
             .expect("validated in try_new")
             .execute_nd(partition, context)?;
         let baseline = BaselineMetrics::new(&self.metrics, partition);
-        Ok(materialize_nd_stream(self.input.schema(), stream, baseline))
+        // Per-column materialization outcome: a real broadcast gather, or a
+        // zero-copy pass-through of an already-full-rank column.
+        let broadcasts =
+            MetricBuilder::new(&self.metrics).counter("implicit_broadcasts", partition);
+        let passthroughs =
+            MetricBuilder::new(&self.metrics).counter("passthrough_columns", partition);
+        Ok(materialize_nd_stream(
+            self.input.schema(),
+            stream,
+            baseline,
+            broadcasts,
+            passthroughs,
+        ))
     }
 
     fn metrics(&self) -> Option<MetricsSet> {

--- a/beacon-datafusion-ext/src/nd/exec/mod.rs
+++ b/beacon-datafusion-ext/src/nd/exec/mod.rs
@@ -8,6 +8,7 @@
 //! also a correct plan on its own.
 
 mod broadcast_exec;
+mod projection_exec;
 mod source_exec;
 
 use std::sync::Arc;
@@ -24,6 +25,7 @@ use futures::stream::BoxStream;
 use super::batch::NdRecordBatch;
 
 pub use broadcast_exec::NdBroadcastExec;
+pub use projection_exec::NdProjectionExec;
 pub use source_exec::NdSourceExec;
 
 /// Stream of nd batches exchanged between nd-aware operators.
@@ -45,6 +47,9 @@ pub fn as_nd_plan(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn NdExecutionPl
     let any = plan.as_any();
     if let Some(source) = any.downcast_ref::<NdSourceExec>() {
         return Some(Arc::new(source.clone()));
+    }
+    if let Some(projection) = any.downcast_ref::<NdProjectionExec>() {
+        return Some(Arc::new(projection.clone()));
     }
     None
 }

--- a/beacon-datafusion-ext/src/nd/exec/mod.rs
+++ b/beacon-datafusion-ext/src/nd/exec/mod.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use arrow::record_batch::RecordBatch;
 use datafusion::error::Result;
 use datafusion::execution::TaskContext;
-use datafusion::physical_plan::metrics::BaselineMetrics;
+use datafusion::physical_plan::metrics::{BaselineMetrics, Count};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 use futures::StreamExt;
@@ -56,11 +56,15 @@ pub fn as_nd_plan(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn NdExecutionPl
 
 /// Adapt an nd batch stream into a standard record batch stream, dropping
 /// empty batches and recording output rows / materialization time into
-/// `baseline`.
+/// `baseline`. Per batch, each column is either broadcast with a gather
+/// (counted in `broadcasts`) or passed through zero-copy because it is already
+/// at full rank (counted in `passthroughs`).
 pub fn materialize_nd_stream(
     schema: arrow::datatypes::SchemaRef,
     stream: SendableNdBatchStream,
     baseline: BaselineMetrics,
+    broadcasts: Count,
+    passthroughs: Count,
 ) -> SendableRecordBatchStream {
     // `baseline` is moved into this synchronous closure once and borrowed per
     // item; it is dropped when the stream ends, which records the end time.
@@ -72,9 +76,11 @@ pub fn materialize_nd_stream(
                         return None;
                     }
                     let _timer = baseline.elapsed_compute().timer();
-                    match batch.materialize() {
-                        Ok(record_batch) => {
+                    match batch.materialize_with_stats() {
+                        Ok((record_batch, batch_broadcasts, batch_passthroughs)) => {
                             baseline.record_output(record_batch.num_rows());
+                            broadcasts.add(batch_broadcasts);
+                            passthroughs.add(batch_passthroughs);
                             Some(Ok(record_batch))
                         }
                         Err(e) => Some(Err(e)),

--- a/beacon-datafusion-ext/src/nd/exec/projection_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/projection_exec.rs
@@ -1,0 +1,302 @@
+//! Projection evaluated *before* broadcast.
+//!
+//! A projection expression is element-wise: the value at grid cell `(t, y, x)`
+//! depends only on its input columns' values at `(t, y, x)`. So instead of
+//! broadcasting every input column onto the full grid and then evaluating (the
+//! job of a plain `ProjectionExec` above [`NdBroadcastExec`]), we evaluate each
+//! expression on the *minimal* sub-grid its inputs span — its **footprint**, the
+//! union of the referenced columns' dimensions — and emit the result as a new nd
+//! column on that footprint. [`NdBroadcastExec`] then broadcasts the (smaller)
+//! result onto the full grid.
+//!
+//! Broadcasting commutes with element-wise evaluation, so the output is
+//! identical to evaluating on the full grid — but a projection touching only a
+//! coordinate axis (e.g. `lat * 2`) evaluates over `|lat|` elements instead of
+//! the full `time·lat·lon` cross-product.
+
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, RecordBatch, RecordBatchOptions};
+use arrow::datatypes::{Field, Schema, SchemaRef};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::utils::{collect_columns, reassign_expr_columns};
+use datafusion::physical_expr::{EquivalenceProperties, PhysicalExpr};
+use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
+};
+use futures::StreamExt;
+
+use crate::nd::array::NdArrowArray;
+use crate::nd::batch::NdRecordBatch;
+use crate::nd::dimensions::Dimensions;
+
+use super::{NdBroadcastExec, NdExecutionPlan, SendableNdBatchStream, as_nd_plan};
+
+/// One output column: an expression rewritten to reference only the columns it
+/// uses, plus the indices of those columns in the child's schema.
+#[derive(Debug, Clone)]
+struct ProjectionColumn {
+    /// The expression, with its `Column`s reindexed against `compact_schema`.
+    expr: Arc<dyn PhysicalExpr>,
+    /// Fields of the referenced input columns, in child-schema order.
+    compact_schema: SchemaRef,
+    /// Indices (into the child batch) of the referenced input columns, aligned
+    /// with `compact_schema`.
+    input_indices: Vec<usize>,
+}
+
+/// Projects a list of element-wise expressions over un-broadcast nd batches,
+/// evaluating each on its footprint sub-grid. Requires an nd-aware child and is
+/// itself nd-aware, so it slots between [`NdSourceExec`](super::NdSourceExec) and
+/// [`NdBroadcastExec`].
+#[derive(Debug, Clone)]
+pub struct NdProjectionExec {
+    /// nd-aware child producing the input nd batches.
+    input: Arc<dyn ExecutionPlan>,
+    /// Output expressions with their aliases, as given (drives display and
+    /// `with_new_children`).
+    exprs: Vec<(Arc<dyn PhysicalExpr>, String)>,
+    /// Per-output-column evaluation plan (derived from `exprs`).
+    columns: Vec<ProjectionColumn>,
+    /// Output (projected) schema.
+    schema: SchemaRef,
+    properties: Arc<PlanProperties>,
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl NdProjectionExec {
+    /// Build a projection over an nd-aware `input`. `exprs` are `(expr, alias)`
+    /// pairs; each expression must be evaluable against `input`'s schema. The
+    /// output schema is derived from the expressions.
+    pub fn try_new(
+        input: Arc<dyn ExecutionPlan>,
+        exprs: Vec<(Arc<dyn PhysicalExpr>, String)>,
+    ) -> Result<Self> {
+        Self::try_new_with_schema(input, exprs, None)
+    }
+
+    /// Like [`try_new`](Self::try_new), but adopts `output_schema` verbatim when
+    /// provided. The pushdown rule passes the `ProjectionExec`'s exact schema so
+    /// the rewrite preserves field metadata and the optimizer's schema check
+    /// holds. When `None`, the schema is derived from the expressions.
+    pub fn try_new_with_schema(
+        input: Arc<dyn ExecutionPlan>,
+        exprs: Vec<(Arc<dyn PhysicalExpr>, String)>,
+        output_schema: Option<SchemaRef>,
+    ) -> Result<Self> {
+        if as_nd_plan(&input).is_none() {
+            return Err(DataFusionError::Plan(format!(
+                "NdProjectionExec requires an nd-aware input, got {}",
+                input.name()
+            )));
+        }
+        let input_schema = input.schema();
+
+        let mut fields = Vec::with_capacity(exprs.len());
+        let mut columns = Vec::with_capacity(exprs.len());
+        for (expr, alias) in &exprs {
+            fields.push(Field::new(
+                alias,
+                expr.data_type(&input_schema)?,
+                expr.nullable(&input_schema)?,
+            ));
+
+            // Referenced input columns, sorted by their child-schema index, form
+            // a compact schema; reindex the expression's `Column`s onto it so it
+            // can be evaluated against a batch of just those columns.
+            let mut input_indices: Vec<usize> =
+                collect_columns(expr).iter().map(|c| c.index()).collect();
+            input_indices.sort_unstable();
+            input_indices.dedup();
+            let compact_schema = Arc::new(Schema::new(
+                input_indices
+                    .iter()
+                    .map(|&i| input_schema.field(i).clone())
+                    .collect::<Vec<_>>(),
+            ));
+            let expr = reassign_expr_columns(expr.clone(), &compact_schema)?;
+            columns.push(ProjectionColumn {
+                expr,
+                compact_schema,
+                input_indices,
+            });
+        }
+
+        let derived = Arc::new(Schema::new(fields));
+        let schema = match output_schema {
+            Some(provided) => {
+                // The provided schema must be type-compatible with the derived
+                // one; only field metadata may differ.
+                if provided.fields().len() != derived.fields().len()
+                    || provided
+                        .fields()
+                        .iter()
+                        .zip(derived.fields().iter())
+                        .any(|(a, b)| a.data_type() != b.data_type())
+                {
+                    return Err(DataFusionError::Plan(format!(
+                        "NdProjectionExec output schema {provided:?} is incompatible with the \
+                         projected expressions {derived:?}"
+                    )));
+                }
+                provided
+            }
+            None => derived,
+        };
+        let properties = Arc::new(
+            input
+                .properties()
+                .as_ref()
+                .clone()
+                .with_eq_properties(EquivalenceProperties::new(schema.clone())),
+        );
+        Ok(Self {
+            input,
+            exprs,
+            columns,
+            schema,
+            properties,
+            metrics: ExecutionPlanMetricsSet::new(),
+        })
+    }
+
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    pub fn expressions(&self) -> &[(Arc<dyn PhysicalExpr>, String)] {
+        &self.exprs
+    }
+
+    /// Project one nd batch: evaluate every output column on its footprint grid.
+    fn project_batch(&self, batch: &NdRecordBatch) -> Result<NdRecordBatch> {
+        let target = batch.target();
+        let mut projected = Vec::with_capacity(self.columns.len());
+
+        for column in &self.columns {
+            // Footprint = the target axes referenced by this expression's input
+            // columns, kept in target order so the sub-grid is C-order-consistent
+            // with the full grid.
+            let footprint = footprint_of(target, batch, &column.input_indices)?;
+
+            // Co-broadcast the referenced columns onto the footprint so they
+            // align element-wise, then evaluate.
+            let arrays: Vec<ArrayRef> = column
+                .input_indices
+                .iter()
+                .map(|&i| batch.column(i).materialize(&footprint))
+                .collect::<Result<_>>()?;
+            let options =
+                RecordBatchOptions::new().with_row_count(Some(footprint.num_elements()));
+            let compact = RecordBatch::try_new_with_options(
+                column.compact_schema.clone(),
+                arrays,
+                &options,
+            )
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+
+            let values = column
+                .expr
+                .evaluate(&compact)?
+                .into_array(footprint.num_elements())?;
+            projected.push(NdArrowArray::try_new(values, footprint)?);
+        }
+
+        NdRecordBatch::try_new(self.schema.clone(), projected, target.clone())
+    }
+}
+
+/// The union of the dimensions of the columns at `input_indices`, ordered by
+/// their position in `target`.
+fn footprint_of(
+    target: &Dimensions,
+    batch: &NdRecordBatch,
+    input_indices: &[usize],
+) -> Result<Dimensions> {
+    let referenced: std::collections::HashSet<&str> = input_indices
+        .iter()
+        .flat_map(|&i| batch.column(i).dims().iter().map(|d| d.name()))
+        .collect();
+    Dimensions::try_new(
+        target
+            .iter()
+            .filter(|d| referenced.contains(d.name()))
+            .cloned()
+            .collect(),
+    )
+}
+
+impl DisplayAs for NdProjectionExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let cols: Vec<String> = self.exprs.iter().map(|(_, alias)| alias.clone()).collect();
+        write!(f, "NdProjectionExec: exprs=[{}]", cols.join(", "))
+    }
+}
+
+impl ExecutionPlan for NdProjectionExec {
+    fn name(&self) -> &str {
+        "NdProjectionExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let [input] = <[_; 1]>::try_from(children).map_err(|_| {
+            DataFusionError::Internal("NdProjectionExec expects exactly one child".to_string())
+        })?;
+        Ok(Arc::new(Self::try_new(input, self.exprs.clone())?))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        // Standalone: borrow NdBroadcastExec's materialization rather than
+        // duplicating it.
+        NdBroadcastExec::try_new(Arc::new(self.clone()))?.execute(partition, context)
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+}
+
+impl NdExecutionPlan for NdProjectionExec {
+    fn execute_nd(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableNdBatchStream> {
+        let baseline = BaselineMetrics::new(&self.metrics, partition);
+        let this = self.clone();
+        let stream = as_nd_plan(&self.input)
+            .expect("validated in try_new")
+            .execute_nd(partition, context)?
+            .map(move |item| {
+                let _timer = baseline.elapsed_compute().timer();
+                let batch = item?;
+                let projected = this.project_batch(&batch)?;
+                baseline.record_output(projected.num_rows());
+                Ok(projected)
+            });
+        Ok(Box::pin(stream))
+    }
+}

--- a/beacon-datafusion-ext/src/nd/exec/projection_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/projection_exec.rs
@@ -392,17 +392,75 @@ impl NdExecutionPlan for NdProjectionExec {
 
 #[cfg(test)]
 mod tests {
+    use std::any::Any;
     use std::sync::Arc;
 
     use arrow::array::{ArrayRef, AsArray, Int32Array};
     use arrow::datatypes::{DataType, Field, Int32Type, Schema, SchemaRef};
-    use datafusion::logical_expr::Operator;
+    use datafusion::common::config::ConfigOptions;
+    use datafusion::logical_expr::{
+        ColumnarValue, Operator, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
+        Volatility,
+    };
+    use datafusion::physical_expr::ScalarFunctionExpr;
     use datafusion::physical_expr::expressions::{binary, col, lit};
     use datafusion::physical_plan::metrics::Count;
 
     use crate::nd::dimensions::Dimension;
 
     use super::*;
+
+    /// A minimal element-wise scalar function that sums all its Int32 arguments
+    /// (arrays and/or scalars) row-wise — enough to exercise projection over
+    /// functions without pulling in datafusion-functions.
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    struct SumUdf {
+        signature: Signature,
+    }
+
+    impl SumUdf {
+        fn new() -> Self {
+            Self {
+                signature: Signature::variadic_any(Volatility::Immutable),
+            }
+        }
+    }
+
+    impl ScalarUDFImpl for SumUdf {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn name(&self) -> &str {
+            "test_sum"
+        }
+        fn signature(&self) -> &Signature {
+            &self.signature
+        }
+        fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+            Ok(DataType::Int32)
+        }
+        fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+            let n = args.number_rows;
+            let mut sums = vec![0i32; n];
+            for arg in &args.args {
+                let array = arg.clone().into_array(n)?;
+                let column = array.as_primitive::<Int32Type>();
+                for (i, s) in sums.iter_mut().enumerate() {
+                    *s += column.value(i);
+                }
+            }
+            Ok(ColumnarValue::Array(Arc::new(Int32Array::from(sums))))
+        }
+    }
+
+    /// Build `test_sum(args...)` as a physical expression against `schema`.
+    fn sum_fn(args: Vec<Arc<dyn PhysicalExpr>>, schema: &Schema) -> Arc<dyn PhysicalExpr> {
+        let udf = Arc::new(ScalarUDF::new_from_impl(SumUdf::new()));
+        Arc::new(
+            ScalarFunctionExpr::try_new(udf, args, schema, Arc::new(ConfigOptions::default()))
+                .unwrap(),
+        )
+    }
 
     fn dims(spec: &[(&str, usize)]) -> Dimensions {
         Dimensions::try_new(
@@ -531,5 +589,79 @@ mod tests {
         assert_eq!(m.broadcasts.value(), 2);
         assert_eq!(m.elements_evaluated.value(), 6);
         assert_eq!(m.elements_saved.value(), 0); // footprint == full grid
+    }
+
+    // ── scalar functions ────────────────────────────────────────────────
+
+    /// A function over a single column takes the fast path: footprint is that
+    /// column's own dims, no co-broadcast.
+    #[test]
+    fn function_of_single_column_does_not_broadcast() {
+        let (schema, batch) = test_batch();
+        let expr = sum_fn(vec![col("lat", &schema).unwrap()], &schema);
+        let column = ProjectionColumn::build(&schema, &expr).unwrap();
+        let m = metrics();
+
+        let out = column.project(&batch, batch.target(), &m).unwrap();
+        assert_eq!(out.dims(), &dims(&[("lat", 3)]));
+        assert_eq!(ints(out.values()), vec![10, 20, 30]);
+        assert_eq!(m.broadcasts.value(), 0);
+        assert_eq!(m.elements_evaluated.value(), 3);
+    }
+
+    /// A function over two columns on different axes unions their footprint and
+    /// co-broadcasts both onto it before evaluating.
+    #[test]
+    fn function_of_two_columns_co_broadcasts() {
+        let (schema, batch) = test_batch();
+        let expr = sum_fn(
+            vec![col("lat", &schema).unwrap(), col("lon", &schema).unwrap()],
+            &schema,
+        );
+        let column = ProjectionColumn::build(&schema, &expr).unwrap();
+        let m = metrics();
+
+        let out = column.project(&batch, batch.target(), &m).unwrap();
+        assert_eq!(out.dims(), &dims(&[("lat", 3), ("lon", 2)]));
+        assert_eq!(ints(out.values()), vec![11, 12, 21, 22, 31, 32]);
+        assert_eq!(m.broadcasts.value(), 2);
+        assert_eq!(m.elements_evaluated.value(), 6);
+    }
+
+    /// A function over one column plus a scalar literal references only that one
+    /// column, so it stays on the fast path — the literal adds no dimensions and
+    /// nothing is broadcast up front.
+    #[test]
+    fn function_of_column_and_scalar_does_not_broadcast() {
+        let (schema, batch) = test_batch();
+        let expr = sum_fn(vec![col("lat", &schema).unwrap(), lit(100i32)], &schema);
+        let column = ProjectionColumn::build(&schema, &expr).unwrap();
+        // Only `lat` is a referenced column; the literal is folded into the expr.
+        assert_eq!(column.input_indices, vec![0]);
+        let m = metrics();
+
+        let out = column.project(&batch, batch.target(), &m).unwrap();
+        assert_eq!(out.dims(), &dims(&[("lat", 3)])); // footprint = lat's dims
+        assert_eq!(ints(out.values()), vec![110, 120, 130]);
+        assert_eq!(m.broadcasts.value(), 0); // no up-front broadcast
+        assert_eq!(m.elements_evaluated.value(), 3); // evaluated over |lat|, not the grid
+    }
+
+    /// A function over only literals references no columns: it evaluates once on
+    /// a rank-0 scalar footprint and broadcasts to a constant column.
+    #[test]
+    fn function_of_only_scalars_is_rank_zero() {
+        let (schema, batch) = test_batch();
+        let expr = sum_fn(vec![lit(1i32), lit(2i32)], &schema);
+        let column = ProjectionColumn::build(&schema, &expr).unwrap();
+        assert!(column.input_indices.is_empty());
+        let m = metrics();
+
+        let out = column.project(&batch, batch.target(), &m).unwrap();
+        assert_eq!(out.dims().rank(), 0); // scalar
+        assert_eq!(ints(out.values()), vec![3]);
+        assert_eq!(m.broadcasts.value(), 0);
+        assert_eq!(m.elements_evaluated.value(), 1);
+        assert_eq!(m.elements_saved.value(), 5); // 6-cell grid minus the 1 scalar
     }
 }

--- a/beacon-datafusion-ext/src/nd/exec/projection_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/projection_exec.rs
@@ -269,8 +269,17 @@ impl ExecutionPlan for NdProjectionExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        // Standalone: borrow NdBroadcastExec's materialization rather than
-        // duplicating it.
+        // This node's real output is the un-broadcast `NdRecordBatch` stream from
+        // `execute_nd`; the generic `ExecutionPlan::execute` must instead yield
+        // flat Arrow `RecordBatch`es, and broadcasting is the only thing that
+        // flattens them. So a standalone execution wraps this node in an
+        // `NdBroadcastExec` to materialize.
+        //
+        // This is *not* structural coupling: it is only the fallback for when the
+        // node is a plan root with nothing broadcasting above it. In a real plan
+        // an `NdBroadcastExec` sits at the top and pulls this node's `execute_nd`
+        // directly (through any nd operators in between), so this path is never
+        // taken — the broadcast stays a separate, single terminal node.
         NdBroadcastExec::try_new(Arc::new(self.clone()))?.execute(partition, context)
     }
 

--- a/beacon-datafusion-ext/src/nd/exec/projection_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/projection_exec.rs
@@ -24,7 +24,9 @@ use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr::utils::{collect_columns, reassign_expr_columns};
 use datafusion::physical_expr::{EquivalenceProperties, PhysicalExpr};
-use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
+};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
 };
@@ -35,6 +37,16 @@ use crate::nd::batch::NdRecordBatch;
 use crate::nd::dimensions::Dimensions;
 
 use super::{NdBroadcastExec, NdExecutionPlan, SendableNdBatchStream, as_nd_plan};
+
+/// Per-partition metric counters recorded while projecting.
+struct ProjectionMetrics {
+    /// Total elements the expressions were evaluated over (∑ footprint sizes).
+    elements_evaluated: Count,
+    /// Elements avoided versus evaluating on the full grid (∑ target − footprint).
+    elements_saved: Count,
+    /// Implicit gathers to co-broadcast referenced columns onto their footprint.
+    broadcasts: Count,
+}
 
 /// One output column: an expression rewritten to reference only the columns it
 /// uses, plus the indices of those columns in the child's schema.
@@ -172,8 +184,14 @@ impl NdProjectionExec {
         &self.exprs
     }
 
-    /// Project one nd batch: evaluate every output column on its footprint grid.
-    fn project_batch(&self, batch: &NdRecordBatch) -> Result<NdRecordBatch> {
+    /// Project one nd batch: evaluate every output column on its footprint grid,
+    /// recording the work done (elements evaluated, elements saved versus the
+    /// full grid, and implicit co-broadcasts) into `metrics`.
+    fn project_batch(
+        &self,
+        batch: &NdRecordBatch,
+        metrics: &ProjectionMetrics,
+    ) -> Result<NdRecordBatch> {
         let target = batch.target();
         let mut projected = Vec::with_capacity(self.columns.len());
 
@@ -183,12 +201,28 @@ impl NdProjectionExec {
             // with the full grid.
             let footprint = footprint_of(target, batch, &column.input_indices)?;
 
+            // The expression runs over the footprint instead of the full grid;
+            // the difference is the work the pushdown avoided.
+            metrics.elements_evaluated.add(footprint.num_elements());
+            metrics
+                .elements_saved
+                .add(target.num_elements().saturating_sub(footprint.num_elements()));
+
             // Co-broadcast the referenced columns onto the footprint so they
-            // align element-wise, then evaluate.
+            // align element-wise, then evaluate. A referenced column on fewer
+            // axes than the footprint needs a real gather (an implicit
+            // broadcast); one already spanning the footprint passes through.
             let arrays: Vec<ArrayRef> = column
                 .input_indices
                 .iter()
-                .map(|&i| batch.column(i).materialize(&footprint))
+                .map(|&i| {
+                    let source = batch.column(i);
+                    let map = source.broadcast_map(&footprint)?;
+                    if !map.is_identity() {
+                        metrics.broadcasts.add(1);
+                    }
+                    source.materialize_with_map(&map)
+                })
                 .collect::<Result<_>>()?;
             let options =
                 RecordBatchOptions::new().with_row_count(Some(footprint.num_elements()));
@@ -295,6 +329,14 @@ impl NdExecutionPlan for NdProjectionExec {
         context: Arc<TaskContext>,
     ) -> Result<SendableNdBatchStream> {
         let baseline = BaselineMetrics::new(&self.metrics, partition);
+        let projection_metrics = ProjectionMetrics {
+            elements_evaluated: MetricBuilder::new(&self.metrics)
+                .counter("elements_evaluated", partition),
+            elements_saved: MetricBuilder::new(&self.metrics)
+                .counter("elements_saved", partition),
+            broadcasts: MetricBuilder::new(&self.metrics)
+                .counter("implicit_broadcasts", partition),
+        };
         let this = self.clone();
         let stream = as_nd_plan(&self.input)
             .expect("validated in try_new")
@@ -302,7 +344,7 @@ impl NdExecutionPlan for NdProjectionExec {
             .map(move |item| {
                 let _timer = baseline.elapsed_compute().timer();
                 let batch = item?;
-                let projected = this.project_batch(&batch)?;
+                let projected = this.project_batch(&batch, &projection_metrics)?;
                 baseline.record_output(projected.num_rows());
                 Ok(projected)
             });

--- a/beacon-datafusion-ext/src/nd/exec/projection_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/projection_exec.rs
@@ -49,6 +49,16 @@ struct ProjectionMetrics {
     broadcasts: Count,
 }
 
+impl ProjectionMetrics {
+    /// Record one output column: `evaluated` elements over its footprint (out of
+    /// `target` on the full grid), and `broadcasts` implicit co-broadcasts.
+    fn record(&self, evaluated: usize, target: usize, broadcasts: usize) {
+        self.elements_evaluated.add(evaluated);
+        self.elements_saved.add(target.saturating_sub(evaluated));
+        self.broadcasts.add(broadcasts);
+    }
+}
+
 /// One output column: an expression rewritten to reference only the columns it
 /// uses, plus the indices of those columns in the child's schema.
 #[derive(Debug, Clone)]
@@ -63,6 +73,91 @@ struct ProjectionColumn {
     /// True when `expr` is a bare column reference — the input nd column can be
     /// reused directly, skipping evaluation entirely.
     passthrough: bool,
+}
+
+impl ProjectionColumn {
+    /// Analyze one expression against the child schema: collect the columns it
+    /// references, build a compact schema of just those, and reindex the
+    /// expression's `Column`s onto it so it can be evaluated against a batch of
+    /// only the referenced columns.
+    fn build(input_schema: &SchemaRef, expr: &Arc<dyn PhysicalExpr>) -> Result<Self> {
+        let mut input_indices: Vec<usize> =
+            collect_columns(expr).iter().map(|c| c.index()).collect();
+        input_indices.sort_unstable();
+        input_indices.dedup();
+        let compact_schema = Arc::new(Schema::new(
+            input_indices
+                .iter()
+                .map(|&i| input_schema.field(i).clone())
+                .collect::<Vec<_>>(),
+        ));
+        let expr = reassign_expr_columns(expr.clone(), &compact_schema)?;
+        let passthrough = expr.as_any().is::<Column>();
+        Ok(Self {
+            expr,
+            compact_schema,
+            input_indices,
+            passthrough,
+        })
+    }
+
+    /// Project this column from one nd batch onto the minimal footprint grid,
+    /// returning an nd column and recording work into `metrics`.
+    fn project(
+        &self,
+        batch: &NdRecordBatch,
+        target: &Dimensions,
+        metrics: &ProjectionMetrics,
+    ) -> Result<NdArrowArray> {
+        // Fast path: a single referenced column needs no co-broadcast — its
+        // footprint is its own dimensions. Evaluate on the native (un-broadcast)
+        // values and leave the one gather onto the full grid to NdBroadcastExec.
+        if self.input_indices.len() == 1 {
+            let source = batch.column(self.input_indices[0]);
+            let n = source.values().len();
+            metrics.record(n, target.num_elements(), 0);
+
+            // A bare column reference reuses the nd array as-is.
+            if self.passthrough {
+                return Ok(source.clone());
+            }
+            let values = self.evaluate(vec![source.values().clone()], n)?;
+            return NdArrowArray::try_new(values, source.dims().clone());
+        }
+
+        // General path: union the referenced columns' footprint (in target
+        // order) and co-broadcast each input onto it before evaluating. A column
+        // on fewer axes than the footprint needs a real gather (implicit
+        // broadcast); one already spanning it passes through.
+        let footprint = footprint_of(target, batch, &self.input_indices)?;
+        let n = footprint.num_elements();
+        let mut broadcasts = 0usize;
+        let arrays: Vec<ArrayRef> = self
+            .input_indices
+            .iter()
+            .map(|&i| {
+                let source = batch.column(i);
+                let map = source.broadcast_map(&footprint)?;
+                if !map.is_identity() {
+                    broadcasts += 1;
+                }
+                source.materialize_with_map(&map)
+            })
+            .collect::<Result<_>>()?;
+        metrics.record(n, target.num_elements(), broadcasts);
+        let values = self.evaluate(arrays, n)?;
+        NdArrowArray::try_new(values, footprint)
+    }
+
+    /// Evaluate the (reindexed) expression on a compact batch of `arrays` with
+    /// `rows` rows, returning the result array.
+    fn evaluate(&self, arrays: Vec<ArrayRef>, rows: usize) -> Result<ArrayRef> {
+        let options = RecordBatchOptions::new().with_row_count(Some(rows));
+        let compact =
+            RecordBatch::try_new_with_options(self.compact_schema.clone(), arrays, &options)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        self.expr.evaluate(&compact)?.into_array(rows)
+    }
 }
 
 /// Projects a list of element-wise expressions over un-broadcast nd batches,
@@ -120,28 +215,7 @@ impl NdProjectionExec {
                 expr.data_type(&input_schema)?,
                 expr.nullable(&input_schema)?,
             ));
-
-            // Referenced input columns, sorted by their child-schema index, form
-            // a compact schema; reindex the expression's `Column`s onto it so it
-            // can be evaluated against a batch of just those columns.
-            let mut input_indices: Vec<usize> =
-                collect_columns(expr).iter().map(|c| c.index()).collect();
-            input_indices.sort_unstable();
-            input_indices.dedup();
-            let compact_schema = Arc::new(Schema::new(
-                input_indices
-                    .iter()
-                    .map(|&i| input_schema.field(i).clone())
-                    .collect::<Vec<_>>(),
-            ));
-            let expr = reassign_expr_columns(expr.clone(), &compact_schema)?;
-            let passthrough = expr.as_any().is::<Column>();
-            columns.push(ProjectionColumn {
-                expr,
-                compact_schema,
-                input_indices,
-                passthrough,
-            });
+            columns.push(ProjectionColumn::build(&input_schema, expr)?);
         }
 
         let derived = Arc::new(Schema::new(fields));
@@ -191,93 +265,19 @@ impl NdProjectionExec {
     }
 
     /// Project one nd batch: evaluate every output column on its footprint grid,
-    /// recording the work done (elements evaluated, elements saved versus the
-    /// full grid, and implicit co-broadcasts) into `metrics`.
+    /// recording work into `metrics`. Per-column logic lives in
+    /// [`ProjectionColumn::project`].
     fn project_batch(
         &self,
         batch: &NdRecordBatch,
         metrics: &ProjectionMetrics,
     ) -> Result<NdRecordBatch> {
         let target = batch.target();
-        let mut projected = Vec::with_capacity(self.columns.len());
-
-        for column in &self.columns {
-            // Fast path: an expression over a single input column needs no
-            // co-broadcast — its footprint is exactly that column's own
-            // dimensions. Evaluate directly on the column's native (un-broadcast)
-            // values and leave the one gather onto the full grid to the terminal
-            // NdBroadcastExec.
-            if column.input_indices.len() == 1 {
-                let source = batch.column(column.input_indices[0]);
-                let n = source.values().len();
-                metrics.elements_evaluated.add(n);
-                metrics
-                    .elements_saved
-                    .add(target.num_elements().saturating_sub(n));
-
-                // A bare column reference reuses the nd array as-is — no
-                // evaluation, no allocation.
-                if column.passthrough {
-                    projected.push(source.clone());
-                    continue;
-                }
-
-                let options = RecordBatchOptions::new().with_row_count(Some(n));
-                let compact = RecordBatch::try_new_with_options(
-                    column.compact_schema.clone(),
-                    vec![source.values().clone()],
-                    &options,
-                )
-                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-                let values = column.expr.evaluate(&compact)?.into_array(n)?;
-                projected.push(NdArrowArray::try_new(values, source.dims().clone())?);
-                continue;
-            }
-
-            // General path: an expression spanning multiple columns unions their
-            // footprint (the target axes they reference, in target order) and
-            // co-broadcasts the inputs onto it before evaluating.
-            let footprint = footprint_of(target, batch, &column.input_indices)?;
-
-            // The expression runs over the footprint instead of the full grid;
-            // the difference is the work the pushdown avoided.
-            metrics.elements_evaluated.add(footprint.num_elements());
-            metrics
-                .elements_saved
-                .add(target.num_elements().saturating_sub(footprint.num_elements()));
-
-            // Co-broadcast the referenced columns onto the footprint so they
-            // align element-wise, then evaluate. A referenced column on fewer
-            // axes than the footprint needs a real gather (an implicit
-            // broadcast); one already spanning the footprint passes through.
-            let arrays: Vec<ArrayRef> = column
-                .input_indices
-                .iter()
-                .map(|&i| {
-                    let source = batch.column(i);
-                    let map = source.broadcast_map(&footprint)?;
-                    if !map.is_identity() {
-                        metrics.broadcasts.add(1);
-                    }
-                    source.materialize_with_map(&map)
-                })
-                .collect::<Result<_>>()?;
-            let options =
-                RecordBatchOptions::new().with_row_count(Some(footprint.num_elements()));
-            let compact = RecordBatch::try_new_with_options(
-                column.compact_schema.clone(),
-                arrays,
-                &options,
-            )
-            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-
-            let values = column
-                .expr
-                .evaluate(&compact)?
-                .into_array(footprint.num_elements())?;
-            projected.push(NdArrowArray::try_new(values, footprint)?);
-        }
-
+        let projected = self
+            .columns
+            .iter()
+            .map(|column| column.project(batch, target, metrics))
+            .collect::<Result<Vec<_>>>()?;
         NdRecordBatch::try_new(self.schema.clone(), projected, target.clone())
     }
 }
@@ -387,5 +387,149 @@ impl NdExecutionPlan for NdProjectionExec {
                 Ok(projected)
             });
         Ok(Box::pin(stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{ArrayRef, AsArray, Int32Array};
+    use arrow::datatypes::{DataType, Field, Int32Type, Schema, SchemaRef};
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_expr::expressions::{binary, col, lit};
+    use datafusion::physical_plan::metrics::Count;
+
+    use crate::nd::dimensions::Dimension;
+
+    use super::*;
+
+    fn dims(spec: &[(&str, usize)]) -> Dimensions {
+        Dimensions::try_new(
+            spec.iter()
+                .map(|(name, size)| Dimension::new(*name, *size))
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    /// Grid (lat=3, lon=2): a `lat` coord, a `lon` coord, and a full-rank
+    /// `temp{lat,lon}` data variable.
+    fn test_batch() -> (SchemaRef, NdRecordBatch) {
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("lat", DataType::Int32, true),
+            Field::new("lon", DataType::Int32, true),
+            Field::new("temp", DataType::Int32, true),
+        ]));
+        let lat = NdArrowArray::try_new(
+            Arc::new(Int32Array::from(vec![10, 20, 30])),
+            dims(&[("lat", 3)]),
+        )
+        .unwrap();
+        let lon =
+            NdArrowArray::try_new(Arc::new(Int32Array::from(vec![1, 2])), dims(&[("lon", 2)]))
+                .unwrap();
+        let temp = NdArrowArray::try_new(
+            Arc::new(Int32Array::from(vec![0, 1, 2, 3, 4, 5])),
+            dims(&[("lat", 3), ("lon", 2)]),
+        )
+        .unwrap();
+        let batch = NdRecordBatch::try_new(
+            schema.clone(),
+            vec![lat, lon, temp],
+            dims(&[("lat", 3), ("lon", 2)]),
+        )
+        .unwrap();
+        (schema, batch)
+    }
+
+    fn metrics() -> ProjectionMetrics {
+        ProjectionMetrics {
+            elements_evaluated: Count::new(),
+            elements_saved: Count::new(),
+            broadcasts: Count::new(),
+        }
+    }
+
+    fn ints(array: &ArrayRef) -> Vec<i32> {
+        array.as_primitive::<Int32Type>().values().to_vec()
+    }
+
+    #[test]
+    fn build_collects_columns_and_flags_passthrough() {
+        let (schema, _) = test_batch();
+
+        // `lat * 2` references only `lat` (index 0) and is not a bare column.
+        let expr =
+            binary(col("lat", &schema).unwrap(), Operator::Multiply, lit(2i32), &schema).unwrap();
+        let column = ProjectionColumn::build(&schema, &expr).unwrap();
+        assert_eq!(column.input_indices, vec![0]);
+        assert!(!column.passthrough);
+
+        // A bare `temp` reference (index 2) is a passthrough.
+        let bare = col("temp", &schema).unwrap();
+        let column = ProjectionColumn::build(&schema, &bare).unwrap();
+        assert_eq!(column.input_indices, vec![2]);
+        assert!(column.passthrough);
+    }
+
+    #[test]
+    fn footprint_is_ordered_by_target() {
+        let (_, batch) = test_batch();
+        // Reference lon (idx 1) then lat (idx 0): footprint keeps target order.
+        let footprint = footprint_of(batch.target(), &batch, &[0, 1]).unwrap();
+        assert_eq!(footprint, dims(&[("lat", 3), ("lon", 2)]));
+    }
+
+    #[test]
+    fn project_single_column_evaluates_on_native_footprint() {
+        let (schema, batch) = test_batch();
+        let expr =
+            binary(col("lat", &schema).unwrap(), Operator::Multiply, lit(2i32), &schema).unwrap();
+        let column = ProjectionColumn::build(&schema, &expr).unwrap();
+        let m = metrics();
+
+        let out = column.project(&batch, batch.target(), &m).unwrap();
+        assert_eq!(out.dims(), &dims(&[("lat", 3)])); // footprint = lat's own dims
+        assert_eq!(ints(out.values()), vec![20, 40, 60]);
+        // No co-broadcast; evaluated over |lat|=3, saved 6-3.
+        assert_eq!(m.broadcasts.value(), 0);
+        assert_eq!(m.elements_evaluated.value(), 3);
+        assert_eq!(m.elements_saved.value(), 3);
+    }
+
+    #[test]
+    fn project_passthrough_reuses_the_nd_array() {
+        let (schema, batch) = test_batch();
+        let column = ProjectionColumn::build(&schema, &col("temp", &schema).unwrap()).unwrap();
+        let m = metrics();
+
+        let out = column.project(&batch, batch.target(), &m).unwrap();
+        assert_eq!(out.dims(), &dims(&[("lat", 3), ("lon", 2)]));
+        assert_eq!(ints(out.values()), vec![0, 1, 2, 3, 4, 5]);
+        assert_eq!(m.broadcasts.value(), 0);
+    }
+
+    #[test]
+    fn project_multi_column_co_broadcasts_onto_footprint() {
+        let (schema, batch) = test_batch();
+        // lat + lon → footprint {lat, lon}; each input gathered onto it.
+        let expr = binary(
+            col("lat", &schema).unwrap(),
+            Operator::Plus,
+            col("lon", &schema).unwrap(),
+            &schema,
+        )
+        .unwrap();
+        let column = ProjectionColumn::build(&schema, &expr).unwrap();
+        let m = metrics();
+
+        let out = column.project(&batch, batch.target(), &m).unwrap();
+        assert_eq!(out.dims(), &dims(&[("lat", 3), ("lon", 2)]));
+        // C-order over {lat, lon}: lat replicated over lon, lon tiled over lat.
+        assert_eq!(ints(out.values()), vec![11, 12, 21, 22, 31, 32]);
+        assert_eq!(m.broadcasts.value(), 2);
+        assert_eq!(m.elements_evaluated.value(), 6);
+        assert_eq!(m.elements_saved.value(), 0); // footprint == full grid
     }
 }

--- a/beacon-datafusion-ext/src/nd/exec/projection_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/projection_exec.rs
@@ -22,6 +22,7 @@ use arrow::array::{ArrayRef, RecordBatch, RecordBatchOptions};
 use arrow::datatypes::{Field, Schema, SchemaRef};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
+use datafusion::physical_expr::expressions::Column;
 use datafusion::physical_expr::utils::{collect_columns, reassign_expr_columns};
 use datafusion::physical_expr::{EquivalenceProperties, PhysicalExpr};
 use datafusion::physical_plan::metrics::{
@@ -59,6 +60,9 @@ struct ProjectionColumn {
     /// Indices (into the child batch) of the referenced input columns, aligned
     /// with `compact_schema`.
     input_indices: Vec<usize>,
+    /// True when `expr` is a bare column reference — the input nd column can be
+    /// reused directly, skipping evaluation entirely.
+    passthrough: bool,
 }
 
 /// Projects a list of element-wise expressions over un-broadcast nd batches,
@@ -131,10 +135,12 @@ impl NdProjectionExec {
                     .collect::<Vec<_>>(),
             ));
             let expr = reassign_expr_columns(expr.clone(), &compact_schema)?;
+            let passthrough = expr.as_any().is::<Column>();
             columns.push(ProjectionColumn {
                 expr,
                 compact_schema,
                 input_indices,
+                passthrough,
             });
         }
 
@@ -196,9 +202,41 @@ impl NdProjectionExec {
         let mut projected = Vec::with_capacity(self.columns.len());
 
         for column in &self.columns {
-            // Footprint = the target axes referenced by this expression's input
-            // columns, kept in target order so the sub-grid is C-order-consistent
-            // with the full grid.
+            // Fast path: an expression over a single input column needs no
+            // co-broadcast — its footprint is exactly that column's own
+            // dimensions. Evaluate directly on the column's native (un-broadcast)
+            // values and leave the one gather onto the full grid to the terminal
+            // NdBroadcastExec.
+            if column.input_indices.len() == 1 {
+                let source = batch.column(column.input_indices[0]);
+                let n = source.values().len();
+                metrics.elements_evaluated.add(n);
+                metrics
+                    .elements_saved
+                    .add(target.num_elements().saturating_sub(n));
+
+                // A bare column reference reuses the nd array as-is — no
+                // evaluation, no allocation.
+                if column.passthrough {
+                    projected.push(source.clone());
+                    continue;
+                }
+
+                let options = RecordBatchOptions::new().with_row_count(Some(n));
+                let compact = RecordBatch::try_new_with_options(
+                    column.compact_schema.clone(),
+                    vec![source.values().clone()],
+                    &options,
+                )
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                let values = column.expr.evaluate(&compact)?.into_array(n)?;
+                projected.push(NdArrowArray::try_new(values, source.dims().clone())?);
+                continue;
+            }
+
+            // General path: an expression spanning multiple columns unions their
+            // footprint (the target axes they reference, in target order) and
+            // co-broadcasts the inputs onto it before evaluating.
             let footprint = footprint_of(target, batch, &column.input_indices)?;
 
             // The expression runs over the footprint instead of the full grid;

--- a/beacon-datafusion-ext/src/nd/mod.rs
+++ b/beacon-datafusion-ext/src/nd/mod.rs
@@ -23,6 +23,7 @@ pub mod broadcast;
 pub mod dimensions;
 pub mod encoding;
 pub mod exec;
+pub mod optimizer;
 
 pub use array::NdArrowArray;
 pub use batch::NdRecordBatch;
@@ -32,6 +33,7 @@ pub use encoding::{
     decode_nd_record_batch, encode_flat_batch_as_nd, encode_nd_record_batch, encoded_schema,
     is_nd_encoded, logical_schema, nd_encoded_field, nd_encoded_type,
 };
+pub use optimizer::{NdProjectionPushdown, is_pushable_expr};
 
 #[cfg(test)]
 mod tests {
@@ -201,5 +203,174 @@ mod tests {
         let broadcast = Arc::new(NdBroadcastExec::try_new(test_source()).unwrap());
         // Wrapping a broadcast (which is not nd-aware) must fail.
         assert!(NdBroadcastExec::try_new(broadcast).is_err());
+    }
+
+    // ── projection pushdown ──────────────────────────────────────────────
+
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_expr::PhysicalExpr;
+    use datafusion::physical_expr::expressions::{binary, col, lit};
+    use datafusion::physical_plan::projection::{ProjectionExec, ProjectionExpr};
+
+    use super::exec::NdProjectionExec;
+
+    /// A mix of projection expressions with different footprints:
+    /// `lat*2` (footprint {lat}), `lon+1` ({lon}), `sst` passthrough
+    /// ({time,lat,lon}), and a constant ({}).
+    fn projection_exprs(schema: &arrow::datatypes::SchemaRef) -> Vec<(Arc<dyn PhysicalExpr>, String)> {
+        vec![
+            (
+                binary(col("lat", schema).unwrap(), Operator::Multiply, lit(2i32), schema).unwrap(),
+                "lat2".to_string(),
+            ),
+            (
+                binary(col("lon", schema).unwrap(), Operator::Plus, lit(1i32), schema).unwrap(),
+                "lon1".to_string(),
+            ),
+            (col("sst", schema).unwrap(), "sst".to_string()),
+            (lit(7i32), "seven".to_string()),
+        ]
+    }
+
+    /// Evaluating a projection *before* broadcast (on footprint sub-grids) yields
+    /// byte-identical output to evaluating it *after* broadcasting the full grid.
+    #[tokio::test]
+    async fn projection_before_broadcast_matches_after() {
+        let schema = test_source().schema();
+        let exprs = projection_exprs(&schema);
+
+        // Reference: broadcast the full grid, then project (plain ProjectionExec).
+        let reference = Arc::new(
+            ProjectionExec::try_new(
+                exprs
+                    .iter()
+                    .cloned()
+                    .map(|(expr, alias)| ProjectionExpr { expr, alias }),
+                Arc::new(NdBroadcastExec::try_new(test_source()).unwrap()),
+            )
+            .unwrap(),
+        );
+        let expected = run(reference).await.unwrap();
+
+        // Optimized: project on footprints first, then broadcast.
+        let nd_proj = Arc::new(NdProjectionExec::try_new(test_source(), exprs).unwrap());
+        let optimized = Arc::new(NdBroadcastExec::try_new(nd_proj).unwrap());
+        let actual = run(optimized).await.unwrap();
+
+        assert_eq!(actual.num_rows(), 24);
+        assert_eq!(actual, expected);
+    }
+
+    /// The rule rewrites `ProjectionExec → NdBroadcastExec` into
+    /// `NdBroadcastExec → NdProjectionExec`, preserving schema and results.
+    #[tokio::test]
+    async fn pushdown_rule_sinks_projection_below_broadcast() {
+        use datafusion::common::config::ConfigOptions;
+        use datafusion::physical_optimizer::PhysicalOptimizerRule;
+        use datafusion::physical_plan::displayable;
+
+        let schema = test_source().schema();
+        let exprs = projection_exprs(&schema);
+
+        let original: Arc<dyn ExecutionPlan> = Arc::new(
+            ProjectionExec::try_new(
+                exprs
+                    .iter()
+                    .cloned()
+                    .map(|(expr, alias)| ProjectionExpr { expr, alias }),
+                Arc::new(NdBroadcastExec::try_new(test_source()).unwrap()),
+            )
+            .unwrap(),
+        );
+        let original_schema = original.schema();
+        let expected = run(original.clone()).await.unwrap();
+
+        let optimized = NdProjectionPushdown::new()
+            .optimize(original, &ConfigOptions::default())
+            .unwrap();
+
+        // Schema is preserved (the rule reports schema_check = true).
+        assert_eq!(optimized.schema(), original_schema);
+
+        // The projection now sits *below* the broadcast.
+        let rendered = displayable(optimized.as_ref()).indent(true).to_string();
+        let broadcast = rendered.find("NdBroadcastExec");
+        let projection = rendered.find("NdProjectionExec");
+        let source = rendered.find("NdSourceExec");
+        assert!(
+            broadcast < projection && projection < source,
+            "expected NdBroadcastExec → NdProjectionExec → NdSourceExec:\n{rendered}"
+        );
+
+        // Results are unchanged by the rewrite.
+        let actual = run(optimized).await.unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    /// The rule leaves a projection in place when any expression is not
+    /// element-wise (here a volatile scalar function): no `NdProjectionExec`.
+    #[tokio::test]
+    async fn pushdown_rule_skips_non_elementwise() {
+        use std::any::Any;
+
+        use datafusion::common::config::ConfigOptions;
+        use datafusion::logical_expr::{
+            ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+        };
+        use datafusion::physical_expr::ScalarFunctionExpr;
+        use datafusion::physical_optimizer::PhysicalOptimizerRule;
+        use datafusion::physical_plan::displayable;
+        use datafusion::scalar::ScalarValue;
+
+        #[derive(Debug, PartialEq, Eq, Hash)]
+        struct VolatileUdf {
+            signature: Signature,
+        }
+        impl ScalarUDFImpl for VolatileUdf {
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+            fn name(&self) -> &str {
+                "test_volatile"
+            }
+            fn signature(&self) -> &Signature {
+                &self.signature
+            }
+            fn return_type(&self, _: &[arrow::datatypes::DataType]) -> Result<arrow::datatypes::DataType> {
+                Ok(arrow::datatypes::DataType::Float64)
+            }
+            fn invoke_with_args(&self, _: ScalarFunctionArgs) -> Result<ColumnarValue> {
+                Ok(ColumnarValue::Scalar(ScalarValue::Float64(Some(0.0))))
+            }
+        }
+
+        let schema = test_source().schema();
+        let udf = Arc::new(ScalarUDF::new_from_impl(VolatileUdf {
+            signature: Signature::exact(vec![], Volatility::Volatile),
+        }));
+        let volatile: Arc<dyn PhysicalExpr> = Arc::new(
+            ScalarFunctionExpr::try_new(udf, vec![], &schema, Arc::new(ConfigOptions::default()))
+                .unwrap(),
+        );
+
+        let original: Arc<dyn ExecutionPlan> = Arc::new(
+            ProjectionExec::try_new(
+                [ProjectionExpr {
+                    expr: volatile,
+                    alias: "r".to_string(),
+                }],
+                Arc::new(NdBroadcastExec::try_new(test_source()).unwrap()),
+            )
+            .unwrap(),
+        );
+
+        let optimized = NdProjectionPushdown::new()
+            .optimize(original, &ConfigOptions::default())
+            .unwrap();
+        let rendered = displayable(optimized.as_ref()).indent(true).to_string();
+        assert!(
+            !rendered.contains("NdProjectionExec"),
+            "volatile projection must not be pushed below the broadcast:\n{rendered}"
+        );
     }
 }

--- a/beacon-datafusion-ext/src/nd/mod.rs
+++ b/beacon-datafusion-ext/src/nd/mod.rs
@@ -318,6 +318,51 @@ mod tests {
         assert_eq!(actual.column(0).as_primitive::<Int32Type>().value(0), -25);
     }
 
+    /// Single-column expressions take the fast path: the projection does no
+    /// co-broadcast (footprint == the column's own dims), leaving the single
+    /// gather to the terminal broadcast. `lat * 2` (single column) and `sst`
+    /// (bare passthrough) both report zero implicit broadcasts, with unchanged
+    /// results.
+    #[tokio::test]
+    async fn single_column_projection_skips_broadcast() {
+        let schema = test_source().schema();
+        let exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = vec![
+            (
+                binary(col("lat", &schema).unwrap(), Operator::Multiply, lit(2i32), &schema)
+                    .unwrap(),
+                "lat2".to_string(),
+            ),
+            (col("sst", &schema).unwrap(), "sst".to_string()),
+        ];
+
+        let reference = Arc::new(
+            ProjectionExec::try_new(
+                exprs
+                    .iter()
+                    .cloned()
+                    .map(|(expr, alias)| ProjectionExpr { expr, alias }),
+                Arc::new(NdBroadcastExec::try_new(test_source()).unwrap()),
+            )
+            .unwrap(),
+        );
+        let expected = run(reference).await.unwrap();
+
+        let projection = Arc::new(NdProjectionExec::try_new(test_source(), exprs).unwrap());
+        let broadcast = Arc::new(NdBroadcastExec::try_new(projection.clone()).unwrap());
+        let actual = run(broadcast).await.unwrap();
+
+        assert_eq!(actual, expected);
+        // The projection performed no gather; only the terminal broadcast did.
+        assert_eq!(
+            projection
+                .metrics()
+                .unwrap()
+                .sum_by_name("implicit_broadcasts")
+                .map(|v| v.as_usize()),
+            Some(0)
+        );
+    }
+
     /// NdProjectionExec reports the work it did and saved: elements evaluated on
     /// footprints, elements avoided versus the full grid, and implicit
     /// co-broadcasts.

--- a/beacon-datafusion-ext/src/nd/mod.rs
+++ b/beacon-datafusion-ext/src/nd/mod.rs
@@ -185,6 +185,21 @@ mod tests {
         let broadcast_metrics = broadcast.metrics().unwrap();
         assert_eq!(broadcast_metrics.output_rows(), Some(24));
 
+        // Each chunk broadcasts time/lat/lon (3) and passes sst through (1);
+        // two chunks → 6 implicit broadcasts, 2 pass-throughs.
+        assert_eq!(
+            broadcast_metrics
+                .sum_by_name("implicit_broadcasts")
+                .map(|v| v.as_usize()),
+            Some(6)
+        );
+        assert_eq!(
+            broadcast_metrics
+                .sum_by_name("passthrough_columns")
+                .map(|v| v.as_usize()),
+            Some(2)
+        );
+
         // Source reports the grid rows it decoded (12 + 12) and the number of
         // nd batches.
         let source_metrics = source.metrics().unwrap();
@@ -301,6 +316,39 @@ mod tests {
         // Spot-check the outer-product semantics: first (lat,lon) cell is
         // lat[-30] + lon[5] = -25.
         assert_eq!(actual.column(0).as_primitive::<Int32Type>().value(0), -25);
+    }
+
+    /// NdProjectionExec reports the work it did and saved: elements evaluated on
+    /// footprints, elements avoided versus the full grid, and implicit
+    /// co-broadcasts.
+    #[tokio::test]
+    async fn projection_reports_metrics() {
+        let schema = test_source().schema();
+        // lat{lat} + lon{lon} → footprint {lat, lon}; both inputs co-broadcast.
+        let exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = vec![(
+            binary(
+                col("lat", &schema).unwrap(),
+                Operator::Plus,
+                col("lon", &schema).unwrap(),
+                &schema,
+            )
+            .unwrap(),
+            "lat_plus_lon".to_string(),
+        )];
+
+        let projection = Arc::new(NdProjectionExec::try_new(test_source(), exprs).unwrap());
+        let broadcast = Arc::new(NdBroadcastExec::try_new(projection.clone()).unwrap());
+        let out = run(broadcast).await.unwrap();
+        assert_eq!(out.num_rows(), 24);
+
+        let m = projection.metrics().unwrap();
+        let count = |name: &str| m.sum_by_name(name).map(|v| v.as_usize());
+        // Per chunk: full grid = 2·3·2 = 12, footprint {lat=3, lon=2} = 6; two
+        // chunks. Evaluated 6·2 = 12, saved (12−6)·2 = 12.
+        assert_eq!(count("elements_evaluated"), Some(12));
+        assert_eq!(count("elements_saved"), Some(12));
+        // Both referenced columns gather onto the footprint: 2 per chunk · 2 = 4.
+        assert_eq!(count("implicit_broadcasts"), Some(4));
     }
 
     /// The rule rewrites `ProjectionExec → NdBroadcastExec` into

--- a/beacon-datafusion-ext/src/nd/mod.rs
+++ b/beacon-datafusion-ext/src/nd/mod.rs
@@ -261,6 +261,48 @@ mod tests {
         assert_eq!(actual, expected);
     }
 
+    /// An expression combining two columns on *different* axes (`lat + lon`,
+    /// dims {lat} and {lon}) co-broadcasts both onto their union footprint
+    /// {lat, lon} before evaluating — matching a post-broadcast projection.
+    #[tokio::test]
+    async fn projection_combines_columns_of_different_dims() {
+        let schema = test_source().schema();
+        // lat{lat} + lon{lon}  → footprint {lat, lon}, evaluated over 3·2 = 6
+        // cells, then broadcast across time to the full 24-row grid.
+        let exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = vec![(
+            binary(
+                col("lat", &schema).unwrap(),
+                Operator::Plus,
+                col("lon", &schema).unwrap(),
+                &schema,
+            )
+            .unwrap(),
+            "lat_plus_lon".to_string(),
+        )];
+
+        let reference = Arc::new(
+            ProjectionExec::try_new(
+                exprs
+                    .iter()
+                    .cloned()
+                    .map(|(expr, alias)| ProjectionExpr { expr, alias }),
+                Arc::new(NdBroadcastExec::try_new(test_source()).unwrap()),
+            )
+            .unwrap(),
+        );
+        let expected = run(reference).await.unwrap();
+
+        let nd_proj = Arc::new(NdProjectionExec::try_new(test_source(), exprs).unwrap());
+        let optimized = Arc::new(NdBroadcastExec::try_new(nd_proj).unwrap());
+        let actual = run(optimized).await.unwrap();
+
+        assert_eq!(actual.num_rows(), 24);
+        assert_eq!(actual, expected);
+        // Spot-check the outer-product semantics: first (lat,lon) cell is
+        // lat[-30] + lon[5] = -25.
+        assert_eq!(actual.column(0).as_primitive::<Int32Type>().value(0), -25);
+    }
+
     /// The rule rewrites `ProjectionExec → NdBroadcastExec` into
     /// `NdBroadcastExec → NdProjectionExec`, preserving schema and results.
     #[tokio::test]

--- a/beacon-datafusion-ext/src/nd/optimizer.rs
+++ b/beacon-datafusion-ext/src/nd/optimizer.rs
@@ -1,0 +1,234 @@
+//! Physical optimizer rule: sink element-wise projections below the broadcast.
+//!
+//! DataFusion plans a `ProjectionExec` above [`NdBroadcastExec`], so projection
+//! expressions run *after* the full grid is materialized. When every output
+//! expression is element-wise (its value at a grid cell depends only on its
+//! inputs at that cell), the projection can instead run on the un-broadcast nd
+//! columns — evaluated on each expression's footprint sub-grid — and be
+//! broadcast afterwards. This rule rewrites
+//!
+//! ```text
+//! ProjectionExec[exprs]              NdBroadcastExec
+//!   NdBroadcastExec           ->       NdProjectionExec[exprs]
+//!     nd-child                           nd-child
+//! ```
+//!
+//! Broadcasting commutes with element-wise evaluation, so the result is
+//! identical — but a projection touching only a coordinate axis now evaluates
+//! over that axis instead of the full cross-product.
+
+use std::sync::Arc;
+
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::error::Result;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::{
+    BinaryExpr, CaseExpr, CastExpr, Column, IsNotNullExpr, IsNullExpr, Literal, NegativeExpr,
+    NotExpr, TryCastExpr,
+};
+use datafusion::physical_expr::ScalarFunctionExpr;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::logical_expr::Volatility;
+
+use super::exec::{NdBroadcastExec, NdProjectionExec};
+
+/// Sinks element-wise `ProjectionExec`s below an [`NdBroadcastExec`] into an
+/// [`NdProjectionExec`], so they evaluate before broadcasting.
+#[derive(Debug, Default)]
+pub struct NdProjectionPushdown;
+
+impl NdProjectionPushdown {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl PhysicalOptimizerRule for NdProjectionPushdown {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        plan.transform_down(|node| {
+            let Some(projection) = node.as_any().downcast_ref::<ProjectionExec>() else {
+                return Ok(Transformed::no(node));
+            };
+            let Some(broadcast) = projection
+                .input()
+                .as_any()
+                .downcast_ref::<NdBroadcastExec>()
+            else {
+                return Ok(Transformed::no(node));
+            };
+
+            // Only sink when every output expression is safe to evaluate before
+            // broadcast; a mixed projection is left in place.
+            if !projection
+                .expr()
+                .iter()
+                .all(|pe| is_pushable_expr(&pe.expr))
+            {
+                return Ok(Transformed::no(node));
+            }
+
+            let exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = projection
+                .expr()
+                .iter()
+                .map(|pe| (pe.expr.clone(), pe.alias.clone()))
+                .collect();
+
+            // Preserve the projection's exact output schema so the rewrite is
+            // schema-preserving for the optimizer's schema check.
+            let nd_projection = Arc::new(NdProjectionExec::try_new_with_schema(
+                broadcast.input().clone(),
+                exprs,
+                Some(projection.schema()),
+            )?);
+            let new_broadcast = Arc::new(NdBroadcastExec::try_new(nd_projection)?);
+            Ok(Transformed::yes(new_broadcast as Arc<dyn ExecutionPlan>))
+        })
+        .map(|t| t.data)
+    }
+
+    fn name(&self) -> &str {
+        "NdProjectionPushdown"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+/// Whether an expression can be evaluated before broadcast and give the same
+/// result after broadcast — i.e. it is element-wise and deterministic.
+///
+/// Conservative: an expression built only from a whitelist of element-wise node
+/// types (arithmetic/comparison/boolean, cast, negation, null checks, `CASE`)
+/// and non-volatile scalar functions is pushable. Any node outside the
+/// whitelist — a volatile function like `random()`, a window/subquery
+/// expression, or anything unrecognized — makes the whole expression stay above
+/// the broadcast.
+pub fn is_pushable_expr(expr: &Arc<dyn PhysicalExpr>) -> bool {
+    is_elementwise_node(expr) && expr.children().iter().all(|c| is_pushable_expr(c))
+}
+
+/// Whether a single node (ignoring its children) is a known element-wise,
+/// deterministic operator.
+fn is_elementwise_node(expr: &Arc<dyn PhysicalExpr>) -> bool {
+    let any = expr.as_any();
+    if any.is::<Column>()
+        || any.is::<Literal>()
+        || any.is::<BinaryExpr>()
+        || any.is::<CastExpr>()
+        || any.is::<TryCastExpr>()
+        || any.is::<NegativeExpr>()
+        || any.is::<NotExpr>()
+        || any.is::<IsNullExpr>()
+        || any.is::<IsNotNullExpr>()
+        || any.is::<CaseExpr>()
+    {
+        return true;
+    }
+    // Scalar functions are row-wise, but a volatile one (e.g. `random()`) would
+    // produce fewer distinct values if evaluated before broadcast.
+    if let Some(func) = any.downcast_ref::<ScalarFunctionExpr>() {
+        return func.fun().signature().volatility != Volatility::Volatile;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+    use std::sync::Arc;
+
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::common::config::ConfigOptions;
+    use datafusion::logical_expr::{
+        ColumnarValue, Operator, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
+        Volatility,
+    };
+    use datafusion::physical_expr::ScalarFunctionExpr;
+    use datafusion::physical_expr::expressions::{binary, cast, col, lit};
+    use datafusion::scalar::ScalarValue;
+
+    use super::*;
+
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("lat", DataType::Int32, true),
+            Field::new("sst", DataType::Float64, true),
+        ])
+    }
+
+    #[test]
+    fn arithmetic_cast_literal_are_pushable() {
+        let s = schema();
+        let lat = col("lat", &s).unwrap();
+        // (lat * 2) + 1
+        let arith = binary(
+            binary(lat.clone(), Operator::Multiply, lit(2i32), &s).unwrap(),
+            Operator::Plus,
+            lit(1i32),
+            &s,
+        )
+        .unwrap();
+        assert!(is_pushable_expr(&arith));
+
+        // CAST(lat AS Float64)
+        let casted = cast(lat, &s, DataType::Float64).unwrap();
+        assert!(is_pushable_expr(&casted));
+
+        // a bare literal
+        let seven: Arc<dyn PhysicalExpr> = lit(7i32);
+        assert!(is_pushable_expr(&seven));
+    }
+
+    /// A minimal volatile scalar function, to prove the volatility guard.
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    struct VolatileUdf {
+        signature: Signature,
+    }
+
+    impl ScalarUDFImpl for VolatileUdf {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn name(&self) -> &str {
+            "test_volatile"
+        }
+        fn signature(&self) -> &Signature {
+            &self.signature
+        }
+        fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+            Ok(DataType::Float64)
+        }
+        fn invoke_with_args(&self, _: ScalarFunctionArgs) -> Result<ColumnarValue> {
+            Ok(ColumnarValue::Scalar(ScalarValue::Float64(Some(0.0))))
+        }
+    }
+
+    #[test]
+    fn volatile_scalar_function_is_not_pushable() {
+        let s = schema();
+        let udf = Arc::new(ScalarUDF::new_from_impl(VolatileUdf {
+            signature: Signature::exact(vec![], Volatility::Volatile),
+        }));
+        let func = ScalarFunctionExpr::try_new(
+            udf,
+            vec![],
+            &s,
+            Arc::new(ConfigOptions::default()),
+        )
+        .unwrap();
+        let expr: Arc<dyn PhysicalExpr> = Arc::new(func);
+        assert!(!is_pushable_expr(&expr));
+
+        // …and a whitelisted node wrapping it is tainted too.
+        let wrapped = binary(expr, Operator::Plus, lit(1.0f64), &s).unwrap();
+        assert!(!is_pushable_expr(&wrapped));
+    }
+}

--- a/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -1061,6 +1061,60 @@ mod tests {
         assert!(mx > mn, "SST must span a range");
     }
 
+    /// End-to-end: with the nd projection-pushdown rule registered (as
+    /// beacon-core does), `SELECT lat * 2` plans with an `NdProjectionExec`
+    /// *below* the `NdBroadcastExec`, and yields the same values as a plain
+    /// session.
+    #[tokio::test]
+    async fn projection_pushdown_fires_end_to_end() {
+        use arrow::compute::concat_batches;
+        use datafusion::execution::session_state::SessionStateBuilder;
+        use datafusion::physical_plan::displayable;
+
+        let store = test_store().await;
+
+        let state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_physical_optimizer_rule(Arc::new(
+                beacon_datafusion_ext::nd::NdProjectionPushdown::new(),
+            ))
+            .build();
+        let ctx = datafusion::prelude::SessionContext::new_with_state(state);
+        register_example(&ctx, store.clone()).await;
+
+        let df = ctx
+            .sql("SELECT lat * 2 AS lat2 FROM gridded_nc")
+            .await
+            .unwrap();
+        let plan = df.clone().create_physical_plan().await.unwrap();
+        let rendered = displayable(plan.as_ref()).indent(true).to_string();
+
+        let broadcast = rendered.find("NdBroadcastExec");
+        let projection = rendered.find("NdProjectionExec");
+        let source = rendered.find("NdSourceExec");
+        assert!(
+            broadcast < projection && projection < source,
+            "projection must be pushed below the broadcast:\n{rendered}"
+        );
+
+        let bare = datafusion::prelude::SessionContext::new();
+        register_example(&bare, store).await;
+        let expected = bare
+            .sql("SELECT lat * 2 AS lat2 FROM gridded_nc")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let actual = df.collect().await.unwrap();
+
+        let schema = actual[0].schema();
+        assert_eq!(
+            concat_batches(&schema, &actual).unwrap(),
+            concat_batches(&schema, &expected).unwrap(),
+        );
+    }
+
     // ── nd pipeline: plan shape + variables & attributes end-to-end ──────
 
     /// The physical plan for an nd scan is the nd spine on top of the standard

--- a/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
@@ -409,8 +409,12 @@ mod tests {
     /// the projection sunk below the broadcast.
     fn ctx_with_pushdown() -> SessionContext {
         use datafusion::execution::session_state::SessionStateBuilder;
+        use datafusion::prelude::SessionConfig;
 
+        // Single partition so row order is deterministic (the differential tests
+        // compare results positionally).
         let state = SessionStateBuilder::new()
+            .with_config(SessionConfig::new().with_target_partitions(1))
             .with_default_features()
             .with_physical_optimizer_rule(Arc::new(
                 beacon_datafusion_ext::nd::NdProjectionPushdown::new(),
@@ -500,6 +504,105 @@ mod tests {
             .map(|b| b.num_rows())
             .sum();
         assert!(rows > 0, "base pipeline must still produce rows");
+    }
+
+    // ── nd projection pushdown: differential integration tests ───────────
+    //
+    // For each projection, plan it with the optimizer ON and assert the
+    // projection sank below the broadcast, then execute it with the optimizer ON
+    // and OFF and assert byte-identical results — using DataFusion's own
+    // (post-broadcast) evaluation as the correctness oracle.
+
+    /// Assert that `SELECT {select_exprs} FROM gridded` (a) pushes the projection
+    /// below the broadcast and (b) yields identical rows with the optimizer on
+    /// and off.
+    async fn check_pushdown(select_exprs: &str) {
+        use arrow::compute::concat_batches;
+        use datafusion::physical_plan::displayable;
+        use datafusion::prelude::SessionConfig;
+
+        let shape_sql = format!("SELECT {select_exprs} FROM gridded");
+        // Bounded so the differential comparison stays cheap; row order is
+        // deterministic (single-file scan) and identical on both paths.
+        let data_sql = format!("SELECT {select_exprs} FROM gridded LIMIT 200");
+
+        // Optimizer ON: the projection must sink below the broadcast.
+        let on = ctx_with_pushdown();
+        register_example(&on).await;
+        let plan = on
+            .sql(&shape_sql)
+            .await
+            .unwrap()
+            .create_physical_plan()
+            .await
+            .unwrap();
+        let rendered = displayable(plan.as_ref()).indent(true).to_string();
+        let broadcast = rendered.find("NdBroadcastExec");
+        let projection = rendered.find("NdProjectionExec");
+        let source = rendered.find("NdSourceExec");
+        assert!(
+            projection.is_some() && broadcast < projection && projection < source,
+            "expected NdBroadcastExec → NdProjectionExec → NdSourceExec for `{shape_sql}`:\n{rendered}"
+        );
+        let actual = on.sql(&data_sql).await.unwrap().collect().await.unwrap();
+
+        // Optimizer OFF: reference result (projection stays above the broadcast).
+        // Same single-partition config so row order matches positionally.
+        let off = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
+        register_example(&off).await;
+        let expected = off.sql(&data_sql).await.unwrap().collect().await.unwrap();
+
+        let schema = expected
+            .first()
+            .map(|b| b.schema())
+            .unwrap_or_else(|| actual[0].schema());
+        assert_eq!(
+            concat_batches(&schema, &actual).unwrap(),
+            concat_batches(&schema, &expected).unwrap(),
+            "results differ with/without the optimizer for `{data_sql}`"
+        );
+    }
+
+    #[tokio::test]
+    async fn pushdown_arithmetic_and_casts() {
+        // Arithmetic with scalars, and two coordinates on different axes.
+        check_pushdown("lat * 2 + 1 AS a, lon - 10 AS b, lat + lon AS s").await;
+        // Casts to wider/narrower and to integer types.
+        check_pushdown(
+            "CAST(lat AS DOUBLE) AS a, CAST(analysed_sst AS INTEGER) AS b, \
+             CAST(time AS BIGINT) AS t",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn pushdown_scalar_functions() {
+        // Single-column functions on a coordinate and on a data variable.
+        check_pushdown("abs(lat) AS a, floor(analysed_sst) AS b, round(analysed_sst) AS c").await;
+        // Column + scalar function, and a function over two cross-axis columns.
+        check_pushdown("power(lat, 2) AS p, abs(lat - lon) AS d").await;
+    }
+
+    #[tokio::test]
+    async fn pushdown_booleans_and_case() {
+        check_pushdown("lat > 40 AS hi, (lat > 40 AND lon > 30) AS both").await;
+        check_pushdown("CASE WHEN lat > 40 THEN 1 ELSE 0 END AS c").await;
+    }
+
+    #[tokio::test]
+    async fn pushdown_attributes_and_mixed() {
+        // A string function over a rank-0 attribute, co-selected with a gridded
+        // coordinate so the attribute broadcasts across the grid.
+        check_pushdown("lat, upper(\"analysed_sst.units\") AS u").await;
+        check_pushdown("lat, (\"analysed_sst.units\" = 'kelvin') AS is_k").await;
+        // Mixed: passthrough columns + a computed column + an attribute function.
+        check_pushdown("lat, lon, lat * 2 AS d, upper(\"analysed_sst.units\") AS u").await;
+    }
+
+    #[tokio::test]
+    async fn pushdown_nested_expressions() {
+        check_pushdown("CAST(round(analysed_sst) AS INTEGER) AS r").await;
+        check_pushdown("abs(CAST(lat AS DOUBLE)) * 2 AS x").await;
     }
 
     #[tokio::test]

--- a/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
@@ -404,6 +404,66 @@ mod tests {
         ctx.register_table("gridded", Arc::new(table)).unwrap();
     }
 
+    /// A session with the nd projection-pushdown rule registered — the same
+    /// wiring beacon-core installs, so a `SELECT`-with-computed-column plan gets
+    /// the projection sunk below the broadcast.
+    fn ctx_with_pushdown() -> SessionContext {
+        use datafusion::execution::session_state::SessionStateBuilder;
+
+        let state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_physical_optimizer_rule(Arc::new(
+                beacon_datafusion_ext::nd::NdProjectionPushdown::new(),
+            ))
+            .build();
+        SessionContext::new_with_state(state)
+    }
+
+    /// End-to-end: with the rule registered, `SELECT lat * 2` plans with an
+    /// `NdProjectionExec` *below* the `NdBroadcastExec`, and produces the same
+    /// values as the unoptimized session.
+    #[tokio::test]
+    async fn projection_pushdown_fires_end_to_end() {
+        use arrow::compute::concat_batches;
+        use datafusion::physical_plan::displayable;
+
+        let ctx = ctx_with_pushdown();
+        register_example(&ctx).await;
+
+        let df = ctx
+            .sql("SELECT lat * 2 AS lat2 FROM gridded")
+            .await
+            .unwrap();
+        let plan = df.clone().create_physical_plan().await.unwrap();
+        let rendered = displayable(plan.as_ref()).indent(true).to_string();
+
+        let broadcast = rendered.find("NdBroadcastExec");
+        let projection = rendered.find("NdProjectionExec");
+        let source = rendered.find("NdSourceExec");
+        assert!(
+            broadcast < projection && projection < source,
+            "projection must be pushed below the broadcast:\n{rendered}"
+        );
+
+        // Same result as a session without the rule.
+        let bare = SessionContext::new();
+        register_example(&bare).await;
+        let expected = bare
+            .sql("SELECT lat * 2 AS lat2 FROM gridded")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let actual = df.collect().await.unwrap();
+
+        let schema = actual[0].schema();
+        assert_eq!(
+            concat_batches(&schema, &actual).unwrap(),
+            concat_batches(&schema, &expected).unwrap(),
+        );
+    }
+
     #[tokio::test]
     async fn factory_discovers_gridded_example() {
         use beacon_datafusion_ext::format_ext::FileFormatFactoryExt;

--- a/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
+++ b/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
@@ -464,6 +464,44 @@ mod tests {
         );
     }
 
+    /// With the nd optimizer *off* (a plain session, as when
+    /// `BEACON_ENABLE_ND_PIPELINE=false`), the base pipeline still works: the
+    /// broadcast and source nodes are present, the projection simply stays above
+    /// the broadcast, and results are correct.
+    #[tokio::test]
+    async fn base_pipeline_works_without_nd_optimizer() {
+        use datafusion::physical_plan::displayable;
+
+        let ctx = SessionContext::new();
+        register_example(&ctx).await;
+
+        let df = ctx
+            .sql("SELECT lat * 2 AS lat2 FROM gridded")
+            .await
+            .unwrap();
+        let plan = df.clone().create_physical_plan().await.unwrap();
+        let rendered = displayable(plan.as_ref()).indent(true).to_string();
+
+        // The base nd pipeline is always present…
+        assert!(rendered.contains("NdBroadcastExec"), "{rendered}");
+        assert!(rendered.contains("NdSourceExec"), "{rendered}");
+        // …but without the rule the projection is not sunk below the broadcast.
+        assert!(
+            !rendered.contains("NdProjectionExec"),
+            "projection must stay above the broadcast when the optimizer is off:\n{rendered}"
+        );
+
+        // It still executes and returns rows.
+        let rows: usize = df
+            .collect()
+            .await
+            .unwrap()
+            .iter()
+            .map(|b| b.num_rows())
+            .sum();
+        assert!(rows > 0, "base pipeline must still produce rows");
+    }
+
     #[tokio::test]
     async fn factory_discovers_gridded_example() {
         use beacon_datafusion_ext::format_ext::FileFormatFactoryExt;

--- a/docs/docs/1.8.0/data-lake/configuration.md
+++ b/docs/docs/1.8.0/data-lake/configuration.md
@@ -74,6 +74,7 @@ rejected rather than writing plaintext.
 | `BEACON_DEFAULT_TABLE` | `default` | Table queried when a request omits the source. Only applies to the JSON query API — SQL queries must always specify a source. |
 | `BEACON_DEFAULT_TABLE_ENGINE` | `lance` | Storage engine for [managed tables](../sql/managed-tables.md) created with `CREATE TABLE`: `lance` (local, supports indexes) or `iceberg` (object-store). Can be overridden per session with `SET beacon.table_engine = '…'`. |
 | `BEACON_ENABLE_PUSHDOWN_PROJECTION` | `true` | Push column projection down into file readers so only requested columns are decoded. |
+| `BEACON_ENABLE_ND_PIPELINE` | `false` | Enable the N-dimensional pipeline optimizer for zarr/netcdf reads: sink element-wise projections below the grid broadcast so `lat * 2` and similar run on the coordinate axis instead of the full cross-product. The base nd pipeline always runs; this only enables the node-rewriting optimization. |
 | `BEACON_SANITIZE_SCHEMA` | `false` | Sanitize dataset schemas (normalize column names/types) during discovery. |
 | `BEACON_ST_WITHIN_POINT_CACHE_SIZE` | `10000` | Cache size for `st_within_point` geometry lookups. |
 | `BEACON_BATCH_SIZE` | `64000` | Batch size, in rows, for NetCDF reads (local and MPIO). |


### PR DESCRIPTION
## Summary

Pushes **element-wise projection expressions below the nd broadcast** so they evaluate on the minimal sub-grid their inputs span instead of the full materialized cross-product. A projection touching only a coordinate axis (`lat * 2`) now evaluates over `|lat|` elements rather than `time·lat·lon`. Broadcasting commutes with element-wise evaluation, so results are identical — just cheaper.

Gated behind an opt-in config flag; the base nd pipeline (`NdSourceExec` → `NdBroadcastExec`) always runs regardless.

## How it works

`NdProjectionExec` (a new nd-aware node) evaluates each expression on its **footprint** — the union of its referenced columns' dimensions — and emits an nd column on that footprint. `NdBroadcastExec` above then broadcasts the (smaller) result onto the full grid.

```
NdBroadcastExec                    NdBroadcastExec
  ProjectionExec[exprs]      ->      NdProjectionExec[exprs]
    NdSourceExec                       NdSourceExec
```

- **`NdProjectionExec`** — per expression: collect referenced columns, evaluate on the footprint sub-grid. A **single-column fast path** skips the co-broadcast entirely (footprint = the column's own dims); a bare column reference is a zero-copy passthrough. Multi-column expressions co-broadcast their inputs onto the union footprint before evaluating (xarray-style outer product).
- **`NdProjectionPushdown`** (a `PhysicalOptimizerRule`) rewrites `ProjectionExec → NdBroadcastExec` into `NdBroadcastExec → NdProjectionExec` when **every** output expression is element-wise and non-volatile (a conservative whitelist: arithmetic/comparison/boolean, cast, negation, null checks, `CASE`, and non-volatile scalar functions). Anything else keeps the projection above the broadcast.

## Config

New opt-in flag **`BEACON_ENABLE_ND_PIPELINE`** (`SqlConfig.enable_nd_pipeline`, default **false**). The runtime registers the optimizer only when set; the base broadcast/source pipeline is unaffected. Documented in the 1.8.0 config page.

## Metrics

Surfaced in `EXPLAIN ANALYZE`:
- `NdBroadcastExec`: `implicit_broadcasts`, `passthrough_columns`
- `NdProjectionExec`: `implicit_broadcasts`, `elements_evaluated`, `elements_saved` (grid elements avoided by the pushdown)