### PR TITLE
fix(nd): fill the chunk shape from the last axis

### DIFF
--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -977,6 +977,54 @@ mod reader_backend_tests {
         assert!(rust > 0, "the predicate must keep some rows");
         assert_eq!(rust, count("netcdf_c").await);
     }
+
+    /// A gridded scan must respect the batch size. `gridded-example.nc` has the
+    /// shape `[time=1, lat=1208, lon=1920]`. The engine cut only the first axis,
+    /// so the short `time` axis gave one chunk that held the whole array. See
+    /// issue #338.
+    ///
+    /// `sea_ice_fraction` is contiguous in the file, so it reports its full
+    /// shape as its chunk shape and the engine computes the chunk itself.
+    #[tokio::test]
+    async fn a_short_first_axis_still_splits_into_batches() {
+        for backend in [ReaderBackend::NetcdfC, ReaderBackend::Oxcdf] {
+            for batch_size in [4096usize, 8192] {
+                let state = SessionStateBuilder::new()
+                    .with_config(
+                        SessionConfig::new()
+                            .with_target_partitions(1)
+                            .with_batch_size(batch_size),
+                    )
+                    .with_default_features()
+                    .build();
+                let ctx = SessionContext::new_with_state(state);
+                register(&ctx, "gridded", backend, GRIDDED_FILE).await;
+
+                let batches = ctx
+                    .sql("SELECT sea_ice_fraction FROM gridded")
+                    .await
+                    .unwrap()
+                    .collect()
+                    .await
+                    .unwrap();
+
+                let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+                let largest = batches.iter().map(|b| b.num_rows()).max().unwrap_or(0);
+                assert_eq!(rows, 1208 * 1920, "{backend:?} must read every row");
+                assert!(
+                    batches.len() > 1,
+                    "{backend:?} at batch size {batch_size} gave {} batch(es)",
+                    batches.len()
+                );
+                // The chunk fills from the last axis, so it holds at most
+                // `batch_size` elements. Here one row of `lon` is 1920 ≤ 4096.
+                assert!(
+                    largest <= batch_size,
+                    "{backend:?} at batch size {batch_size} gave a batch of {largest} rows"
+                );
+            }
+        }
+    }
 }
 
 // #[cfg(test)]

--- a/beacon-db/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
@@ -449,8 +449,12 @@ mod tests {
             "projection must be pushed below the broadcast:\n{rendered}"
         );
 
-        // Same result as a session without the rule.
-        let bare = SessionContext::new();
+        // Same result as a session without the rule. This session also needs a
+        // single partition: the scan yields one batch per chunk, and a
+        // repartition would interleave them and break the positional compare.
+        let bare = SessionContext::new_with_config(
+            datafusion::prelude::SessionConfig::new().with_target_partitions(1),
+        );
         register_example(&bare).await;
         let expected = bare
             .sql("SELECT lat * 2 AS lat2 FROM gridded")

--- a/beacon-db/beacon-file-formats/beacon-nd-array/src/arrow/batch.rs
+++ b/beacon-db/beacon-file-formats/beacon-nd-array/src/arrow/batch.rs
@@ -629,16 +629,39 @@ pub(crate) fn generate_array_subset_from_chunk(
     ArraySubset::new(start, shape)
 }
 
-/// Compute a C-memory-ordered chunk shape targeting approximately `batch_size` elements.
-/// Inner dimensions are kept whole; only the outermost axis is cut.
+/// Compute a C-memory-ordered chunk shape that holds about `batch_size` elements.
+///
+/// The chunk fills from the last axis. An axis stays whole while the chunk fits.
+/// The first axis that does not fit is cut. Every axis outside that one keeps a
+/// length of one. A shape with a short first axis therefore still gives many
+/// chunks: `[1, 1208, 1920]` at `batch_size` 8192 gives the chunk `[1, 4, 1920]`.
+///
+/// The chunk is one continuous run in C order, so the row order does not change.
 pub(crate) fn c_order_chunk_shape(shape: &[usize], batch_size: usize) -> Vec<usize> {
     if shape.is_empty() {
         return vec![];
     }
-    let inner: usize = shape[1..].iter().product::<usize>().max(1);
-    let rows = (batch_size / inner).max(1).min(shape[0].max(1));
-    let mut chunk = shape.to_vec();
-    chunk[0] = rows;
+
+    let mut chunk = vec![1usize; shape.len()];
+    // Element count of the axes that are already whole.
+    let mut inner = 1usize;
+
+    for axis in (0..shape.len()).rev() {
+        let len = shape[axis].max(1);
+        // `checked_mul` guards a shape that overflows `usize`. An overflow never fits.
+        match inner.checked_mul(len) {
+            Some(size) if size <= batch_size => {
+                chunk[axis] = len;
+                inner = size;
+            }
+            _ => {
+                // This axis does not fit. Cut it and leave the outer axes at 1.
+                chunk[axis] = (batch_size / inner).max(1).min(len);
+                break;
+            }
+        }
+    }
+
     chunk
 }
 
