### PR TITLE
fix(netcdf): null the _FillValue cells of a CF time variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ tag. Releases before 2.0.0 are recorded in the
 
 ### Fixed
 
+- **A netCDF time variable kept its `_FillValue` cells as dates.** Both netCDF readers dropped the
+  `_FillValue` of a CF time variable, so a fill cell reached a query as a real timestamp:
+  `units = "days since 1970-01-01"` with `_FillValue = -32768` gave `1880-03-15`. Such a value
+  passed a filter and joined a group. The readers now decode the fill with the same CF arithmetic
+  as the data, and the cell is NULL. Zarr already did this, so the same dataset gave two answers.
 - **`read_schema(paths, format)` never existed.** The docs, and one integration test, called a
   generic function that is not registered. The real API is a per-reader counterpart —
   `read_parquet_schema`, `read_netcdf_schema`, and so on, one for every reader including

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/cf_time_fill_tests.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/cf_time_fill_tests.rs
@@ -1,0 +1,183 @@
+//! A CF time variable must null its `_FillValue` cells.
+//!
+//! Regression test for a wrong value, not for a missing one. Both readers used
+//! to drop the `_FillValue` of a time variable, so the Arrow layer masked
+//! nothing and every fill cell reached a query as a real date. A variable with
+//! `units = "days since 1970-01-01"` and `_FillValue = -32768` gave `1880-03-15`
+//! for each of those cells. The date passed a filter and joined a group.
+//!
+//! The two readers share one CF conversion, so the fixture and the assertions
+//! are shared too. Each reader decodes the same file and must give the same
+//! nulls and the same values.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, TimestampNanosecondArray};
+use beacon_nd_array::{
+    arrow::array::ndarray_to_arrow_array, datatypes::TimestampNanosecond, NdArray, NdArrayD,
+};
+use object_store::{local::LocalFileSystem, path::Path, ObjectStore};
+use oxcdf::AsyncNetcdfFile;
+
+/// The `_FillValue` of the fixture, in days since the Unix epoch.
+const FILL: i16 = -32768;
+/// The name of the fixture object, inside the temp directory.
+const FILE: &str = "cf_time_fill.nc";
+const NANOS_PER_DAY: i64 = 86_400 * 1_000_000_000;
+/// Maximum rounding error (nanoseconds) of the `f64` conversion chain of
+/// hifitime. 1 µs is far tighter than any real time precision.
+const MAX_NS_ERROR: i64 = 1_000;
+
+/// Write a time variable of `i16` days, with two fill cells.
+///
+/// Cell order: day 0, fill, day 1, fill.
+fn write_fixture(directory: &std::path::Path) -> std::path::PathBuf {
+    let path = directory.join(FILE);
+    {
+        let mut nc = netcdf::create(&path).expect("create the fixture");
+        nc.add_dimension("obs", 4).unwrap();
+        let mut variable = nc.add_variable::<i16>("time", &["obs"]).unwrap();
+        // netCDF-4 refuses a `_FillValue` after the first write, so set the
+        // attributes first.
+        variable.put_attribute("_FillValue", FILL).unwrap();
+        variable
+            .put_attribute("units", "days since 1970-01-01")
+            .unwrap();
+        variable
+            .put_values(&[0i16, FILL, 1, FILL], netcdf::Extents::All)
+            .unwrap();
+    }
+    path
+}
+
+/// The `time` array of the fixture, through the netcdf-c reader.
+fn read_with_netcdf_c(path: &std::path::Path) -> Arc<dyn NdArrayD> {
+    crate::reader::read_arrays(path)
+        .expect("read the fixture with netcdf-c")
+        .swap_remove("time")
+        .expect("the fixture holds a 'time' variable")
+}
+
+/// The `time` array of the fixture, through the oxcdf reader.
+async fn read_with_oxcdf(directory: &std::path::Path) -> Arc<dyn NdArrayD> {
+    let store: Arc<dyn ObjectStore> =
+        Arc::new(LocalFileSystem::new_with_prefix(directory).expect("a store on the temp dir"));
+    let file = Arc::new(
+        AsyncNetcdfFile::open_store(store, Path::from(FILE))
+            .await
+            .expect("open the fixture with oxcdf"),
+    );
+    crate::oxcdf_reader::read_arrays(&file)
+        .expect("read the fixture with oxcdf")
+        .swap_remove("time")
+        .expect("the fixture holds a 'time' variable")
+}
+
+/// The decoded `_FillValue` the reader exposes to the Arrow layer.
+async fn fill_value(array: &Arc<dyn NdArrayD>) -> Option<TimestampNanosecond> {
+    array
+        .as_any()
+        .downcast_ref::<NdArray<TimestampNanosecond>>()
+        .expect("a timestamp array")
+        .fill_value()
+        .await
+}
+
+/// The array as Arrow, with the fill cells masked.
+async fn as_arrow(array: &Arc<dyn NdArrayD>) -> TimestampNanosecondArray {
+    ndarray_to_arrow_array(array.as_ref())
+        .await
+        .expect("convert to Arrow")
+        .as_any()
+        .downcast_ref::<TimestampNanosecondArray>()
+        .expect("a timestamp array")
+        .clone()
+}
+
+/// The fill value carries the CF arithmetic of the variable, not the raw number.
+fn assert_fill_matches_cf_arithmetic(fill: Option<TimestampNanosecond>, reader: &str) {
+    let fill = fill.unwrap_or_else(|| panic!("{reader} drops the fill value of a time variable"));
+    let expected = FILL as i64 * NANOS_PER_DAY;
+    assert!(
+        (fill.0 - expected).abs() <= MAX_NS_ERROR,
+        "{reader}: fill mismatch: got {}, expected ~{expected}",
+        fill.0
+    );
+}
+
+/// Cells 1 and 3 hold the fill value, so they are NULL. Cells 0 and 2 keep
+/// their dates.
+fn assert_fill_cells_are_null(array: &TimestampNanosecondArray, reader: &str) {
+    assert_eq!(array.len(), 4, "{reader}: cell count");
+    assert_eq!(array.null_count(), 2, "{reader}: two cells hold the fill");
+    assert!(array.is_null(1), "{reader}: cell 1 holds the fill");
+    assert!(array.is_null(3), "{reader}: cell 3 holds the fill");
+    assert!(array.is_valid(0), "{reader}: cell 0 holds day 0");
+    assert!(array.is_valid(2), "{reader}: cell 2 holds day 1");
+    assert_eq!(array.value(0), 0, "{reader}: day 0 is the Unix epoch");
+    assert!(
+        (array.value(2) - NANOS_PER_DAY).abs() <= MAX_NS_ERROR,
+        "{reader}: day 1 mismatch: got {}, expected ~{NANOS_PER_DAY}",
+        array.value(2)
+    );
+}
+
+// ── netcdf-c ───────────────────────────────────────────────────────────────
+
+#[test]
+fn netcdf_c_decodes_the_fill_value_of_a_time_variable() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = write_fixture(directory.path());
+
+    let array = read_with_netcdf_c(&path);
+    let fill = futures::executor::block_on(fill_value(&array));
+    assert_fill_matches_cf_arithmetic(fill, "netcdf-c");
+}
+
+#[tokio::test]
+async fn netcdf_c_nulls_the_fill_cells_of_a_time_variable() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = write_fixture(directory.path());
+
+    let array = as_arrow(&read_with_netcdf_c(&path)).await;
+    assert_fill_cells_are_null(&array, "netcdf-c");
+}
+
+// ── oxcdf ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn oxcdf_decodes_the_fill_value_of_a_time_variable() {
+    let directory = tempfile::tempdir().unwrap();
+    write_fixture(directory.path());
+
+    let array = read_with_oxcdf(directory.path()).await;
+    assert_fill_matches_cf_arithmetic(fill_value(&array).await, "oxcdf");
+}
+
+#[tokio::test]
+async fn oxcdf_nulls_the_fill_cells_of_a_time_variable() {
+    let directory = tempfile::tempdir().unwrap();
+    write_fixture(directory.path());
+
+    let array = as_arrow(&read_with_oxcdf(directory.path()).await).await;
+    assert_fill_cells_are_null(&array, "oxcdf");
+}
+
+// ── Parity ─────────────────────────────────────────────────────────────────
+
+/// The same file gives the same answer on both readers. A dataset must not
+/// change its values when the reader flag changes.
+#[tokio::test]
+async fn both_readers_null_the_same_cells() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = write_fixture(directory.path());
+
+    let c = as_arrow(&read_with_netcdf_c(&path)).await;
+    let rust = as_arrow(&read_with_oxcdf(directory.path()).await).await;
+
+    assert_eq!(
+        c.nulls().map(|n| n.iter().collect::<Vec<_>>()),
+        rust.nulls().map(|n| n.iter().collect::<Vec<_>>())
+    );
+    assert_eq!(c.values(), rust.values());
+}

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/compat.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/compat.rs
@@ -81,13 +81,18 @@ where
         return Ok(Arc::new(nd_array));
     }
 
