### PR TITLE
feat(netcdf): add the oxcdf pure-Rust reader behind a flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,6 +1464,7 @@ dependencies = [
  "num-traits",
  "object_store 0.13.2",
  "ordered-float 5.3.0",
+ "oxcdf",
  "serde",
  "tempfile",
  "tokio",
@@ -7605,6 +7606,36 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "oxcdf"
+version = "0.1.0"
+source = "git+https://github.com/robinskil/oxcdf.git#ac3c1b93446fea41c81d70b6fd3556508ccde798"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "ndarray 0.17.2",
+ "object_store 0.13.2",
+ "oxcdf-hdf5",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "oxcdf-hdf5"
+version = "0.1.0"
+source = "git+https://github.com/robinskil/oxcdf.git#ac3c1b93446fea41c81d70b6fd3556508ccde798"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "flate2",
+ "lz4_flex 0.11.6",
+ "moka",
+ "object_store 0.13.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "zstd",
+]
 
 [[package]]
 name = "page_size"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,10 @@ datafusion-federation = { version = "=0.5.3", features = ["sql"] }
 datafusion-table-providers = { version = "=0.11.0", default-features = false }
 geodatafusion = "0.4.0"
 object_store = { version = "0.13.1", features = ["aws", "gcp", "azure", "http"] }
+# Pure-Rust netCDF-4 / classic reader. It parses the HDF5 container itself, so it
+# holds no global lock and reads through `object_store` by byte range. The
+# netcdf-c bindings do neither. See `beacon-arrow-netcdf`, which offers both.
+oxcdf = { git = "https://github.com/robinskil/oxcdf.git", version = "0.1.0", features = ["async", "object-store", "ndarray"] }
 tonic = "0.14.1"
 
 

