### PR TITLE
fix(netcdf): report the chunk shape of the file

### DIFF
--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/backend.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/backend.rs
@@ -8,27 +8,56 @@ use beacon_nd_array::{
     datatypes::NdArrayType,
 };
 
+/// The chunk shape the file stores for a variable.
+///
+/// The read costs no bytes. A netCDF-4 file keeps the layout of each variable
+/// in its header, which the open already read.
+///
+/// The value falls back to `shape`:
+///
+/// - for a contiguous variable, and for a classic file, which has no chunks;
+/// - for a chunk shape of a lower rank than `shape`, which cannot map onto it.
+///
+/// A fixed-size string variable drops its length axis from `shape`. The chunk
+/// shape drops the same axis, so both keep the same rank.
+fn file_chunk_shape(nc_file: &netcdf::File, variable_name: &str, shape: &[usize]) -> Vec<usize> {
+    let chunks = nc_file
+        .variable(variable_name)
+        .and_then(|variable| variable.chunking().ok().flatten());
+
+    match chunks {
+        Some(chunks) if chunks.len() >= shape.len() => chunks[..shape.len()].to_vec(),
+        _ => shape.to_vec(),
+    }
+}
+
 /// Backend that reads variable data lazily from a NetCDF file.
 #[derive(Debug)]
 pub struct VariableBackend<T: NdArrayType + 'static> {
     decoder: Arc<dyn VariableDecoder<T>>,
     nc_file: Arc<netcdf::File>,
     shape: Vec<usize>,
+    chunk_shape: Vec<usize>,
     dimensions: Vec<String>,
 }
 
 impl<T: NdArrayType + 'static> VariableBackend<T> {
     /// Create a lazy variable backend.
+    ///
+    /// The chunk shape comes from the file once, here. A later read of it costs
+    /// nothing.
     pub fn new(
         decoder: Arc<dyn VariableDecoder<T>>,
         nc_file: Arc<netcdf::File>,
         shape: Vec<usize>,
         dimensions: Vec<String>,
     ) -> Self {
+        let chunk_shape = file_chunk_shape(&nc_file, decoder.variable_name(), &shape);
         Self {
             decoder,
             nc_file,
             shape,
+            chunk_shape,
             dimensions,
         }
     }