+    // CF time units → nanosecond timestamps. The `_FillValue` decodes with the
+    // same arithmetic, so a fill cell nulls out instead of reaching a query as a
+    // real date.
     if let Some((epoch, unit)) = cf_time_epoch_unit {
+        let raw_fill = fill_value.map(|f| f.as_());
         let time_backend = VariableBackend::new(
             Arc::new(CFTimeVariableDecoder::new(
                 variable_name.to_string(),
                 default_decoder,
                 epoch,
                 unit,
+                raw_fill,
             )),
             nc_file,
             shape,

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/decoders/cf_time.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/decoders/cf_time.rs
@@ -17,10 +17,11 @@ pub struct CFTimeVariableDecoder<T>
 where
     T: NcTypeDescriptor + AsPrimitive<f64>,
 {
-    pub variable_name: String,
-    pub inner_decoder: Arc<dyn VariableDecoder<T>>,
-    pub epoch: hifitime::Epoch,
-    pub unit: hifitime::Unit,
+    variable_name: String,
+    inner_decoder: Arc<dyn VariableDecoder<T>>,
+    epoch: hifitime::Epoch,
+    unit: hifitime::Unit,
+    fill_value: Option<TimestampNanosecond>,
 }
 
 impl<T> CFTimeVariableDecoder<T>
@@ -30,18 +31,23 @@ where
     /// Create a CF-time decoder.
     ///
     /// `inner_decoder` provides the raw numeric values; `epoch` and `unit`
-    /// define the CF conversion rule.
+    /// define the CF conversion rule. `raw_fill_value` is the fill value in the
+    /// *numeric* units of the variable; it goes through the same CF arithmetic
+    /// so a raw fill cell maps exactly onto the decoded fill, which the engine
+    /// then nulls.
     pub fn new(
         variable_name: String,
         inner_decoder: Arc<dyn VariableDecoder<T>>,
         epoch: hifitime::Epoch,
         unit: hifitime::Unit,
+        raw_fill_value: Option<f64>,
     ) -> Self {
         Self {
             variable_name,
             inner_decoder,
             epoch,
             unit,
+            fill_value: raw_fill_value.map(|f| cf_offset_to_timestamp(f, epoch, unit)),
         }
     }
 }
@@ -60,9 +66,30 @@ where
         Ok(ts_array)
     }
 