--- a/beacon-db/beacon-file-formats/beacon-arrow-hdf5/src/format.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-hdf5/src/format.rs
@@ -76,8 +76,10 @@ impl FileFormatFactory for Hdf5FormatFactory {
 }
 
 impl FileFormatFactoryExt for Hdf5FormatFactory {
-    /// Delegates to the netCDF factory's native-root path — HDF5 is read by netcdf-c, which opens
-    /// a local path / http(s) URL, exactly like netCDF.
+    /// Delegates to the netCDF factory's native-root path, which handles both readers: netcdf-c
+    /// opens a local path / http(s) URL, and the pure-Rust reader goes through the object store.
+    /// A NetCDF-4 file is HDF5 and both readers parse plain HDF5 too, so neither needs a change
+    /// here.
     fn create_with_native_root(
         &self,
         state: &dyn Session,
@@ -150,7 +152,10 @@ mod tests {
     #[test]
     fn advertises_hdf5_extensions_and_name() {
         let f = factory("hdf5");
-        assert_eq!(f.file_extensions(), vec!["h5".to_string(), "hdf5".to_string()]);
+        assert_eq!(
+            f.file_extensions(),
+            vec!["h5".to_string(), "hdf5".to_string()]
+        );
         assert_eq!(f.get_ext(), "hdf5");
         assert_eq!(f.file_format_name(), "hdf5");
     }
@@ -160,7 +165,10 @@ mod tests {
         let f = factory("h5");
         assert_eq!(f.get_ext(), "h5");
         // The recognized extensions are the same regardless of which key this instance answers to.
-        assert_eq!(f.file_extensions(), vec!["h5".to_string(), "hdf5".to_string()]);
+        assert_eq!(
+            f.file_extensions(),
+            vec!["h5".to_string(), "hdf5".to_string()]
+        );
     }
 
     #[test]

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/Cargo.toml
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/Cargo.toml
@@ -15,6 +15,10 @@ static = ["netcdf/static", "netcdf-sys/static"]
 [dependencies]
 netcdf = { git ="https://github.com/robinskil/netcdf.git", features = ["ndarray"], version = "0.11.1"}
 netcdf-sys = { git ="https://github.com/robinskil/netcdf.git", package = "netcdf-sys" }
+# The second reader. It is always compiled; the format picks between the two at
+# runtime (see `datafusion::ReaderBackend`). It is pure Rust and pulls in no C
+# library, so it costs the build almost nothing.
+oxcdf = { workspace = true }
 arrow = { workspace = true }
 
 anyhow = { workspace=true }

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -40,7 +40,7 @@ pub mod source;
 pub mod statistics;
 pub mod table_function;
 
-pub use reader::NetcdfReaderCache;
+pub use reader::{NetcdfInput, NetcdfReaderCache, ReaderBackend};
 pub use table_function::ReadNetCDFFunc;
 
 /// Runtime configuration for the NetCDF format.
@@ -57,6 +57,13 @@ pub struct NetcdfConfig {
     pub reader_cache_size: usize,
     /// Whether to generate per-file statistics during planning.
     pub enable_statistics: bool,
+    /// Whether reads go through the pure-Rust [`oxcdf`] reader instead of
+    /// netcdf-c.
+    ///
+    /// Off by default, so the netcdf-c path stays the one a runtime uses until
+    /// an operator opts in. Turn it on to get parallel reads and native object
+    /// store access; see [`crate::oxcdf_reader`]. Writes always use netcdf-c.
+    pub use_rust_reader: bool,
 }
 
 impl Default for NetcdfConfig {
@@ -65,6 +72,7 @@ impl Default for NetcdfConfig {
             use_reader_cache: true,
             reader_cache_size: 128,
             enable_statistics: true,
+            use_rust_reader: false,
         }
     }
 }
@@ -114,12 +122,23 @@ impl NetCDFFormatFactory {
         options: NetcdfOptions,
         use_reader_cache: bool,
         enable_statistics: bool,
+        reader_backend: ReaderBackend,
     ) -> NetcdfFormat {
         let cache = use_reader_cache.then(|| self.cache.clone());
         NetcdfFormat::new(self.listing_factory.clone(), options)
             .with_cache(cache)
             .with_enable_statistics(enable_statistics)
+            .with_reader_backend(reader_backend)
             .with_output_dir(self.output_dir.clone())
+    }
+}
+
+/// The reader a `use_rust_reader` setting selects.
+fn reader_backend_for(use_rust_reader: bool) -> ReaderBackend {
+    if use_rust_reader {
+        ReaderBackend::Oxcdf
+    } else {
+        ReaderBackend::NetcdfC
     }
 }
 
@@ -134,6 +153,7 @@ impl FileFormatFactory for NetCDFFormatFactory {
         let mut options = self.options.clone();
         let mut use_reader_cache = self.config.use_reader_cache;
         let mut enable_statistics = self.config.enable_statistics;
+        let mut use_rust_reader = self.config.use_rust_reader;
 
         if let Some(value) = format_options.get("read_dimensions") {
             options.read_dimensions = Some(
@@ -150,11 +170,15 @@ impl FileFormatFactory for NetCDFFormatFactory {
         if let Some(value) = format_options.get("enable_statistics") {
             enable_statistics = parse_bool_option("enable_statistics", value)?;
         }
+        if let Some(value) = format_options.get("use_rust_reader") {
+            use_rust_reader = parse_bool_option("use_rust_reader", value)?;
+        }
 
         Ok(Arc::new(self.build_format(
             options,
             use_reader_cache,
             enable_statistics,
+            reader_backend_for(use_rust_reader),
         )))
     }
 
@@ -163,6 +187,7 @@ impl FileFormatFactory for NetCDFFormatFactory {
             self.options.clone(),
             self.config.use_reader_cache,
             self.config.enable_statistics,
+            reader_backend_for(self.config.use_rust_reader),
         ))
     }
 
@@ -178,13 +203,17 @@ impl GetExt for NetCDFFormatFactory {
 }
 
 impl FileFormatFactoryExt for NetCDFFormatFactory {
-    /// netCDF is read by netcdf-c, which opens a local path or an http(s) URL and
-    /// never the object store, so the format needs a [`NetCDFObjectResolver`] built
-    /// from the root store `url` resolves against. Plain [`FileFormatFactory::create`]
-    /// has no location to work from and yields a format whose resolver always errors.
+    /// netcdf-c opens a local path or an http(s) URL and never the object store,
+    /// so a format on that reader needs a [`NetCDFObjectResolver`] built from the
+    /// root store `url` resolves against. Plain [`FileFormatFactory::create`] has
+    /// no location to work from and yields a format whose resolver always errors.
     ///
     /// `native_read_root` rejects a scheme netcdf-c cannot open (s3/gs/az) here,
     /// naming the location, rather than failing later per listed object.
+    ///
+    /// The `oxcdf` reader reads through the object store, so it needs no
+    /// resolver and no native root. A format on that reader is returned as it
+    /// is, which is what lets a table live in s3, gs or az.
     fn create_with_native_root(
         &self,
         state: &dyn Session,
@@ -192,7 +221,6 @@ impl FileFormatFactoryExt for NetCDFFormatFactory {
         url: &datafusion::datasource::listing::ListingTableUrl,
         listing: &ListingFactory,
     ) -> datafusion::error::Result<Arc<dyn FileFormat>> {
-        let root = listing.native_read_root(url)?;
         let format = self.create(state, format_options)?;
         let netcdf = format
             .as_any()
@@ -200,9 +228,14 @@ impl FileFormatFactoryExt for NetCDFFormatFactory {
             .ok_or_else(|| {
                 exec_datafusion_err!("the NetCDF factory did not produce a NetcdfFormat")
             })?
-            .clone()
-            .with_object_path_resolver(object_meta_resolver::create_object_resolver(&root));
-        Ok(Arc::new(netcdf))
+            .clone();
+        if netcdf.reader_backend == ReaderBackend::Oxcdf {
+            return Ok(Arc::new(netcdf));
+        }
+        let root = listing.native_read_root(url)?;
+        Ok(Arc::new(netcdf.with_object_path_resolver(
+            object_meta_resolver::create_object_resolver(&root),
+        )))
     }
 
     fn discover_datasets(
@@ -237,6 +270,8 @@ pub struct NetcdfFormat {
     enable_statistics: bool,
     /// Local directory the netcdf-c writer emits output files into.
     output_dir: PathBuf,
+    /// The reader that opens each file of this table.
+    pub reader_backend: ReaderBackend,
     pub object_path_resolver: Arc<dyn NetCDFObjectResolver>,
 }
 
@@ -248,8 +283,29 @@ impl NetcdfFormat {
             cache: None,
             enable_statistics: false,
             output_dir: std::env::temp_dir(),
+            reader_backend: ReaderBackend::default(),
             object_path_resolver: Arc::new(DefaultNetCDFObjectResolver),
         }
+    }
+
+    /// Select the reader that opens each file.
+    pub fn with_reader_backend(mut self, reader_backend: ReaderBackend) -> Self {
+        self.reader_backend = reader_backend;
+        self
+    }
+
+    /// Describe where one object's bytes come from, for the format's reader.
+    fn input_for(
+        &self,
+        store: &Arc<dyn ObjectStore>,
+        object: &ObjectMeta,
+    ) -> datafusion::error::Result<NetcdfInput> {
+        reader::netcdf_input(
+            self.reader_backend,
+            &self.object_path_resolver,
+            store,
+            object,
+        )
     }
 
     /// Wire in a reader cache (`Some`) or disable caching (`None`).
@@ -301,21 +357,15 @@ impl FileFormat for NetcdfFormat {
     async fn infer_schema(
         &self,
         _state: &dyn Session,
-        _store: &Arc<dyn ObjectStore>,
+        store: &Arc<dyn ObjectStore>,
         objects: &[ObjectMeta],
     ) -> datafusion::error::Result<SchemaRef> {
         let mut tasks = vec![];
         let cache = self.cache.as_ref();
         for object in objects {
-            let native_path = self.object_path_resolver.resolve(object).map_err(|e| {
-                exec_datafusion_err!(
-                    "Failed to resolve object metadata (path) to NetCDF native path: {}",
-                    e
-                )
-            })?;
             let task = reader::fetch_schema(
                 cache,
-                native_path,
+                self.input_for(store, object)?,
                 object.clone(),
                 self.options.read_dimensions.clone(),
             );
@@ -338,31 +388,24 @@ impl FileFormat for NetcdfFormat {
     async fn infer_stats(
         &self,
         _state: &dyn Session,
-        _store: &Arc<dyn ObjectStore>,
+        store: &Arc<dyn ObjectStore>,
         table_schema: SchemaRef,
         object: &ObjectMeta,
     ) -> datafusion::error::Result<Statistics> {
         if self.enable_statistics {
-            // Resolved through the same resolver the reader uses, so statistics and
-            // scans can never disagree about where a file is.
-            let native_path = self.object_path_resolver.resolve(object).map_err(|e| {
-                exec_datafusion_err!(
-                    "Failed to resolve object metadata (path) to NetCDF native path: {}",
-                    e
-                )
-            })?;
-            Ok(
-                statistics::generate_statistics(native_path, &table_schema)
-                    .await
-                    .unwrap_or_else(|e| {
-                        tracing::warn!(
-                            "Failed to generate statistics for object {}: {}",
-                            object.location,
-                            e
-                        );
-                        Statistics::new_unknown(&table_schema)
-                    }),
-            )
+            // Built the same way the reader builds it, so statistics and scans
+            // can never disagree about where a file is or which reader opens it.
+            let input = self.input_for(store, object)?;
+            Ok(statistics::generate_statistics(input, &table_schema)
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::warn!(
+                        "Failed to generate statistics for object {}: {}",
+                        object.location,
+                        e
+                    );
+                    Statistics::new_unknown(&table_schema)
+                }))
         } else {
             Ok(Statistics::new_unknown(&table_schema))
         }
@@ -393,6 +436,7 @@ impl FileFormat for NetcdfFormat {
             table_schema,
         )
         .with_cache(self.cache.clone())
+        .with_reader_backend(self.reader_backend)
         .with_projection(projection);
         let conf = FileScanConfigBuilder::from(conf)
             .with_source(Arc::new(source))
@@ -474,8 +518,340 @@ impl FileFormat for NetcdfFormat {
                 self.options.read_dimensions.clone(),
                 table_schema,
             )
-            .with_cache(self.cache.clone()),
+            .with_cache(self.cache.clone())
+            .with_reader_backend(self.reader_backend),
         )
+    }
+}
+
+/// The reader-backend flag: how it is set, and that both readers agree.
+#[cfg(test)]
+mod reader_backend_tests {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    use beacon_common::super_table::SuperListingTable;
+    use beacon_datafusion_ext::listing_factory::RootStore;
+    use datafusion::datasource::listing::ListingTableUrl;
+    use datafusion::execution::session_state::SessionStateBuilder;
+    use datafusion::prelude::{SessionConfig, SessionContext};
+
+    use super::*;
+
+    const GRIDDED_FILE: &str = "gridded-example.nc";
+    const WOD_FILE: &str = "wod_ctd_1964.nc";
+
+    /// The absolute path of a bundled test file.
+    fn test_file(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("test_files")
+            .join(name)
+    }
+
+    fn factory() -> NetCDFFormatFactory {
+        NetCDFFormatFactory::new(
+            Arc::new(ListingFactory::dynamic()),
+            std::env::temp_dir(),
+            NetcdfOptions::default(),
+            NetcdfConfig::default(),
+        )
+    }
+
+    /// The backend of a format the factory built from `format_options`.
+    fn backend_of(
+        factory: &NetCDFFormatFactory,
+        state: &dyn Session,
+        format_options: &HashMap<String, String>,
+    ) -> datafusion::error::Result<ReaderBackend> {
+        let format = factory.create(state, format_options)?;
+        Ok(format
+            .as_any()
+            .downcast_ref::<NetcdfFormat>()
+            .expect("the factory builds a NetcdfFormat")
+            .reader_backend)
+    }
+
+    /// A format on `backend`, ready to read the bundled test files.
+    ///
+    /// netcdf-c opens a path itself, so it gets a resolver over the filesystem
+    /// root. `oxcdf` reads through the object store and needs none.
+    fn format_on(backend: ReaderBackend) -> NetcdfFormat {
+        let format = NetcdfFormat::new(
+            Arc::new(ListingFactory::dynamic()),
+            NetcdfOptions::default(),
+        )
+        .with_reader_backend(backend);
+
+        match backend {
+            ReaderBackend::NetcdfC => {
+                format.with_object_path_resolver(object_meta_resolver::create_object_resolver(
+                    &RootStore::FileSystem(PathBuf::from("/")),
+                ))
+            }
+            ReaderBackend::Oxcdf => format,
+        }
+    }
+
+    /// A single-partition session, so a scan yields rows in a stable order.
+    fn session() -> SessionContext {
+        let state = SessionStateBuilder::new()
+            .with_config(SessionConfig::new().with_target_partitions(1))
+            .with_default_features()
+            .build();
+        SessionContext::new_with_state(state)
+    }
+
+    /// Register one test file as a table read on `backend`.
+    async fn register(ctx: &SessionContext, table: &str, backend: ReaderBackend, file: &str) {
+        let url = ListingTableUrl::parse(test_file(file).to_string_lossy()).unwrap();
+        let listing = SuperListingTable::new(&ctx.state(), Arc::new(format_on(backend)), vec![url])
+            .await
+            .unwrap_or_else(|e| panic!("register {file} on {backend:?}: {e}"));
+        ctx.register_table(table, Arc::new(listing)).unwrap();
+    }
+
+    // ── The flag ───────────────────────────────────────────────────────
+
+    /// netcdf-c stays the reader until an operator opts in.
+    #[test]
+    fn the_default_config_keeps_netcdf_c() {
+        assert!(!NetcdfConfig::default().use_rust_reader);
+        assert_eq!(ReaderBackend::default(), ReaderBackend::NetcdfC);
+    }
+
+    #[tokio::test]
+    async fn a_table_option_selects_the_rust_reader() {
+        let factory = factory();
+        let ctx = session();
+        let state = ctx.state();
+
+        assert_eq!(
+            backend_of(&factory, &state, &HashMap::new()).unwrap(),
+            ReaderBackend::NetcdfC,
+            "no option means the runtime default"
+        );
+
+        let options = HashMap::from([("use_rust_reader".to_string(), "true".to_string())]);
+        assert_eq!(
+            backend_of(&factory, &state, &options).unwrap(),
+            ReaderBackend::Oxcdf
+        );
+
+        let options = HashMap::from([("use_rust_reader".to_string(), "off".to_string())]);
+        assert_eq!(
+            backend_of(&factory, &state, &options).unwrap(),
+            ReaderBackend::NetcdfC
+        );
+
+        let options = HashMap::from([("use_rust_reader".to_string(), "maybe".to_string())]);
+        assert!(
+            backend_of(&factory, &state, &options).is_err(),
+            "a malformed boolean is a hard error"
+        );
+    }
+
+    /// The runtime config sets the default that a table inherits.
+    #[tokio::test]
+    async fn the_runtime_config_sets_the_default() {
+        let factory = NetCDFFormatFactory::new(
+            Arc::new(ListingFactory::dynamic()),
+            std::env::temp_dir(),
+            NetcdfOptions::default(),
+            NetcdfConfig {
+                use_rust_reader: true,
+                ..NetcdfConfig::default()
+            },
+        );
+        let ctx = session();
+
+        assert_eq!(
+            backend_of(&factory, &ctx.state(), &HashMap::new()).unwrap(),
+            ReaderBackend::Oxcdf
+        );
+
+        // And one table can still opt back out.
+        let options = HashMap::from([("use_rust_reader".to_string(), "false".to_string())]);
+        assert_eq!(
+            backend_of(&factory, &ctx.state(), &options).unwrap(),
+            ReaderBackend::NetcdfC
+        );
+    }
+
+    /// `FileFormatFactory::default` also carries the configured reader.
+    #[test]
+    fn the_default_format_carries_the_configured_reader() {
+        let factory = NetCDFFormatFactory::new(
+            Arc::new(ListingFactory::dynamic()),
+            std::env::temp_dir(),
+            NetcdfOptions::default(),
+            NetcdfConfig {
+                use_rust_reader: true,
+                ..NetcdfConfig::default()
+            },
+        );
+        let format = FileFormatFactory::default(&factory);
+        assert_eq!(
+            format
+                .as_any()
+                .downcast_ref::<NetcdfFormat>()
+                .unwrap()
+                .reader_backend,
+            ReaderBackend::Oxcdf
+        );
+    }
+
+    // ── Both readers agree ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn both_readers_infer_the_same_schema() {
+        for file in [GRIDDED_FILE, WOD_FILE] {
+            let ctx = session();
+            register(&ctx, "netcdf_c", ReaderBackend::NetcdfC, file).await;
+            register(&ctx, "rust", ReaderBackend::Oxcdf, file).await;
+
+            // Compare the Arrow schemas: a `DFSchema` also carries the table
+            // name, which differs here by construction.
+            let c = ctx
+                .table("netcdf_c")
+                .await
+                .unwrap()
+                .schema()
+                .as_arrow()
+                .clone();
+            let rust = ctx.table("rust").await.unwrap().schema().as_arrow().clone();
+            assert_eq!(rust, c, "schemas differ for {file}");
+        }
+    }
+
+    /// A full scan through the object store gives the same rows as netcdf-c.
+    #[tokio::test]
+    async fn both_readers_return_the_same_rows() {
+        use arrow::compute::concat_batches;
+
+        let ctx = session();
+        register(&ctx, "netcdf_c", ReaderBackend::NetcdfC, GRIDDED_FILE).await;
+        register(&ctx, "rust", ReaderBackend::Oxcdf, GRIDDED_FILE).await;
+
+        let query = "SELECT analysed_sst, lat, lon FROM {table}";
+        let collect = async |table: &str| {
+            let batches = ctx
+                .sql(&query.replace("{table}", table))
+                .await
+                .unwrap()
+                .collect()
+                .await
+                .unwrap();
+            let schema = batches[0].schema();
+            concat_batches(&schema, &batches).unwrap()
+        };
+
+        let rust = collect("rust").await;
+        assert!(rust.num_rows() > 0, "the scan must return rows");
+        assert_eq!(rust, collect("netcdf_c").await);
+    }
+
+    // ── Partitioning ───────────────────────────────────────────────────
+
+    /// A scan of many files already runs one file for each partition, on either
+    /// reader: `ListingTable` splits the file groups by `target_partitions`
+    /// before `FileSource::repartitioned` is ever consulted. So neither reader
+    /// needs a repartition rule to read files in parallel. What the Rust reader
+    /// adds is that those partitions then run at the same time, because it
+    /// holds no global lock.
+    #[tokio::test]
+    async fn a_multi_file_scan_gets_one_partition_for_each_file() {
+        use datafusion::physical_plan::ExecutionPlanProperties;
+
+        let files = 4;
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..files {
+            std::fs::copy(test_file(GRIDDED_FILE), dir.path().join(format!("f{i}.nc"))).unwrap();
+        }
+
+        for backend in [ReaderBackend::NetcdfC, ReaderBackend::Oxcdf] {
+            let state = SessionStateBuilder::new()
+                .with_config(SessionConfig::new().with_target_partitions(files))
+                .with_default_features()
+                .build();
+            let ctx = SessionContext::new_with_state(state);
+            let url = ListingTableUrl::parse(dir.path().to_string_lossy()).unwrap();
+            let table =
+                SuperListingTable::new(&ctx.state(), Arc::new(format_on(backend)), vec![url])
+                    .await
+                    .unwrap();
+            ctx.register_table("many", Arc::new(table)).unwrap();
+
+            let plan = ctx
+                .sql("SELECT analysed_sst FROM many")
+                .await
+                .unwrap()
+                .create_physical_plan()
+                .await
+                .unwrap();
+            assert_eq!(
+                plan.output_partitioning().partition_count(),
+                files,
+                "{backend:?} should scan {files} files in {files} partitions"
+            );
+        }
+    }
+
+    /// [`NetCDFSource::repartitioned`] must keep returning `None`, on either
+    /// reader. DataFusion's file-group partitioner splits a file by **byte
+    /// range**, and a byte range of a NetCDF file is not a NetCDF file. The
+    /// opener ignores [`PartitionedFile::range`] and opens the whole dataset, so
+    /// a range split would return every row once for each range. File-level
+    /// parallelism does not go through here (see the test above).
+    ///
+    /// [`PartitionedFile::range`]: datafusion::datasource::listing::PartitionedFile::range
+    #[test]
+    fn the_source_never_splits_a_file_by_byte_range() {
+        use datafusion::datasource::table_schema::TableSchema;
+        use datafusion::execution::object_store::ObjectStoreUrl;
+
+        for backend in [ReaderBackend::NetcdfC, ReaderBackend::Oxcdf] {
+            let table_schema =
+                TableSchema::from_file_schema(Arc::new(arrow::datatypes::Schema::empty()));
+            let source = NetCDFSource::new(
+                Arc::new(object_meta_resolver::DefaultNetCDFObjectResolver),
+                None,
+                table_schema,
+            )
+            .with_reader_backend(backend);
+            let config = FileScanConfigBuilder::new(
+                ObjectStoreUrl::local_filesystem(),
+                Arc::new(source.clone()) as Arc<dyn FileSource>,
+            )
+            .build();
+
+            assert!(
+                source.repartitioned(8, 1, None, &config).unwrap().is_none(),
+                "{backend:?} must not accept a byte-range repartition"
+            );
+        }
+    }
+
+    /// A projection and a predicate push down the same way on either reader.
+    #[tokio::test]
+    async fn a_pushed_down_predicate_gives_the_same_answer() {
+        let ctx = session();
+        register(&ctx, "netcdf_c", ReaderBackend::NetcdfC, GRIDDED_FILE).await;
+        register(&ctx, "rust", ReaderBackend::Oxcdf, GRIDDED_FILE).await;
+
+        let count = async |table: &str| {
+            let sql = format!("SELECT count(*) FROM {table} WHERE lat > 0");
+            let batches = ctx.sql(&sql).await.unwrap().collect().await.unwrap();
+            batches[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::Int64Array>()
+                .unwrap()
+                .value(0)
+        };
+
+        let rust = count("rust").await;
+        assert!(rust > 0, "the predicate must keep some rows");
+        assert_eq!(rust, count("netcdf_c").await);
     }
 }
 

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -881,6 +881,71 @@ mod reader_backend_tests {
         }
     }
 
+    /// Every column, including every attribute, comes back identical.
+    ///
+    /// The other comparisons check data variables, or check that attributes are
+    /// *present* with the right type and shape. Neither would catch an
+    /// attribute whose **value** differs between the readers. `SELECT *` reads
+    /// the lot: data variables, variable attributes (`analysed_sst.units`) and
+    /// global attributes (`.Conventions`), the last two broadcast onto every
+    /// row by the nd pipeline.
+    #[tokio::test]
+    async fn both_readers_return_identical_values_for_every_column() {
+        use arrow::compute::concat_batches;
+
+        // The ragged file in full, and a slice of the gridded one — a whole
+        // gridded scan is millions of rows and does not need materialising to
+        // prove the point.
+        for (file, query) in [
+            (WOD_FILE, "SELECT * FROM {table}"),
+            (GRIDDED_FILE, "SELECT * FROM {table} LIMIT 512"),
+        ] {
+            let ctx = session();
+            register(&ctx, "netcdf_c", ReaderBackend::NetcdfC, file).await;
+            register(&ctx, "rust", ReaderBackend::Oxcdf, file).await;
+
+            let collect = async |table: &str| {
+                let batches = ctx
+                    .sql(&query.replace("{table}", table))
+                    .await
+                    .unwrap()
+                    .collect()
+                    .await
+                    .unwrap();
+                let schema = batches[0].schema();
+                concat_batches(&schema, &batches).unwrap()
+            };
+
+            let rust = collect("rust").await;
+            let c = collect("netcdf_c").await;
+
+            assert!(rust.num_rows() > 0, "{file}: the scan must return rows");
+            // Guard the guard: a column set that lost the attributes would make
+            // the comparison below pass without checking any of them.
+            let schema = rust.schema();
+            let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+            assert!(
+                names.iter().any(|n| n.starts_with('.')),
+                "{file}: no global attribute in {names:?}"
+            );
+            assert!(
+                names.iter().any(|n| n.contains('.') && !n.starts_with('.')),
+                "{file}: no variable attribute in {names:?}"
+            );
+
+            // Compare column by column, so a failure names the column.
+            for (i, field) in rust.schema().fields().iter().enumerate() {
+                assert_eq!(
+                    rust.column(i),
+                    c.column(i),
+                    "{file}: column '{}' differs between the readers",
+                    field.name()
+                );
+            }
+            assert_eq!(rust, c, "{file}: batches differ");
+        }
+    }
+
     /// A projection and a predicate push down the same way on either reader.
     #[tokio::test]
     async fn a_pushed_down_predicate_gives_the_same_answer() {

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -885,7 +885,7 @@ mod reader_backend_tests {
     ///
     /// The other comparisons check data variables, or check that attributes are
     /// *present* with the right type and shape. Neither would catch an
-    /// attribute whose **value** differs between the readers. `SELECT *` reads
+    /// attribute whose **value** differs between the readers. This one reads
     /// the lot: data variables, variable attributes (`analysed_sst.units`) and
     /// global attributes (`.Conventions`), the last two broadcast onto every
     /// row by the nd pipeline.
@@ -893,12 +893,21 @@ mod reader_backend_tests {
     async fn both_readers_return_identical_values_for_every_column() {
         use arrow::compute::concat_batches;
 
-        // The ragged file in full, and a slice of the gridded one — a whole
-        // gridded scan is millions of rows and does not need materialising to
-        // prove the point.
+        // The ragged file in full: 418 rows over 147 columns, ~1 MiB.
+        //
+        // The gridded file gets an explicit column list, not `SELECT *`. Its
+        // grid is 2.3M rows, and `LIMIT` does not bound what the scan
+        // materialises: the nd broadcast emits the whole grid as one batch and
+        // the limit only slices it, so `SELECT *` here costs ~10 GiB for each
+        // reader. The columns below are the ones this test is actually for — a
+        // global attribute, a variable attribute, and the two CF decodes.
         for (file, query) in [
             (WOD_FILE, "SELECT * FROM {table}"),
-            (GRIDDED_FILE, "SELECT * FROM {table} LIMIT 512"),
+            (
+                GRIDDED_FILE,
+                r#"SELECT ".Conventions", "analysed_sst.units", analysed_sst, time
+                   FROM {table}"#,
+            ),
         ] {
             let ctx = session();
             register(&ctx, "netcdf_c", ReaderBackend::NetcdfC, file).await;

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -23,7 +23,6 @@ use datafusion::{
 };
 use object_store::{ObjectMeta, ObjectStore};
 
-use crate::datafusion::object_meta_resolver::{DefaultNetCDFObjectResolver, NetCDFObjectResolver};
 use crate::datafusion::{
     options::NetcdfOptions,
     sink::{NetCDFNdSink, NetCDFSink},
@@ -42,7 +41,7 @@ pub mod source;
 pub mod statistics;
 pub mod table_function;
 
-pub use reader::{NetcdfInput, NetcdfReaderCache, ReaderBackend};
+pub use reader::{FileAccess, NetcdfInput, NetcdfReaderCache, ReaderBackend};
 pub use table_function::ReadNetCDFFunc;
 
 /// Runtime configuration for the NetCDF format.
@@ -124,23 +123,28 @@ impl NetCDFFormatFactory {
         options: NetcdfOptions,
         use_reader_cache: bool,
         enable_statistics: bool,
-        reader_backend: ReaderBackend,
+        access: FileAccess,
     ) -> NetcdfFormat {
         let cache = use_reader_cache.then(|| self.cache.clone());
         NetcdfFormat::new(self.listing_factory.clone(), options)
             .with_cache(cache)
             .with_enable_statistics(enable_statistics)
-            .with_reader_backend(reader_backend)
+            .with_access(access)
             .with_output_dir(self.output_dir.clone())
     }
 }
 
-/// The reader a `use_rust_reader` setting selects.
-fn reader_backend_for(use_rust_reader: bool) -> ReaderBackend {
+/// The access a `use_rust_reader` setting selects, for a format built without a
+/// location.
+///
+/// `oxcdf` is complete as it stands: it reads through the scan's object store.
+/// netcdf-c needs a resolver it cannot have yet, so it gets the unresolvable
+/// default; `create_with_native_root` is where it gets a real one.
+fn access_for(use_rust_reader: bool) -> FileAccess {
     if use_rust_reader {
-        ReaderBackend::Oxcdf
+        FileAccess::Oxcdf
     } else {
-        ReaderBackend::NetcdfC
+        FileAccess::default()
     }
 }
 
@@ -180,7 +184,7 @@ impl FileFormatFactory for NetCDFFormatFactory {
             options,
             use_reader_cache,
             enable_statistics,
-            reader_backend_for(use_rust_reader),
+            access_for(use_rust_reader),
         )))
     }
 
@@ -189,7 +193,7 @@ impl FileFormatFactory for NetCDFFormatFactory {
             self.options.clone(),
             self.config.use_reader_cache,
             self.config.enable_statistics,
-            reader_backend_for(self.config.use_rust_reader),
+            access_for(self.config.use_rust_reader),
         ))
     }
 
@@ -205,17 +209,19 @@ impl GetExt for NetCDFFormatFactory {
 }
 
 impl FileFormatFactoryExt for NetCDFFormatFactory {
+    /// This is where a [`FileAccess::NetcdfC`] gets its resolver.
+    ///
     /// netcdf-c opens a local path or an http(s) URL and never the object store,
-    /// so a format on that reader needs a [`NetCDFObjectResolver`] built from the
-    /// root store `url` resolves against. Plain [`FileFormatFactory::create`] has
-    /// no location to work from and yields a format whose resolver always errors.
+    /// so it needs a resolver built from the root store `url` resolves against.
+    /// Plain [`FileFormatFactory::create`] has no location to work from, so it
+    /// leaves [`FileAccess::default`] in place, which resolves nothing.
     ///
     /// `native_read_root` rejects a scheme netcdf-c cannot open (s3/gs/az) here,
     /// naming the location, rather than failing later per listed object.
     ///
-    /// The `oxcdf` reader reads through the object store, so it needs no
-    /// resolver and no native root. A format on that reader is returned as it
-    /// is, which is what lets a table live in s3, gs or az.
+    /// [`FileAccess::Oxcdf`] reads through the object store, so it needs no
+    /// resolver and no native root. It is returned as it is, which is what lets
+    /// a table live in s3, gs or az.
     fn create_with_native_root(
         &self,
         state: &dyn Session,
@@ -231,13 +237,17 @@ impl FileFormatFactoryExt for NetCDFFormatFactory {
                 exec_datafusion_err!("the NetCDF factory did not produce a NetcdfFormat")
             })?
             .clone();
-        if netcdf.reader_backend == ReaderBackend::Oxcdf {
-            return Ok(Arc::new(netcdf));
+        match netcdf.access {
+            // Already complete: it reads through the scan's object store.
+            FileAccess::Oxcdf => Ok(Arc::new(netcdf)),
+            // Supply the resolver `create` had no location to build.
+            FileAccess::NetcdfC { .. } => {
+                let root = listing.native_read_root(url)?;
+                Ok(Arc::new(netcdf.with_access(FileAccess::netcdf_c(
+                    object_meta_resolver::create_object_resolver(&root),
+                ))))
+            }
         }
-        let root = listing.native_read_root(url)?;
-        Ok(Arc::new(netcdf.with_object_path_resolver(
-            object_meta_resolver::create_object_resolver(&root),
-        )))
     }
 
     fn discover_datasets(
@@ -272,9 +282,8 @@ pub struct NetcdfFormat {
     enable_statistics: bool,
     /// Local directory the netcdf-c writer emits output files into.
     output_dir: PathBuf,
-    /// The reader that opens each file of this table.
-    pub reader_backend: ReaderBackend,
-    pub object_path_resolver: Arc<dyn NetCDFObjectResolver>,
+    /// How this table reaches its files, and which reader opens them.
+    pub access: FileAccess,
 }
 
 impl NetcdfFormat {
@@ -285,29 +294,19 @@ impl NetcdfFormat {
             cache: None,
             enable_statistics: false,
             output_dir: std::env::temp_dir(),
-            reader_backend: ReaderBackend::default(),
-            object_path_resolver: Arc::new(DefaultNetCDFObjectResolver),
+            access: FileAccess::default(),
         }
     }
 
-    /// Select the reader that opens each file.
-    pub fn with_reader_backend(mut self, reader_backend: ReaderBackend) -> Self {
-        self.reader_backend = reader_backend;
+    /// Set how this format reaches its files.
+    pub fn with_access(mut self, access: FileAccess) -> Self {
+        self.access = access;
         self
     }
 
-    /// Describe where one object's bytes come from, for the format's reader.
-    fn input_for(
-        &self,
-        store: &Arc<dyn ObjectStore>,
-        object: &ObjectMeta,
-    ) -> datafusion::error::Result<NetcdfInput> {
-        reader::netcdf_input(
-            self.reader_backend,
-            &self.object_path_resolver,
-            store,
-            object,
-        )
+    /// The reader this format opens files with.
+    pub fn reader_backend(&self) -> ReaderBackend {
+        self.access.backend()
     }
 
     /// Wire in a reader cache (`Some`) or disable caching (`None`).
@@ -326,11 +325,6 @@ impl NetcdfFormat {
     /// OS temp dir).
     pub fn with_output_dir(mut self, output_dir: PathBuf) -> Self {
         self.output_dir = output_dir;
-        self
-    }
-
-    pub fn with_object_path_resolver(mut self, resolver: Arc<dyn NetCDFObjectResolver>) -> Self {
-        self.object_path_resolver = resolver;
         self
     }
 }
@@ -367,7 +361,7 @@ impl FileFormat for NetcdfFormat {
         for object in objects {
             let task = reader::fetch_schema(
                 cache,
-                self.input_for(store, object)?,
+                self.access.input_for(store, object)?,
                 object.clone(),
                 self.options.read_dimensions.clone(),
             );
@@ -397,7 +391,7 @@ impl FileFormat for NetcdfFormat {
         if self.enable_statistics {
             // Built the same way the reader builds it, so statistics and scans
             // can never disagree about where a file is or which reader opens it.
-            let input = self.input_for(store, object)?;
+            let input = self.access.input_for(store, object)?;
             Ok(statistics::generate_statistics(input, &table_schema)
                 .await
                 .unwrap_or_else(|e| {
@@ -433,12 +427,11 @@ impl FileFormat for NetcdfFormat {
         // source — rebuilding the source below would otherwise drop it.
         let projection = conf.file_source().projection().cloned();
         let source = NetCDFSource::new(
-            self.object_path_resolver.clone(),
+            self.access.clone(),
             self.options.read_dimensions.clone(),
             table_schema,
         )
         .with_cache(self.cache.clone())
-        .with_reader_backend(self.reader_backend)
         .with_projection(projection);
         let conf = FileScanConfigBuilder::from(conf)
             .with_source(Arc::new(source))
@@ -516,12 +509,11 @@ impl FileFormat for NetcdfFormat {
     ) -> Arc<dyn FileSource> {
         Arc::new(
             NetCDFSource::new(
-                self.object_path_resolver.clone(),
+                self.access.clone(),
                 self.options.read_dimensions.clone(),
                 table_schema,
             )
-            .with_cache(self.cache.clone())
-            .with_reader_backend(self.reader_backend),
+            .with_cache(self.cache.clone()),
         )
     }
 }
@@ -570,28 +562,31 @@ mod reader_backend_tests {
             .as_any()
             .downcast_ref::<NetcdfFormat>()
             .expect("the factory builds a NetcdfFormat")
-            .reader_backend)
+            .reader_backend())
     }
 
-    /// A format on `backend`, ready to read the bundled test files.
+    /// The access that reads the bundled test files on `backend`.
     ///
-    /// netcdf-c opens a path itself, so it gets a resolver over the filesystem
-    /// root. `oxcdf` reads through the object store and needs none.
-    fn format_on(backend: ReaderBackend) -> NetcdfFormat {
-        let format = NetcdfFormat::new(
-            Arc::new(ListingFactory::dynamic()),
-            NetcdfOptions::default(),
-        )
-        .with_reader_backend(backend);
-
+    /// netcdf-c opens a path itself, so it takes a resolver over the filesystem
+    /// root. `oxcdf` reads through the object store and takes nothing.
+    fn access_on(backend: ReaderBackend) -> FileAccess {
         match backend {
             ReaderBackend::NetcdfC => {
-                format.with_object_path_resolver(object_meta_resolver::create_object_resolver(
+                FileAccess::netcdf_c(object_meta_resolver::create_object_resolver(
                     &RootStore::FileSystem(PathBuf::from("/")),
                 ))
             }
-            ReaderBackend::Oxcdf => format,
+            ReaderBackend::Oxcdf => FileAccess::Oxcdf,
         }
+    }
+
+    /// A format on `backend`, ready to read the bundled test files.
+    fn format_on(backend: ReaderBackend) -> NetcdfFormat {
+        NetcdfFormat::new(
+            Arc::new(ListingFactory::dynamic()),
+            NetcdfOptions::default(),
+        )
+        .with_access(access_on(backend))
     }
 
     /// A single-partition session, so a scan yields rows in a stable order.
@@ -610,6 +605,64 @@ mod reader_backend_tests {
             .await
             .unwrap_or_else(|e| panic!("register {file} on {backend:?}: {e}"));
         ctx.register_table(table, Arc::new(listing)).unwrap();
+    }
+
+    // ── FileAccess ─────────────────────────────────────────────────────
+
+    /// Each variant carries what its own reader needs, so the two cannot be
+    /// mismatched: `Oxcdf` reads through the store it is handed, and `NetcdfC`
+    /// cannot be built without a resolver.
+    #[test]
+    fn each_access_resolves_an_object_its_own_way() {
+        let store: Arc<dyn ObjectStore> = Arc::new(object_store::local::LocalFileSystem::new());
+        let object = ObjectMeta {
+            location: object_store::path::Path::from("dir/file.nc"),
+            last_modified: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            size: 0,
+            e_tag: None,
+            version: None,
+        };
+
+        // oxcdf keeps the store and the object path as they are.
+        let input = FileAccess::Oxcdf.input_for(&store, &object).unwrap();
+        assert!(matches!(input, NetcdfInput::Oxcdf { .. }));
+        assert_eq!(input.backend(), ReaderBackend::Oxcdf);
+        assert_eq!(input.location(), "dir/file.nc");
+
+        // netcdf-c turns it into a native path through its resolver.
+        let access = FileAccess::netcdf_c(object_meta_resolver::create_object_resolver(
+            &RootStore::HttpsStore("https://example.org/data".to_string()),
+        ));
+        let input = access.input_for(&store, &object).unwrap();
+        assert_eq!(input.backend(), ReaderBackend::NetcdfC);
+        assert_eq!(
+            input.location(),
+            "https://example.org/data/dir/file.nc#mode=bytes"
+        );
+    }
+
+    /// The default is netcdf-c with no location supplied yet. It fails per
+    /// object, naming the path, rather than being silently unusable.
+    #[test]
+    fn the_default_access_cannot_resolve_and_says_so() {
+        let store: Arc<dyn ObjectStore> = Arc::new(object_store::local::LocalFileSystem::new());
+        let object = ObjectMeta {
+            location: object_store::path::Path::from("dir/file.nc"),
+            last_modified: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            size: 0,
+            e_tag: None,
+            version: None,
+        };
+
+        assert_eq!(FileAccess::default().backend(), ReaderBackend::NetcdfC);
+        let err = FileAccess::default()
+            .input_for(&store, &object)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("dir/file.nc"),
+            "error should name the path: {err}"
+        );
     }
 
     // ── The flag ───────────────────────────────────────────────────────
@@ -697,7 +750,7 @@ mod reader_backend_tests {
                 .as_any()
                 .downcast_ref::<NetcdfFormat>()
                 .unwrap()
-                .reader_backend,
+                .reader_backend(),
             ReaderBackend::Oxcdf
         );
     }
@@ -814,12 +867,7 @@ mod reader_backend_tests {
         for backend in [ReaderBackend::NetcdfC, ReaderBackend::Oxcdf] {
             let table_schema =
                 TableSchema::from_file_schema(Arc::new(arrow::datatypes::Schema::empty()));
-            let source = NetCDFSource::new(
-                Arc::new(object_meta_resolver::DefaultNetCDFObjectResolver),
-                None,
-                table_schema,
-            )
-            .with_reader_backend(backend);
+            let source = NetCDFSource::new(access_on(backend), None, table_schema);
             let config = FileScanConfigBuilder::new(
                 ObjectStoreUrl::local_filesystem(),
                 Arc::new(source.clone()) as Arc<dyn FileSource>,

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/partition_coverage_tests.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/partition_coverage_tests.rs
@@ -20,7 +20,7 @@ use beacon_datafusion_ext::file_collection::FileCollection;
 use beacon_datafusion_ext::listing_factory::{ListingFactory, RootStore};
 use datafusion::prelude::{SessionConfig, SessionContext};
 
-use crate::datafusion::{options::NetcdfOptions, NetcdfFormat, ReaderBackend};
+use crate::datafusion::{options::NetcdfOptions, FileAccess, NetcdfFormat, ReaderBackend};
 
 /// Copy the ragged fixture `copies` times into a fresh temp dir.
 fn stage_files(copies: usize) -> tempfile::TempDir {
@@ -43,20 +43,20 @@ async fn ctx_for(
     let ctx = SessionContext::new_with_config(config);
     let state = ctx.state();
 
-    let factory = Arc::new(ListingFactory::dynamic());
-    let format = NetcdfFormat::new(factory, NetcdfOptions::default()).with_reader_backend(backend);
-    // netcdf-c opens a path itself, so it needs the wiring
-    // `create_with_native_root` does for a `file://` listing url: object paths
+    // netcdf-c opens a path itself, so it takes the resolver
+    // `create_with_native_root` builds for a `file://` listing url: object paths
     // are absolute w.r.t. the filesystem root. The `oxcdf` reader goes through
-    // the object store and needs no resolver.
-    let format = Arc::new(match backend {
-        ReaderBackend::NetcdfC => format.with_object_path_resolver(
+    // the object store and takes nothing.
+    let access = match backend {
+        ReaderBackend::NetcdfC => FileAccess::netcdf_c(
             crate::datafusion::object_meta_resolver::create_object_resolver(
                 &RootStore::FileSystem(std::path::PathBuf::from("/")),
             ),
         ),
-        ReaderBackend::Oxcdf => format,
-    });
+        ReaderBackend::Oxcdf => FileAccess::Oxcdf,
+    };
+    let factory = Arc::new(ListingFactory::dynamic());
+    let format = Arc::new(NetcdfFormat::new(factory, NetcdfOptions::default()).with_access(access));
 
     let url = datafusion::datasource::listing::ListingTableUrl::parse(format!(
         "file://{}/",

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/partition_coverage_tests.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/partition_coverage_tests.rs
@@ -9,6 +9,10 @@
 //!
 //! `count(*)` did not catch it: it is answered without decoding nd arrays, so
 //! it stayed correct while the scan returned fewer rows.
+//!
+//! The decode layer is shared, so the loss hit both readers. Each case
+//! therefore runs on both, and the two must agree on the row count as well as
+//! reach the expected one.
 
 use std::sync::Arc;
 
@@ -16,7 +20,7 @@ use beacon_datafusion_ext::file_collection::FileCollection;
 use beacon_datafusion_ext::listing_factory::{ListingFactory, RootStore};
 use datafusion::prelude::{SessionConfig, SessionContext};
 
-use crate::datafusion::{options::NetcdfOptions, NetcdfFormat};
+use crate::datafusion::{options::NetcdfOptions, NetcdfFormat, ReaderBackend};
 
 /// Copy the ragged fixture `copies` times into a fresh temp dir.
 fn stage_files(copies: usize) -> tempfile::TempDir {
@@ -30,20 +34,29 @@ fn stage_files(copies: usize) -> tempfile::TempDir {
     dir
 }
 
-async fn ctx_for(dir: &tempfile::TempDir, target_partitions: usize) -> SessionContext {
+async fn ctx_for(
+    dir: &tempfile::TempDir,
+    target_partitions: usize,
+    backend: ReaderBackend,
+) -> SessionContext {
     let config = SessionConfig::new().with_target_partitions(target_partitions);
     let ctx = SessionContext::new_with_config(config);
     let state = ctx.state();
 
     let factory = Arc::new(ListingFactory::dynamic());
-    // Same wiring `create_with_native_root` does for a `file://` listing url:
-    // object paths are absolute w.r.t. the filesystem root.
-    let resolver = crate::datafusion::object_meta_resolver::create_object_resolver(
-        &RootStore::FileSystem(std::path::PathBuf::from("/")),
-    );
-    let format = Arc::new(
-        NetcdfFormat::new(factory, NetcdfOptions::default()).with_object_path_resolver(resolver),
-    );
+    let format = NetcdfFormat::new(factory, NetcdfOptions::default()).with_reader_backend(backend);
+    // netcdf-c opens a path itself, so it needs the wiring
+    // `create_with_native_root` does for a `file://` listing url: object paths
+    // are absolute w.r.t. the filesystem root. The `oxcdf` reader goes through
+    // the object store and needs no resolver.
+    let format = Arc::new(match backend {
+        ReaderBackend::NetcdfC => format.with_object_path_resolver(
+            crate::datafusion::object_meta_resolver::create_object_resolver(
+                &RootStore::FileSystem(std::path::PathBuf::from("/")),
+            ),
+        ),
+        ReaderBackend::Oxcdf => format,
+    });
 
     let url = datafusion::datasource::listing::ListingTableUrl::parse(format!(
         "file://{}/",
@@ -90,10 +103,16 @@ async fn count_star(ctx: &SessionContext) -> usize {
 async fn scan_reads_every_file_regardless_of_target_partitions() {
     const FILES: usize = 32;
 
-    // One file first, to learn the per-file row count.
+    // One file first, to learn the per-file row count. Both readers must agree
+    // on it, or the comparison below rests on nothing.
     let one = stage_files(1);
-    let per_file = scanned_rows(&ctx_for(&one, 4).await).await;
+    let per_file = scanned_rows(&ctx_for(&one, 4, ReaderBackend::NetcdfC).await).await;
     assert!(per_file > 0, "fixture produced no rows");
+    assert_eq!(
+        scanned_rows(&ctx_for(&one, 4, ReaderBackend::Oxcdf).await).await,
+        per_file,
+        "the two readers disagree on the row count of one file"
+    );
 
     let dir = stage_files(FILES);
     let expected = per_file * FILES;
@@ -102,19 +121,27 @@ async fn scan_reads_every_file_regardless_of_target_partitions() {
     // do not, so a coalescing RoundRobinBatch repartition is inserted — those
     // were the shapes that silently lost files. 33 exceeds the file count, so
     // coalescing has nothing to merge.
+    //
+    // The decode layer is shared, so both readers meet the same coalescing.
     let mut failures = vec![];
-    for tp in [1usize, 8, 9, 16, 24, 31, 32, 33] {
-        let ctx = ctx_for(&dir, tp).await;
-        let scanned = scanned_rows(&ctx).await;
-        let counted = count_star(&ctx).await;
+    for backend in [ReaderBackend::NetcdfC, ReaderBackend::Oxcdf] {
+        for tp in [1usize, 8, 9, 16, 24, 31, 32, 33] {
+            let ctx = ctx_for(&dir, tp, backend).await;
+            let scanned = scanned_rows(&ctx).await;
+            let counted = count_star(&ctx).await;
 
-        if scanned != expected || counted != expected {
-            failures.push(format!(
-                "target_partitions={tp}: scanned {scanned} ({} files), count(*) {counted}, \
-                 expected {expected}",
-                scanned / per_file
-            ));
+            if scanned != expected || counted != expected {
+                failures.push(format!(
+                    "{backend:?} target_partitions={tp}: scanned {scanned} ({} files), \
+                     count(*) {counted}, expected {expected}",
+                    scanned / per_file
+                ));
+            }
         }
     }
-    assert!(failures.is_empty(), "row loss:\n  {}", failures.join("\n  "));
+    assert!(
+        failures.is_empty(),
+        "row loss:\n  {}",
+        failures.join("\n  ")
+    );
 }

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/reader.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/reader.rs
@@ -3,12 +3,15 @@ use std::sync::Arc;
 use beacon_nd_array::dataset::AnyDataset;
 use object_store::{ObjectMeta, ObjectStore};
 
-use crate::datafusion::object_meta_resolver::NetCDFObjectResolver;
+use crate::datafusion::object_meta_resolver::{DefaultNetCDFObjectResolver, NetCDFObjectResolver};
 
 /// Which reader opens a NetCDF file.
 ///
 /// The two readers produce the same dataset, so this only decides how the bytes
 /// are fetched and decoded. See [`crate::oxcdf_reader`] for the trade-off.
+///
+/// This is the bare choice, small enough to key a cache by. [`FileAccess`] is
+/// the choice plus whatever that reader needs to reach a file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum ReaderBackend {
     /// netcdf-c, through its Rust bindings. The default.
@@ -18,11 +21,87 @@ pub enum ReaderBackend {
     Oxcdf,
 }
 
+/// How a table reaches its files, and which reader opens them.
+///
+/// The two readers do not need the same things, so each variant carries exactly
+/// what its reader needs and nothing else. That is the point of the type: a
+/// format cannot hold a resolver the reader never consults, and it cannot pick
+/// netcdf-c without one.
+#[derive(Debug, Clone)]
+pub enum FileAccess {
+    /// netcdf-c opens a path itself, so it cannot work without a resolver to
+    /// turn an object path into that path.
+    NetcdfC {
+        /// Builds the native path netcdf-c opens, from the table's root store.
+        resolver: Arc<dyn NetCDFObjectResolver>,
+    },
+    /// `oxcdf` reads byte ranges through the scan's own object store. It needs
+    /// nothing else, which is why this variant carries nothing.
+    Oxcdf,
+}
+
+impl Default for FileAccess {
+    /// netcdf-c with a resolver that cannot resolve anything.
+    ///
+    /// This is the "no location was supplied" state, which
+    /// [`FileFormatFactory::create`](datafusion::datasource::file_format::FileFormatFactory::create)
+    /// and [`FileFormatFactory::default`](datafusion::datasource::file_format::FileFormatFactory::default)
+    /// produce. A scan on it fails per object, naming the path it could not
+    /// resolve. See [`FileFormatFactoryExt::create_with_native_root`](beacon_datafusion_ext::format_ext::FileFormatFactoryExt::create_with_native_root)
+    /// for the path that supplies one.
+    fn default() -> Self {
+        Self::NetcdfC {
+            resolver: Arc::new(DefaultNetCDFObjectResolver),
+        }
+    }
+}
+
+impl FileAccess {
+    /// netcdf-c, reading through `resolver`.
+    pub fn netcdf_c(resolver: Arc<dyn NetCDFObjectResolver>) -> Self {
+        Self::NetcdfC { resolver }
+    }
+
+    /// The reader this access uses.
+    pub fn backend(&self) -> ReaderBackend {
+        match self {
+            FileAccess::NetcdfC { .. } => ReaderBackend::NetcdfC,
+            FileAccess::Oxcdf => ReaderBackend::Oxcdf,
+        }
+    }
+
+    /// Describe where one object's bytes come from.
+    ///
+    /// netcdf-c resolves the object to a native path. `oxcdf` takes the scan's
+    /// store and the object path as they are, so it also reads s3, gs and az.
+    /// The format, the statistics and the opener all come through here, so they
+    /// can never disagree about a file.
+    pub fn input_for(
+        &self,
+        store: &Arc<dyn ObjectStore>,
+        object: &ObjectMeta,
+    ) -> datafusion::error::Result<NetcdfInput> {
+        match self {
+            FileAccess::NetcdfC { resolver } => {
+                let native_path = resolver.resolve(object).map_err(|e| {
+                    datafusion::error::DataFusionError::Execution(format!(
+                        "Failed to resolve object metadata (path) to NetCDF native path: {e}"
+                    ))
+                })?;
+                Ok(NetcdfInput::NetcdfC(native_path))
+            }
+            FileAccess::Oxcdf => Ok(NetcdfInput::Oxcdf {
+                store: store.clone(),
+                path: object.location.clone(),
+            }),
+        }
+    }
+}
+
 /// Where a reader gets the bytes of one NetCDF object.
 ///
 /// The variant also names the reader: netcdf-c opens a path itself, and `oxcdf`
-/// reads through the object store. A caller builds the variant that matches the
-/// format's [`ReaderBackend`].
+/// reads through the object store. Build one with [`FileAccess::input_for`].
 #[derive(Debug, Clone)]
 pub enum NetcdfInput {
     /// netcdf-c opens this native path directly. It is a local path, or an
@@ -66,34 +145,6 @@ impl NetcdfInput {
                 crate::oxcdf_reader::open_dataset(store, path).await
             }
         }
-    }
-}
-
-/// Describe where one object's bytes come from, for the given reader.
-///
-/// netcdf-c needs a native path, which `resolver` builds from the table's root
-/// store. `oxcdf` takes the store and the object path as they are, so it also
-/// reads s3, gs and az. The format and the opener both call this, so a scan and
-/// its statistics can never disagree about a file.
-pub fn netcdf_input(
-    backend: ReaderBackend,
-    resolver: &Arc<dyn NetCDFObjectResolver>,
-    store: &Arc<dyn ObjectStore>,
-    object: &ObjectMeta,
-) -> datafusion::error::Result<NetcdfInput> {
-    match backend {
-        ReaderBackend::NetcdfC => {
-            let native_path = resolver.resolve(object).map_err(|e| {
-                datafusion::error::DataFusionError::Execution(format!(
-                    "Failed to resolve object metadata (path) to NetCDF native path: {e}"
-                ))
-            })?;
-            Ok(NetcdfInput::NetcdfC(native_path))
-        }
-        ReaderBackend::Oxcdf => Ok(NetcdfInput::Oxcdf {
-            store: store.clone(),
-            path: object.location.clone(),
-        }),
     }
 }
 

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/reader.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/reader.rs
@@ -1,9 +1,101 @@
 use std::sync::Arc;
 
 use beacon_nd_array::dataset::AnyDataset;
-use object_store::ObjectMeta;
+use object_store::{ObjectMeta, ObjectStore};
 
-use crate::reader;
+use crate::datafusion::object_meta_resolver::NetCDFObjectResolver;
+
+/// Which reader opens a NetCDF file.
+///
+/// The two readers produce the same dataset, so this only decides how the bytes
+/// are fetched and decoded. See [`crate::oxcdf_reader`] for the trade-off.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum ReaderBackend {
+    /// netcdf-c, through its Rust bindings. The default.
+    #[default]
+    NetcdfC,
+    /// `oxcdf`, pure Rust over `object_store`.
+    Oxcdf,
+}
+
+/// Where a reader gets the bytes of one NetCDF object.
+///
+/// The variant also names the reader: netcdf-c opens a path itself, and `oxcdf`
+/// reads through the object store. A caller builds the variant that matches the
+/// format's [`ReaderBackend`].
+#[derive(Debug, Clone)]
+pub enum NetcdfInput {
+    /// netcdf-c opens this native path directly. It is a local path, or an
+    /// `http(s)` URL that carries the `#mode=bytes` suffix.
+    NetcdfC(String),
+    /// `oxcdf` range-reads the object through the store. No local copy is made,
+    /// so this also covers s3, gs and az.
+    Oxcdf {
+        /// The store the object lives in.
+        store: Arc<dyn ObjectStore>,
+        /// The object, relative to that store.
+        path: object_store::path::Path,
+    },
+}
+
+impl NetcdfInput {
+    /// The reader this input belongs to.
+    pub fn backend(&self) -> ReaderBackend {
+        match self {
+            NetcdfInput::NetcdfC(_) => ReaderBackend::NetcdfC,
+            NetcdfInput::Oxcdf { .. } => ReaderBackend::Oxcdf,
+        }
+    }
+
+    /// The location to name in an error message.
+    pub fn location(&self) -> String {
+        match self {
+            NetcdfInput::NetcdfC(path) => path.clone(),
+            NetcdfInput::Oxcdf { path, .. } => path.to_string(),
+        }
+    }
+
+    /// Open the dataset this input points at, with no caching.
+    ///
+    /// [`open_dataset`] adds the cache. Use this one where a cache entry has no
+    /// value, such as one-off statistics.
+    pub async fn open(self) -> anyhow::Result<AnyDataset> {
+        match self {
+            NetcdfInput::NetcdfC(path) => crate::reader::open_dataset(path).await,
+            NetcdfInput::Oxcdf { store, path } => {
+                crate::oxcdf_reader::open_dataset(store, path).await
+            }
+        }
+    }
+}
+
+/// Describe where one object's bytes come from, for the given reader.
+///
+/// netcdf-c needs a native path, which `resolver` builds from the table's root
+/// store. `oxcdf` takes the store and the object path as they are, so it also
+/// reads s3, gs and az. The format and the opener both call this, so a scan and
+/// its statistics can never disagree about a file.
+pub fn netcdf_input(
+    backend: ReaderBackend,
+    resolver: &Arc<dyn NetCDFObjectResolver>,
+    store: &Arc<dyn ObjectStore>,
+    object: &ObjectMeta,
+) -> datafusion::error::Result<NetcdfInput> {
+    match backend {
+        ReaderBackend::NetcdfC => {
+            let native_path = resolver.resolve(object).map_err(|e| {
+                datafusion::error::DataFusionError::Execution(format!(
+                    "Failed to resolve object metadata (path) to NetCDF native path: {e}"
+                ))
+            })?;
+            Ok(NetcdfInput::NetcdfC(native_path))
+        }
+        ReaderBackend::Oxcdf => Ok(NetcdfInput::Oxcdf {
+            store: store.clone(),
+            path: object.location.clone(),
+        }),
+    }
+}
 
 /// A NetCDF dataset reader cache, sized at construction time.
 ///
@@ -31,6 +123,10 @@ impl NetcdfReaderCache {
 struct CacheKey {
     pub object: object_store::path::Path,
     pub last_modified: chrono::DateTime<chrono::Utc>,
+    /// The reader that produced the entry. One runtime can serve tables on
+    /// either reader, and their datasets are not interchangeable, so the key
+    /// keeps them apart.
+    pub backend: ReaderBackend,
 }
 
 /// Open a NetCDF dataset, optionally consulting `cache`.
@@ -41,12 +137,13 @@ struct CacheKey {
 /// out of caching).
 pub async fn open_dataset(
     cache: Option<&NetcdfReaderCache>,
-    native_path: String,
+    input: NetcdfInput,
     object: ObjectMeta,
 ) -> anyhow::Result<AnyDataset> {
     let key = CacheKey {
         object: object.location.clone(),
         last_modified: object.last_modified,
+        backend: input.backend(),
     };
 
     if let Some(cache) = cache {
@@ -55,7 +152,7 @@ pub async fn open_dataset(
         }
     }
 
-    let dataset = reader::open_dataset(native_path).await?;
+    let dataset = input.open().await?;
 
     if let Some(cache) = cache {
         cache.cache.insert(key, Arc::new(dataset.clone())).await;
@@ -75,19 +172,17 @@ pub async fn open_dataset(
 /// what `SELECT *` can actually return.
 pub async fn fetch_schema(
     cache: Option<&NetcdfReaderCache>,
-    native_path: String,
+    input: NetcdfInput,
     object: ObjectMeta,
     read_dimensions: Option<Vec<String>>,
 ) -> datafusion::error::Result<arrow::datatypes::SchemaRef> {
     // Schema inference does not consult the reader cache; the cache benefits
     // repeated data scans, which flow through `NetCDFSource`.
-    let dataset = open_dataset(cache, native_path, object)
-        .await
-        .map_err(|e| {
-            datafusion::error::DataFusionError::Execution(format!(
-                "Failed to open NetCDF dataset for schema inference: {e}"
-            ))
-        })?;
+    let dataset = open_dataset(cache, input, object).await.map_err(|e| {
+        datafusion::error::DataFusionError::Execution(format!(
+            "Failed to open NetCDF dataset for schema inference: {e}"
+        ))
+    })?;
 
     let dataset = if let Some(dims) = beacon_nd_array::dataset::resolve_read_dimensions(
         &dataset,

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/source.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/source.rs
@@ -34,7 +34,7 @@ use object_store::ObjectMeta;
 
 use crate::datafusion::object_meta_resolver::NetCDFObjectResolver;
 
-use super::reader::{self, NetcdfReaderCache};
+use super::reader::{self, NetcdfInput, NetcdfReaderCache, ReaderBackend};
 
 /// DataFusion [`FileSource`] for NetCDF (`.nc`) files.
 ///
@@ -51,6 +51,8 @@ pub struct NetCDFSource {
     predicate: Option<Arc<dyn PhysicalExpr>>,
     /// Reader cache to consult for this scan. `None` disables caching.
     cache: Option<NetcdfReaderCache>,
+    /// The reader that opens each file of this scan.
+    reader_backend: ReaderBackend,
     /// Projection pushed down by the scan, applied on top of the table schema.
     projection: Option<ProjectionExprs>,
 }
@@ -70,6 +72,7 @@ impl NetCDFSource {
             batch_size: usize::MAX,
             predicate: None,
             cache: None,
+            reader_backend: ReaderBackend::default(),
             projection: None,
         }
     }
@@ -78,6 +81,12 @@ impl NetCDFSource {
     /// opened datasets. The format wires in the runtime's shared cache here.
     pub fn with_cache(mut self, cache: Option<NetcdfReaderCache>) -> Self {
         self.cache = cache;
+        self
+    }
+
+    /// Returns a copy of this source that opens files with `reader_backend`.
+    pub fn with_reader_backend(mut self, reader_backend: ReaderBackend) -> Self {
+        self.reader_backend = reader_backend;
         self
     }
 
@@ -93,7 +102,7 @@ impl NetCDFSource {
 impl FileSource for NetCDFSource {
     fn create_file_opener(
         &self,
-        _object_store: Arc<dyn object_store::ObjectStore>,
+        object_store: Arc<dyn object_store::ObjectStore>,
         base_config: &FileScanConfig,
         partition: usize,
     ) -> datafusion::error::Result<Arc<dyn FileOpener>> {
@@ -110,6 +119,8 @@ impl FileSource for NetCDFSource {
             self.cache.clone(),
             self.execution_plan_metrics.clone(),
             partition,
+            self.reader_backend,
+            object_store,
         )))
     }
 
@@ -205,6 +216,11 @@ struct NetCDFOpener {
     metrics: ExecutionPlanMetricsSet,
     partition: usize,
     object_path_resolver: Arc<dyn NetCDFObjectResolver>,
+    /// The reader that opens each file.
+    reader_backend: ReaderBackend,
+    /// The store the scan lists from. The `oxcdf` reader reads through it; the
+    /// netcdf-c reader ignores it and opens a resolved native path instead.
+    object_store: Arc<dyn object_store::ObjectStore>,
 }
 
 impl NetCDFOpener {
@@ -219,6 +235,8 @@ impl NetCDFOpener {
         cache: Option<NetcdfReaderCache>,
         metrics: ExecutionPlanMetricsSet,
         partition: usize,
+        reader_backend: ReaderBackend,
+        object_store: Arc<dyn object_store::ObjectStore>,
     ) -> Self {
         let pruning_predicate = predicate
             .as_ref()
@@ -235,12 +253,24 @@ impl NetCDFOpener {
             metrics,
             partition,
             object_path_resolver,
+            reader_backend,
+            object_store,
         }
+    }
+
+    /// Describe where one object's bytes come from, for this opener's reader.
+    fn input_for(&self, object: &ObjectMeta) -> datafusion::error::Result<NetcdfInput> {
+        reader::netcdf_input(
+            self.reader_backend,
+            &self.object_path_resolver,
+            &self.object_store,
+            object,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
     async fn read_task(
-        object_path_resolver: Arc<dyn NetCDFObjectResolver>,
+        input: NetcdfInput,
         object: ObjectMeta,
         projected_schema: SchemaRef,
         read_dimensions: Option<Vec<String>>,
@@ -249,13 +279,7 @@ impl NetCDFOpener {
         cache: Option<NetcdfReaderCache>,
         metrics: Option<DatasetReadMetrics>,
     ) -> datafusion::error::Result<BoxStream<'static, datafusion::error::Result<RecordBatch>>> {
-        let native_path = object_path_resolver.resolve(&object).map_err(|e| {
-            datafusion::error::DataFusionError::Execution(format!(
-                "Failed to resolve object metadata (path) to NetCDF native path: {}",
-                e
-            ))
-        })?;
-        let dataset = reader::open_dataset(cache.as_ref(), native_path, object.clone())
+        let dataset = reader::open_dataset(cache.as_ref(), input, object.clone())
             .await
             .map_err(|e| {
                 datafusion::error::DataFusionError::Execution(format!(
@@ -430,8 +454,9 @@ impl FileOpener for NetCDFOpener {
         };
 
         let metrics = Some(DatasetReadMetrics::new(&self.metrics, self.partition));
+        let input = self.input_for(&file.object_meta)?;
         let fut = Self::read_task(
-            self.object_path_resolver.clone(),
+            input,
             file.object_meta,
             self.projected_schema.clone(),
             self.read_dimensions.clone(),

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/source.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/source.rs
@@ -32,9 +32,7 @@ use datafusion::{
 use futures::{stream::BoxStream, FutureExt, StreamExt, TryStreamExt};
 use object_store::ObjectMeta;
 
-use crate::datafusion::object_meta_resolver::NetCDFObjectResolver;
-
-use super::reader::{self, NetcdfInput, NetcdfReaderCache, ReaderBackend};
+use super::reader::{self, FileAccess, NetcdfInput, NetcdfReaderCache};
 
 /// DataFusion [`FileSource`] for NetCDF (`.nc`) files.
 ///
@@ -43,7 +41,8 @@ use super::reader::{self, NetcdfInput, NetcdfReaderCache, ReaderBackend};
 #[derive(Debug, Clone)]
 pub struct NetCDFSource {
     schema_adapter_factory: Option<Arc<dyn SchemaAdapterFactory>>,
-    object_path_resolver: Arc<dyn NetCDFObjectResolver>,
+    /// How this scan reaches its files, and which reader opens them.
+    access: FileAccess,
     table_schema: TableSchema,
     execution_plan_metrics: ExecutionPlanMetricsSet,
     read_dimensions: Option<Vec<String>>,
@@ -51,28 +50,25 @@ pub struct NetCDFSource {
     predicate: Option<Arc<dyn PhysicalExpr>>,
     /// Reader cache to consult for this scan. `None` disables caching.
     cache: Option<NetcdfReaderCache>,
-    /// The reader that opens each file of this scan.
-    reader_backend: ReaderBackend,
     /// Projection pushed down by the scan, applied on top of the table schema.
     projection: Option<ProjectionExprs>,
 }
 
 impl NetCDFSource {
     pub fn new(
-        object_path_resolver: Arc<dyn NetCDFObjectResolver>,
+        access: FileAccess,
         read_dimensions: Option<Vec<String>>,
         table_schema: TableSchema,
     ) -> Self {
         Self {
             schema_adapter_factory: None,
-            object_path_resolver,
+            access,
             table_schema,
             execution_plan_metrics: ExecutionPlanMetricsSet::new(),
             read_dimensions,
             batch_size: usize::MAX,
             predicate: None,
             cache: None,
-            reader_backend: ReaderBackend::default(),
             projection: None,
         }
     }
@@ -81,12 +77,6 @@ impl NetCDFSource {
     /// opened datasets. The format wires in the runtime's shared cache here.
     pub fn with_cache(mut self, cache: Option<NetcdfReaderCache>) -> Self {
         self.cache = cache;
-        self
-    }
-
-    /// Returns a copy of this source that opens files with `reader_backend`.
-    pub fn with_reader_backend(mut self, reader_backend: ReaderBackend) -> Self {
-        self.reader_backend = reader_backend;
         self
     }
 
@@ -110,7 +100,7 @@ impl FileSource for NetCDFSource {
         let projected_schema = base_config.projected_schema()?;
 
         Ok(Arc::new(NetCDFOpener::new(
-            self.object_path_resolver.clone(),
+            self.access.clone(),
             projected_schema,
             self.read_dimensions.clone(),
             self.batch_size,
@@ -119,7 +109,6 @@ impl FileSource for NetCDFSource {
             self.cache.clone(),
             self.execution_plan_metrics.clone(),
             partition,
-            self.reader_backend,
             object_store,
         )))
     }
@@ -215,9 +204,8 @@ struct NetCDFOpener {
     cache: Option<NetcdfReaderCache>,
     metrics: ExecutionPlanMetricsSet,
     partition: usize,
-    object_path_resolver: Arc<dyn NetCDFObjectResolver>,
-    /// The reader that opens each file.
-    reader_backend: ReaderBackend,
+    /// How this opener reaches its files, and which reader opens them.
+    access: FileAccess,
     /// The store the scan lists from. The `oxcdf` reader reads through it; the
     /// netcdf-c reader ignores it and opens a resolved native path instead.
     object_store: Arc<dyn object_store::ObjectStore>,
@@ -226,7 +214,7 @@ struct NetCDFOpener {
 impl NetCDFOpener {
     #[allow(clippy::too_many_arguments)]
     fn new(
-        object_path_resolver: Arc<dyn NetCDFObjectResolver>,
+        access: FileAccess,
         projected_schema: SchemaRef,
         read_dimensions: Option<Vec<String>>,
         batch_size: usize,
@@ -235,7 +223,6 @@ impl NetCDFOpener {
         cache: Option<NetcdfReaderCache>,
         metrics: ExecutionPlanMetricsSet,
         partition: usize,
-        reader_backend: ReaderBackend,
         object_store: Arc<dyn object_store::ObjectStore>,
     ) -> Self {
         let pruning_predicate = predicate
@@ -252,20 +239,9 @@ impl NetCDFOpener {
             cache,
             metrics,
             partition,
-            object_path_resolver,
-            reader_backend,
+            access,
             object_store,
         }
-    }
-
-    /// Describe where one object's bytes come from, for this opener's reader.
-    fn input_for(&self, object: &ObjectMeta) -> datafusion::error::Result<NetcdfInput> {
-        reader::netcdf_input(
-            self.reader_backend,
-            &self.object_path_resolver,
-            &self.object_store,
-            object,
-        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -454,7 +430,9 @@ impl FileOpener for NetCDFOpener {
         };
 
         let metrics = Some(DatasetReadMetrics::new(&self.metrics, self.partition));
-        let input = self.input_for(&file.object_meta)?;
+        let input = self
+            .access
+            .input_for(&self.object_store, &file.object_meta)?;
         let fut = Self::read_task(
             input,
             file.object_meta,

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/statistics.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/statistics.rs
@@ -18,22 +18,25 @@ use datafusion::{
     scalar::ScalarValue,
 };
 
-use crate::reader::open_dataset;
+use crate::datafusion::reader::NetcdfInput;
 
 // ─── Public entry point ─────────────────────────────────────────────────────
 
-/// Open the NetCDF file at `netcdf_path` and return DataFusion [`Statistics`] for
-/// the columns in `table_schema`.
+/// Open the NetCDF object `input` names and return DataFusion [`Statistics`]
+/// for the columns in `table_schema`.
 ///
-/// `netcdf_path` is the already-resolved path/URL the netCDF-c reader opens
-/// directly, produced by the format's `NetCDFObjectResolver`. Resolution is the
-/// caller's job so statistics and scans go through one mechanism (see
-/// `datafusion::reader::open_dataset` for how the scheme is interpreted).
+/// `input` already says which reader opens the file and where its bytes are.
+/// The caller builds it, so statistics and scans go through one mechanism and
+/// can never disagree about a file (see [`NetcdfInput`]).
 pub async fn generate_statistics(
-    netcdf_path: String,
+    input: NetcdfInput,
     table_schema: &arrow::datatypes::Schema,
 ) -> anyhow::Result<Statistics> {
-    let dataset = open_dataset(netcdf_path).await?;
+    let location = input.location();
+    let dataset = input
+        .open()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to open NetCDF dataset {location}: {e}"))?;
 
     match dataset {
         AnyDataset::Regular(dataset) => {

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/table_function.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/table_function.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Weak};
 
 use arrow::datatypes::{DataType, Field};
 use beacon_common::super_table::SuperListingTable;
-use beacon_datafusion_ext::listing_factory::ListingFactory;
+use beacon_datafusion_ext::listing_factory::{ListingFactory, RootStore};
 use datafusion::{
     catalog::TableFunctionImpl,
     common::plan_err,
@@ -14,7 +14,7 @@ use datafusion::{
 use beacon_common::table_function::BeaconTableFunctionImpl;
 
 use crate::datafusion::object_meta_resolver::create_object_resolver;
-use crate::datafusion::NetcdfFormat;
+use crate::datafusion::{NetcdfFormat, ReaderBackend};
 
 /// Format identity the NetCDF factory is registered under (its `get_ext`).
 const NETCDF_FORMAT: &str = "nc";
@@ -120,41 +120,15 @@ impl TableFunctionImpl for ReadNetCDFFunc {
 
         tracing::debug!("read_netcdf glob paths: {:?}", glob_paths);
 
-        let mut root_store = None;
-        let mut listing_urls = vec![];
-        for path in &glob_paths {
-            tracing::debug!("read_netcdf processing path: {}", path);
-            let url = listing_factory.parse_listing_table_url(&state, path)?;
-            let native_read_store = listing_factory.native_read_root(&url)?;
-            // NetCDF is read natively (by path / http range-read), so reject a
-            // remote object store (s3/gs/az) here with a clear error rather than
-            // failing later inside the reader.
-            listing_urls.push(url);
-            match &mut root_store {
-                Some(store) => {
-                    // Compare if store is the same as the first one, if not, return an error
-                    if store != &native_read_store {
-                        return plan_err!(
-                            "read_netcdf: all glob paths must resolve to the same root store (local or http/https)"
-                        );
-                    }
-                }
-                None => {
-                    root_store = Some(native_read_store);
-                }
-            };
-        }
+        let listing_urls = glob_paths
+            .iter()
+            .inspect(|path| tracing::debug!("read_netcdf processing path: {}", path))
+            .map(|path| listing_factory.parse_listing_table_url(&state, path))
+            .collect::<datafusion::error::Result<Vec<_>>>()?;
 
         if listing_urls.is_empty() {
             return plan_err!("read_netcdf: no valid glob paths provided");
         }
-
-        let object_resolver = match root_store {
-            Some(store) => create_object_resolver(&store),
-            None => {
-                return plan_err!("read_netcdf: no root store could be determined from the provided glob paths. NetCDF files only work for local or http/https paths.");
-            }
-        };
 
         tracing::debug!("read_netcdf listing urls: {:?}", listing_urls);
 
@@ -184,8 +158,34 @@ impl TableFunctionImpl for ReadNetCDFFunc {
                         .to_string(),
                 )
             })?
-            .clone()
-            .with_object_path_resolver(object_resolver);
+            .clone();
+
+        // netcdf-c opens a path itself, so the format needs a resolver built from
+        // the one root store every path shares. The `oxcdf` reader reads through
+        // the object store, so it needs neither, and it takes s3, gs and az too.
+        let netcdf_file_format = if netcdf_file_format.reader_backend == ReaderBackend::Oxcdf {
+            netcdf_file_format
+        } else {
+            let mut root_store: Option<RootStore> = None;
+            for url in &listing_urls {
+                // Reject a remote object store (s3/gs/az) here with a clear
+                // error rather than failing later inside the reader.
+                let native_read_store = listing_factory.native_read_root(url)?;
+                match &root_store {
+                    Some(store) if store != &native_read_store => {
+                        return plan_err!(
+                            "read_netcdf: all glob paths must resolve to the same root store (local or http/https)"
+                        );
+                    }
+                    Some(_) => {}
+                    None => root_store = Some(native_read_store),
+                }
+            }
+            let Some(root_store) = root_store else {
+                return plan_err!("read_netcdf: no root store could be determined from the provided glob paths. NetCDF files only work for local or http/https paths.");
+            };
+            netcdf_file_format.with_object_path_resolver(create_object_resolver(&root_store))
+        };
 
         let super_listing_table = tokio::task::block_in_place(|| {
             self.runtime_handle.block_on(async {

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/table_function.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/table_function.rs
@@ -14,7 +14,7 @@ use datafusion::{
 use beacon_common::table_function::BeaconTableFunctionImpl;
 
 use crate::datafusion::object_meta_resolver::create_object_resolver;
-use crate::datafusion::{NetcdfFormat, ReaderBackend};
+use crate::datafusion::{FileAccess, NetcdfFormat};
 
 /// Format identity the NetCDF factory is registered under (its `get_ext`).
 const NETCDF_FORMAT: &str = "nc";
@@ -162,29 +162,31 @@ impl TableFunctionImpl for ReadNetCDFFunc {
 
         // netcdf-c opens a path itself, so the format needs a resolver built from
         // the one root store every path shares. The `oxcdf` reader reads through
-        // the object store, so it needs neither, and it takes s3, gs and az too.
-        let netcdf_file_format = if netcdf_file_format.reader_backend == ReaderBackend::Oxcdf {
-            netcdf_file_format
-        } else {
-            let mut root_store: Option<RootStore> = None;
-            for url in &listing_urls {
-                // Reject a remote object store (s3/gs/az) here with a clear
-                // error rather than failing later inside the reader.
-                let native_read_store = listing_factory.native_read_root(url)?;
-                match &root_store {
-                    Some(store) if store != &native_read_store => {
-                        return plan_err!(
-                            "read_netcdf: all glob paths must resolve to the same root store (local or http/https)"
-                        );
+        // the object store, so it needs none, and it takes s3, gs and az too.
+        let netcdf_file_format = match netcdf_file_format.access {
+            FileAccess::Oxcdf => netcdf_file_format,
+            FileAccess::NetcdfC { .. } => {
+                let mut root_store: Option<RootStore> = None;
+                for url in &listing_urls {
+                    // Reject a remote object store (s3/gs/az) here with a clear
+                    // error rather than failing later inside the reader.
+                    let native_read_store = listing_factory.native_read_root(url)?;
+                    match &root_store {
+                        Some(store) if store != &native_read_store => {
+                            return plan_err!(
+                                "read_netcdf: all glob paths must resolve to the same root store (local or http/https)"
+                            );
+                        }
+                        Some(_) => {}
+                        None => root_store = Some(native_read_store),
                     }
-                    Some(_) => {}
-                    None => root_store = Some(native_read_store),
                 }
+                let Some(root_store) = root_store else {
+                    return plan_err!("read_netcdf: no root store could be determined from the provided glob paths. NetCDF files only work for local or http/https paths.");
+                };
+                netcdf_file_format
+                    .with_access(FileAccess::netcdf_c(create_object_resolver(&root_store)))
             }
-            let Some(root_store) = root_store else {
-                return plan_err!("read_netcdf: no root store could be determined from the provided glob paths. NetCDF files only work for local or http/https paths.");
-            };
-            netcdf_file_format.with_object_path_resolver(create_object_resolver(&root_store))
         };
 
         let super_listing_table = tokio::task::block_in_place(|| {

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/decoders/cf_time.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/decoders/cf_time.rs
@@ -65,7 +65,11 @@ where
     }
 }
 
-fn convert_to_timestamp_nanoseconds<T>(
+/// Convert numeric CF time offsets into nanosecond timestamps.
+///
+/// Shared with the [`oxcdf`](crate::oxcdf_reader) path, so both readers apply
+/// the same arithmetic.
+pub(crate) fn convert_to_timestamp_nanoseconds<T>(
     array: ndarray::ArrayViewD<T>,
     epoch: hifitime::Epoch,
     unit: hifitime::Unit,

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/lib.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/lib.rs
@@ -5,8 +5,23 @@
 //! - Writing Arrow record batches into NetCDF files.
 //! - Decoder/encoder building blocks for extending conversion behaviour.
 //!
+//! # Two readers
+//!
+//! The crate reads a file in one of two ways:
+//!
+//! - [`reader`] calls netcdf-c. It is the default, and it is the only path that
+//!   writes files.
+//! - [`oxcdf_reader`] calls [`oxcdf`], a pure-Rust reader. It holds no global
+//!   lock and reads through `object_store`, so scans run in parallel and S3,
+//!   GCS and Azure need no local copy.
+//!
+//! Both produce the same dataset. The
+//! [`use_rust_reader`](datafusion::NetcdfConfig::use_rust_reader) flag selects
+//! between them.
+//!
 //! # Key modules
-//! - [`reader`]: high-level NetCDF -> Arrow reader API.
+//! - [`reader`]: high-level NetCDF -> Arrow reader API (netcdf-c).
+//! - [`oxcdf_reader`]: the same API over [`oxcdf`] and `object_store`.
 //! - [`writer`]: high-level Arrow -> NetCDF writer API.
 //! - [`compat`]: variable/attribute conversion helpers.
 //! - [`decoders`] and [`encoders`]: pluggable conversion components.
@@ -25,6 +40,8 @@ pub mod writer;
 pub use netcdf;
 /// Re-export of low-level `netcdf-sys` bindings.
 pub use netcdf_sys;
+/// Re-export of the pure-Rust `oxcdf` reader used by [`oxcdf_reader`].
+pub use oxcdf;
 /// Array backend implementations used by decoders.
 pub mod backend;
 /// Conversion helpers from NetCDF values to ND Arrow arrays.
@@ -33,6 +50,8 @@ pub mod compat;
 pub mod datafusion;
 /// Decoder implementations and decoder traits.
 pub mod decoders;
+/// Pure-Rust NetCDF reader over `object_store`.
+pub mod oxcdf_reader;
 
 /// Placeholder wrapper for fixed-size string payload bytes.
 ///

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/backend.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/backend.rs
@@ -1,0 +1,370 @@
+//! Lazy array backends that read variable data through [`oxcdf`].
+//!
+//! The netcdf-c path stacks [`VariableDecoder`](crate::decoders::VariableDecoder)
+//! values on top of one typed read. It must: `netcdf::Variable::get` returns
+//! only the type the file stores, so a CF transform needs a wrapper for each
+//! source type. [`oxcdf`] converts on read, so every transform here is one
+//! backend over an `f64` read or a raw byte read. That removes the decoder
+//! layer from this path.
+
+use std::sync::Arc;
+
+use beacon_nd_array::{
+    array::{backend::ArrayBackend, subset::ArraySubset},
+    datatypes::{NdArrayType, TimestampNanosecond},
+};
+use ndarray::ArrayD;
+use oxcdf::{AsyncNetcdfFile, AsyncVariable, Extent, Extents};
+
+/// One variable, bound to the file that holds it.
+///
+/// [`AsyncVariable`] borrows the file, so a backend cannot keep one. It keeps
+/// the variable name instead and binds on each read. The bind reads no bytes:
+/// the open holds every piece of metadata.
+#[derive(Debug)]
+pub struct VariableRef {
+    file: Arc<AsyncNetcdfFile>,
+    name: String,
+    /// The logical shape. A fixed-size string variable drops its length axis.
+    shape: Vec<usize>,
+    /// The logical dimension names, one for each axis of `shape`.
+    dimensions: Vec<String>,
+    /// The trailing string-length axis, when the variable has one. It is part
+    /// of the read but not of the logical shape.
+    string_width: Option<usize>,
+}
+
+impl VariableRef {
+    /// Bind a variable of the given logical shape.
+    pub fn new(
+        file: Arc<AsyncNetcdfFile>,
+        name: String,
+        shape: Vec<usize>,
+        dimensions: Vec<String>,
+    ) -> Self {
+        Self {
+            file,
+            name,
+            shape,
+            dimensions,
+            string_width: None,
+        }
+    }
+
+    /// Add the trailing string-length axis of a fixed-size string variable.
+    ///
+    /// The axis stays out of `shape`, because it holds the characters of one
+    /// string rather than a dimension of the data.
+    pub fn with_string_width(mut self, width: usize) -> Self {
+        self.string_width = Some(width);
+        self
+    }
+
+    /// The variable, bound to its file.
+    fn bind(&self) -> anyhow::Result<AsyncVariable<'_>> {
+        self.file
+            .variable(&self.name)
+            .ok_or_else(|| anyhow::anyhow!("Variable '{}' not found in NetCDF file", self.name))
+    }
+
+    /// Translate a subset into the extents [`oxcdf`] reads.
+    ///
+    /// A fixed-size string variable gets its length axis appended, in full.
+    fn extents(&self, subset: &ArraySubset) -> anyhow::Result<Extents> {
+        let mut extents = Vec::with_capacity(self.shape.len() + 1);
+        for axis in 0..self.shape.len() {
+            let start = subset.start.get(axis).copied().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Variable '{}' subset is missing start for axis {}",
+                    self.name,
+                    axis
+                )
+            })?;
+            let count = subset.shape.get(axis).copied().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Variable '{}' subset is missing length for axis {}",
+                    self.name,
+                    axis
+                )
+            })?;
+            extents.push(Extent::SliceCount {
+                start,
+                count,
+                stride: 1,
+            });
+        }
+        if let Some(width) = self.string_width {
+            extents.push(Extent::SliceCount {
+                start: 0,
+                count: width,
+                stride: 1,
+            });
+        }
+        Ok(Extents::Extent(extents))
+    }
+
+    /// Number of elements in the logical shape.
+    fn element_count(&self) -> usize {
+        self.shape.iter().product()
+    }
+}
+
+/// Reshape flat, row-major values into the shape the subset selected.
+fn shaped<T>(name: &str, subset: &ArraySubset, values: Vec<T>) -> anyhow::Result<ArrayD<T>> {
+    ArrayD::from_shape_vec(ndarray::IxDyn(&subset.shape), values).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to shape the values of variable '{}' into {:?}: {}",
+            name,
+            subset.shape,
+            e
+        )
+    })
+}
+
+/// Reads a numeric variable as `T`.
+///
+/// [`oxcdf`] converts from the stored type, so `T` is the logical type this
+/// crate wants rather than the one the file holds.
+#[derive(Debug)]
+pub struct NumericBackend<T> {
+    variable: VariableRef,
+    fill_value: Option<T>,
+}
+
+impl<T> NumericBackend<T> {
+    /// Build a numeric backend with an optional `_FillValue`.
+    pub fn new(variable: VariableRef, fill_value: Option<T>) -> Self {
+        Self {
+            variable,
+            fill_value,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<T> ArrayBackend<T> for NumericBackend<T>
+where
+    T: NdArrayType + oxcdf::Element,
+{
+    fn len(&self) -> usize {
+        self.variable.element_count()
+    }
+
+    fn shape(&self) -> Vec<usize> {
+        self.variable.shape.clone()
+    }
+
+    fn dimensions(&self) -> Vec<String> {
+        self.variable.dimensions.clone()
+    }
+
+    fn fill_value(&self) -> Option<T> {
+        self.fill_value
+    }
+
+    async fn read_subset(&self, subset: ArraySubset) -> anyhow::Result<ArrayD<T>> {
+        let variable = self.variable.bind()?;
+        let extents = self.variable.extents(&subset)?;
+        Ok(variable.get::<T, _>(extents).await?)
+    }
+}
+
+/// Reads a packed numeric variable and applies CF `scale_factor` /
+/// `add_offset`.
+///
+/// The values come back as `f64` and decode as `raw * scale + offset`, which
+/// matches [`ScaleOffsetVariableDecoder`](crate::decoders::scale_offset::ScaleOffsetVariableDecoder)
+/// on the netcdf-c path.
+#[derive(Debug)]
+pub struct ScaleOffsetBackend {
+    variable: VariableRef,
+    scale: f64,
+    offset: f64,
+    fill_value: Option<f64>,
+}
+
+impl ScaleOffsetBackend {
+    /// Build a scale/offset backend.
+    ///
+    /// `raw_fill_value` is the fill in packed units. It decodes with the same
+    /// arithmetic, so a packed fill cell maps onto the decoded fill and the
+    /// engine nulls it after the decode.
+    pub fn new(
+        variable: VariableRef,
+        scale: f64,
+        offset: f64,
+        raw_fill_value: Option<f64>,
+    ) -> Self {
+        Self {
+            variable,
+            scale,
+            offset,
+            fill_value: raw_fill_value.map(|f| f * scale + offset),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ArrayBackend<f64> for ScaleOffsetBackend {
+    fn len(&self) -> usize {
+        self.variable.element_count()
+    }
+
+    fn shape(&self) -> Vec<usize> {
+        self.variable.shape.clone()
+    }
+
+    fn dimensions(&self) -> Vec<String> {
+        self.variable.dimensions.clone()
+    }
+
+    fn fill_value(&self) -> Option<f64> {
+        self.fill_value
+    }
+
+    async fn read_subset(&self, subset: ArraySubset) -> anyhow::Result<ArrayD<f64>> {
+        let variable = self.variable.bind()?;
+        let extents = self.variable.extents(&subset)?;
+        let array = variable.get::<f64, _>(extents).await?;
+        let (scale, offset) = (self.scale, self.offset);
+        Ok(array.mapv(|v| v * scale + offset))
+    }
+}
+
+/// Reads a CF time variable and converts it to nanosecond timestamps.
+#[derive(Debug)]
+pub struct TimestampBackend {
+    variable: VariableRef,
+    epoch: hifitime::Epoch,
+    unit: hifitime::Unit,
+}
+
+impl TimestampBackend {
+    /// Build a CF time backend from a reference epoch and a unit.
+    pub fn new(variable: VariableRef, epoch: hifitime::Epoch, unit: hifitime::Unit) -> Self {
+        Self {
+            variable,
+            epoch,
+            unit,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ArrayBackend<TimestampNanosecond> for TimestampBackend {
+    fn len(&self) -> usize {
+        self.variable.element_count()
+    }
+
+    fn shape(&self) -> Vec<usize> {
+        self.variable.shape.clone()
+    }
+
+    fn dimensions(&self) -> Vec<String> {
+        self.variable.dimensions.clone()
+    }
+
+    async fn read_subset(
+        &self,
+        subset: ArraySubset,
+    ) -> anyhow::Result<ArrayD<TimestampNanosecond>> {
+        let variable = self.variable.bind()?;
+        let extents = self.variable.extents(&subset)?;
+        let array = variable.get::<f64, _>(extents).await?;
+        Ok(crate::decoders::cf_time::convert_to_timestamp_nanoseconds(
+            array.view(),
+            self.epoch,
+            self.unit,
+        ))
+    }
+}
+
+/// How a string variable stores its text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StringSource {
+    /// A netCDF `string` variable. One whole string sits in each element.
+    Native,
+    /// A `char` variable whose last axis holds the length of one string.
+    FixedChar,
+    /// A `char` variable with no length axis. Each byte becomes one string.
+    Char,
+}
+
+/// Reads a string-like variable as UTF-8 strings.
+#[derive(Debug)]
+pub struct StringBackend {
+    variable: VariableRef,
+    source: StringSource,
+    fill_value: Option<String>,
+}
+
+impl StringBackend {
+    /// Build a string backend for the given storage form.
+    pub fn new(variable: VariableRef, source: StringSource, fill_value: Option<String>) -> Self {
+        Self {
+            variable,
+            source,
+            fill_value,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ArrayBackend<String> for StringBackend {
+    fn len(&self) -> usize {
+        self.variable.element_count()
+    }
+
+    fn shape(&self) -> Vec<usize> {
+        self.variable.shape.clone()
+    }
+
+    fn dimensions(&self) -> Vec<String> {
+        self.variable.dimensions.clone()
+    }
+
+    fn fill_value(&self) -> Option<String> {
+        self.fill_value.clone()
+    }
+
+    async fn read_subset(&self, subset: ArraySubset) -> anyhow::Result<ArrayD<String>> {
+        let variable = self.variable.bind()?;
+        let extents = self.variable.extents(&subset)?;
+        let name = &self.variable.name;
+
+        let values: Vec<String> = match self.source {
+            StringSource::Native => variable.get_strings(extents).await?,
+            StringSource::FixedChar => {
+                let width = self.variable.string_width.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Variable '{}' decodes as a fixed-size string but carries no string length",
+                        name
+                    )
+                })?;
+                let bytes = variable.get_raw_values(extents).await?;
+                if width == 0 {
+                    // A zero-width length axis holds no characters, so every
+                    // selected element is the empty string.
+                    vec![String::new(); subset.shape.iter().product()]
+                } else {
+                    bytes
+                        .chunks(width)
+                        .map(|chunk| {
+                            String::from_utf8_lossy(chunk)
+                                .trim_end_matches(|c: char| c == '\0' || c.is_whitespace())
+                                .to_string()
+                        })
+                        .collect()
+                }
+            }
+            StringSource::Char => variable
+                .get_raw_values(extents)
+                .await?
+                .into_iter()
+                .map(|byte| (byte as char).to_string())
+                .collect(),
+        };
+
+        shaped(name, &subset, values)
+    }
+}

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/compat.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/compat.rs
@@ -1,0 +1,298 @@
+//! Conversion from [`oxcdf`] variables and attributes to ND arrays.
+//!
+//! This is the [`oxcdf`] twin of [`crate::compat`]. It applies the same CF
+//! rules, in the same order, so both readers give a variable the same logical
+//! type:
+//!
+//! 1. `scale_factor` / `add_offset` packing decodes to `f64`.
+//! 2. A CF `units` string decodes to a nanosecond timestamp.
+//! 3. Everything else keeps the type the file stores.
+//!
+//! Rule 1 wins over rule 2. A variable carries one or the other, never both.
+
+use std::sync::Arc;
+
+use beacon_nd_array::{datatypes::NdArrayType, NdArray, NdArrayD};
+use num_traits::AsPrimitive;
+use oxcdf::{AsyncNetcdfFile, AsyncVariable, AttributeValue, DType};
+
+use crate::{
+    backend::AttributeBackend,
+    decoders::cf_time::parse_time_units,
+    oxcdf_reader::backend::{
+        NumericBackend, ScaleOffsetBackend, StringBackend, StringSource, TimestampBackend,
+        VariableRef,
+    },
+};
+
+/// Take the `_FillValue` attribute only when it is stored as the variable's own
+/// type.
+///
+/// A netCDF writer gives `_FillValue` the type of its variable. Both readers
+/// keep to that rule, so both null out the same cells.
+macro_rules! fill_value_of {
+    ($variable:expr, $variant:ident) => {
+        match $variable.attribute("_FillValue").map(|a| &a.value) {
+            Some(AttributeValue::$variant(value)) => Some(*value),
+            _ => None,
+        }
+    };
+}
+
+/// Interpret a scalar attribute (`scale_factor`, `add_offset`) as an `f64`.
+///
+/// Returns `None` for a textual or multi-valued attribute.
+fn attribute_as_f64(attribute: &AttributeValue) -> Option<f64> {
+    if attribute.len() != 1 {
+        return None;
+    }
+    // `as_f64` rejects the textual and raw variants for us.
+    attribute.as_f64()
+}
+
+/// The `_FillValue` attribute as a string, for a string-typed variable.
+fn string_fill_value(variable: &AsyncVariable<'_>) -> Option<String> {
+    match variable.attribute("_FillValue").map(|a| &a.value) {
+        Some(AttributeValue::Str(fill)) => Some(fill.clone()),
+        _ => None,
+    }
+}
+
+/// Build the ND array of a numeric variable, with the CF transforms applied.
+fn numeric_variable_to_nd_array<T>(
+    variable: VariableRef,
+    fill_value: Option<T>,
+    cf_time_epoch_unit: Option<(hifitime::Epoch, hifitime::Unit)>,
+    scale_offset: Option<(f64, f64)>,
+) -> anyhow::Result<Arc<dyn NdArrayD>>
+where
+    T: NdArrayType + oxcdf::Element + AsPrimitive<f64>,
+{
+    if let Some((scale, offset)) = scale_offset {
+        let raw_fill = fill_value.map(|f| f.as_());
+        let backend = ScaleOffsetBackend::new(variable, scale, offset, raw_fill);
+        return Ok(Arc::new(NdArray::new_with_backend(backend)?));
+    }
+
+    if let Some((epoch, unit)) = cf_time_epoch_unit {
+        let backend = TimestampBackend::new(variable, epoch, unit);
+        return Ok(Arc::new(NdArray::new_with_backend(backend)?));
+    }
+
+    let backend = NumericBackend::new(variable, fill_value);
+    Ok(Arc::new(NdArray::new_with_backend(backend)?))
+}
+
+/// Convert an [`oxcdf`] attribute value into a rank-0 ND array.
+///
+/// Returns an error when the attribute type has no ND equivalent.
+pub fn attribute_to_nd_array(
+    attribute_name: &str,
+    attribute_value: &AttributeValue,
+) -> anyhow::Result<Arc<dyn NdArrayD>> {
+    /// One scalar, or a one-element list of the same type.
+    macro_rules! scalar {
+        ($single:ident, $plural:ident) => {
+            match attribute_value {
+                AttributeValue::$single(value) => Some(value.clone()),
+                AttributeValue::$plural(values) if values.len() == 1 => Some(values[0].clone()),
+                _ => None,
+            }
+        };
+    }
+
+    /// Wrap a scalar in an ND array as soon as one of the arms matches.
+    macro_rules! try_scalar {
+        ($($single:ident / $plural:ident),* $(,)?) => {
+            $(
+                if let Some(value) = scalar!($single, $plural) {
+                    return Ok(Arc::new(NdArray::new_with_backend(AttributeBackend::new(value))?));
+                }
+            )*
+        };
+    }
+
+    try_scalar!(
+        Uchar / Uchars,
+        Schar / Schars,
+        Ushort / Ushorts,
+        Short / Shorts,
+        Uint / Uints,
+        Int / Ints,
+        Ulonglong / Ulonglongs,
+        Longlong / Longlongs,
+        Float / Floats,
+        Double / Doubles,
+        Str / Strs,
+    );
+
+    Err(anyhow::anyhow!(
+        "Unsupported attribute type for attribute '{}'",
+        attribute_name
+    ))
+}
+
+/// Convert an [`oxcdf`] variable into a lazy ND array.
+///
+/// The conversion handles:
+/// - CF-time numeric variables (`units` attribute).
+/// - CF `scale_factor` / `add_offset` packing.
+/// - netCDF string variables and char arrays with a trailing length dimension.
+/// - `_FillValue` for the numeric and string types.
+pub fn variable_to_nd_array(
+    file: Arc<AsyncNetcdfFile>,
+    variable: &AsyncVariable<'_>,
+) -> anyhow::Result<Arc<dyn NdArrayD>> {
+    let name = variable.name.clone();
+    let shape: Vec<usize> = variable.shape.iter().map(|&len| len as usize).collect();
+    let dimensions = variable.dimensions.clone();
+
+    // The optional CF `calendar` attribute selects how the reference date is
+    // read. It defaults to Gregorian when absent.
+    let calendar = variable
+        .attribute("calendar")
+        .and_then(|a| a.value.as_text())
+        .map(|c| c.to_string());
+    let cf_time_epoch_unit = variable
+        .attribute("units")
+        .and_then(|a| a.value.as_text())
+        .and_then(|units| parse_time_units(units, calendar.as_deref()));
+
+    // CF `scale_factor` / `add_offset` packing. A missing factor defaults to
+    // the identity, as it does on the netcdf-c path.
+    let scale = variable
+        .attribute("scale_factor")
+        .and_then(|a| attribute_as_f64(&a.value));
+    let offset = variable
+        .attribute("add_offset")
+        .and_then(|a| attribute_as_f64(&a.value));
+    let scale_offset = (scale.is_some() || offset.is_some())
+        .then(|| (scale.unwrap_or(1.0), offset.unwrap_or(0.0)));
+
+    let variable_ref = || {
+        VariableRef::new(
+            file.clone(),
+            name.clone(),
+            shape.clone(),
+            dimensions.clone(),
+        )
+    };
+
+    match variable.vartype() {
+        DType::Int(1) => numeric_variable_to_nd_array::<i8>(
+            variable_ref(),
+            fill_value_of!(variable, Schar),
+            cf_time_epoch_unit,
+            scale_offset,
+        ),
+        DType::Int(2) => numeric_variable_to_nd_array::<i16>(
+            variable_ref(),
+            fill_value_of!(variable, Short),
+            cf_time_epoch_unit,
+            scale_offset,
+        ),
+        DType::Int(4) => numeric_variable_to_nd_array::<i32>(
+            variable_ref(),
+            fill_value_of!(variable, Int),
+            cf_time_epoch_unit,
+            scale_offset,
+        ),
+        DType::Int(8) => numeric_variable_to_nd_array::<i64>(
+            variable_ref(),
+            fill_value_of!(variable, Longlong),
+            cf_time_epoch_unit,
+            scale_offset,
+        ),
+        DType::Uint(1) => numeric_variable_to_nd_array::<u8>(
+            variable_ref(),
+            fill_value_of!(variable, Uchar),
+            cf_time_epoch_unit,
+            scale_offset,
+        ),
+        DType::Uint(2) => numeric_variable_to_nd_array::<u16>(
+            variable_ref(),
+            fill_value_of!(variable, Ushort),
+            cf_time_epoch_unit,
+            scale_offset,
+        ),
+        DType::Uint(4) => numeric_variable_to_nd_array::<u32>(
+            variable_ref(),
+            fill_value_of!(variable, Uint),
+            cf_time_epoch_unit,
+            scale_offset,
+        ),
+        DType::Uint(8) => numeric_variable_to_nd_array::<u64>(
+            variable_ref(),
+            fill_value_of!(variable, Ulonglong),
+            cf_time_epoch_unit,
+            scale_offset,
+        ),
+        DType::Float(4) => numeric_variable_to_nd_array::<f32>(
+            variable_ref(),
+            fill_value_of!(variable, Float),
+            cf_time_epoch_unit,
+            scale_offset,
+        ),
+        DType::Float(8) => numeric_variable_to_nd_array::<f64>(
+            variable_ref(),
+            fill_value_of!(variable, Double),
+            cf_time_epoch_unit,
+            scale_offset,
+        ),
+        // A netCDF `string` variable, and a fixed-length string wider than one
+        // byte, both hold one whole string in each element.
+        DType::String | DType::FixedString(_) => {
+            let backend = StringBackend::new(
+                variable_ref(),
+                StringSource::Native,
+                string_fill_value(variable),
+            );
+            Ok(Arc::new(NdArray::new_with_backend(backend)?))
+        }
+        DType::Char => {
+            // A char variable whose last dimension is named for a string length
+            // holds one string in each row of that axis. The axis is the string
+            // itself, so it stays out of the logical shape.
+            let is_fixed_string_array = dimensions
+                .last()
+                .map(|dim| {
+                    let dim = dim.to_lowercase();
+                    dim.starts_with("string")
+                        || dim.starts_with("strlen")
+                        || dim.starts_with("strnlen")
+                })
+                .unwrap_or(false);
+
+            let backend = if is_fixed_string_array {
+                let width = *shape
+                    .last()
+                    .expect("a trailing dimension name implies a trailing axis");
+                let logical = VariableRef::new(
+                    file.clone(),
+                    name.clone(),
+                    shape[..shape.len() - 1].to_vec(),
+                    dimensions[..dimensions.len() - 1].to_vec(),
+                )
+                .with_string_width(width);
+                StringBackend::new(
+                    logical,
+                    StringSource::FixedChar,
+                    string_fill_value(variable),
+                )
+            } else {
+                StringBackend::new(
+                    variable_ref(),
+                    StringSource::Char,
+                    string_fill_value(variable),
+                )
+            };
+
+            Ok(Arc::new(NdArray::new_with_backend(backend)?))
+        }
+        other => Err(anyhow::anyhow!(
+            "Unsupported variable type '{:?}' for variable '{}'",
+            other,
+            name
+        )),
+    }
+}

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/mod.rs
@@ -1,0 +1,44 @@
+//! The pure-Rust NetCDF read path, built on [`oxcdf`].
+//!
+//! This module is the second of the two readers in this crate. The first one,
+//! [`crate::reader`], calls netcdf-c. Both produce the same
+//! [`AnyDataset`](beacon_nd_array::dataset::AnyDataset), so a query gets the
+//! same schema and the same values from either one.
+//!
+//! # Why a second reader
+//!
+//! netcdf-c is not thread safe. Its Rust bindings put one process-global mutex
+//! around every call, and that mutex covers the input, the decompression and
+//! the type conversion. A scan of many files therefore runs one file at a time.
+//! netcdf-c also opens a local path or an `http(s)` URL only, so a file in an
+//! object store needs a local copy first.
+//!
+//! [`oxcdf`] parses the HDF5 container in Rust. It holds no lock, and it reads
+//! byte ranges through [`object_store`]. Scans run in parallel, and S3, GCS and
+//! Azure need no local copy.
+//!
+//! # Which reader runs
+//!
+//! netcdf-c stays the default. Set the `use_rust_reader` flag on
+//! [`NetcdfConfig`](crate::datafusion::NetcdfConfig), or the `use_rust_reader`
+//! option of one table, to select this path.
+//!
+//! # Limits
+//!
+//! [`oxcdf`] reads files. It does not write them. The
+//! [`writer`](crate::writer) and the DataFusion sinks always use netcdf-c.
+//!
+//! # Layout
+//!
+//! * [`backend`] holds the lazy array backends that read variable data.
+//! * [`compat`] turns one variable or attribute into an ND array.
+//! * [`reader`] opens a file and assembles the dataset.
+
+/// Lazy array backends that read variable data through [`oxcdf`].
+pub mod backend;
+/// Conversion from [`oxcdf`] variables and attributes to ND arrays.
+pub mod compat;
+/// High-level reader that opens an object and returns a dataset.
+pub mod reader;
+
+pub use reader::{open_dataset, read_arrays};

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/reader.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/reader.rs
@@ -1,0 +1,345 @@
+//! High-level [`oxcdf`] reader that produces [`AnyDataset`] values.
+//!
+//! The entry point is [`open_dataset`]. It opens an object through
+//! [`object_store`], turns every variable and attribute into a lazy
+//! [`NdArrayD`] wrapper, and returns the result as an [`AnyDataset`].
+//!
+//! This is the [`oxcdf`] twin of [`crate::reader`]. The two follow the same
+//! conventions, so a table keeps its schema when the reader changes.
+//!
+//! # CF conventions
+//!
+//! - A variable whose last dimension name starts with `string`, `strlen` or
+//!   `strnlen` decodes as UTF-8 strings instead of raw characters.
+//! - A variable with a `units` attribute in the CF time form (for example
+//!   `"days since 1950-01-01"`) decodes as nanosecond timestamps.
+//! - `scale_factor` and `add_offset` decode a packed variable to `f64`.
+//!
+//! # Naming conventions
+//!
+//! - Each variable becomes a named array in the dataset.
+//! - A variable attribute becomes an array named `"variable_name.attribute_name"`.
+//! - A global attribute becomes an array named `".attribute_name"`.
+//!
+//! # Groups
+//!
+//! Only the root group is read, which is what netcdf-c's `File::variables`
+//! returns. Both readers therefore report the same variables.
+//!
+//! # Example
+//!
+//! ```no_run
+//! # use std::sync::Arc;
+//! # async fn example(store: Arc<dyn object_store::ObjectStore>) -> anyhow::Result<()> {
+//! use object_store::path::Path;
+//!
+//! let any =
+//!     beacon_arrow_netcdf::oxcdf_reader::open_dataset(store, Path::from("data.nc")).await?;
+//! for name in any.dataset().arrays.keys() {
+//!     println!("{name}");
+//! }
+//! # Ok(())
+//! # }
+//! ```
+
+use std::sync::Arc;
+
+use beacon_nd_array::{
+    dataset::{AnyDataset, Dataset},
+    NdArrayD,
+};
+use indexmap::IndexMap;
+use object_store::{path::Path, ObjectStore};
+use oxcdf::AsyncNetcdfFile;
+
+use crate::oxcdf_reader::compat;
+
+/// Open a NetCDF object from `store` and return its contents as an
+/// [`AnyDataset`].
+///
+/// The reader fetches byte ranges. It never copies the whole object, so an
+/// object in S3, GCS or Azure needs no local file.
+///
+/// Variable data is **not** read eagerly. The backends fetch data on demand
+/// when individual arrays are accessed.
+///
+/// # Errors
+///
+/// Returns an error when the object cannot be opened, or when a variable uses a
+/// type this reader does not support.
+pub async fn open_dataset(store: Arc<dyn ObjectStore>, path: Path) -> anyhow::Result<AnyDataset> {
+    let name = path.to_string();
+    let file = Arc::new(AsyncNetcdfFile::open_store(store, path).await?);
+    let arrays = read_arrays(&file)?;
+    let dataset = Dataset::new(name, arrays).await;
+    AnyDataset::try_from_dataset(dataset).await
+}
+
+/// Read every variable and attribute of an opened file into an ordered map of
+/// lazy ND arrays.
+///
+/// The map is sorted by key, so iteration order is stable. This is the
+/// lower-level building block behind [`open_dataset`].
+///
+/// # Errors
+///
+/// Returns an error when an attribute of the file cannot be read. A variable
+/// this reader cannot model is skipped, as it is on the netcdf-c path.
+pub fn read_arrays(
+    file: &Arc<AsyncNetcdfFile>,
+) -> anyhow::Result<IndexMap<String, Arc<dyn NdArrayD>>> {
+    let mut arrays: IndexMap<String, Arc<dyn NdArrayD>> = IndexMap::new();
+
+    // ── Variables and their per-variable attributes ──────────────────────
+    for info in &file.root().variables {
+        let Some(variable) = file.variable(&info.path) else {
+            continue;
+        };
+
+        if let Ok(array) = compat::variable_to_nd_array(file.clone(), &variable) {
+            arrays.insert(info.name.clone(), array);
+        }
+
+        for attribute in variable.attributes() {
+            let full_name = format!("{}.{}", info.name, attribute.name);
+            if let Ok(array) = compat::attribute_to_nd_array(&full_name, &attribute.value) {
+                arrays.insert(full_name, array);
+            }
+        }
+    }
+
+    // ── Global file attributes ──────────────────────────────────────────
+    for attribute in file.attributes() {
+        let key = format!(".{}", attribute.name);
+        if let Ok(array) = compat::attribute_to_nd_array(&key, &attribute.value) {
+            arrays.insert(key, array);
+        }
+    }
+
+    // Deterministic ordering by name.
+    arrays.sort_keys();
+
+    Ok(arrays)
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use beacon_nd_array::{
+        datatypes::{NdArrayDataType, TimestampNanosecond},
+        NdArray,
+    };
+    use object_store::local::LocalFileSystem;
+
+    const WOD_FILE: &str = "wod_ctd_1964.nc";
+    const GRIDDED_FILE: &str = "gridded-example.nc";
+
+    /// A store rooted at this crate's `test_files` directory.
+    fn test_store() -> Arc<dyn ObjectStore> {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("test_files");
+        Arc::new(LocalFileSystem::new_with_prefix(root).expect("test_files store"))
+    }
+
+    async fn open(file: &str) -> AnyDataset {
+        open_dataset(test_store(), Path::from(file))
+            .await
+            .unwrap_or_else(|e| panic!("open {file}: {e}"))
+    }
+
+    /// The same file, through the netcdf-c reader, for a side-by-side check.
+    async fn open_with_netcdf_c(file: &str) -> AnyDataset {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("test_files")
+            .join(file);
+        crate::reader::open_dataset(path).await.unwrap()
+    }
+
+    // ── Opening ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn open_dataset_reads_a_ragged_file() {
+        let any = open(WOD_FILE).await;
+        assert!(any.is_ragged(), "the WOD file is a ragged dataset");
+        assert!(!any.dataset().arrays.is_empty());
+    }
+
+    #[tokio::test]
+    async fn open_dataset_reads_a_gridded_file() {
+        let any = open(GRIDDED_FILE).await;
+        assert!(any.get_array("analysed_sst").is_some());
+    }
+
+    #[tokio::test]
+    async fn open_dataset_returns_an_error_for_a_missing_object() {
+        assert!(open_dataset(test_store(), Path::from("nope.nc"))
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn dataset_name_is_the_object_path() {
+        let any = open(WOD_FILE).await;
+        assert_eq!(any.name(), WOD_FILE);
+    }
+
+    // ── Parity with the netcdf-c reader ────────────────────────────────
+
+    /// Both readers must surface the same arrays. A table keeps its schema
+    /// when the reader flag changes only if this holds.
+    #[tokio::test]
+    async fn both_readers_surface_the_same_arrays() {
+        for file in [WOD_FILE, GRIDDED_FILE] {
+            let rust = open(file).await;
+            let c = open_with_netcdf_c(file).await;
+
+            let rust_keys: Vec<&String> = rust.dataset().arrays.keys().collect();
+            let c_keys: Vec<&String> = c.dataset().arrays.keys().collect();
+            assert_eq!(rust_keys, c_keys, "array names differ for {file}");
+
+            for key in rust_keys {
+                assert_eq!(
+                    rust.get_array(key).unwrap().datatype(),
+                    c.get_array(key).unwrap().datatype(),
+                    "data type of '{key}' differs for {file}"
+                );
+                assert_eq!(
+                    rust.get_array(key).unwrap().shape(),
+                    c.get_array(key).unwrap().shape(),
+                    "shape of '{key}' differs for {file}"
+                );
+            }
+        }
+    }
+
+    /// Values, not only names. `z` is a plain `f32` observation variable.
+    #[tokio::test]
+    async fn both_readers_read_the_same_f32_values() {
+        let rust = open(WOD_FILE).await;
+        let c = open_with_netcdf_c(WOD_FILE).await;
+
+        let rust_values = rust
+            .get_array("z")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<NdArray<f32>>()
+            .unwrap()
+            .clone_into_raw_vec()
+            .await;
+        let c_values = c
+            .get_array("z")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<NdArray<f32>>()
+            .unwrap()
+            .clone_into_raw_vec()
+            .await;
+        assert_eq!(rust_values, c_values);
+    }
+
+    /// The decoded `analysed_sst` values of a dataset.
+    async fn sst_values(dataset: &AnyDataset) -> Vec<f64> {
+        dataset
+            .get_array("analysed_sst")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<NdArray<f64>>()
+            .unwrap()
+            .clone_into_raw_vec()
+            .await
+    }
+
+    // ── CF decoding ────────────────────────────────────────────────────
+
+    /// `analysed_sst` is packed `int16` with `scale_factor` and `add_offset`,
+    /// so it decodes to `f64`. The decoded values match the netcdf-c path, and
+    /// the real (non-fill) cells sit in a physical kelvin range.
+    #[tokio::test]
+    async fn scale_and_offset_decode_to_f64() {
+        let any = open(GRIDDED_FILE).await;
+        let c = open_with_netcdf_c(GRIDDED_FILE).await;
+
+        let array = any.get_array("analysed_sst").unwrap();
+        assert_eq!(array.datatype(), NdArrayDataType::F64);
+
+        let rust_values = sst_values(&any).await;
+        assert_eq!(
+            rust_values,
+            sst_values(&c).await,
+            "decoded values must match"
+        );
+
+        // The fill cells decode to the packed fill run through the same
+        // arithmetic, so take the maximum to reach a real measurement.
+        let warmest = rust_values.iter().copied().fold(f64::MIN, f64::max);
+        assert!(
+            (200.0..400.0).contains(&warmest),
+            "decoded SST must be a kelvin value, got {warmest}"
+        );
+    }
+
+    /// A `units` attribute in the CF time form decodes to a timestamp.
+    #[tokio::test]
+    async fn cf_time_decodes_to_a_timestamp() {
+        let any = open(GRIDDED_FILE).await;
+        let array = any.get_array("time").unwrap();
+        assert_eq!(array.datatype(), NdArrayDataType::Timestamp);
+
+        let typed = array
+            .as_any()
+            .downcast_ref::<NdArray<TimestampNanosecond>>()
+            .unwrap();
+        let raw = typed.clone_into_raw_vec().await;
+        assert!(!raw.is_empty());
+    }
+
+    /// A char variable with a trailing length dimension decodes as strings,
+    /// and the length axis stays out of the shape.
+    #[tokio::test]
+    async fn fixed_size_char_variable_decodes_as_strings() {
+        let any = open(WOD_FILE).await;
+        let c = open_with_netcdf_c(WOD_FILE).await;
+
+        // Find a string array that the netcdf-c reader also reports as strings.
+        let name = c
+            .dataset()
+            .arrays
+            .iter()
+            .find(|(_, array)| array.datatype() == NdArrayDataType::String)
+            .map(|(name, _)| name.clone())
+            .expect("the WOD file holds a string variable");
+
+        let array = any.get_array(&name).unwrap();
+        assert_eq!(array.datatype(), NdArrayDataType::String);
+        assert_eq!(array.shape(), c.get_array(&name).unwrap().shape());
+    }
+
+    // ── Attributes ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn a_global_attribute_gets_a_leading_dot() {
+        let any = open(WOD_FILE).await;
+        assert!(any.get_array(".Conventions").is_some());
+        assert!(any.get_array("Conventions").is_none());
+    }
+
+    #[tokio::test]
+    async fn a_variable_attribute_gets_a_dotted_name() {
+        let any = open(GRIDDED_FILE).await;
+        assert!(any.get_array("analysed_sst.units").is_some());
+    }
+
+    #[tokio::test]
+    async fn array_names_are_sorted() {
+        let file = Arc::new(
+            AsyncNetcdfFile::open_store(test_store(), Path::from(WOD_FILE))
+                .await
+                .unwrap(),
+        );
+        let keys: Vec<String> = read_arrays(&file).unwrap().keys().cloned().collect();
+        let mut sorted = keys.clone();
+        sorted.sort();
+        assert_eq!(keys, sorted);
+    }
+}

--- a/beacon-server/beacon-server-config/src/lib.rs
+++ b/beacon-server/beacon-server-config/src/lib.rs
@@ -404,6 +404,14 @@ struct RawConfig {
     #[envconfig(from = "BEACON_NETCDF_READER_CACHE_SIZE", default = "128")]
     netcdf_reader_cache_size: usize,
 
+    /// Read netCDF with the pure-Rust `oxcdf` reader instead of netcdf-c.
+    ///
+    /// Off by default: netcdf-c is the path this server has always used. Turn
+    /// it on for parallel reads and for netCDF files in an object store (s3, gs
+    /// or az), which netcdf-c cannot open. Writes always use netcdf-c.
+    #[envconfig(from = "BEACON_NETCDF_USE_RUST_READER", default = "false")]
+    netcdf_use_rust_reader: bool,
+
     #[envconfig(from = "BEACON_ATLAS_USE_READER_CACHE", default = "true")]
     atlas_use_reader_cache: bool,
     #[envconfig(from = "BEACON_ATLAS_READER_CACHE_SIZE", default = "32")]
@@ -520,6 +528,7 @@ impl From<RawConfig> for Config {
                 use_reader_cache: raw.netcdf_use_reader_cache,
                 reader_cache_size: raw.netcdf_reader_cache_size,
                 enable_statistics: raw.netcdf_enable_statistics,
+                use_rust_reader: raw.netcdf_use_rust_reader,
             },
             atlas: AtlasConfig {
                 use_reader_cache: raw.atlas_use_reader_cache,
@@ -725,7 +734,9 @@ fn create_dir(path: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_master_key, normalize_base_path, validate_storage, Config, PathBuf, RawConfig};
+    use super::{
+        decode_master_key, normalize_base_path, validate_storage, Config, PathBuf, RawConfig,
+    };
     use envconfig::Envconfig;
     use std::collections::HashMap;
 
@@ -805,7 +816,10 @@ mod tests {
         // A trailing slash on the endpoint must not double up.
         let mut slashed = minio.to_vec();
         slashed[2] = ("AWS_ENDPOINT", "http://minio:9000/");
-        assert_eq!(with(&slashed).as_deref(), Some("http://minio:9000/datasets"));
+        assert_eq!(
+            with(&slashed).as_deref(),
+            Some("http://minio:9000/datasets")
+        );
 
         // No endpoint: real AWS, where the region is part of the hostname.
         let aws = [

--- a/docs/docs/2.0.0-rc2/server/configuration.md
+++ b/docs/docs/2.0.0-rc2/server/configuration.md
@@ -195,6 +195,7 @@ change them.
 | `BEACON_NETCDF_ENABLE_STATISTICS` | `true` | Compute and cache per-file statistics used for query pruning. |
 | `BEACON_NETCDF_USE_READER_CACHE` | `true` | Cache opened NetCDF readers in memory. |
 | `BEACON_NETCDF_READER_CACHE_SIZE` | `128` | Max NetCDF reader entries to keep cached. |
+| `BEACON_NETCDF_USE_RUST_READER` | `false` | Read NetCDF with the pure-Rust reader instead of the netCDF-C library. |
 
 ### Atlas
 

--- a/docs/docs/2.0.0-rc2/server/performance-tuning.md
+++ b/docs/docs/2.0.0-rc2/server/performance-tuning.md
@@ -109,6 +109,35 @@ For a deployment with many NetCDF files:
 `BEACON_NETCDF_ENABLE_STATISTICS` controls the statistics of each file. Beacon uses them to prune a
 query. The default is `true`. Keep it on. Switch it off only to debug the pruning.
 
+### Pure-Rust reader (parallel reads and object storage)
+
+#### `BEACON_NETCDF_USE_RUST_READER`
+
+Beacon reads NetCDF with the netCDF-C library by default. That library is not thread safe. Its Rust
+bindings hold one lock for each call. The lock covers the input, the decompression and the type
+conversion. A query that reads many files therefore reads one file at a time. The library also opens
+only a local path or an `http`/`https` URL.
+
+Set `BEACON_NETCDF_USE_RUST_READER=true` to use the pure-Rust reader. It holds no lock, so Beacon
+reads many files at the same time. It also reads byte ranges through the object store, so a file in
+S3, GCS or Azure needs no local copy.
+
+Recommendations:
+
+- Set it to `true` for a query that scans many NetCDF files.
+- Set it to `true` for NetCDF files in an object store. The netCDF-C library cannot open those.
+- Keep the default `false` if you must match the behaviour of the netCDF-C library exactly.
+
+Both readers give the same schema and the same values. Writes always use the netCDF-C library.
+
+You can also set the reader for one table:
+
+```sql
+CREATE EXTERNAL TABLE my_table STORED AS NC
+LOCATION 's3://bucket/data/'
+OPTIONS ('use_rust_reader' 'true');
+```
+
 ## Zarr predicate pushdown
 
 The Zarr reader of Beacon applies predicate pushdown **automatically**. It uses the shared


### PR DESCRIPTION
## Why

netcdf-c is not thread safe. Its Rust bindings hold one process-global mutex for every call, and that mutex covers the input, the decompression and the type conversion — so a scan of many files decodes one file at a time. netcdf-c also opens only a local path or an `http(s)` URL, so a netCDF file in an object store needs a local copy first.

[oxcdf](https://github.com/robinskil/oxcdf) parses the HDF5 container in Rust. It holds no lock and reads byte ranges through `object_store`.

This adds it as a **second reader**, selected at runtime. netcdf-c stays the default.

## How to turn it on

| Scope | How |
| --- | --- |
| Runtime | `BEACON_NETCDF_USE_RUST_READER=true` |
| One table | `OPTIONS ('use_rust_reader' 'true')` |

```sql
CREATE EXTERNAL TABLE my_table STORED AS NC
LOCATION 's3://bucket/data/'
OPTIONS ('use_rust_reader' 'true');
```

## What changed

**New module `oxcdf_reader`**, mirroring `reader`:

- `backend.rs` — four lazy `ArrayBackend`s (numeric, scale/offset, CF time, string). The netcdf-c path needs a decoder chain because `netcdf::Variable::get` returns only the stored type; oxcdf converts on read, so each transform is one backend over an `f64` or raw-byte read.
- `compat.rs` — the same CF rules in the same order (scale/offset wins over CF time), the same exact-variant `_FillValue` matching, the same `string`/`strlen`/`strnlen` char handling.
- `reader.rs` — opens an object from a store, reads the root group, same `var.attr` / `.global` array naming.

**Plumbing.** A `NetcdfInput` enum says where one object's bytes come from and which reader opens it. The format and the opener both build it through one helper, so a scan and its statistics can never disagree about a file. The reader-cache key gained the backend, because one runtime can serve tables on either reader and their datasets are not interchangeable. `create_with_native_root` and `read_netcdf` skip the native-root resolution on the oxcdf path — that is what lets a table live in s3/gs/az. `beacon-arrow-hdf5` inherits all of it through its delegating factory.

**Writes are unchanged.** oxcdf reads files; it does not write them. Every sink still uses netcdf-c.

## On partitioning

`NetCDFSource::repartitioned` keeps returning `None` on both readers, deliberately. DataFusion's `FileGroupPartitioner` splits by **byte range**, and a byte range of a netCDF file is not a netCDF file — the opener ignores `PartitionedFile::range` and opens the whole dataset, so a range split would return every row once per range.

File-level parallelism does not need it. `ListingTable` already splits file groups by `target_partitions` before `FileSource::repartitioned` is consulted, so a scan of N files runs in N partitions on either reader:

```
### backend=Oxcdf copies=4 target_partitions=4 -> partition_count=4
NdBroadcastExec
  NdSourceExec
    DataSourceExec: file_groups={4 groups: [[f0.nc], [f1.nc], [f2.nc], [f3.nc]]}, file_type=netcdf
```

What oxcdf adds is that those partitions then actually run at the same time. Both facts have a regression test, so nobody "fixes" the `None` by mistake.

Still open: a single large file is one partition. Splitting one file across partitions needs leading-dimension slabs rather than byte ranges — separate work, worth doing only if the bottleneck turns out to be few-big-files.

## Measured effect

8 copies of the gridded fixture, 8 partitions, warm page cache, release build:

| reader | run 1 | run 2 |
| --- | --- | --- |
| netcdf-c | 107 ms | 102 ms |
| oxcdf | 94 ms | 91 ms |

~12%. On this fixture the time is dominated by the shared nd→Arrow conversion and the aggregation, not by decode, so the mutex is not the bottleneck here. It should matter much more where decode dominates: many files, heavily compressed, wide reads. **This wants re-measuring on a real corpus** — I deliberately put no number in the docs.

## Testing

101 lib tests pass, including:

- parity tests reading the bundled ragged and gridded fixtures both ways, asserting identical array names, data types, shapes and values;
- end-to-end DataFusion checks that a projection and a pushed-down predicate return identical batches from either reader;
- the two partitioning regression tests above.

`beacon-core`'s netCDF integration tests (`read_functions`, `explain_analyze_external_netcdf`, `dynamic_store`) still pass, and `cargo check --workspace --all-targets` is clean.

## Review notes

- The `oxcdf` dependency is unpinned (git, no rev), matching how the `netcdf` fork is declared. `Cargo.lock` pins it for now; worth a tag once oxcdf stabilises.
- Both readers enumerate root-group variables only, deliberately, so the schema does not change when the flag flips. oxcdf's `file.variables()` is recursive; if nested groups are wanted later, both paths need the change together.