@@ -981,13 +1004,73 @@ mod tests {
 
     #[test]
     fn test_c_order_chunk_shape_batch_smaller_than_row() {
-        // batch_size < one inner row → rows=1 (minimum)
-        assert_eq!(c_order_chunk_shape(&[10, 100], 50), vec![1, 100]);
+        // batch_size < one inner row → the last axis is cut too
+        assert_eq!(c_order_chunk_shape(&[10, 100], 50), vec![1, 50]);
     }
 
     #[test]
     fn test_c_order_chunk_shape_empty() {
         assert_eq!(c_order_chunk_shape(&[], 100), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn test_c_order_chunk_shape_short_first_axis_cuts_inner_axis() {
+        // A gridded file: shape [time=1, lat=1208, lon=1920].
+        // The first axis is 1, so a cut of that axis alone gives one chunk.
+        // The last axis fits whole (1920 ≤ 8192). The middle axis is cut:
+        // 8192 / 1920 = 4 → [1, 4, 1920] = 7680 elements.
+        assert_eq!(
+            c_order_chunk_shape(&[1, 1208, 1920], 8192),
+            vec![1, 4, 1920]
+        );
+    }
+
+    #[test]
+    fn test_c_order_chunk_shape_never_much_larger_than_batch_size() {
+        // Every axis is longer than the batch size, so only the last axis is cut.
+        assert_eq!(c_order_chunk_shape(&[500, 500, 500], 128), vec![1, 1, 128]);
+    }
+
+    #[test]
+    fn test_c_order_chunk_shape_outer_axes_stay_at_one() {
+        // The last axis fits whole, the middle axis is cut, so the first stays at 1.
+        assert_eq!(c_order_chunk_shape(&[8, 6, 4], 10), vec![1, 2, 4]);
+    }
+
+    #[tokio::test]
+    async fn test_chunked_stream_short_first_axis_splits_and_keeps_order() {
+        // shape [1, 4, 3] — a first axis of 1. The old rule gave one batch.
+        // batch_size 6 → chunk [1, 2, 3] → 2 batches of 6 rows, in C order.
+        let nd = NdArray::<i32>::try_new_from_vec_in_mem(
+            (1..=12).collect::<Vec<i32>>(),
+            vec![1, 4, 3],
+            vec!["time".to_string(), "y".to_string(), "x".to_string()],
+            None,
+        )
+        .unwrap();
+        let ds = make_dataset(vec![("vals", Arc::new(nd))]).await;
+        let batches: Vec<RecordBatch> = dataset_as_record_batch_stream(ds, 6, None, None)
+            .try_collect()
+            .await
+            .unwrap();
+
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].num_rows(), 6);
+        assert_eq!(batches[1].num_rows(), 6);
+
+        // The row order matches the flat C order of the array.
+        let values: Vec<i32> = batches
+            .iter()
+            .flat_map(|b| {
+                b.column(0)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        assert_eq!(values, (1..=12).collect::<Vec<i32>>());
     }
 
     #[tokio::test]

--- a/beacon-db/beacon-file-formats/beacon-nd-array/src/arrow/nd_provider.rs
+++ b/beacon-db/beacon-file-formats/beacon-nd-array/src/arrow/nd_provider.rs
@@ -67,8 +67,8 @@ pub fn dataset_as_nd_stream(
         Err(e) => return futures::stream::once(async move { Err(exec_err(e)) }).boxed(),
     };
 
-    // Honour a native chunk layout when present; otherwise cut the outer axis to
-    // approach `batch_size`.
+    // Honour a native chunk layout when present; otherwise fill a chunk from the
+    // last axis to approach `batch_size`.
     let effective_chunk_shape = if chunk_shape != max_shape {
         chunk_shape
     } else {


### PR DESCRIPTION
Closes #338.

## Problem

`c_order_chunk_shape` changed only the first axis. Every other axis kept its full length. An array with a short first axis got one chunk, so the batch size had no effect.

`gridded-example.nc` has the shape `[time=1, lat=1208, lon=1920]`. The old rule gave `inner = 1208 * 1920`, `rows = 1`, and the chunk `[1, 1208, 1920]` — the whole array in one batch. One time step for each file is normal for a gridded file.

## Fix

The chunk now fills from the last axis. An axis stays whole while the chunk fits. The first axis that does not fit is cut. Every axis outside that one keeps a length of one.

For `[1, 1208, 1920]` at batch size 8192 the chunk becomes `[1, 4, 1920]`: 7680 elements in 302 chunks. `checked_mul` guards a shape that overflows `usize`.

Each chunk covers the full length of every axis inside the cut one, so it stays one continuous run in C order. The chunk grid iterates the last axis first. The row order does not change.

## Effect

`SELECT sea_ice_fraction` on `test_files/gridded-example.nc`, netcdf-c reader:

| batch size | batches (before) | largest (before) | batches (after) | largest (after) |
| --- | --- | --- | --- | --- |
| 4096 | 1 | 2319360 | 604 | 3840 |
| 8192 | 1 | 2319360 | 302 | 7680 |

## Tests

- `beacon-nd-array`: four unit tests for the new rule, plus a stream test that asserts the row order over a `[1, 4, 3]` array.
- `beacon-arrow-netcdf`: `a_short_first_axis_still_splits_into_batches` scans the gridded file on both readers at two batch sizes. It fails on `main` with `NetcdfC at batch size 4096 gave 1 batch(es)`.
- `test_c_order_chunk_shape_batch_smaller_than_row` changes from `[1, 100]` to `[1, 50]`. A batch size below one inner row now cuts the last axis too, so no batch is much larger than the batch size.
- The zarr pushdown test compared two sessions positionally, but pinned only one of them to a single partition. The scan gave one batch before, so a repartition could not reorder anything. It gives many batches now, so both sessions need the same partition count.

`cargo test --workspace --lib --bins --tests`: 1076 passed, 0 failed.

## Limit

The engine honours a native chunk shape when the backend reports one, and that path still ignores the batch size. `SELECT analysed_sst` on the same file reports the chunk shape `[1, 604, 960]` after #341, so it gives 4 batches of 579840 rows. Issue #338 scopes the fix to `c_order_chunk_shape`, so that path is untouched here.