+    fn fill_value(&self) -> Option<TimestampNanosecond> {
+        self.fill_value
+    }
+
     fn variable_name(&self) -> &str {
         &self.variable_name
     }
+}
+
+/// Convert one numeric CF time offset into a nanosecond timestamp.
+///
+/// Every CF time value takes this path, the data cells and the `_FillValue`
+/// alike. One function keeps the two results comparable, so the engine nulls a
+/// fill cell.
+pub(crate) fn cf_offset_to_timestamp<T>(
+    value: T,
+    epoch: hifitime::Epoch,
+    unit: hifitime::Unit,
+) -> TimestampNanosecond
+where
+    T: num_traits::cast::AsPrimitive<f64>,
+{
+    let time = epoch + (value.as_() * unit);
+    TimestampNanosecond(time.to_unix(hifitime::Unit::Nanosecond).as_())
 }
 
 /// Convert numeric CF time offsets into nanosecond timestamps.
@@ -77,12 +104,7 @@ pub(crate) fn convert_to_timestamp_nanoseconds<T>(
 where
     T: num_traits::cast::AsPrimitive<f64>,
 {
-    let array: ndarray::ArrayD<TimestampNanosecond> = array.mapv(|v| {
-        let time = epoch + (v.as_() * unit);
-        TimestampNanosecond(time.to_unix(hifitime::Unit::Nanosecond).as_())
-    });
-
-    array
+    array.mapv(|v| cf_offset_to_timestamp(v, epoch, unit))
 }
 
 /// Parse a CF `units` (and optional `calendar`) attribute into a reference
@@ -161,12 +183,13 @@ mod tests {
             None,
         ));
 
