### PR TITLE
nd filter pushdown: run WHERE predicates before the broadcast

### DIFF
--- a/beacon-core/src/runtime.rs
+++ b/beacon-core/src/runtime.rs
@@ -437,17 +437,21 @@ impl Runtime {
             // `FederatedPlanner` lives in `BeaconQueryPlanner`'s extension planners.
             .with_optimizer_rules(datafusion_federation::default_optimizer_rules());
 
-        // Opt-in nd-pipeline optimizer (BEACON_ENABLE_ND_PIPELINE): sink
-        // element-wise projections below the nd broadcast so they run on
-        // un-broadcast coordinate axes instead of the full grid. Appended after
-        // the default physical rules, so it sees the planned `ProjectionExec`
-        // above `NdBroadcastExec`. The base pipeline (`NdSourceExec` →
-        // `NdBroadcastExec`) is emitted by the formats and always runs; only this
-        // node-rewriting rule is gated.
+        // Opt-in nd-pipeline optimizers (BEACON_ENABLE_ND_PIPELINE): sink
+        // element-wise projections and filter predicates below the nd broadcast
+        // so they run on un-broadcast coordinate axes instead of the full grid.
+        // Appended after the default physical rules, so they see the planned
+        // `ProjectionExec`/`FilterExec` above `NdBroadcastExec`. The base pipeline
+        // (`NdSourceExec` → `NdBroadcastExec`) is emitted by the formats and
+        // always runs; only these node-rewriting rules are gated.
         if enable_nd_pipeline {
-            state_builder = state_builder.with_physical_optimizer_rule(Arc::new(
-                beacon_datafusion_ext::nd::NdProjectionPushdown::new(),
-            ));
+            state_builder = state_builder
+                .with_physical_optimizer_rule(Arc::new(
+                    beacon_datafusion_ext::nd::NdFilterPushdown::new(),
+                ))
+                .with_physical_optimizer_rule(Arc::new(
+                    beacon_datafusion_ext::nd::NdProjectionPushdown::new(),
+                ));
         }
 
         let session_state = state_builder

--- a/beacon-datafusion-ext/src/nd/array.rs
+++ b/beacon-datafusion-ext/src/nd/array.rs
@@ -65,8 +65,15 @@ impl NdArrowArray {
         if map.is_identity() {
             return Ok(self.values.clone());
         }
-        let indices = map.gather_indices();
-        arrow::compute::take(self.values.as_ref(), &indices, None)
+        self.take_indices(&map.gather_indices())
+    }
+
+    /// Gather `indices` from the flat values with a single Arrow `take`. Used to
+    /// materialize a broadcast-and-select in one pass: `indices` are the source
+    /// offsets for the retained target cells (see
+    /// [`BroadcastMap::gather_indices_at`]).
+    pub fn take_indices(&self, indices: &arrow::array::UInt64Array) -> Result<ArrayRef> {
+        arrow::compute::take(self.values.as_ref(), indices, None)
             .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
     }
 }

--- a/beacon-datafusion-ext/src/nd/batch.rs
+++ b/beacon-datafusion-ext/src/nd/batch.rs
@@ -1,7 +1,7 @@
 //! Grid-shaped record batches: columns with heterogeneous dimension subsets
 //! over a shared target grid.
 
-use arrow::array::{ArrayRef, RecordBatchOptions};
+use arrow::array::{Array, ArrayRef, RecordBatchOptions, UInt64Array};
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
 use datafusion::common::plan_err;
@@ -15,11 +15,20 @@ use super::dimensions::Dimensions;
 /// attribute, a 1-D coordinate, a full-rank data variable, …). Columns stay
 /// un-broadcast until [`NdRecordBatch::materialize`], which broadcasts each one
 /// onto the full target grid.
+///
+/// An optional [`selection`](Self::selection) restricts the batch to a subset of
+/// the target cells (their row-major linear indices). It is how an
+/// [`NdFilterExec`](crate::nd::exec::NdFilterExec) records a predicate without
+/// moving data: the columns are untouched, and materialization gathers only the
+/// retained cells — the broadcast and the selection fuse into one gather per
+/// column, so the filtered-out cross-product never exists.
 #[derive(Debug, Clone)]
 pub struct NdRecordBatch {
     schema: SchemaRef,
     columns: Vec<NdArrowArray>,
     target: Dimensions,
+    /// Retained target-cell indices (row-major), or `None` for the full grid.
+    selection: Option<UInt64Array>,
 }
 
 impl NdRecordBatch {
@@ -52,7 +61,29 @@ impl NdRecordBatch {
             schema,
             columns,
             target,
+            selection: None,
         })
