### PR TITLE
fix(nd): decode every row of a coalesced nd batch

### DIFF
--- a/beacon-db/beacon-datafusion-ext/src/nd/encoding.rs
+++ b/beacon-db/beacon-datafusion-ext/src/nd/encoding.rs
@@ -251,10 +251,33 @@ pub fn logical_schema(encoded: &Schema) -> Result<SchemaRef> {
     Ok(Arc::new(Schema::new(fields)))
 }
 
-/// Decode an nd-encoded `RecordBatch` (row 0 of each struct column) back into an
-/// [`NdRecordBatch`]. The target grid is inferred as the union of the columns'
-/// dimensions, ordered by the highest-rank column.
+/// Decode row 0 of an nd-encoded `RecordBatch` back into an [`NdRecordBatch`].
+///
+/// An encoded row carries one whole nd array per column, so a batch with more
+/// than one row carries *several* nd batches; this only sees the first. Use
+/// [`nd_batch_count`] + [`decode_nd_record_batch_row`] to decode all of them —
+/// anything that concatenates encoded batches (DataFusion's `RoundRobinBatch`
+/// repartitioning coalesces small batches, for one) produces multi-row batches.
 pub fn decode_nd_record_batch(batch: &RecordBatch) -> Result<NdRecordBatch> {
+    decode_nd_record_batch_row(batch, 0)
+}
+
+/// How many nd batches an encoded `RecordBatch` carries.
+///
+/// One per row, except for a zero-column `COUNT(*)`-style carrier, whose rows
+/// are the payload rather than an nd-array-per-row.
+pub fn nd_batch_count(batch: &RecordBatch) -> usize {
+    if batch.num_columns() == 0 {
+        1
+    } else {
+        batch.num_rows()
+    }
+}
+
+/// Decode a single row of an nd-encoded `RecordBatch` into an [`NdRecordBatch`].
+/// The target grid is inferred as the union of the columns' dimensions, ordered
+/// by the highest-rank column.
+pub fn decode_nd_record_batch_row(batch: &RecordBatch, row: usize) -> Result<NdRecordBatch> {
     // A zero-column batch is a COUNT(*)-style row carrier: preserve its row
     // count via a synthetic one-axis grid so the broadcast reproduces it.
     if batch.num_columns() == 0 {
@@ -265,7 +288,7 @@ pub fn decode_nd_record_batch(batch: &RecordBatch) -> Result<NdRecordBatch> {
     let columns = batch
         .columns()
         .iter()
-        .map(|column| decode_nd_array(column, 0))
+        .map(|column| decode_nd_array(column, row))
         .collect::<Result<Vec<_>>>()?;
 
     let target = infer_target(&columns)?;
@@ -499,6 +522,41 @@ mod tests {
         let decoded = decode_nd_array(&encode_nd_array(&scalar), 0).unwrap();
         assert_eq!(decoded.dims().rank(), 0);
         assert_eq!(decoded.values().len(), 1);
+    }
+
+    #[test]
+    fn every_row_of_a_coalesced_encoded_batch_decodes() {
+        // `encode_nd_record_batch` emits one row per nd batch, but any operator
+        // that concatenates batches (RoundRobinBatch repartitioning coalesces
+        // small ones) yields a multi-row encoded batch. Decoding row 0 alone
+        // silently drops the rest, which loses whole files from a scan.
+        let batch_of = |values: Vec<i32>, rows: usize, cols: usize| {
+            let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, true)]));
+            let column = NdArrowArray::try_new(
+                Arc::new(Int32Array::from(values)),
+                dims(&[("time", rows), ("lat", cols)]),
+            )
+            .unwrap();
+            let target = dims(&[("time", rows), ("lat", cols)]);
+            NdRecordBatch::try_new(schema, vec![column], target).unwrap()
+        };
+
+        let first = encode_nd_record_batch(&batch_of(vec![1, 2, 3, 4, 5, 6], 2, 3)).unwrap();
+        let second = encode_nd_record_batch(&batch_of(vec![7, 8, 9, 10], 2, 2)).unwrap();
+        assert_eq!(first.num_rows(), 1);
+        assert_eq!(second.num_rows(), 1);
+
+        let merged =
+            arrow::compute::concat_batches(&first.schema(), &[first, second]).unwrap();
+        assert_eq!(nd_batch_count(&merged), 2);
+
+        let rows: Vec<usize> = (0..nd_batch_count(&merged))
+            .map(|r| decode_nd_record_batch_row(&merged, r).unwrap().num_rows())
+            .collect();
+        assert_eq!(rows, vec![6, 4], "both nd batches must survive the concat");
+
+        // The row-0-only helper still sees exactly the first one.
+        assert_eq!(decode_nd_record_batch(&merged).unwrap().num_rows(), 6);
     }
 
     #[test]