-        let decoder = CFTimeVariableDecoder {
-            variable_name: var_name.to_string(),
-            inner_decoder: inner,
-            epoch: unix_epoch(),
-            unit: hifitime::Unit::Day,
-        };
+        let decoder = CFTimeVariableDecoder::new(
+            var_name.to_string(),
+            inner,
+            unix_epoch(),
+            hifitime::Unit::Day,
+            None,
+        );
 
         let array = decoder
             .read(&variable, netcdf::Extents::All)
@@ -202,12 +225,13 @@ mod tests {
             None,
         ));
 
-        let decoder = CFTimeVariableDecoder {
-            variable_name: var_name.to_string(),
-            inner_decoder: inner,
-            epoch: unix_epoch(),
-            unit: hifitime::Unit::Second,
-        };
+        let decoder = CFTimeVariableDecoder::new(
+            var_name.to_string(),
+            inner,
+            unix_epoch(),
+            hifitime::Unit::Second,
+            None,
+        );
 
         let array = decoder
             .read(&variable, netcdf::Extents::All)
@@ -243,12 +267,13 @@ mod tests {
             None,
         ));
 
-        let decoder = CFTimeVariableDecoder {
-            variable_name: var_name.to_string(),
-            inner_decoder: inner,
-            epoch: unix_epoch(),
-            unit: hifitime::Unit::Day,
-        };
+        let decoder = CFTimeVariableDecoder::new(
+            var_name.to_string(),
+            inner,
+            unix_epoch(),
+            hifitime::Unit::Day,
+            None,
+        );
 
         let array = decoder
             .read(&variable, netcdf::Extents::All)
@@ -279,12 +304,13 @@ mod tests {
             None,
         ));
 
-        let decoder = CFTimeVariableDecoder {
-            variable_name: var_name.to_string(),
-            inner_decoder: inner,
-            epoch: unix_epoch(),
-            unit: hifitime::Unit::Day,
-        };
+        let decoder = CFTimeVariableDecoder::new(
+            var_name.to_string(),
+            inner,
+            unix_epoch(),
+            hifitime::Unit::Day,
+            None,
+        );
 
         let array = decoder
             .read(&variable, netcdf::Extents::All)