+    }
+
+    /// Attach (or clear) a selection restricting the batch to a subset of target
+    /// cells, given as their row-major linear indices. Consumes and returns the
+    /// batch. Indices are validated to fall within the target grid.
+    pub fn with_selection(mut self, selection: Option<UInt64Array>) -> Result<Self> {
+        if let Some(sel) = &selection {
+            let n = self.target.num_elements() as u64;
+            if sel.null_count() > 0 {
+                return plan_err!("nd selection must not contain null indices");
+            }
+            if let Some(&max) = sel.values().iter().max() {
+                if max >= n {
+                    return plan_err!(
+                        "nd selection index {max} is out of bounds for target grid of {n} cells"
+                    );
+                }
+            }
+        }
+        self.selection = selection;
+        Ok(self)
     }
 
     pub fn schema(&self) -> &SchemaRef {
@@ -71,9 +102,18 @@ impl NdRecordBatch {
         &self.target
     }
 
-    /// Rows in the materialized (fully broadcast) grid.
+    /// The retained target-cell indices, or `None` when the full grid is kept.
+    pub fn selection(&self) -> Option<&UInt64Array> {
+        self.selection.as_ref()
+    }
+
+    /// Rows in the materialized batch: the selection size when filtered, else
+    /// the full broadcast grid.
     pub fn num_rows(&self) -> usize {
-        self.target.num_elements()
+        match &self.selection {
+            Some(sel) => sel.len(),
+            None => self.target.num_elements(),
+        }
     }
 
     /// Materialize into a flat Arrow [`RecordBatch`] by broadcasting each
@@ -95,12 +135,20 @@ impl NdRecordBatch {
             .iter()
             .map(|column| {
                 let map = column.broadcast_map(&self.target)?;
+                // The broadcast shape drives the metric even under a selection:
+                // a full-rank column is a pass-through, a lower-rank one a
+                // broadcast — the selection only narrows which cells are gathered.
                 if map.is_identity() {
                     passthroughs += 1;
                 } else {
                     broadcasts += 1;
                 }
-                column.materialize_with_map(&map)
+                match &self.selection {
+                    // Broadcast and selection fuse into one gather: source
+                    // offsets for exactly the retained target cells.
+                    Some(sel) => column.take_indices(&map.gather_indices_at(sel)),
+                    None => column.materialize_with_map(&map),
+                }
             })
             .collect::<Result<_>>()?;
 
@@ -115,7 +163,7 @@ impl NdRecordBatch {
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::{AsArray, Float64Array, Int32Array};
+    use arrow::array::{AsArray, Float64Array, Int32Array, UInt64Array};
     use arrow::datatypes::{DataType, Field, Float64Type, Int32Type, Schema};
 
     use super::*;
@@ -175,6 +223,39 @@ mod tests {
             batch.column(2).as_primitive::<Float64Type>().values(),
             &[0.0, 0.1, 0.2, 1.0, 1.1, 1.2]
         );
+    }
+
+    #[test]
+    fn materialize_with_selection_gathers_retained_cells() {
+        // Keep target cells 1, 3, 5 of the (time=2, lat=3) grid.
+        let batch = test_batch()
+            .with_selection(Some(UInt64Array::from(vec![1u64, 3, 5])))
+            .unwrap();
+        assert_eq!(batch.num_rows(), 3);
+
+        let out = batch.materialize().unwrap();
+        assert_eq!(out.num_rows(), 3);
+        // Full grid: time=[7,7,7,8,8,8], lat=[10,20,30,10,20,30], sst=[..].
+        // Cells 1,3,5 → time=[7,8,8], lat=[20,10,30], sst=[0.1,1.0,1.2].
+        assert_eq!(
+            out.column(0).as_primitive::<Int32Type>().values(),
+            &[7, 8, 8]
+        );
+        assert_eq!(
+            out.column(1).as_primitive::<Int32Type>().values(),
+            &[20, 10, 30]
+        );
+        assert_eq!(
+            out.column(2).as_primitive::<Float64Type>().values(),
+            &[0.1, 1.0, 1.2]
+        );
+    }
+
+    #[test]
+    fn out_of_bounds_selection_rejected() {
+        // Grid has 6 cells; index 6 is out of range.
+        let result = test_batch().with_selection(Some(UInt64Array::from(vec![0u64, 6])));
+        assert!(result.is_err());
     }
 
     #[test]

--- a/beacon-datafusion-ext/src/nd/broadcast.rs
+++ b/beacon-datafusion-ext/src/nd/broadcast.rs
@@ -88,6 +88,37 @@ impl BroadcastMap {
         true
     }
 
+    /// Source take-indices for a *subset* of target cells, given their
+    /// row-major target linear indices. For each `t`, decompose it into per-axis
+    /// target coordinates and dot them with the source strides — the same
+    /// mapping [`gather_indices`](Self::gather_indices) applies to every cell,
+    /// evaluated only for the retained ones. This is how a broadcast composes
+    /// with an accumulated selection into a single gather: the un-broadcast
+    /// cross-product of filtered-out cells is never built.
+    pub fn gather_indices_at(&self, targets: &UInt64Array) -> UInt64Array {
+        let rank = self.target_shape.len();
+        let out: Vec<u64> = targets
+            .values()
+            .iter()
+            .map(|&t| {
+                let mut rem = t as usize;
+                let mut source = 0usize;
+                // Decode C-order coordinates from the innermost axis outward.
+                for axis in (0..rank).rev() {
+                    let size = self.target_shape[axis];
+                    if size == 0 {
+                        continue;
+                    }
+                    let coord = rem % size;
+                    rem /= size;
+                    source += coord * self.strides[axis];
+                }
+                source as u64
+            })
+            .collect();
+        UInt64Array::from(out)
+    }
+
     /// Take indices for the broadcast view, in row-major target order.
     pub fn gather_indices(&self) -> UInt64Array {
         let rank = self.target_shape.len();
@@ -208,6 +239,21 @@ mod tests {
         // source flat layout: (l0,t0),(l0,t1),(l1,t0),(l1,t1),(l2,t0),(l2,t1)
         assert_eq!(indices(&map), vec![0, 2, 4, 1, 3, 5]);
         assert!(!map.is_identity());
+    }
+
+    #[test]
+    fn gather_indices_at_selects_subset() {
+        // lat[3] onto (time=2, lat=3): full gather tiles the lat pattern.
+        let map = BroadcastMap::try_new(&dims(&[("lat", 3)]), &dims(&[("time", 2), ("lat", 3)]))
+            .unwrap();
+        let full = indices(&map);
+        assert_eq!(full, vec![0, 1, 2, 0, 1, 2]);
+
+        // Selecting a subset of target cells returns exactly those source offsets.
+        let targets = UInt64Array::from(vec![0u64, 2, 4, 5]);
+        let picked = map.gather_indices_at(&targets).values().to_vec();
+        assert_eq!(picked, vec![full[0], full[2], full[4], full[5]]);
+        assert_eq!(picked, vec![0, 2, 1, 2]);
     }
 
     #[test]

--- a/beacon-datafusion-ext/src/nd/exec/expr_column.rs
+++ b/beacon-datafusion-ext/src/nd/exec/expr_column.rs
@@ -1,0 +1,441 @@
+//! Element-wise expression evaluation on footprint sub-grids, shared by the nd
+//! operators that push work below the broadcast.
+//!
+//! An element-wise expression's value at grid cell `(t, y, x)` depends only on
+//! its input columns at `(t, y, x)`. So instead of broadcasting every input onto
+//! the full grid and then evaluating, it can be evaluated on the *minimal*
+//! sub-grid its inputs span — its **footprint**, the union of the referenced
+//! columns' dimensions. [`NdProjectionExec`](super::NdProjectionExec) emits the
+//! result as an output column; [`NdFilterExec`](super::NdFilterExec) evaluates a
+//! boolean predicate the same way and turns it into a grid selection. The two
+//! share [`NdExprColumn`] and [`ProjectMetrics`].
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, RecordBatch, RecordBatchOptions};
+use arrow::datatypes::{Schema, SchemaRef};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::utils::{collect_columns, reassign_expr_columns};
+use datafusion::physical_plan::metrics::Count;
+
+use crate::nd::array::NdArrowArray;
+use crate::nd::batch::NdRecordBatch;
+use crate::nd::dimensions::Dimensions;
+
+/// Per-partition counters shared by the footprint-evaluating nd operators.
+pub(super) struct ProjectMetrics {
+    /// Total elements the expressions were evaluated over (∑ footprint sizes).
+    pub elements_evaluated: Count,
+    /// Elements avoided versus evaluating on the full grid (∑ target − footprint).
+    pub elements_saved: Count,
+    /// Implicit gathers to co-broadcast referenced columns onto their footprint.
+    pub broadcasts: Count,
+}
+
+impl ProjectMetrics {
+    /// Record one evaluated expression: `evaluated` elements over its footprint
+    /// (out of `target` on the full grid), and `broadcasts` implicit co-broadcasts.
+    pub fn record(&self, evaluated: usize, target: usize, broadcasts: usize) {
+        self.elements_evaluated.add(evaluated);
+        self.elements_saved.add(target.saturating_sub(evaluated));
+        self.broadcasts.add(broadcasts);
+    }
+}
+
+/// One element-wise expression rewritten to reference only the columns it uses,
+/// plus the indices of those columns in the child's schema.
+#[derive(Debug, Clone)]
+pub(super) struct NdExprColumn {
+    /// The expression, with its `Column`s reindexed against `compact_schema`.
+    expr: Arc<dyn PhysicalExpr>,
+    /// Fields of the referenced input columns, in child-schema order.
+    compact_schema: SchemaRef,
+    /// Indices (into the child batch) of the referenced input columns, aligned
+    /// with `compact_schema`.
+    input_indices: Vec<usize>,
+    /// True when `expr` is a bare column reference — the input nd column can be
+    /// reused directly, skipping evaluation entirely.
+    passthrough: bool,
+}
+
+impl NdExprColumn {
+    /// Analyze one expression against the child schema: collect the columns it
+    /// references, build a compact schema of just those, and reindex the
+    /// expression's `Column`s onto it so it can be evaluated against a batch of
+    /// only the referenced columns.
+    pub fn build(input_schema: &SchemaRef, expr: &Arc<dyn PhysicalExpr>) -> Result<Self> {
+        let mut input_indices: Vec<usize> =
+            collect_columns(expr).iter().map(|c| c.index()).collect();
+        input_indices.sort_unstable();
+        input_indices.dedup();
+        let compact_schema = Arc::new(Schema::new(
+            input_indices
+                .iter()
+                .map(|&i| input_schema.field(i).clone())
+                .collect::<Vec<_>>(),
+        ));
+        let expr = reassign_expr_columns(expr.clone(), &compact_schema)?;
+        let passthrough = expr.as_any().is::<Column>();
+        Ok(Self {
+            expr,
+            compact_schema,
+            input_indices,
+            passthrough,
+        })
+    }
+
+    /// Evaluate this expression over one nd batch on its minimal footprint grid,
+    /// returning an nd column and recording work into `metrics`.
+    pub fn project(
+        &self,
+        batch: &NdRecordBatch,
+        target: &Dimensions,
+        metrics: &ProjectMetrics,
+    ) -> Result<NdArrowArray> {
+        // Fast path: a single referenced column needs no co-broadcast — its
+        // footprint is its own dimensions. Evaluate on the native (un-broadcast)
+        // values and leave the one gather onto the full grid to NdBroadcastExec.
+        if self.input_indices.len() == 1 {
+            let source = batch.column(self.input_indices[0]);
+            let n = source.values().len();
+            metrics.record(n, target.num_elements(), 0);
+
+            // A bare column reference reuses the nd array as-is.
+            if self.passthrough {
+                return Ok(source.clone());
+            }
+            let values = self.evaluate(vec![source.values().clone()], n)?;
+            return NdArrowArray::try_new(values, source.dims().clone());
+        }
+
+        // General path: union the referenced columns' footprint (in target
+        // order) and co-broadcast each input onto it before evaluating. A column
+        // on fewer axes than the footprint needs a real gather (implicit
+        // broadcast); one already spanning it passes through.
+        let footprint = footprint_of(target, batch, &self.input_indices)?;
+        let n = footprint.num_elements();
+        let mut broadcasts = 0usize;
+        let arrays: Vec<ArrayRef> = self
+            .input_indices
+            .iter()
+            .map(|&i| {
+                let source = batch.column(i);
+                let map = source.broadcast_map(&footprint)?;
+                if !map.is_identity() {
+                    broadcasts += 1;
+                }
+                source.materialize_with_map(&map)
+            })
+            .collect::<Result<_>>()?;
+        metrics.record(n, target.num_elements(), broadcasts);
+        let values = self.evaluate(arrays, n)?;
+        NdArrowArray::try_new(values, footprint)
+    }
+
+    /// Evaluate the (reindexed) expression on a compact batch of `arrays` with
+    /// `rows` rows, returning the result array.
+    fn evaluate(&self, arrays: Vec<ArrayRef>, rows: usize) -> Result<ArrayRef> {
+        let options = RecordBatchOptions::new().with_row_count(Some(rows));
+        let compact =
+            RecordBatch::try_new_with_options(self.compact_schema.clone(), arrays, &options)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        self.expr.evaluate(&compact)?.into_array(rows)
+    }
+}
+
+/// The union of the dimensions of the columns at `input_indices`, ordered by
+/// their position in `target`.
+pub(super) fn footprint_of(
+    target: &Dimensions,
+    batch: &NdRecordBatch,
+    input_indices: &[usize],
+) -> Result<Dimensions> {
+    let referenced: HashSet<&str> = input_indices
+        .iter()
+        .flat_map(|&i| batch.column(i).dims().iter().map(|d| d.name()))
+        .collect();
+    Dimensions::try_new(
+        target
+            .iter()
+            .filter(|d| referenced.contains(d.name()))
+            .cloned()
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+    use std::sync::Arc;
+
+    use arrow::array::{ArrayRef, AsArray, Int32Array};
+    use arrow::datatypes::{DataType, Field, Int32Type, Schema, SchemaRef};
+    use datafusion::common::config::ConfigOptions;
+    use datafusion::logical_expr::{
+        ColumnarValue, Operator, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
+        Volatility,
+    };
+    use datafusion::physical_expr::ScalarFunctionExpr;
+    use datafusion::physical_expr::expressions::{binary, col, lit};
+    use datafusion::physical_plan::metrics::Count;
+
+    use crate::nd::dimensions::Dimension;
+
+    use super::*;
+
+    /// A minimal element-wise scalar function that sums all its Int32 arguments
+    /// (arrays and/or scalars) row-wise — enough to exercise evaluation over
+    /// functions without pulling in datafusion-functions.
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    struct SumUdf {
+        signature: Signature,
+    }
+
+    impl SumUdf {
+        fn new() -> Self {
+            Self {
+                signature: Signature::variadic_any(Volatility::Immutable),
+            }
+        }
+    }
+
+    impl ScalarUDFImpl for SumUdf {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn name(&self) -> &str {
+            "test_sum"
+        }
+        fn signature(&self) -> &Signature {
+            &self.signature
+        }
+        fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+            Ok(DataType::Int32)
+        }
+        fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+            let n = args.number_rows;
+            let mut sums = vec![0i32; n];
+            for arg in &args.args {
+                let array = arg.clone().into_array(n)?;
+                let column = array.as_primitive::<Int32Type>();
+                for (i, s) in sums.iter_mut().enumerate() {
+                    *s += column.value(i);
+                }
+            }
+            Ok(ColumnarValue::Array(Arc::new(Int32Array::from(sums))))
+        }
+    }
+
+    /// Build `test_sum(args...)` as a physical expression against `schema`.
+    fn sum_fn(args: Vec<Arc<dyn PhysicalExpr>>, schema: &Schema) -> Arc<dyn PhysicalExpr> {
+        let udf = Arc::new(ScalarUDF::new_from_impl(SumUdf::new()));
+        Arc::new(
+            ScalarFunctionExpr::try_new(udf, args, schema, Arc::new(ConfigOptions::default()))
+                .unwrap(),
+        )
+    }
+
+    fn dims(spec: &[(&str, usize)]) -> Dimensions {
+        Dimensions::try_new(
+            spec.iter()
+                .map(|(name, size)| Dimension::new(*name, *size))
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    /// Grid (lat=3, lon=2): a `lat` coord, a `lon` coord, and a full-rank
+    /// `temp{lat,lon}` data variable.
+    fn test_batch() -> (SchemaRef, NdRecordBatch) {
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("lat", DataType::Int32, true),
+            Field::new("lon", DataType::Int32, true),
+            Field::new("temp", DataType::Int32, true),
+        ]));
+        let lat = NdArrowArray::try_new(
+            Arc::new(Int32Array::from(vec![10, 20, 30])),
+            dims(&[("lat", 3)]),
+        )
+        .unwrap();
+        let lon =
+            NdArrowArray::try_new(Arc::new(Int32Array::from(vec![1, 2])), dims(&[("lon", 2)]))
+                .unwrap();
+        let temp = NdArrowArray::try_new(
+            Arc::new(Int32Array::from(vec![0, 1, 2, 3, 4, 5])),
+            dims(&[("lat", 3), ("lon", 2)]),
+        )
+        .unwrap();
+        let batch = NdRecordBatch::try_new(
+            schema.clone(),
+            vec![lat, lon, temp],
+            dims(&[("lat", 3), ("lon", 2)]),
+        )
+        .unwrap();
+        (schema, batch)
+    }
+
+    fn metrics() -> ProjectMetrics {
+        ProjectMetrics {
+            elements_evaluated: Count::new(),
+            elements_saved: Count::new(),
+            broadcasts: Count::new(),
+        }
+    }
+
+    fn ints(array: &ArrayRef) -> Vec<i32> {
+        array.as_primitive::<Int32Type>().values().to_vec()
+    }
+
+    #[test]
+    fn build_collects_columns_and_flags_passthrough() {
+        let (schema, _) = test_batch();
+
+        // `lat * 2` references only `lat` (index 0) and is not a bare column.
+        let expr =
+            binary(col("lat", &schema).unwrap(), Operator::Multiply, lit(2i32), &schema).unwrap();
+        let column = NdExprColumn::build(&schema, &expr).unwrap();
+        assert_eq!(column.input_indices, vec![0]);
+        assert!(!column.passthrough);
+
+        // A bare `temp` reference (index 2) is a passthrough.
+        let bare = col("temp", &schema).unwrap();
+        let column = NdExprColumn::build(&schema, &bare).unwrap();
+        assert_eq!(column.input_indices, vec![2]);
+        assert!(column.passthrough);
+    }
+
+    #[test]
+    fn footprint_is_ordered_by_target() {
+        let (_, batch) = test_batch();
+        // Reference lon (idx 1) then lat (idx 0): footprint keeps target order.
+        let footprint = footprint_of(batch.target(), &batch, &[0, 1]).unwrap();
+        assert_eq!(footprint, dims(&[("lat", 3), ("lon", 2)]));
+    }
+
+    #[test]
+    fn project_single_column_evaluates_on_native_footprint() {
+        let (schema, batch) = test_batch();
+        let expr =
+            binary(col("lat", &schema).unwrap(), Operator::Multiply, lit(2i32), &schema).unwrap();
+        let column = NdExprColumn::build(&schema, &expr).unwrap();
+        let m = metrics();
+
+        let out = column.project(&batch, batch.target(), &m).unwrap();
+        assert_eq!(out.dims(), &dims(&[("lat", 3)])); // footprint = lat's own dims
+        assert_eq!(ints(out.values()), vec![20, 40, 60]);
+        // No co-broadcast; evaluated over |lat|=3, saved 6-3.
+        assert_eq!(m.broadcasts.value(), 0);
+        assert_eq!(m.elements_evaluated.value(), 3);
+        assert_eq!(m.elements_saved.value(), 3);
+    }
+
+    #[test]
+    fn project_passthrough_reuses_the_nd_array() {
+        let (schema, batch) = test_batch();
+        let column = NdExprColumn::build(&schema, &col("temp", &schema).unwrap()).unwrap();
+        let m = metrics();
+
+        let out = column.project(&batch, batch.target(), &m).unwrap();
+        assert_eq!(out.dims(), &dims(&[("lat", 3), ("lon", 2)]));
+        assert_eq!(ints(out.values()), vec![0, 1, 2, 3, 4, 5]);
+        assert_eq!(m.broadcasts.value(), 0);
+    }
+
+    #[test]
+    fn project_multi_column_co_broadcasts_onto_footprint() {
+        let (schema, batch) = test_batch();
+        // lat + lon → footprint {lat, lon}; each input gathered onto it.
+        let expr = binary(
+            col("lat", &schema).unwrap(),
+            Operator::Plus,
+            col("lon", &schema).unwrap(),
+            &schema,
+        )
+        .unwrap();
+        let column = NdExprColumn::build(&schema, &expr).unwrap();
+        let m = metrics();
+
+        let out = column.project(&batch, batch.target(), &m).unwrap();
+        assert_eq!(out.dims(), &dims(&[("lat", 3), ("lon", 2)]));
+        // C-order over {lat, lon}: lat replicated over lon, lon tiled over lat.
+        assert_eq!(ints(out.values()), vec![11, 12, 21, 22, 31, 32]);
+        assert_eq!(m.broadcasts.value(), 2);
+        assert_eq!(m.elements_evaluated.value(), 6);
+        assert_eq!(m.elements_saved.value(), 0); // footprint == full grid
+    }
+
+    /// A function over a single column takes the fast path: footprint is that
+    /// column's own dims, no co-broadcast.
+    #[test]
+    fn function_of_single_column_does_not_broadcast() {
+        let (schema, batch) = test_batch();
+        let expr = sum_fn(vec![col("lat", &schema).unwrap()], &schema);
+        let column = NdExprColumn::build(&schema, &expr).unwrap();
+        let m = metrics();
+
+        let out = column.project(&batch, batch.target(), &m).unwrap();
+        assert_eq!(out.dims(), &dims(&[("lat", 3)]));
+        assert_eq!(ints(out.values()), vec![10, 20, 30]);
+        assert_eq!(m.broadcasts.value(), 0);
+        assert_eq!(m.elements_evaluated.value(), 3);
+    }
+
+    /// A function over two columns on different axes unions their footprint and
+    /// co-broadcasts both onto it before evaluating.
+    #[test]
+    fn function_of_two_columns_co_broadcasts() {
+        let (schema, batch) = test_batch();
+        let expr = sum_fn(
+            vec![col("lat", &schema).unwrap(), col("lon", &schema).unwrap()],
+            &schema,
+        );
+        let column = NdExprColumn::build(&schema, &expr).unwrap();
+        let m = metrics();
+
+        let out = column.project(&batch, batch.target(), &m).unwrap();
+        assert_eq!(out.dims(), &dims(&[("lat", 3), ("lon", 2)]));
+        assert_eq!(ints(out.values()), vec![11, 12, 21, 22, 31, 32]);
+        assert_eq!(m.broadcasts.value(), 2);
+        assert_eq!(m.elements_evaluated.value(), 6);
+    }
+
+    /// A function over one column plus a scalar literal references only that one
+    /// column, so it stays on the fast path — the literal adds no dimensions and
+    /// nothing is broadcast up front.
+    #[test]
+    fn function_of_column_and_scalar_does_not_broadcast() {
+        let (schema, batch) = test_batch();
+        let expr = sum_fn(vec![col("lat", &schema).unwrap(), lit(100i32)], &schema);
+        let column = NdExprColumn::build(&schema, &expr).unwrap();
+        // Only `lat` is a referenced column; the literal is folded into the expr.
+        assert_eq!(column.input_indices, vec![0]);
+        let m = metrics();
+
+        let out = column.project(&batch, batch.target(), &m).unwrap();
+        assert_eq!(out.dims(), &dims(&[("lat", 3)])); // footprint = lat's dims
+        assert_eq!(ints(out.values()), vec![110, 120, 130]);
+        assert_eq!(m.broadcasts.value(), 0); // no up-front broadcast
+        assert_eq!(m.elements_evaluated.value(), 3); // evaluated over |lat|, not the grid
+    }
+
+    /// A function over only literals references no columns: it evaluates once on
+    /// a rank-0 scalar footprint and broadcasts to a constant column.
+    #[test]
+    fn function_of_only_scalars_is_rank_zero() {
+        let (schema, batch) = test_batch();
+        let expr = sum_fn(vec![lit(1i32), lit(2i32)], &schema);
+        let column = NdExprColumn::build(&schema, &expr).unwrap();
+        assert!(column.input_indices.is_empty());
+        let m = metrics();
+
+        let out = column.project(&batch, batch.target(), &m).unwrap();
+        assert_eq!(out.dims().rank(), 0); // scalar
+        assert_eq!(ints(out.values()), vec![3]);
+        assert_eq!(m.broadcasts.value(), 0);
+        assert_eq!(m.elements_evaluated.value(), 1);
+        assert_eq!(m.elements_saved.value(), 5); // 6-cell grid minus the 1 scalar
+    }
+}