--- a/beacon-db/beacon-datafusion-ext/src/nd/exec/source_exec.rs
+++ b/beacon-db/beacon-datafusion-ext/src/nd/exec/source_exec.rs
@@ -16,7 +16,7 @@ use datafusion::physical_plan::{
 };
 use futures::{StreamExt, TryStreamExt};
 
-use crate::nd::encoding::{decode_nd_record_batch, logical_schema};
+use crate::nd::encoding::{decode_nd_record_batch_row, logical_schema, nd_batch_count};
 
 use super::{NdBroadcastExec, NdExecutionPlan, SendableNdBatchStream};
 
@@ -127,16 +127,28 @@ impl NdExecutionPlan for NdSourceExec {
                 let _timer = baseline.elapsed_compute().timer();
                 match item {
                     // An empty encoded batch carries no nd array — skip it.
-                    Ok(batch) if batch.num_rows() == 0 => Ok(None),
-                    Ok(batch) => decode_nd_record_batch(&batch).map(|nd| {
-                        nd_batches.add(1);
-                        baseline.record_output(nd.num_rows());
-                        Some(nd)
-                    }),
+                    Ok(batch) if batch.num_rows() == 0 => Ok(Vec::new()),
+                    Ok(batch) => {
+                        // One nd array per encoded row: a batch that has been
+                        // through a coalescing operator (RoundRobinBatch
+                        // repartitioning, `CoalesceBatchesExec`, …) carries
+                        // several, and decoding only row 0 would silently drop
+                        // the rest.
+                        let count = nd_batch_count(&batch);
+                        let mut decoded = Vec::with_capacity(count);
+                        for row in 0..count {
+                            let nd = decode_nd_record_batch_row(&batch, row)?;
+                            nd_batches.add(1);
+                            baseline.record_output(nd.num_rows());
+                            decoded.push(nd);
+                        }
+                        Ok(decoded)
+                    }
                     Err(e) => Err(e),
                 }
             })
-            .try_filter_map(|decoded| async move { Ok(decoded) });
+            .map_ok(|decoded| futures::stream::iter(decoded.into_iter().map(Ok)))
+            .try_flatten();
         Ok(Box::pin(stream))
     }
 }

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -34,6 +34,8 @@ pub const NETCDF_EXTENSION: &str = "nc";
 
 pub mod object_meta_resolver;
 pub mod options;