@@ -311,14 +337,88 @@ mod tests {
     fn test_cf_time_variable_name() {
         let inner = Arc::new(DefaultVariableDecoder::<f64>::new("time".to_string(), None));
 
-        let decoder = CFTimeVariableDecoder {
-            variable_name: "time".to_string(),
-            inner_decoder: inner,
-            epoch: unix_epoch(),
-            unit: hifitime::Unit::Day,
-        };
+        let decoder = CFTimeVariableDecoder::new(
+            "time".to_string(),
+            inner,
+            unix_epoch(),
+            hifitime::Unit::Day,
+            None,
+        );
 
         assert_eq!(decoder.variable_name(), "time");
+    }
+
+    // ── _FillValue ─────────────────────────────────────────────────────────
+
+    /// The decoded fill value equals the raw fill run through the same CF
+    /// arithmetic, so a fill cell nulls out.
+    #[test]
+    fn decoded_fill_matches_cf_time_arithmetic() {
+        let inner = Arc::new(DefaultVariableDecoder::<i16>::new(
+            "time".to_string(),
+            Some(-32768),
+        ));
+
+        let decoder = CFTimeVariableDecoder::new(
+            "time".to_string(),
+            inner,
+            unix_epoch(),
+            hifitime::Unit::Day,
+            Some(-32768.0),
+        );
+
+        let fill = decoder
+            .fill_value()
+            .expect("the decoder holds a fill value");
+        let expected = -32768 * NANOS_PER_DAY;
+        assert!(
+            (fill.0 - expected).abs() <= MAX_NS_ERROR,
+            "fill mismatch: got {}, expected ~{expected}",
+            fill.0
+        );
+    }
+
+    /// The fill value follows the unit of the variable, not only its number.
+    #[test]
+    fn decoded_fill_follows_the_cf_unit() {
+        let inner = Arc::new(DefaultVariableDecoder::<f64>::new(
+            "time".to_string(),
+            Some(-999.0),
+        ));
+
+        let decoder = CFTimeVariableDecoder::new(
+            "time".to_string(),
+            inner,
+            unix_epoch(),
+            hifitime::Unit::Second,
+            Some(-999.0),
+        );
+
+        let fill = decoder
+            .fill_value()
+            .expect("the decoder holds a fill value");
+        let expected = -999 * NANOS_PER_SECOND;
+        assert!(
+            (fill.0 - expected).abs() <= MAX_NS_ERROR,
+            "fill mismatch: got {}, expected ~{expected}",
+            fill.0
+        );
+    }
+
+    /// A variable with no `_FillValue` masks nothing.
+    #[test]
+    fn no_fill_stays_none() {
+        let inner = Arc::new(DefaultVariableDecoder::<f64>::new("time".to_string(), None));
+
+        let decoder = CFTimeVariableDecoder::new(
+            "time".to_string(),
+            inner,
+            unix_epoch(),
+            hifitime::Unit::Day,
+            None,
+        );
+
+        assert_eq!(decoder.fill_value(), None);
     }
 
     #[test]

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/lib.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/lib.rs
@@ -44,6 +44,8 @@ pub use netcdf_sys;
 pub use oxcdf;
 /// Array backend implementations used by decoders.
 pub mod backend;
+#[cfg(test)]
+mod cf_time_fill_tests;
 /// Conversion helpers from NetCDF values to ND Arrow arrays.
 pub mod compat;
 /// DataFusion integration components.

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/backend.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/backend.rs
@@ -279,15 +279,27 @@ pub struct TimestampBackend {
     variable: VariableRef,
     epoch: hifitime::Epoch,
     unit: hifitime::Unit,
+    fill_value: Option<TimestampNanosecond>,
 }
 
 impl TimestampBackend {
     /// Build a CF time backend from a reference epoch and a unit.
-    pub fn new(variable: VariableRef, epoch: hifitime::Epoch, unit: hifitime::Unit) -> Self {
+    ///
+    /// `raw_fill_value` is the fill in the numeric units of the variable. It
+    /// decodes with the same arithmetic as the data, so a fill cell maps onto
+    /// the decoded fill and the engine nulls it after the decode.
+    pub fn new(
+        variable: VariableRef,
+        epoch: hifitime::Epoch,
+        unit: hifitime::Unit,
+        raw_fill_value: Option<f64>,
+    ) -> Self {
         Self {
             variable,
             epoch,
             unit,
+            fill_value: raw_fill_value
+                .map(|f| crate::decoders::cf_time::cf_offset_to_timestamp(f, epoch, unit)),
         }
     }
 }
@@ -308,6 +320,10 @@ impl ArrayBackend<TimestampNanosecond> for TimestampBackend {
 
     fn dimensions(&self) -> Vec<String> {
         self.variable.dimensions.clone()
+    }
+
+    fn fill_value(&self) -> Option<TimestampNanosecond> {
+        self.fill_value
     }
 
     async fn read_subset(

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/compat.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/oxcdf_reader/compat.rs
@@ -74,8 +74,12 @@ where
         return Ok(Arc::new(NdArray::new_with_backend(backend)?));
     }
 
+    // The `_FillValue` of a time variable decodes with the same arithmetic as
+    // the data, so a fill cell nulls out instead of reaching a query as a real
+    // date.
     if let Some((epoch, unit)) = cf_time_epoch_unit {
-        let backend = TimestampBackend::new(variable, epoch, unit);
+        let raw_fill = fill_value.map(|f| f.as_());
+        let backend = TimestampBackend::new(variable, epoch, unit, raw_fill);
         return Ok(Arc::new(NdArray::new_with_backend(backend)?));
     }
 

--- a/docs/docs/2.0.0-rc2/cf-decoding.md
+++ b/docs/docs/2.0.0-rc2/cf-decoding.md
@@ -140,6 +140,12 @@ A variable can be both packed and filled. Beacon then decodes the fill value wit
 arithmetic before it compares. A packed sentinel maps to the decoded fill exactly. Beacon sets it to
 `NULL`. You do not unpack the sentinel yourself.
 
+### Fill and time together
+
+A time variable can carry a `_FillValue` too. Beacon decodes that fill with the same time arithmetic
+as the data, then compares. A fill cell becomes `NULL`, not a date far outside the record. A
+`_FillValue = -32768` on `days since 1970-01-01` is a null, not `1880-03-15`.
+
 ### `missing_value` is not applied
 
 CF also allows an older `missing_value` attribute. Beacon does **not** treat it as a null. Those


### PR DESCRIPTION
Fixes #342

## Problem

Both netCDF readers left `fill_value()` at the trait default `None` for a CF time variable, so the Arrow layer masked nothing. A fill cell reached a query as a real timestamp. A variable with `units = "days since 1970-01-01"` and `_FillValue = -32768` gave `1880-03-15` for every fill cell. That date passed a filter, joined a group and reached the output.

The same file gave two answers. Read as Zarr, the fill cells were NULL. Read as netCDF, they were dates.

## Fix

Both readers decode the fill through the same CF arithmetic as the data, which is what `ScaleOffsetVariableDecoder` already does for packing:

- `CFTimeVariableDecoder` (netcdf-c) takes the raw fill in `new()` and returns the decoded one from `fill_value()`.
- `TimestampBackend` (oxcdf) does the same.
- `cf_offset_to_timestamp` holds the one-value conversion. The data cells and the fill take the same path, so the two compare exactly and the equality mask is not subject to rounding.

Each `compat.rs` passes the `_FillValue` of the variable, in raw numeric units, to the decoder.

## Tests

- `decoders::cf_time`: three unit tests on the decoded fill (days, seconds, and no fill stays `None`).
- `cf_time_fill_tests`: one written file with two fill cells, read by both readers. Each asserts the decoded fill, asserts NULL on cells 1 and 3, and asserts the real dates survive. One parity test asserts both readers give the same null mask and the same values.

Verified that all six new assertions fail with the two `fill_value()` overrides removed.

```
cargo +1.91 test -p beacon-arrow-netcdf   # 124 passed, 1 ignored (network)
cargo +1.91 check --workspace --lib --bins --tests   # clean
```

## Also

- A `CHANGELOG.md` entry under `Fixed`, because the bug returned wrong data.
- A `cf-decoding.md` subsection on fill and time, next to the one on fill and packing.