--- a/beacon-datafusion-ext/src/nd/exec/filter_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/filter_exec.rs
@@ -391,4 +391,114 @@ mod tests {
         let pred = binary(col("lat", &schema).unwrap(), Operator::Gt, lit(15i32), &schema).unwrap();
         assert_eq!(select(&schema, &batch, vec![pred]), vec![2, 4]);
     }
+
+    /// Two conjuncts on the *same* axis form a range: `lat > 10 AND lat < 30`
+    /// keeps lat = 20, i.e. cells 2 and 3.
+    #[test]
+    fn same_axis_conjuncts_form_a_range() {
+        let (schema, batch) = test_batch();
+        let lo = binary(col("lat", &schema).unwrap(), Operator::Gt, lit(10i32), &schema).unwrap();
+        let hi = binary(col("lat", &schema).unwrap(), Operator::Lt, lit(30i32), &schema).unwrap();
+        assert_eq!(select(&schema, &batch, vec![lo, hi]), vec![2, 3]);
+    }
+
+    /// A predicate on the *inner* axis only (`lon = 2`) tiles across lat: cells
+    /// 1, 3, 5.
+    #[test]
+    fn inner_axis_predicate_tiles() {
+        let (schema, batch) = test_batch();
+        let pred = binary(col("lon", &schema).unwrap(), Operator::Eq, lit(2i32), &schema).unwrap();
+        assert_eq!(select(&schema, &batch, vec![pred]), vec![1, 3, 5]);
+    }
+
+    /// A predicate on a full-rank data variable (`temp >= 3`) selects an
+    /// arbitrary subset directly on the grid: cells 3, 4, 5.
+    #[test]
+    fn data_variable_predicate_selects_cells() {
+        let (schema, batch) = test_batch();
+        let pred =
+            binary(col("temp", &schema).unwrap(), Operator::GtEq, lit(3i32), &schema).unwrap();
+        assert_eq!(select(&schema, &batch, vec![pred]), vec![3, 4, 5]);
+    }
+
+    /// A single conjunct containing an `OR` (not split) unions its branches:
+    /// `lat < 15 OR lon = 2` keeps cells 0,1 (lat=10) ∪ 1,3,5 (lon=2) = {0,1,3,5}.
+    #[test]
+    fn or_predicate_unions_branches() {
+        let (schema, batch) = test_batch();
+        let pred = binary(
+            binary(col("lat", &schema).unwrap(), Operator::Lt, lit(15i32), &schema).unwrap(),
+            Operator::Or,
+            binary(col("lon", &schema).unwrap(), Operator::Eq, lit(2i32), &schema).unwrap(),
+            &schema,
+        )
+        .unwrap();
+        assert_eq!(select(&schema, &batch, vec![pred]), vec![0, 1, 3, 5]);
+    }
+
+    /// A cross-axis conjunct intersected with a single-axis one:
+    /// `lat + lon > 22 AND lon = 1` keeps only cell 4.
+    #[test]
+    fn cross_axis_and_single_axis_intersect() {
+        let (schema, batch) = test_batch();
+        let cross = binary(
+            binary(
+                col("lat", &schema).unwrap(),
+                Operator::Plus,
+                col("lon", &schema).unwrap(),
+                &schema,
+            )
+            .unwrap(),
+            Operator::Gt,
+            lit(22i32),
+            &schema,
+        )
+        .unwrap();
+        let inner = binary(col("lon", &schema).unwrap(), Operator::Eq, lit(1i32), &schema).unwrap();
+        assert_eq!(select(&schema, &batch, vec![cross, inner]), vec![4]);
+    }
+
+    /// A predicate no cell satisfies yields an empty selection.
+    #[test]
+    fn predicate_selecting_nothing_is_empty() {
+        let (schema, batch) = test_batch();
+        let pred = binary(col("lat", &schema).unwrap(), Operator::Gt, lit(100i32), &schema).unwrap();
+        assert_eq!(select(&schema, &batch, vec![pred]), Vec::<u64>::new());
+    }
+
+    /// A predicate every cell satisfies retains the whole grid, in order.
+    #[test]
+    fn predicate_selecting_everything_keeps_all() {
+        let (schema, batch) = test_batch();
+        let pred = binary(col("lat", &schema).unwrap(), Operator::GtEq, lit(10i32), &schema).unwrap();
+        assert_eq!(select(&schema, &batch, vec![pred]), vec![0, 1, 2, 3, 4, 5]);
+    }
+
+    /// A cell where the predicate evaluates to NULL is excluded (SQL `WHERE`
+    /// keeps only TRUE). With `lat = [10, null, 30]`, `lat > 15` drops the null
+    /// slice and keeps only the lat=30 cells.
+    #[test]
+    fn null_predicate_value_excludes_cell() {
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("lat", DataType::Int32, true),
+            Field::new("lon", DataType::Int32, true),
+        ]));
+        let lat = NdArrowArray::try_new(
+            Arc::new(Int32Array::from(vec![Some(10), None, Some(30)])),
+            dims(&[("lat", 3)]),
+        )
+        .unwrap();
+        let lon =
+            NdArrowArray::try_new(Arc::new(Int32Array::from(vec![1, 2])), dims(&[("lon", 2)]))
+                .unwrap();
+        let batch = NdRecordBatch::try_new(
+            schema.clone(),
+            vec![lat, lon],
+            dims(&[("lat", 3), ("lon", 2)]),
+        )
+        .unwrap();
+
+        let pred = binary(col("lat", &schema).unwrap(), Operator::Gt, lit(15i32), &schema).unwrap();
+        assert_eq!(select(&schema, &batch, vec![pred]), vec![4, 5]);
+    }
 }