@@ -42,6 +71,9 @@ impl<T: NdArrayType + 'static> ArrayBackend<T> for VariableBackend<T> {
 
     fn shape(&self) -> Vec<usize> {
         self.shape.clone()
+    }
+    fn chunk_shape(&self) -> Vec<usize> {
+        self.chunk_shape.clone()
     }
     fn dimensions(&self) -> Vec<String> {
         self.dimensions.clone()

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/backend.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/backend.rs
@@ -16,6 +16,28 @@ use beacon_nd_array::{
 use ndarray::ArrayD;
 use oxcdf::{AsyncNetcdfFile, AsyncVariable, Extent, Extents};
 
+/// The chunk shape the file stores for a variable.
+///
+/// The read costs no bytes. The open holds the layout of every variable.
+///
+/// The value falls back to `shape`:
+///
+/// - for a contiguous variable, and for a classic file, which has no chunks;
+/// - for a chunk shape of a lower rank than `shape`, which cannot map onto it.
+///
+/// A fixed-size string variable drops its length axis from `shape`. The chunk
+/// shape drops the same axis, so both keep the same rank.
+fn file_chunk_shape(file: &AsyncNetcdfFile, name: &str, shape: &[usize]) -> Vec<usize> {
+    let chunks = file
+        .variable(name)
+        .and_then(|variable| variable.chunking().ok().flatten());
+
+    match chunks {
+        Some(chunks) if chunks.len() >= shape.len() => chunks[..shape.len()].to_vec(),
+        _ => shape.to_vec(),
+    }
+}
+
 /// One variable, bound to the file that holds it.
 ///
 /// [`AsyncVariable`] borrows the file, so a backend cannot keep one. It keeps
@@ -27,6 +49,8 @@ pub struct VariableRef {
     name: String,
     /// The logical shape. A fixed-size string variable drops its length axis.
     shape: Vec<usize>,
+    /// The chunk shape of the file, on the axes of `shape`.
+    chunk_shape: Vec<usize>,
     /// The logical dimension names, one for each axis of `shape`.
     dimensions: Vec<String>,
     /// The trailing string-length axis, when the variable has one. It is part
@@ -36,16 +60,21 @@ pub struct VariableRef {
 
 impl VariableRef {
     /// Bind a variable of the given logical shape.
+    ///
+    /// The chunk shape comes from the file once, here. A later read of it costs
+    /// nothing.
     pub fn new(
         file: Arc<AsyncNetcdfFile>,
         name: String,
         shape: Vec<usize>,
         dimensions: Vec<String>,
     ) -> Self {
+        let chunk_shape = file_chunk_shape(&file, &name, &shape);
         Self {
             file,
             name,
             shape,
+            chunk_shape,
             dimensions,
             string_width: None,
         }
@@ -107,6 +136,11 @@ impl VariableRef {
     fn element_count(&self) -> usize {
         self.shape.iter().product()
     }
+
+    /// The chunk shape the file stores, on the axes of the logical shape.
+    fn chunk_shape(&self) -> Vec<usize> {
+        self.chunk_shape.clone()
+    }
 }
 
 /// Reshape flat, row-major values into the shape the subset selected.
@@ -152,6 +186,10 @@ where
 
     fn shape(&self) -> Vec<usize> {
         self.variable.shape.clone()
+    }
+
+    fn chunk_shape(&self) -> Vec<usize> {
+        self.variable.chunk_shape()
     }
 
     fn dimensions(&self) -> Vec<String> {
@@ -214,6 +252,10 @@ impl ArrayBackend<f64> for ScaleOffsetBackend {
         self.variable.shape.clone()
     }
 
+    fn chunk_shape(&self) -> Vec<usize> {
+        self.variable.chunk_shape()
+    }
+
     fn dimensions(&self) -> Vec<String> {
         self.variable.dimensions.clone()
     }
@@ -258,6 +300,10 @@ impl ArrayBackend<TimestampNanosecond> for TimestampBackend {
 
     fn shape(&self) -> Vec<usize> {
         self.variable.shape.clone()
+    }
+
+    fn chunk_shape(&self) -> Vec<usize> {
+        self.variable.chunk_shape()
     }
 
     fn dimensions(&self) -> Vec<String> {
@@ -317,6 +363,10 @@ impl ArrayBackend<String> for StringBackend {
 
     fn shape(&self) -> Vec<usize> {
         self.variable.shape.clone()
+    }
+
+    fn chunk_shape(&self) -> Vec<usize> {
+        self.variable.chunk_shape()
     }
 
     fn dimensions(&self) -> Vec<String> {

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/reader.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/reader.rs
@@ -250,6 +250,70 @@ mod tests {
             .await
     }
 
+    // ── Chunk shape ────────────────────────────────────────────────────
+
+    /// A chunked variable reports the chunk shape the file stores, not the
+    /// full shape. The nd engine reads one chunk at a time with it.
+    #[tokio::test]
+    async fn a_chunked_variable_reports_the_chunk_shape_of_the_file() {
+        let any = open(GRIDDED_FILE).await;
+
+        let sst = any.get_array("analysed_sst").unwrap();
+        assert_eq!(sst.shape(), vec![1, 1208, 1920]);
+        assert_eq!(sst.chunk_shape(), vec![1, 604, 960]);
+
+        let error = any.get_array("analysis_error").unwrap();
+        assert_eq!(error.chunk_shape(), vec![1, 604, 960]);
+
+        let lon = any.get_array("lon").unwrap();
+        assert_eq!(lon.chunk_shape(), vec![1920]);
+    }
+
+    /// One chunk holds the whole array. The two shapes are then equal.
+    #[tokio::test]
+    async fn a_single_chunk_reports_the_full_shape() {
+        let any = open(GRIDDED_FILE).await;
+
+        let ice = any.get_array("sea_ice_fraction").unwrap();
+        assert_eq!(ice.chunk_shape(), vec![1, 1208, 1920]);
+
+        let mask = any.get_array("mask").unwrap();
+        assert_eq!(mask.chunk_shape(), vec![1, 1208, 1920]);
+    }
+
+    /// The WOD file stores every variable contiguously. A variable with no
+    /// chunks reports its full shape. That includes the fixed-size string
+    /// variables, which drop their length axis from both shapes.
+    #[tokio::test]
+    async fn a_variable_with_no_chunks_reports_the_full_shape() {
+        let any = open(WOD_FILE).await;
+        for (name, array) in &any.dataset().arrays {
+            assert_eq!(
+                array.chunk_shape(),
+                array.shape(),
+                "'{name}' has no chunks, so it must report its full shape"
+            );
+        }
+    }
+
+    /// Both readers must report the same chunk shape. The nd engine picks its
+    /// batch size from it, so a table keeps its batches when the reader changes.
+    #[tokio::test]
+    async fn both_readers_report_the_same_chunk_shape() {
+        for file in [WOD_FILE, GRIDDED_FILE] {
+            let rust = open(file).await;
+            let c = open_with_netcdf_c(file).await;
+
+            for key in rust.dataset().arrays.keys() {
+                assert_eq!(
+                    rust.get_array(key).unwrap().chunk_shape(),
+                    c.get_array(key).unwrap().chunk_shape(),
+                    "chunk shape of '{key}' differs for {file}"
+                );
+            }
+        }
+    }
+
     // ── CF decoding ────────────────────────────────────────────────────
 
     /// `analysed_sst` is packed `int16` with `scale_factor` and `add_offset`,

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/reader.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/reader.rs
@@ -459,6 +459,75 @@ mod tests {
         assert_eq!(arrays["obs3d"].shape(), &[n_obs, n_calib, n_param]);
     }
 
+    // ── Chunk shape ────────────────────────────────────────────────────
+
+    mod chunk_shape {
+        use super::*;
+
+        const GRIDDED_PATH: &str =
+            concat!(env!("CARGO_MANIFEST_DIR"), "/test_files/gridded-example.nc");
+        const WOD_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/test_files/wod_ctd_1964.nc");
+
+        /// A chunked variable reports the chunk shape the file stores, not the
+        /// full shape. The nd engine reads one chunk at a time with it.
+        #[test]
+        fn a_chunked_variable_reports_the_chunk_shape_of_the_file() {
+            let arrays = read_arrays(GRIDDED_PATH).unwrap();
+            assert_eq!(arrays["analysed_sst"].shape(), vec![1, 1208, 1920]);
+            assert_eq!(arrays["analysed_sst"].chunk_shape(), vec![1, 604, 960]);
+            assert_eq!(arrays["analysis_error"].chunk_shape(), vec![1, 604, 960]);
+            assert_eq!(arrays["lon"].chunk_shape(), vec![1920]);
+        }
+
+        /// One chunk holds the whole array. The two shapes are then equal.
+        #[test]
+        fn a_single_chunk_reports_the_full_shape() {
+            let arrays = read_arrays(GRIDDED_PATH).unwrap();
+            assert_eq!(
+                arrays["sea_ice_fraction"].chunk_shape(),
+                vec![1, 1208, 1920]
+            );
+            assert_eq!(arrays["mask"].chunk_shape(), vec![1, 1208, 1920]);
+        }
+
+        /// The WOD file stores every variable contiguously. A variable with no
+        /// chunks reports its full shape.
+        #[test]
+        fn a_variable_with_no_chunks_reports_the_full_shape() {
+            let arrays = read_arrays(WOD_PATH).unwrap();
+            for (name, array) in &arrays {
+                assert_eq!(
+                    array.chunk_shape(),
+                    array.shape(),
+                    "'{name}' has no chunks, so it must report its full shape"
+                );
+            }
+        }
+
+        /// A fixed-size string variable drops its length axis from the shape.
+        /// The chunk shape drops the same axis.
+        #[test]
+        fn a_string_variable_keeps_the_rank_of_its_shape() {
+            let tmp = make_char_nc("station", &["ABC", "DEF"], 8);
+            let arrays = read_arrays(tmp.path()).unwrap();
+            assert_eq!(arrays["station"].shape(), vec![2]);
+            assert_eq!(arrays["station"].chunk_shape(), vec![2]);
+        }
+
+        /// Every array keeps one chunk length for each of its axes.
+        #[test]
+        fn every_array_keeps_the_rank_of_its_shape() {
+            let arrays = read_arrays(GRIDDED_PATH).unwrap();
+            for (name, array) in &arrays {
+                assert_eq!(
+                    array.chunk_shape().len(),
+                    array.shape().len(),
+                    "rank of the chunk shape of '{name}'"
+                );
+            }
+        }
+    }
+
     // ── Dataset dimensions ─────────────────────────────────────────────
 
     #[tokio::test]


### PR DESCRIPTION
Closes #339.

## Problem

The nd engine asks each array backend for a chunk shape. Zarr, TIFF and Atlas report the native one. The two NetCDF backends used the default, which is the full array shape. The engine saw `chunk_shape == max_shape` and fell back to `c_order_chunk_shape` for every netCDF file.

## Fix

Both backends now take the chunk shape from their reader:

- `beacon-arrow-netcdf/src/backend.rs` uses `netcdf::Variable::chunking`.
- `beacon-arrow-netcdf/src/oxcdf_reader/backend.rs` uses `oxcdf::AsyncVariable::chunking`.

The value is read once, at construction. Neither call fetches bytes: the file header holds the layout, which the open already read.

Two rules keep the value usable:

- A variable with no chunks — a contiguous variable, or a classic file — reports its full shape.
- A fixed-size string variable drops its length axis from the logical shape. The chunk shape drops the same axis, so both keep the same rank.

## Verification

`test_files/gridded-example.nc` now reports what `ncdump -hs` shows:

| variable | shape | chunk shape |
| --- | --- | --- |
| `analysed_sst` | `[1, 1208, 1920]` | `[1, 604, 960]` |
| `analysis_error` | `[1, 1208, 1920]` | `[1, 604, 960]` |
| `sea_ice_fraction` | `[1, 1208, 1920]` | `[1, 1208, 1920]` |
| `mask` | `[1, 1208, 1920]` | `[1, 1208, 1920]` |
| `lon` | `[1920]` | `[1920]` |

New tests, one set for each reader:

- A chunked variable reports the chunk shape of the file. This test fails without the change.
- A single chunk reports the full shape.
- Every variable of `wod_ctd_1964.nc` is contiguous, so each reports its full shape. That covers the fixed-size string variables.
- Both readers report the same chunk shape for every array of both files.

`cargo test -p beacon-arrow-netcdf --lib`: 114 passed, 1 ignored (needs network).

## Limit

This does not control the batch size. The engine picks the largest array that spans every axis. Four arrays of the test file tie on size, and the engine takes `sea_ice_fraction`, whose chunk shape equals the full shape. #338 stays necessary.