+#[cfg(test)]
+mod partition_coverage_tests;
 pub mod reader;
 pub mod sink;
 pub mod source;

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/partition_coverage_tests.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/partition_coverage_tests.rs
@@ -1,0 +1,120 @@
+//! A NetCDF scan must read every file whatever `target_partitions` is.
+//!
+//! Regression test for silent row loss: when the scan's file-group count does
+//! not equal `target_partitions`, DataFusion inserts a
+//! `RepartitionExec(RoundRobinBatch)`, which *coalesces* small batches. Each
+//! nd-encoded batch is one row carrying one file's nd array, so coalescing
+//! produced multi-row encoded batches — and the decoder only read row 0, so
+//! every file after the first in a coalesced batch vanished from the results.
+//!
+//! `count(*)` did not catch it: it is answered without decoding nd arrays, so
+//! it stayed correct while the scan returned fewer rows.
+
+use std::sync::Arc;
+
+use beacon_datafusion_ext::file_collection::FileCollection;
+use beacon_datafusion_ext::listing_factory::{ListingFactory, RootStore};
+use datafusion::prelude::{SessionConfig, SessionContext};
+
+use crate::datafusion::{options::NetcdfOptions, NetcdfFormat};
+
+/// Copy the ragged fixture `copies` times into a fresh temp dir.
+fn stage_files(copies: usize) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("test_files")
+        .join("wod_ctd_1964.nc");
+    for i in 0..copies {
+        std::fs::copy(&src, dir.path().join(format!("part_{i:04}.nc"))).expect("copy fixture");
+    }
+    dir
+}
+
+async fn ctx_for(dir: &tempfile::TempDir, target_partitions: usize) -> SessionContext {
+    let config = SessionConfig::new().with_target_partitions(target_partitions);
+    let ctx = SessionContext::new_with_config(config);
+    let state = ctx.state();
+
+    let factory = Arc::new(ListingFactory::dynamic());
+    // Same wiring `create_with_native_root` does for a `file://` listing url:
+    // object paths are absolute w.r.t. the filesystem root.
+    let resolver = crate::datafusion::object_meta_resolver::create_object_resolver(
+        &RootStore::FileSystem(std::path::PathBuf::from("/")),
+    );
+    let format = Arc::new(
+        NetcdfFormat::new(factory, NetcdfOptions::default()).with_object_path_resolver(resolver),
+    );
+
+    let url = datafusion::datasource::listing::ListingTableUrl::parse(format!(
+        "file://{}/",
+        dir.path().to_string_lossy().replace('\\', "/")
+    ))
+    .expect("listing url");
+
+    let table = FileCollection::new(&state, format, vec![url])
+        .await
+        .expect("file collection");
+    ctx.register_table("nc", Arc::new(table)).unwrap();
+    ctx
+}
+
+/// Rows the pipeline actually produces, by draining the record batches.
+async fn scanned_rows(ctx: &SessionContext) -> usize {
+    let batches = ctx
+        .sql("SELECT * FROM nc")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    batches.iter().map(|b| b.num_rows()).sum()
+}
+
+async fn count_star(ctx: &SessionContext) -> usize {
+    let batches = ctx
+        .sql("SELECT count(*) FROM nc")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<arrow::array::Int64Array>()
+        .expect("int64 count")
+        .value(0) as usize
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_reads_every_file_regardless_of_target_partitions() {
+    const FILES: usize = 32;
+
+    // One file first, to learn the per-file row count.
+    let one = stage_files(1);
+    let per_file = scanned_rows(&ctx_for(&one, 4).await).await;
+    assert!(per_file > 0, "fixture produced no rows");
+
+    let dir = stage_files(FILES);
+    let expected = per_file * FILES;
+
+    // 8/16/32 give one file group per partition (no repartition). 9, 24 and 31
+    // do not, so a coalescing RoundRobinBatch repartition is inserted — those
+    // were the shapes that silently lost files. 33 exceeds the file count, so
+    // coalescing has nothing to merge.
+    let mut failures = vec![];
+    for tp in [1usize, 8, 9, 16, 24, 31, 32, 33] {
+        let ctx = ctx_for(&dir, tp).await;
+        let scanned = scanned_rows(&ctx).await;
+        let counted = count_star(&ctx).await;
+
+        if scanned != expected || counted != expected {
+            failures.push(format!(
+                "target_partitions={tp}: scanned {scanned} ({} files), count(*) {counted}, \
+                 expected {expected}",
+                scanned / per_file
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "row loss:\n  {}", failures.join("\n  "));
+}


### PR DESCRIPTION
## The bug

A NetCDF scan silently returns fewer rows than the files hold. No error and no warning appear. `count(*)` stays correct, so the usual check passes while the data is wrong.

The trigger is not the file count on its own. With 32 files, `target_partitions` values 1, 2, 4, 8, 16 and 32 are correct. Value 9 loses 23 files, and value 24 loses 8. Loss hits 19 of the first 40 values.

## Cause

An nd-encoded `RecordBatch` is an envelope, not a table. One row carries one whole nd array, and `encode_nd_record_batch` sets the row count to 1. The decoder relied on that rule and always read row 0.

DataFusion does not know the batch is an envelope. It sees a 1-row batch as small, and it merges small batches. `RepartitionExec` with `RoundRobinBatch` concatenates them. The result is a multi-row encoded batch. The decoder kept row 0 and dropped the rest. Each dropped row is a complete file.

The planner inserts that repartition only when the scan group count differs from `target_partitions`. `split_files(n)` makes `ceil(F/chunk)` groups from `chunk = ceil(F/n)`, which often gives fewer groups than `n`. `target_partitions` defaults to the core count, so the fault depends on the ratio between core count and file count.

Measurements at 32 files and `target_partitions` 24:

| node | partitions | batches | rows |
|---|---|---|---|
| `DataSourceExec` | 16 | 32 | 32 |
| `RepartitionExec` | 24 | 24 | 24 |

The listing keeps every file. The loss happens above the scan. A control against stock DataFusion confirms the merge itself is correct: it turned 32 batches into 24 and kept all 32 rows.

## Fix

- `decode_nd_record_batch_row` takes a row index. `decode_nd_record_batch` keeps the row-0 behaviour for callers that hold a single-row batch.
- `nd_batch_count` reports how many arrays an envelope holds. It returns 1 for a zero-column `count(*)` carrier, whose rows are payload.
- `NdSourceExec::execute_nd` emits one nd batch per encoded row. Rows can carry different grids, so they flatten into the stream and do not merge into one batch. Metrics now count decoded arrays.

A block on the merge is the alternative. It is worse. Any operator may concatenate batches, including `CoalesceBatchesExec`, sorts and unions. A block also costs parallelism.

The fix sits in the shared nd layer, so Zarr and Atlas get it too.

## Verification

| check | before | after |
|---|---|---|
| sweep, 32 files, `target_partitions` 1 to 40 | 19 values lose rows | all correct |
| `NdSourceExec`, 32 files, `target_partitions` 24 | 24 batches, 10032 rows | 32 batches, 13376 rows |

New tests:

- `every_row_of_a_coalesced_encoded_batch_decodes` in `encoding.rs` concatenates two encoded batches with different shapes and asserts that both decode.
- `scan_reads_every_file_regardless_of_target_partitions` in the netcdf crate covers the partition shapes that failed.