--- a/beacon-datafusion-ext/src/nd/exec/filter_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/filter_exec.rs
@@ -1,0 +1,394 @@
+//! Filter evaluated *before* broadcast.
+//!
+//! A `WHERE` predicate is element-wise: whether grid cell `(t, y, x)` is kept
+//! depends only on its input columns at `(t, y, x)`. So instead of broadcasting
+//! every column onto the full grid and then filtering (a plain `FilterExec`
+//! above [`NdBroadcastExec`]), each conjunct is evaluated on the *minimal*
+//! sub-grid its inputs span — its footprint — and the resulting boolean mask is
+//! lifted to the target grid. The conjunct masks are combined (null → excluded)
+//! into the set of retained target cells, which rides the nd batch as a
+//! [`selection`](NdRecordBatch::selection).
+//!
+//! No column data moves here: the filter attaches an index array.
+//! [`NdBroadcastExec`] then fuses the broadcast with the selection into one
+//! gather per column, so the filtered-out cross-product is never materialized —
+//! and every operator above the broadcast sees only the surviving rows.
+
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+use arrow::array::{Array, BooleanArray, UInt64Array};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
+};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
+};
+use futures::StreamExt;
+
+use crate::nd::batch::NdRecordBatch;
+
+use super::expr_column::{NdExprColumn, ProjectMetrics};
+use super::{NdBroadcastExec, NdExecutionPlan, SendableNdBatchStream, as_nd_plan};
+
+/// Per-partition counters recorded while filtering.
+struct FilterMetrics {
+    /// Target cells seen before filtering (∑ grid sizes, honoring any inbound
+    /// selection).
+    input_rows: Count,
+    /// Cells removed by the predicate.
+    rows_pruned: Count,
+    /// Footprint evaluation work of the conjuncts (shared with projection).
+    project: ProjectMetrics,
+}
+
+/// Applies a conjunction of element-wise predicates over un-broadcast nd
+/// batches, recording the result as a grid selection instead of dropping
+/// columns. Requires an nd-aware child and is itself nd-aware, so it slots
+/// between [`NdSourceExec`](super::NdSourceExec) and [`NdBroadcastExec`].
+#[derive(Debug, Clone)]
+pub struct NdFilterExec {
+    /// nd-aware child producing the input nd batches.
+    input: Arc<dyn ExecutionPlan>,
+    /// Predicate conjuncts, ANDed together (each must be boolean).
+    predicates: Vec<Arc<dyn PhysicalExpr>>,
+    /// Per-conjunct evaluation plan (derived from `predicates`).
+    columns: Vec<NdExprColumn>,
+    properties: Arc<PlanProperties>,
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl NdFilterExec {
+    /// Build a filter over an nd-aware `input`. `predicates` are the conjuncts to
+    /// apply (ANDed); each must be evaluable against `input`'s schema and yield a
+    /// boolean. The output schema equals the input schema — a filter selects
+    /// rows, it does not change columns.
+    pub fn try_new(
+        input: Arc<dyn ExecutionPlan>,
+        predicates: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Self> {
+        if as_nd_plan(&input).is_none() {
+            return Err(DataFusionError::Plan(format!(
+                "NdFilterExec requires an nd-aware input, got {}",
+                input.name()
+            )));
+        }
+        if predicates.is_empty() {
+            return Err(DataFusionError::Plan(
+                "NdFilterExec requires at least one predicate".to_string(),
+            ));
+        }
+        let input_schema = input.schema();
+        let columns = predicates
+            .iter()
+            .map(|expr| NdExprColumn::build(&input_schema, expr))
+            .collect::<Result<Vec<_>>>()?;
+
+        // A filter preserves its input's columns and ordering; only row count
+        // and statistics change, so reuse the child's plan properties.
+        let properties = input.properties().clone();
+        Ok(Self {
+            input,
+            predicates,
+            columns,
+            properties,
+            metrics: ExecutionPlanMetricsSet::new(),
+        })
+    }
+
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    pub fn predicates(&self) -> &[Arc<dyn PhysicalExpr>] {
+        &self.predicates
+    }
+
+    /// Filter one nd batch: compute the retained target cells and attach them as
+    /// the batch's selection (intersected with any inbound selection).
+    fn filter_batch(&self, batch: &NdRecordBatch, metrics: &FilterMetrics) -> Result<NdRecordBatch> {
+        metrics.input_rows.add(batch.num_rows());
+        let retained = retained_indices(&self.columns, batch, &metrics.project)?;
+        metrics
+            .rows_pruned
+            .add(batch.num_rows().saturating_sub(retained.len()));
+        batch.clone().with_selection(Some(retained))
+    }
+}
+
+/// Evaluate the conjuncts over one nd batch and return the retained target-cell
+/// indices (row-major). Each conjunct is evaluated on its footprint, its boolean
+/// mask is broadcast onto the target grid, and the masks are ANDed — a null
+/// predicate value excludes the cell. The result is intersected with any
+/// selection a child already accumulated, so it is always a subset of the
+/// batch's current rows.
+fn retained_indices(
+    columns: &[NdExprColumn],
+    batch: &NdRecordBatch,
+    metrics: &ProjectMetrics,
+) -> Result<UInt64Array> {
+    let target = batch.target();
+    let n = target.num_elements();
+
+    // `keep[i]` starts true and is ANDed with each conjunct's mask over the full
+    // target grid, so all conjuncts combine in one coordinate system.
+    let mut keep = vec![true; n];
+    for column in columns {
+        let masked = column.project(batch, target, metrics)?;
+        let broadcast = masked.materialize(target)?;
+        let mask = broadcast
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .ok_or_else(|| {
+                DataFusionError::Plan(
+                    "NdFilterExec predicate did not evaluate to a boolean".to_string(),
+                )
+            })?;
+        for (i, slot) in keep.iter_mut().enumerate() {
+            *slot &= mask.is_valid(i) && mask.value(i);
+        }
+    }
+
+    Ok(match batch.selection() {
+        Some(sel) => sel
+            .values()
+            .iter()
+            .copied()
+            .filter(|&t| keep[t as usize])
+            .collect(),
+        None => (0..n as u64).filter(|&t| keep[t as usize]).collect(),
+    })
+}
+
+impl DisplayAs for NdFilterExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let preds: Vec<String> = self.predicates.iter().map(|p| p.to_string()).collect();
+        write!(f, "NdFilterExec: predicate=[{}]", preds.join(" AND "))
+    }
+}
+
+impl ExecutionPlan for NdFilterExec {
+    fn name(&self) -> &str {
+        "NdFilterExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let [input] = <[_; 1]>::try_from(children).map_err(|_| {
+            DataFusionError::Internal("NdFilterExec expects exactly one child".to_string())
+        })?;
+        Ok(Arc::new(Self::try_new(input, self.predicates.clone())?))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        // Like the other nd operators, the real output is the un-broadcast nd
+        // stream from `execute_nd`; a standalone execution wraps this node in an
+        // `NdBroadcastExec` to materialize. In a real plan an `NdBroadcastExec`
+        // sits above and pulls `execute_nd` directly, so this path is unused.
+        NdBroadcastExec::try_new(Arc::new(self.clone()))?.execute(partition, context)
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+}
+
+impl NdExecutionPlan for NdFilterExec {
+    fn execute_nd(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableNdBatchStream> {
+        let baseline = BaselineMetrics::new(&self.metrics, partition);
+        let filter_metrics = FilterMetrics {
+            input_rows: MetricBuilder::new(&self.metrics).counter("input_rows", partition),
+            rows_pruned: MetricBuilder::new(&self.metrics).counter("rows_pruned", partition),
+            project: ProjectMetrics {
+                elements_evaluated: MetricBuilder::new(&self.metrics)
+                    .counter("elements_evaluated", partition),
+                elements_saved: MetricBuilder::new(&self.metrics)
+                    .counter("elements_saved", partition),
+                broadcasts: MetricBuilder::new(&self.metrics)
+                    .counter("implicit_broadcasts", partition),
+            },
+        };
+        let this = self.clone();
+        let stream = as_nd_plan(&self.input)
+            .expect("validated in try_new")
+            .execute_nd(partition, context)?
+            .map(move |item| {
+                let _timer = baseline.elapsed_compute().timer();
+                let batch = item?;
+                let filtered = this.filter_batch(&batch, &filter_metrics)?;
+                baseline.record_output(filtered.num_rows());
+                Ok(filtered)
+            });
+        Ok(Box::pin(stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{AsArray, Int32Array};
+    use arrow::datatypes::{DataType, Field, Int32Type, Schema, SchemaRef};
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_expr::expressions::{binary, col, lit};
+
+    use crate::nd::array::NdArrowArray;
+    use crate::nd::dimensions::{Dimension, Dimensions};
+
+    use super::*;
+
+    fn dims(spec: &[(&str, usize)]) -> Dimensions {
+        Dimensions::try_new(
+            spec.iter()
+                .map(|(name, size)| Dimension::new(*name, *size))
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    /// Grid (lat=3, lon=2): a `lat` coord, a `lon` coord, and a full-rank
+    /// `temp{lat,lon}` data variable.
+    fn test_batch() -> (SchemaRef, NdRecordBatch) {
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("lat", DataType::Int32, true),
+            Field::new("lon", DataType::Int32, true),
+            Field::new("temp", DataType::Int32, true),
+        ]));
+        let lat = NdArrowArray::try_new(
+            Arc::new(Int32Array::from(vec![10, 20, 30])),
+            dims(&[("lat", 3)]),
+        )
+        .unwrap();
+        let lon =
+            NdArrowArray::try_new(Arc::new(Int32Array::from(vec![1, 2])), dims(&[("lon", 2)]))
+                .unwrap();
+        let temp = NdArrowArray::try_new(
+            Arc::new(Int32Array::from(vec![0, 1, 2, 3, 4, 5])),
+            dims(&[("lat", 3), ("lon", 2)]),
+        )
+        .unwrap();
+        let batch = NdRecordBatch::try_new(
+            schema.clone(),
+            vec![lat, lon, temp],
+            dims(&[("lat", 3), ("lon", 2)]),
+        )
+        .unwrap();
+        (schema, batch)
+    }
+
+    fn no_metrics() -> ProjectMetrics {
+        ProjectMetrics {
+            elements_evaluated: Count::new(),
+            elements_saved: Count::new(),
+            broadcasts: Count::new(),
+        }
+    }
+
+    /// Build the per-conjunct evaluation plan and compute the retained cells.
+    fn select(schema: &SchemaRef, batch: &NdRecordBatch, preds: Vec<Arc<dyn PhysicalExpr>>) -> Vec<u64> {
+        let columns = preds
+            .iter()
+            .map(|expr| NdExprColumn::build(schema, expr))
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
+        retained_indices(&columns, batch, &no_metrics())
+            .unwrap()
+            .values()
+            .to_vec()
+    }
+
+    /// A single-axis predicate (`lat > 15`) selects whole lat-slices: cells
+    /// where lat ∈ {20, 30}, i.e. target rows 2,3,4,5 of the C-order grid.
+    #[test]
+    fn single_axis_predicate_selects_slices() {
+        let (schema, batch) = test_batch();
+        let pred = binary(col("lat", &schema).unwrap(), Operator::Gt, lit(15i32), &schema).unwrap();
+        assert_eq!(select(&schema, &batch, vec![pred]), vec![2, 3, 4, 5]);
+
+        // Materializing the selected batch gathers exactly those cells.
+        let out = batch
+            .with_selection(Some(UInt64Array::from(vec![2u64, 3, 4, 5])))
+            .unwrap()
+            .materialize()
+            .unwrap();
+        assert_eq!(
+            out.column(0).as_primitive::<Int32Type>().values(),
+            &[20, 20, 30, 30]
+        );
+        assert_eq!(
+            out.column(2).as_primitive::<Int32Type>().values(),
+            &[2, 3, 4, 5]
+        );
+    }
+
+    /// A cross-axis predicate (`lat + lon > 22`) selects an arbitrary,
+    /// non-factorizable subset of the grid — handled the same way.
+    #[test]
+    fn cross_axis_predicate_selects_arbitrary_cells() {
+        let (schema, batch) = test_batch();
+        // Grid cells (lat,lon): (10,1)=11,(10,2)=12,(20,1)=21,(20,2)=22,
+        // (30,1)=31,(30,2)=32. `>22` keeps cells 4,5 (lat=30).
+        let pred = binary(
+            binary(
+                col("lat", &schema).unwrap(),
+                Operator::Plus,
+                col("lon", &schema).unwrap(),
+                &schema,
+            )
+            .unwrap(),
+            Operator::Gt,
+            lit(22i32),
+            &schema,
+        )
+        .unwrap();
+        assert_eq!(select(&schema, &batch, vec![pred]), vec![4, 5]);
+    }
+
+    /// Two conjuncts intersect: `lat > 15 AND lon = 2` keeps cells 3 and 5.
+    #[test]
+    fn conjuncts_intersect() {
+        let (schema, batch) = test_batch();
+        let p1 = binary(col("lat", &schema).unwrap(), Operator::Gt, lit(15i32), &schema).unwrap();
+        let p2 = binary(col("lon", &schema).unwrap(), Operator::Eq, lit(2i32), &schema).unwrap();
+        assert_eq!(select(&schema, &batch, vec![p1, p2]), vec![3, 5]);
+    }
+
+    /// A filter over an already-selected batch intersects with the inbound
+    /// selection rather than replacing it.
+    #[test]
+    fn intersects_inbound_selection() {
+        let (schema, batch) = test_batch();
+        let batch = batch
+            .with_selection(Some(UInt64Array::from(vec![0u64, 2, 4])))
+            .unwrap();
+        // lat > 15 keeps target rows 2,3,4,5; intersect with {0,2,4} → {2,4}.
+        let pred = binary(col("lat", &schema).unwrap(), Operator::Gt, lit(15i32), &schema).unwrap();
+        assert_eq!(select(&schema, &batch, vec![pred]), vec![2, 4]);
+    }
+}

--- a/beacon-datafusion-ext/src/nd/exec/mod.rs
+++ b/beacon-datafusion-ext/src/nd/exec/mod.rs
@@ -8,6 +8,8 @@
 //! also a correct plan on its own.
 
 mod broadcast_exec;
+mod expr_column;
+mod filter_exec;
 mod projection_exec;
 mod source_exec;
 
@@ -25,6 +27,7 @@ use futures::stream::BoxStream;
 use super::batch::NdRecordBatch;
 
 pub use broadcast_exec::NdBroadcastExec;
+pub use filter_exec::NdFilterExec;
 pub use projection_exec::NdProjectionExec;
 pub use source_exec::NdSourceExec;
 
@@ -50,6 +53,9 @@ pub fn as_nd_plan(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn NdExecutionPl
     }
     if let Some(projection) = any.downcast_ref::<NdProjectionExec>() {
         return Some(Arc::new(projection.clone()));
+    }
+    if let Some(filter) = any.downcast_ref::<NdFilterExec>() {
+        return Some(Arc::new(filter.clone()));
     }
     None
 }

--- a/beacon-datafusion-ext/src/nd/exec/projection_exec.rs
+++ b/beacon-datafusion-ext/src/nd/exec/projection_exec.rs
@@ -18,147 +18,22 @@ use std::any::Any;
 use std::fmt;
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, RecordBatch, RecordBatchOptions};
 use arrow::datatypes::{Field, Schema, SchemaRef};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
-use datafusion::physical_expr::expressions::Column;
-use datafusion::physical_expr::utils::{collect_columns, reassign_expr_columns};
 use datafusion::physical_expr::{EquivalenceProperties, PhysicalExpr};
 use datafusion::physical_plan::metrics::{
-    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
+    BaselineMetrics, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
 };
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
 };
 use futures::StreamExt;
 
-use crate::nd::array::NdArrowArray;
 use crate::nd::batch::NdRecordBatch;
-use crate::nd::dimensions::Dimensions;
 
+use super::expr_column::{NdExprColumn, ProjectMetrics};
 use super::{NdBroadcastExec, NdExecutionPlan, SendableNdBatchStream, as_nd_plan};
-
-/// Per-partition metric counters recorded while projecting.
-struct ProjectionMetrics {
-    /// Total elements the expressions were evaluated over (∑ footprint sizes).
-    elements_evaluated: Count,
-    /// Elements avoided versus evaluating on the full grid (∑ target − footprint).
-    elements_saved: Count,
-    /// Implicit gathers to co-broadcast referenced columns onto their footprint.
-    broadcasts: Count,
-}
-
-impl ProjectionMetrics {
-    /// Record one output column: `evaluated` elements over its footprint (out of
-    /// `target` on the full grid), and `broadcasts` implicit co-broadcasts.
-    fn record(&self, evaluated: usize, target: usize, broadcasts: usize) {
-        self.elements_evaluated.add(evaluated);
-        self.elements_saved.add(target.saturating_sub(evaluated));
-        self.broadcasts.add(broadcasts);
-    }
-}
-
-/// One output column: an expression rewritten to reference only the columns it
-/// uses, plus the indices of those columns in the child's schema.
-#[derive(Debug, Clone)]
-struct ProjectionColumn {
-    /// The expression, with its `Column`s reindexed against `compact_schema`.
-    expr: Arc<dyn PhysicalExpr>,
-    /// Fields of the referenced input columns, in child-schema order.
-    compact_schema: SchemaRef,
-    /// Indices (into the child batch) of the referenced input columns, aligned
-    /// with `compact_schema`.
-    input_indices: Vec<usize>,
-    /// True when `expr` is a bare column reference — the input nd column can be
-    /// reused directly, skipping evaluation entirely.
-    passthrough: bool,
-}
-
-impl ProjectionColumn {
-    /// Analyze one expression against the child schema: collect the columns it
-    /// references, build a compact schema of just those, and reindex the
-    /// expression's `Column`s onto it so it can be evaluated against a batch of
-    /// only the referenced columns.
-    fn build(input_schema: &SchemaRef, expr: &Arc<dyn PhysicalExpr>) -> Result<Self> {
-        let mut input_indices: Vec<usize> =
-            collect_columns(expr).iter().map(|c| c.index()).collect();
-        input_indices.sort_unstable();
-        input_indices.dedup();
-        let compact_schema = Arc::new(Schema::new(
-            input_indices
-                .iter()
-                .map(|&i| input_schema.field(i).clone())
-                .collect::<Vec<_>>(),
-        ));
-        let expr = reassign_expr_columns(expr.clone(), &compact_schema)?;
-        let passthrough = expr.as_any().is::<Column>();
-        Ok(Self {
-            expr,
-            compact_schema,
-            input_indices,
-            passthrough,
-        })
-    }
-
-    /// Project this column from one nd batch onto the minimal footprint grid,
-    /// returning an nd column and recording work into `metrics`.
-    fn project(
-        &self,
-        batch: &NdRecordBatch,
-        target: &Dimensions,
-        metrics: &ProjectionMetrics,
-    ) -> Result<NdArrowArray> {
-        // Fast path: a single referenced column needs no co-broadcast — its
-        // footprint is its own dimensions. Evaluate on the native (un-broadcast)
-        // values and leave the one gather onto the full grid to NdBroadcastExec.
-        if self.input_indices.len() == 1 {
-            let source = batch.column(self.input_indices[0]);
-            let n = source.values().len();
-            metrics.record(n, target.num_elements(), 0);
-
-            // A bare column reference reuses the nd array as-is.
-            if self.passthrough {
-                return Ok(source.clone());
-            }
-            let values = self.evaluate(vec![source.values().clone()], n)?;
-            return NdArrowArray::try_new(values, source.dims().clone());
-        }
-
-        // General path: union the referenced columns' footprint (in target
-        // order) and co-broadcast each input onto it before evaluating. A column
-        // on fewer axes than the footprint needs a real gather (implicit
-        // broadcast); one already spanning it passes through.
-        let footprint = footprint_of(target, batch, &self.input_indices)?;
-        let n = footprint.num_elements();
-        let mut broadcasts = 0usize;
-        let arrays: Vec<ArrayRef> = self
-            .input_indices
-            .iter()
-            .map(|&i| {
-                let source = batch.column(i);
-                let map = source.broadcast_map(&footprint)?;
-                if !map.is_identity() {
-                    broadcasts += 1;
-                }
-                source.materialize_with_map(&map)
-            })
-            .collect::<Result<_>>()?;
-        metrics.record(n, target.num_elements(), broadcasts);
-        let values = self.evaluate(arrays, n)?;
-        NdArrowArray::try_new(values, footprint)
-    }
-
-    /// Evaluate the (reindexed) expression on a compact batch of `arrays` with
-    /// `rows` rows, returning the result array.
-    fn evaluate(&self, arrays: Vec<ArrayRef>, rows: usize) -> Result<ArrayRef> {
-        let options = RecordBatchOptions::new().with_row_count(Some(rows));
-        let compact =
-            RecordBatch::try_new_with_options(self.compact_schema.clone(), arrays, &options)
-                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-        self.expr.evaluate(&compact)?.into_array(rows)
-    }
-}
 
 /// Projects a list of element-wise expressions over un-broadcast nd batches,
 /// evaluating each on its footprint sub-grid. Requires an nd-aware child and is
@@ -172,7 +47,7 @@ pub struct NdProjectionExec {
     /// `with_new_children`).
     exprs: Vec<(Arc<dyn PhysicalExpr>, String)>,
     /// Per-output-column evaluation plan (derived from `exprs`).
-    columns: Vec<ProjectionColumn>,
+    columns: Vec<NdExprColumn>,
     /// Output (projected) schema.
     schema: SchemaRef,
     properties: Arc<PlanProperties>,
@@ -215,7 +90,7 @@ impl NdProjectionExec {
                 expr.data_type(&input_schema)?,
                 expr.nullable(&input_schema)?,
             ));
-            columns.push(ProjectionColumn::build(&input_schema, expr)?);
+            columns.push(NdExprColumn::build(&input_schema, expr)?);
         }
 
         let derived = Arc::new(Schema::new(fields));
@@ -266,11 +141,16 @@ impl NdProjectionExec {
 
     /// Project one nd batch: evaluate every output column on its footprint grid,
     /// recording work into `metrics`. Per-column logic lives in
-    /// [`ProjectionColumn::project`].
+    /// [`NdExprColumn::project`].
+    ///
+    /// Any grid selection accumulated by a child (e.g. an [`NdFilterExec`]) is
+    /// carried through unchanged: element-wise projection commutes with row
+    /// selection, and the output columns live on the same target grid, so the
+    /// same retained-cell indices still apply.
     fn project_batch(
         &self,
         batch: &NdRecordBatch,
-        metrics: &ProjectionMetrics,
+        metrics: &ProjectMetrics,
     ) -> Result<NdRecordBatch> {
         let target = batch.target();
         let projected = self
@@ -278,28 +158,9 @@ impl NdProjectionExec {
             .iter()
             .map(|column| column.project(batch, target, metrics))
             .collect::<Result<Vec<_>>>()?;
-        NdRecordBatch::try_new(self.schema.clone(), projected, target.clone())
+        NdRecordBatch::try_new(self.schema.clone(), projected, target.clone())?
+            .with_selection(batch.selection().cloned())
     }
-}
-
-/// The union of the dimensions of the columns at `input_indices`, ordered by
-/// their position in `target`.
-fn footprint_of(
-    target: &Dimensions,
-    batch: &NdRecordBatch,
-    input_indices: &[usize],
-) -> Result<Dimensions> {
-    let referenced: std::collections::HashSet<&str> = input_indices
-        .iter()
-        .flat_map(|&i| batch.column(i).dims().iter().map(|d| d.name()))
-        .collect();
-    Dimensions::try_new(
-        target
-            .iter()
-            .filter(|d| referenced.contains(d.name()))
-            .cloned()
-            .collect(),
-    )
 }
 
 impl DisplayAs for NdProjectionExec {
@@ -367,7 +228,7 @@ impl NdExecutionPlan for NdProjectionExec {
         context: Arc<TaskContext>,
     ) -> Result<SendableNdBatchStream> {
         let baseline = BaselineMetrics::new(&self.metrics, partition);
-        let projection_metrics = ProjectionMetrics {
+        let projection_metrics = ProjectMetrics {
             elements_evaluated: MetricBuilder::new(&self.metrics)
                 .counter("elements_evaluated", partition),
             elements_saved: MetricBuilder::new(&self.metrics)
@@ -387,281 +248,5 @@ impl NdExecutionPlan for NdProjectionExec {
                 Ok(projected)
             });
         Ok(Box::pin(stream))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::any::Any;
-    use std::sync::Arc;
-
-    use arrow::array::{ArrayRef, AsArray, Int32Array};
-    use arrow::datatypes::{DataType, Field, Int32Type, Schema, SchemaRef};
-    use datafusion::common::config::ConfigOptions;
-    use datafusion::logical_expr::{
-        ColumnarValue, Operator, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
-        Volatility,
-    };
-    use datafusion::physical_expr::ScalarFunctionExpr;
-    use datafusion::physical_expr::expressions::{binary, col, lit};
-    use datafusion::physical_plan::metrics::Count;
-
-    use crate::nd::dimensions::Dimension;
-
-    use super::*;
-
-    /// A minimal element-wise scalar function that sums all its Int32 arguments
-    /// (arrays and/or scalars) row-wise — enough to exercise projection over
-    /// functions without pulling in datafusion-functions.
-    #[derive(Debug, PartialEq, Eq, Hash)]
-    struct SumUdf {
-        signature: Signature,
-    }
-
-    impl SumUdf {
-        fn new() -> Self {
-            Self {
-                signature: Signature::variadic_any(Volatility::Immutable),
-            }
-        }
-    }
-
-    impl ScalarUDFImpl for SumUdf {
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-        fn name(&self) -> &str {
-            "test_sum"
-        }
-        fn signature(&self) -> &Signature {
-            &self.signature
-        }
-        fn return_type(&self, _: &[DataType]) -> Result<DataType> {
-            Ok(DataType::Int32)
-        }
-        fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-            let n = args.number_rows;
-            let mut sums = vec![0i32; n];
-            for arg in &args.args {
-                let array = arg.clone().into_array(n)?;
-                let column = array.as_primitive::<Int32Type>();
-                for (i, s) in sums.iter_mut().enumerate() {
-                    *s += column.value(i);
-                }
-            }
-            Ok(ColumnarValue::Array(Arc::new(Int32Array::from(sums))))
-        }
-    }
-
-    /// Build `test_sum(args...)` as a physical expression against `schema`.
-    fn sum_fn(args: Vec<Arc<dyn PhysicalExpr>>, schema: &Schema) -> Arc<dyn PhysicalExpr> {
-        let udf = Arc::new(ScalarUDF::new_from_impl(SumUdf::new()));
-        Arc::new(
-            ScalarFunctionExpr::try_new(udf, args, schema, Arc::new(ConfigOptions::default()))
-                .unwrap(),
-        )
-    }
-
-    fn dims(spec: &[(&str, usize)]) -> Dimensions {
-        Dimensions::try_new(
-            spec.iter()
-                .map(|(name, size)| Dimension::new(*name, *size))
-                .collect(),
-        )
-        .unwrap()
-    }
-
-    /// Grid (lat=3, lon=2): a `lat` coord, a `lon` coord, and a full-rank
-    /// `temp{lat,lon}` data variable.
-    fn test_batch() -> (SchemaRef, NdRecordBatch) {
-        let schema: SchemaRef = Arc::new(Schema::new(vec![
-            Field::new("lat", DataType::Int32, true),
-            Field::new("lon", DataType::Int32, true),
-            Field::new("temp", DataType::Int32, true),
-        ]));
-        let lat = NdArrowArray::try_new(
-            Arc::new(Int32Array::from(vec![10, 20, 30])),
-            dims(&[("lat", 3)]),
-        )
-        .unwrap();
-        let lon =
-            NdArrowArray::try_new(Arc::new(Int32Array::from(vec![1, 2])), dims(&[("lon", 2)]))
-                .unwrap();
-        let temp = NdArrowArray::try_new(
-            Arc::new(Int32Array::from(vec![0, 1, 2, 3, 4, 5])),
-            dims(&[("lat", 3), ("lon", 2)]),
-        )
-        .unwrap();
-        let batch = NdRecordBatch::try_new(
-            schema.clone(),
-            vec![lat, lon, temp],
-            dims(&[("lat", 3), ("lon", 2)]),
-        )
-        .unwrap();
-        (schema, batch)
-    }
-
-    fn metrics() -> ProjectionMetrics {
-        ProjectionMetrics {
-            elements_evaluated: Count::new(),
-            elements_saved: Count::new(),
-            broadcasts: Count::new(),
-        }
-    }
-
-    fn ints(array: &ArrayRef) -> Vec<i32> {
-        array.as_primitive::<Int32Type>().values().to_vec()
-    }
-
-    #[test]
-    fn build_collects_columns_and_flags_passthrough() {
-        let (schema, _) = test_batch();
-
-        // `lat * 2` references only `lat` (index 0) and is not a bare column.
-        let expr =
-            binary(col("lat", &schema).unwrap(), Operator::Multiply, lit(2i32), &schema).unwrap();
-        let column = ProjectionColumn::build(&schema, &expr).unwrap();
-        assert_eq!(column.input_indices, vec![0]);
-        assert!(!column.passthrough);
-
-        // A bare `temp` reference (index 2) is a passthrough.
-        let bare = col("temp", &schema).unwrap();
-        let column = ProjectionColumn::build(&schema, &bare).unwrap();
-        assert_eq!(column.input_indices, vec![2]);
-        assert!(column.passthrough);
-    }
-
-    #[test]
-    fn footprint_is_ordered_by_target() {
-        let (_, batch) = test_batch();
-        // Reference lon (idx 1) then lat (idx 0): footprint keeps target order.
-        let footprint = footprint_of(batch.target(), &batch, &[0, 1]).unwrap();
-        assert_eq!(footprint, dims(&[("lat", 3), ("lon", 2)]));
-    }
-
-    #[test]
-    fn project_single_column_evaluates_on_native_footprint() {
-        let (schema, batch) = test_batch();
-        let expr =
-            binary(col("lat", &schema).unwrap(), Operator::Multiply, lit(2i32), &schema).unwrap();
-        let column = ProjectionColumn::build(&schema, &expr).unwrap();
-        let m = metrics();
-
-        let out = column.project(&batch, batch.target(), &m).unwrap();
-        assert_eq!(out.dims(), &dims(&[("lat", 3)])); // footprint = lat's own dims
-        assert_eq!(ints(out.values()), vec![20, 40, 60]);
-        // No co-broadcast; evaluated over |lat|=3, saved 6-3.
-        assert_eq!(m.broadcasts.value(), 0);
-        assert_eq!(m.elements_evaluated.value(), 3);
-        assert_eq!(m.elements_saved.value(), 3);
-    }
-
-    #[test]
-    fn project_passthrough_reuses_the_nd_array() {
-        let (schema, batch) = test_batch();
-        let column = ProjectionColumn::build(&schema, &col("temp", &schema).unwrap()).unwrap();
-        let m = metrics();
-
-        let out = column.project(&batch, batch.target(), &m).unwrap();
-        assert_eq!(out.dims(), &dims(&[("lat", 3), ("lon", 2)]));
-        assert_eq!(ints(out.values()), vec![0, 1, 2, 3, 4, 5]);
-        assert_eq!(m.broadcasts.value(), 0);
-    }
-
-    #[test]
-    fn project_multi_column_co_broadcasts_onto_footprint() {
-        let (schema, batch) = test_batch();
-        // lat + lon → footprint {lat, lon}; each input gathered onto it.
-        let expr = binary(
-            col("lat", &schema).unwrap(),
-            Operator::Plus,
-            col("lon", &schema).unwrap(),
-            &schema,
-        )
-        .unwrap();
-        let column = ProjectionColumn::build(&schema, &expr).unwrap();
-        let m = metrics();
-
-        let out = column.project(&batch, batch.target(), &m).unwrap();
-        assert_eq!(out.dims(), &dims(&[("lat", 3), ("lon", 2)]));
-        // C-order over {lat, lon}: lat replicated over lon, lon tiled over lat.
-        assert_eq!(ints(out.values()), vec![11, 12, 21, 22, 31, 32]);
-        assert_eq!(m.broadcasts.value(), 2);
-        assert_eq!(m.elements_evaluated.value(), 6);
-        assert_eq!(m.elements_saved.value(), 0); // footprint == full grid
-    }
-
-    // ── scalar functions ────────────────────────────────────────────────
-
-    /// A function over a single column takes the fast path: footprint is that
-    /// column's own dims, no co-broadcast.
-    #[test]
-    fn function_of_single_column_does_not_broadcast() {
-        let (schema, batch) = test_batch();
-        let expr = sum_fn(vec![col("lat", &schema).unwrap()], &schema);
-        let column = ProjectionColumn::build(&schema, &expr).unwrap();
-        let m = metrics();
-
-        let out = column.project(&batch, batch.target(), &m).unwrap();
-        assert_eq!(out.dims(), &dims(&[("lat", 3)]));
-        assert_eq!(ints(out.values()), vec![10, 20, 30]);
-        assert_eq!(m.broadcasts.value(), 0);
-        assert_eq!(m.elements_evaluated.value(), 3);
-    }
-
-    /// A function over two columns on different axes unions their footprint and
-    /// co-broadcasts both onto it before evaluating.
-    #[test]
-    fn function_of_two_columns_co_broadcasts() {
-        let (schema, batch) = test_batch();
-        let expr = sum_fn(
-            vec![col("lat", &schema).unwrap(), col("lon", &schema).unwrap()],
-            &schema,
-        );
-        let column = ProjectionColumn::build(&schema, &expr).unwrap();
-        let m = metrics();
-
-        let out = column.project(&batch, batch.target(), &m).unwrap();
-        assert_eq!(out.dims(), &dims(&[("lat", 3), ("lon", 2)]));
-        assert_eq!(ints(out.values()), vec![11, 12, 21, 22, 31, 32]);
-        assert_eq!(m.broadcasts.value(), 2);
-        assert_eq!(m.elements_evaluated.value(), 6);
-    }
-
-    /// A function over one column plus a scalar literal references only that one
-    /// column, so it stays on the fast path — the literal adds no dimensions and
-    /// nothing is broadcast up front.
-    #[test]
-    fn function_of_column_and_scalar_does_not_broadcast() {
-        let (schema, batch) = test_batch();
-        let expr = sum_fn(vec![col("lat", &schema).unwrap(), lit(100i32)], &schema);
-        let column = ProjectionColumn::build(&schema, &expr).unwrap();
-        // Only `lat` is a referenced column; the literal is folded into the expr.
-        assert_eq!(column.input_indices, vec![0]);
-        let m = metrics();
-
-        let out = column.project(&batch, batch.target(), &m).unwrap();
-        assert_eq!(out.dims(), &dims(&[("lat", 3)])); // footprint = lat's dims
-        assert_eq!(ints(out.values()), vec![110, 120, 130]);
-        assert_eq!(m.broadcasts.value(), 0); // no up-front broadcast
-        assert_eq!(m.elements_evaluated.value(), 3); // evaluated over |lat|, not the grid
-    }
-
-    /// A function over only literals references no columns: it evaluates once on
-    /// a rank-0 scalar footprint and broadcasts to a constant column.
-    #[test]
-    fn function_of_only_scalars_is_rank_zero() {
-        let (schema, batch) = test_batch();
-        let expr = sum_fn(vec![lit(1i32), lit(2i32)], &schema);
-        let column = ProjectionColumn::build(&schema, &expr).unwrap();
-        assert!(column.input_indices.is_empty());
-        let m = metrics();
-
-        let out = column.project(&batch, batch.target(), &m).unwrap();
-        assert_eq!(out.dims().rank(), 0); // scalar
-        assert_eq!(ints(out.values()), vec![3]);
-        assert_eq!(m.broadcasts.value(), 0);
-        assert_eq!(m.elements_evaluated.value(), 1);
-        assert_eq!(m.elements_saved.value(), 5); // 6-cell grid minus the 1 scalar
     }
 }

--- a/beacon-datafusion-ext/src/nd/mod.rs
+++ b/beacon-datafusion-ext/src/nd/mod.rs
@@ -33,7 +33,7 @@ pub use encoding::{
     decode_nd_record_batch, encode_flat_batch_as_nd, encode_nd_record_batch, encoded_schema,
     is_nd_encoded, logical_schema, nd_encoded_field, nd_encoded_type,
 };
-pub use optimizer::{NdProjectionPushdown, is_pushable_expr};
+pub use optimizer::{NdFilterPushdown, NdProjectionPushdown, is_pushable_expr};
 
 #[cfg(test)]
 mod tests {
@@ -506,6 +506,245 @@ mod tests {
         assert!(
             !rendered.contains("NdProjectionExec"),
             "volatile projection must not be pushed below the broadcast:\n{rendered}"
+        );
+    }
+
+    // ── filter pushdown ──────────────────────────────────────────────────
+
+    use datafusion::physical_plan::filter::FilterExec;
+
+    use super::exec::NdFilterExec;
+
+    /// Filtering *before* broadcast (as a grid selection applied by the broadcast)
+    /// yields byte-identical output to filtering *after* broadcasting the full
+    /// grid — for coordinate-axis, cross-axis, and data-variable predicates.
+    #[tokio::test]
+    async fn filter_before_broadcast_matches_after() {
+        let schema = test_source().schema();
+        let predicates: Vec<Arc<dyn PhysicalExpr>> = vec![
+            // Coordinate axis: keeps lat ∈ {0, 30}.
+            binary(col("lat", &schema).unwrap(), Operator::Gt, lit(-1i32), &schema).unwrap(),
+            // Cross-axis: footprint {lat, lon}.
+            binary(
+                binary(
+                    col("lat", &schema).unwrap(),
+                    Operator::Plus,
+                    col("lon", &schema).unwrap(),
+                    &schema,
+                )
+                .unwrap(),
+                Operator::Gt,
+                lit(10i32),
+                &schema,
+            )
+            .unwrap(),
+            // Full-rank data variable: footprint {time, lat, lon}.
+            binary(col("sst", &schema).unwrap(), Operator::Gt, lit(5.0f64), &schema).unwrap(),
+        ];
+
+        for predicate in predicates {
+            // Reference: broadcast the full grid, then filter (plain FilterExec).
+            let reference = Arc::new(
+                FilterExec::try_new(
+                    predicate.clone(),
+                    Arc::new(NdBroadcastExec::try_new(test_source()).unwrap()),
+                )
+                .unwrap(),
+            );
+            let expected = run(reference).await.unwrap();
+
+            // Optimized: filter on footprints first (as a selection), then broadcast.
+            let nd_filter =
+                Arc::new(NdFilterExec::try_new(test_source(), vec![predicate.clone()]).unwrap());
+            let optimized = Arc::new(NdBroadcastExec::try_new(nd_filter).unwrap());
+            let actual = run(optimized).await.unwrap();
+
+            assert_eq!(actual, expected, "mismatch for predicate {predicate}");
+        }
+    }
+
+    /// A filter below a projection: the selection accumulated by the nd filter is
+    /// carried through the nd projection and applied by the terminal broadcast,
+    /// matching `Projection(Filter(full grid))`.
+    #[tokio::test]
+    async fn filter_then_projection_matches_reference() {
+        let schema = test_source().schema();
+        let predicate: Arc<dyn PhysicalExpr> =
+            binary(col("lat", &schema).unwrap(), Operator::Gt, lit(-1i32), &schema).unwrap();
+        let exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = vec![
+            (
+                binary(col("lat", &schema).unwrap(), Operator::Multiply, lit(2i32), &schema)
+                    .unwrap(),
+                "lat2".to_string(),
+            ),
+            (col("sst", &schema).unwrap(), "sst".to_string()),
+        ];
+
+        // Reference: project over filter over the broadcast full grid.
+        let reference = Arc::new(
+            ProjectionExec::try_new(
+                exprs
+                    .iter()
+                    .cloned()
+                    .map(|(expr, alias)| ProjectionExpr { expr, alias }),
+                Arc::new(
+                    FilterExec::try_new(
+                        predicate.clone(),
+                        Arc::new(NdBroadcastExec::try_new(test_source()).unwrap()),
+                    )
+                    .unwrap(),
+                ),
+            )
+            .unwrap(),
+        );
+        let expected = run(reference).await.unwrap();
+
+        // Optimized: nd filter → nd projection → broadcast.
+        let nd_filter = Arc::new(NdFilterExec::try_new(test_source(), vec![predicate]).unwrap());
+        let nd_proj = Arc::new(NdProjectionExec::try_new(nd_filter, exprs).unwrap());
+        let optimized = Arc::new(NdBroadcastExec::try_new(nd_proj).unwrap());
+        let actual = run(optimized).await.unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    /// The rule rewrites `FilterExec → NdBroadcastExec` into
+    /// `NdBroadcastExec → NdFilterExec`, dropping the filter when every conjunct
+    /// is element-wise, and preserving schema and results.
+    #[tokio::test]
+    async fn pushdown_rule_sinks_filter_below_broadcast() {
+        use datafusion::common::config::ConfigOptions;
+        use datafusion::physical_optimizer::PhysicalOptimizerRule;
+        use datafusion::physical_plan::displayable;
+
+        let schema = test_source().schema();
+        // `lat > -1 AND lon = 5`: two element-wise conjuncts.
+        let predicate: Arc<dyn PhysicalExpr> = binary(
+            binary(col("lat", &schema).unwrap(), Operator::Gt, lit(-1i32), &schema).unwrap(),
+            Operator::And,
+            binary(col("lon", &schema).unwrap(), Operator::Eq, lit(5i32), &schema).unwrap(),
+            &schema,
+        )
+        .unwrap();
+
+        let original: Arc<dyn ExecutionPlan> = Arc::new(
+            FilterExec::try_new(
+                predicate,
+                Arc::new(NdBroadcastExec::try_new(test_source()).unwrap()),
+            )
+            .unwrap(),
+        );
+        let original_schema = original.schema();
+        let expected = run(original.clone()).await.unwrap();
+
+        let optimized = NdFilterPushdown::new()
+            .optimize(original, &ConfigOptions::default())
+            .unwrap();
+
+        assert_eq!(optimized.schema(), original_schema);
+
+        // Every conjunct is pushable, so no FilterExec remains and the nd filter
+        // sits below the broadcast, above the source.
+        let rendered = displayable(optimized.as_ref()).indent(true).to_string();
+        assert!(
+            !rendered
+                .lines()
+                .any(|l| l.trim_start().starts_with("FilterExec:")),
+            "all-pushable filter should leave no residual FilterExec:\n{rendered}"
+        );
+        let broadcast = rendered.find("NdBroadcastExec");
+        let filter = rendered.find("NdFilterExec");
+        let source = rendered.find("NdSourceExec");
+        assert!(
+            broadcast < filter && filter < source,
+            "expected NdBroadcastExec → NdFilterExec → NdSourceExec:\n{rendered}"
+        );
+
+        let actual = run(optimized).await.unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    /// A non-element-wise conjunct (a volatile function) stays in a residual
+    /// `FilterExec` above the broadcast, while the element-wise conjunct sinks
+    /// into an `NdFilterExec` below it.
+    #[tokio::test]
+    async fn pushdown_rule_splits_mixed_predicate() {
+        use std::any::Any;
+
+        use datafusion::common::config::ConfigOptions;
+        use datafusion::logical_expr::{
+            ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+        };
+        use datafusion::physical_expr::ScalarFunctionExpr;
+        use datafusion::physical_optimizer::PhysicalOptimizerRule;
+        use datafusion::physical_plan::displayable;
+        use datafusion::scalar::ScalarValue;
+
+        #[derive(Debug, PartialEq, Eq, Hash)]
+        struct VolatilePred {
+            signature: Signature,
+        }
+        impl ScalarUDFImpl for VolatilePred {
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+            fn name(&self) -> &str {
+                "test_volatile_pred"
+            }
+            fn signature(&self) -> &Signature {
+                &self.signature
+            }
+            fn return_type(&self, _: &[arrow::datatypes::DataType]) -> Result<arrow::datatypes::DataType> {
+                Ok(arrow::datatypes::DataType::Boolean)
+            }
+            fn invoke_with_args(&self, _: ScalarFunctionArgs) -> Result<ColumnarValue> {
+                Ok(ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))))
+            }
+        }
+
+        let schema = test_source().schema();
+        let udf = Arc::new(ScalarUDF::new_from_impl(VolatilePred {
+            signature: Signature::exact(vec![], Volatility::Volatile),
+        }));
+        let volatile: Arc<dyn PhysicalExpr> = Arc::new(
+            ScalarFunctionExpr::try_new(udf, vec![], &schema, Arc::new(ConfigOptions::default()))
+                .unwrap(),
+        );
+        // `lat > -1 AND volatile()`: one pushable, one not.
+        let predicate: Arc<dyn PhysicalExpr> = binary(
+            binary(col("lat", &schema).unwrap(), Operator::Gt, lit(-1i32), &schema).unwrap(),
+            Operator::And,
+            volatile,
+            &schema,
+        )
+        .unwrap();
+
+        let original: Arc<dyn ExecutionPlan> = Arc::new(
+            FilterExec::try_new(
+                predicate,
+                Arc::new(NdBroadcastExec::try_new(test_source()).unwrap()),
+            )
+            .unwrap(),
+        );
+
+        let optimized = NdFilterPushdown::new()
+            .optimize(original, &ConfigOptions::default())
+            .unwrap();
+        let rendered = displayable(optimized.as_ref()).indent(true).to_string();
+
+        // Residual FilterExec on top, nd filter below the broadcast. Match the
+        // residual by a line starting with `FilterExec:` (not `NdFilterExec:`).
+        let line_of = |needle: &str| {
+            rendered
+                .lines()
+                .position(|l| l.trim_start().starts_with(needle))
+        };
+        let residual = line_of("FilterExec:");
+        let broadcast = line_of("NdBroadcastExec");
+        let nd_filter = line_of("NdFilterExec:");
+        assert!(
+            residual.is_some() && residual < broadcast && broadcast < nd_filter,
+            "expected FilterExec → NdBroadcastExec → NdFilterExec:\n{rendered}"
         );
     }
 }

--- a/beacon-datafusion-ext/src/nd/mod.rs
+++ b/beacon-datafusion-ext/src/nd/mod.rs
@@ -524,6 +524,18 @@ mod tests {
         let predicates: Vec<Arc<dyn PhysicalExpr>> = vec![
             // Coordinate axis: keeps lat ∈ {0, 30}.
             binary(col("lat", &schema).unwrap(), Operator::Gt, lit(-1i32), &schema).unwrap(),
+            // Single-axis range as one ANDed conjunct: time ∈ {101, 102}.
+            binary(
+                binary(col("time", &schema).unwrap(), Operator::GtEq, lit(101i32), &schema)
+                    .unwrap(),
+                Operator::And,
+                binary(col("time", &schema).unwrap(), Operator::LtEq, lit(102i32), &schema)
+                    .unwrap(),
+                &schema,
+            )
+            .unwrap(),
+            // Inequality on a coordinate axis: drops the time=101 slices.
+            binary(col("time", &schema).unwrap(), Operator::NotEq, lit(101i32), &schema).unwrap(),
             // Cross-axis: footprint {lat, lon}.
             binary(
                 binary(
@@ -538,8 +550,24 @@ mod tests {
                 &schema,
             )
             .unwrap(),
+            // Disjunction across two axes: footprint {lat, lon}.
+            binary(
+                binary(col("lat", &schema).unwrap(), Operator::Lt, lit(0i32), &schema).unwrap(),
+                Operator::Or,
+                binary(col("lon", &schema).unwrap(), Operator::Eq, lit(15i32), &schema).unwrap(),
+                &schema,
+            )
+            .unwrap(),
             // Full-rank data variable: footprint {time, lat, lon}.
             binary(col("sst", &schema).unwrap(), Operator::Gt, lit(5.0f64), &schema).unwrap(),
+            // Coordinate axis combined with a data variable in one conjunct.
+            binary(
+                binary(col("lat", &schema).unwrap(), Operator::Gt, lit(-30i32), &schema).unwrap(),
+                Operator::And,
+                binary(col("sst", &schema).unwrap(), Operator::Lt, lit(20.0f64), &schema).unwrap(),
+                &schema,
+            )
+            .unwrap(),
         ];
 
         for predicate in predicates {
@@ -561,6 +589,87 @@ mod tests {
 
             assert_eq!(actual, expected, "mismatch for predicate {predicate}");
         }
+    }
+
+    /// Several *separate* conjuncts across different axes handed to one
+    /// `NdFilterExec` intersect correctly, matching a single `FilterExec` whose
+    /// predicate is their `AND`.
+    #[tokio::test]
+    async fn multiple_conjuncts_across_axes_match_reference() {
+        let schema = test_source().schema();
+        let c1 = binary(col("time", &schema).unwrap(), Operator::Gt, lit(100i32), &schema).unwrap();
+        let c2 = binary(col("lat", &schema).unwrap(), Operator::GtEq, lit(0i32), &schema).unwrap();
+        let c3 = binary(col("lon", &schema).unwrap(), Operator::Eq, lit(5i32), &schema).unwrap();
+
+        // Reference: one FilterExec over `c1 AND c2 AND c3`.
+        let combined: Arc<dyn PhysicalExpr> = binary(
+            binary(c1.clone(), Operator::And, c2.clone(), &schema).unwrap(),
+            Operator::And,
+            c3.clone(),
+            &schema,
+        )
+        .unwrap();
+        let reference = Arc::new(
+            FilterExec::try_new(
+                combined,
+                Arc::new(NdBroadcastExec::try_new(test_source()).unwrap()),
+            )
+            .unwrap(),
+        );
+        let expected = run(reference).await.unwrap();
+
+        // Optimized: the three conjuncts as separate selections.
+        let nd_filter =
+            Arc::new(NdFilterExec::try_new(test_source(), vec![c1, c2, c3]).unwrap());
+        let optimized = Arc::new(NdBroadcastExec::try_new(nd_filter).unwrap());
+        let actual = run(optimized).await.unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    /// A predicate no cell satisfies yields an empty result — the broadcast emits
+    /// nothing, matching a `FilterExec` that drops every row.
+    #[tokio::test]
+    async fn filter_selecting_no_rows_is_empty() {
+        let schema = test_source().schema();
+        let predicate: Arc<dyn PhysicalExpr> =
+            binary(col("time", &schema).unwrap(), Operator::Gt, lit(1000i32), &schema).unwrap();
+
+        let reference = Arc::new(
+            FilterExec::try_new(
+                predicate.clone(),
+                Arc::new(NdBroadcastExec::try_new(test_source()).unwrap()),
+            )
+            .unwrap(),
+        );
+        let expected = run(reference).await.unwrap();
+
+        let nd_filter = Arc::new(NdFilterExec::try_new(test_source(), vec![predicate]).unwrap());
+        let optimized = Arc::new(NdBroadcastExec::try_new(nd_filter).unwrap());
+        let actual = run(optimized).await.unwrap();
+
+        assert_eq!(actual.num_rows(), 0);
+        assert_eq!(actual, expected);
+    }
+
+    /// A predicate every cell satisfies retains the whole grid, byte-identical to
+    /// the unfiltered broadcast.
+    #[tokio::test]
+    async fn filter_selecting_all_rows_matches_unfiltered() {
+        let schema = test_source().schema();
+        // time is always ≥ 100, so `time > 0` keeps every cell.
+        let predicate: Arc<dyn PhysicalExpr> =
+            binary(col("time", &schema).unwrap(), Operator::Gt, lit(0i32), &schema).unwrap();
+
+        let unfiltered =
+            run(Arc::new(NdBroadcastExec::try_new(test_source()).unwrap())).await.unwrap();
+
+        let nd_filter = Arc::new(NdFilterExec::try_new(test_source(), vec![predicate]).unwrap());
+        let optimized = Arc::new(NdBroadcastExec::try_new(nd_filter).unwrap());
+        let actual = run(optimized).await.unwrap();
+
+        assert_eq!(actual.num_rows(), 24);
+        assert_eq!(actual, unfiltered);
     }
 
     /// A filter below a projection: the selection accumulated by the nd filter is

--- a/beacon-datafusion-ext/src/nd/optimizer.rs
+++ b/beacon-datafusion-ext/src/nd/optimizer.rs
@@ -27,13 +27,14 @@ use datafusion::physical_expr::expressions::{
     BinaryExpr, CaseExpr, CastExpr, Column, IsNotNullExpr, IsNullExpr, Literal, NegativeExpr,
     NotExpr, TryCastExpr,
 };
-use datafusion::physical_expr::ScalarFunctionExpr;
+use datafusion::physical_expr::{ScalarFunctionExpr, conjunction, split_conjunction};
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::filter::FilterExec;
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::logical_expr::Volatility;
 
-use super::exec::{NdBroadcastExec, NdProjectionExec};
+use super::exec::{NdBroadcastExec, NdFilterExec, NdProjectionExec};
 
 /// Sinks element-wise `ProjectionExec`s below an [`NdBroadcastExec`] into an
 /// [`NdProjectionExec`], so they evaluate before broadcasting.
@@ -95,6 +96,93 @@ impl PhysicalOptimizerRule for NdProjectionPushdown {
 
     fn name(&self) -> &str {
         "NdProjectionPushdown"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+/// Sinks the element-wise conjuncts of a `FilterExec` below an
+/// [`NdBroadcastExec`] into an [`NdFilterExec`], so the predicate selects rows on
+/// the un-broadcast nd columns and the broadcast fuses with the selection.
+///
+/// DataFusion plans a `FilterExec` above [`NdBroadcastExec`], so the `WHERE`
+/// predicate runs *after* the full grid is materialized. A predicate is a
+/// conjunction; each element-wise conjunct (its value at a grid cell depends only
+/// on its inputs there) can instead be evaluated before broadcast — on its
+/// footprint sub-grid — and recorded as a grid selection the broadcast applies.
+/// This rule rewrites
+///
+/// ```text
+/// FilterExec[a AND b AND c]          FilterExec[c]            (residual, only if any)
+///   NdBroadcastExec           ->       NdBroadcastExec
+///     nd-child                           NdFilterExec[a, b]   (element-wise conjuncts)
+///                                          nd-child
+/// ```
+///
+/// where `a`, `b` are element-wise ([`is_pushable_expr`]) and `c` is not (e.g. a
+/// volatile function or a subquery). If every conjunct is pushable, the residual
+/// `FilterExec` is dropped entirely. The rewrite is schema-preserving: a filter
+/// never changes columns.
+#[derive(Debug, Default)]
+pub struct NdFilterPushdown;
+
+impl NdFilterPushdown {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl PhysicalOptimizerRule for NdFilterPushdown {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        plan.transform_down(|node| {
+            let Some(filter) = node.as_any().downcast_ref::<FilterExec>() else {
+                return Ok(Transformed::no(node));
+            };
+            // A `FilterExec` carrying an embedded projection also changes the
+            // schema; leave those in place so the rewrite stays a pure row
+            // selection.
+            if filter.projection().is_some() {
+                return Ok(Transformed::no(node));
+            }
+            let Some(broadcast) = filter.input().as_any().downcast_ref::<NdBroadcastExec>() else {
+                return Ok(Transformed::no(node));
+            };
+
+            // Split the predicate and route each conjunct: element-wise ones sink
+            // into the nd filter, the rest stay in a residual filter above.
+            let mut push: Vec<Arc<dyn PhysicalExpr>> = Vec::new();
+            let mut keep: Vec<Arc<dyn PhysicalExpr>> = Vec::new();
+            for conjunct in split_conjunction(filter.predicate()) {
+                if is_pushable_expr(conjunct) {
+                    push.push(conjunct.clone());
+                } else {
+                    keep.push(conjunct.clone());
+                }
+            }
+            if push.is_empty() {
+                return Ok(Transformed::no(node));
+            }
+
+            let nd_filter = Arc::new(NdFilterExec::try_new(broadcast.input().clone(), push)?);
+            let new_broadcast = Arc::new(NdBroadcastExec::try_new(nd_filter)?);
+            let rewritten: Arc<dyn ExecutionPlan> = if keep.is_empty() {
+                new_broadcast
+            } else {
+                Arc::new(FilterExec::try_new(conjunction(keep), new_broadcast)?)
+            };
+            Ok(Transformed::yes(rewritten))
+        })
+        .map(|t| t.data)
+    }
+
+    fn name(&self) -> &str {
+        "NdFilterPushdown"
     }
 
     fn schema_check(&self) -> bool {


### PR DESCRIPTION
## Summary

Adds an `NdFilterExec` + `NdFilterPushdown` rule to `beacon-datafusion-ext::nd`, mirroring the recently merged projection pushdown (#329). Certain conjuncts of a `WHERE` predicate are now pushed **below** `NdBroadcastExec` and run before the broadcast — applied as a **grid selection** the broadcast fuses into its per-column gather, so the filtered-out cross-product is never materialized and every operator above the broadcast sees only surviving rows. (This is the design already anticipated in `NdBroadcastExec`'s doc comment: *"Broadcast and any accumulated selection compose into a single gather per column."*)

Like the projection rule, it is opt-in behind `BEACON_ENABLE_ND_PIPELINE`.

## Approach

A predicate is recorded as a selection over the target grid (retained C-order cell indices). This is fully general — coordinate-axis (`lat > 0`), cross-axis (`lat + lon > 5`), and data-variable (`sst > 5`) predicates all work — and needs no static footprint analysis, since per-column dimensions are only known per-batch at run time (they live in the encoded struct data, not the schema).

```text
FilterExec[a AND b AND c]          FilterExec[c]            (residual, only if any non-element-wise)
  NdBroadcastExec           ->       NdBroadcastExec
    nd-child                           NdFilterExec[a, b]   (element-wise conjuncts)
                                         nd-child
```

## Changes

- **`NdRecordBatch`** gains an optional `selection: Option<UInt64Array>` (+ `with_selection`, bounds-validated); `materialize_with_stats` gathers only retained cells via the new **`BroadcastMap::gather_indices_at`**, fusing broadcast + selection into one `take`.
- **`exec/expr_column.rs`** (new): the footprint machinery (`NdExprColumn`, `ProjectMetrics`, `footprint_of`) extracted from `projection_exec.rs` and shared by both projection and filter (net reduction, projection behavior unchanged).
- **`exec/filter_exec.rs`** (new): `NdFilterExec` evaluates each element-wise conjunct on its footprint, broadcasts the boolean mask to the grid (null → excluded), ANDs them, and intersects with any inbound selection — no column data moves.
- **`NdProjectionExec`** propagates a child's selection through unchanged (projection commutes with row selection).
- **`NdFilterPushdown`** splits the predicate: `is_pushable_expr` conjuncts sink into `NdFilterExec`, the rest stay in a residual `FilterExec` (dropped entirely if all are pushable). Guarded on `filter.projection().is_none()`; schema-preserving.
- Registered in `runtime.rs` behind `BEACON_ENABLE_ND_PIPELINE`, filter rule before projection so `Projection(Filter(Broadcast))` fully lowers.

## Testing

`cargo test -p beacon-core -p beacon-datafusion-ext` — 188 lib tests pass. New coverage:

- Filtering before broadcast is byte-identical to filtering after, across coordinate-axis, cross-axis, and data-variable predicates.
- Filter-then-projection: the selection propagates through the nd projection to the terminal broadcast.
- The rule sinks an all-pushable filter (no residual) and splits a mixed predicate (residual `FilterExec` on top, `NdFilterExec` below the broadcast).
- Unit tests for `gather_indices_at`, batch selection materialization + bounds checking, and the per-conjunct selection logic.