### PR TITLE
See what file statistics are doing, and collect them at boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,6 +1790,7 @@ dependencies = [
  "futures",
  "geodatafusion",
  "geojson",
+ "glob",
  "iceberg",
  "iceberg-datafusion",
  "num_cpus",
@@ -3244,7 +3245,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4361,7 +4362,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4530,7 +4531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4909,8 +4910,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -5615,7 +5616,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5687,7 +5688,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6119,7 +6120,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7582,7 +7583,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8251,8 +8252,8 @@ checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "oxcdf"
-version = "0.1.0"
-source = "git+https://github.com/robinskil/oxcdf.git#1580ee5baed3d1d6cde618cd7f7f4f4b032610fc"
+version = "0.2.0"
+source = "git+https://github.com/robinskil/oxcdf.git#36f98c6e137230590209e3fc09988ec05053fd33"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8265,8 +8266,8 @@ dependencies = [
 
 [[package]]
 name = "oxcdf-hdf5"
-version = "0.1.0"
-source = "git+https://github.com/robinskil/oxcdf.git#1580ee5baed3d1d6cde618cd7f7f4f4b032610fc"
+version = "0.2.0"
+source = "git+https://github.com/robinskil/oxcdf.git#36f98c6e137230590209e3fc09988ec05053fd33"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8788,7 +8789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -8807,7 +8808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9011,7 +9012,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -9050,9 +9051,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9826,7 +9827,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9884,7 +9885,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10716,10 +10717,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11283,7 +11284,7 @@ version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 dependencies = [
- "rand 0.10.2",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -11817,7 +11818,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -11833,7 +11834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -11845,7 +11846,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -11862,25 +11863,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -11925,7 +11913,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,11 +92,11 @@ object_store = { version = "0.13.1", features = ["aws", "gcp", "azure", "http"] 
 # Pure-Rust netCDF-4 / classic reader. It parses the HDF5 container itself, so it
 # holds no global lock and reads through `object_store` by byte range. The
 # netcdf-c bindings do neither. See `beacon-arrow-netcdf`, which offers both.
-oxcdf = { git = "https://github.com/robinskil/oxcdf.git", version = "0.1.0", features = ["async", "object-store", "ndarray"] }
+oxcdf = { git = "https://github.com/robinskil/oxcdf.git", version = "0.2.0", features = ["async", "object-store", "ndarray"] }
 # The HDF5 container alone, with no netCDF layer on top. `beacon-arrow-hdf5` uses
 # it for the layouts the netCDF data model cannot express, such as a compound
 # dataset. Same repository as `oxcdf`, so cargo resolves one revision for both.
-oxcdf-hdf5 = { git = "https://github.com/robinskil/oxcdf.git", version = "0.1.0", features = ["async", "object-store"] }
+oxcdf-hdf5 = { git = "https://github.com/robinskil/oxcdf.git", version = "0.2.0", features = ["async", "object-store"] }
 tonic = "0.14.1"
 
 

--- a/beacon-db/beacon-common/src/file_stats_config.rs
+++ b/beacon-db/beacon-common/src/file_stats_config.rs
@@ -13,6 +13,15 @@ pub struct FileStatsConfig {
     pub enable: bool,
     /// Seconds between passes.
     pub interval_secs: u64,
+    /// Collect at startup instead of waiting for the first tick.
+    ///
+    /// The timer's first pass lands one whole interval after boot, so a fresh
+    /// server holds no statistics for 15 minutes by default — and a server that
+    /// restarts more often than the interval never collects at all, because the
+    /// interval starts again on each boot. This runs a pass as soon as the
+    /// runtime is up, in the background, and keeps going until the queue is
+    /// empty. The timer takes over from there.
+    pub on_startup: bool,
     /// Files analyzed at once.
     ///
     /// Analysis is spawned, so this is real parallelism. It is also a background
@@ -54,6 +63,9 @@ impl Default for FileStatsConfig {
             // through every file to store nothing.
             enable: false,
             interval_secs: 900,
+            // Off, so enabling statistics alone does not turn boot into a
+            // backfill on an archive that has never been analyzed.
+            on_startup: false,
             concurrency: default_concurrency(),
             batch_files: 10_000,
             target_group_files: 10_000,

--- a/beacon-db/beacon-core/Cargo.toml
+++ b/beacon-db/beacon-core/Cargo.toml
@@ -46,6 +46,9 @@ secrecy = { workspace = true }
 base64 = { workspace = true }
 
 tracing = { workspace=true}
+# `file_statistics('argo/**')` matches registry paths with the same globbing the
+# `read_*` functions use for object paths.
+glob = { workspace = true }
 # Local dependencies
 beacon-auth = { path = "../beacon-auth" }
 beacon-common = { path = "../beacon-common" }

--- a/beacon-db/beacon-core/src/file_stats.rs
+++ b/beacon-db/beacon-core/src/file_stats.rs
@@ -51,9 +51,9 @@ use std::time::Duration;
 
 use arrow::datatypes::{DataType, SchemaRef};
 use beacon_arrow_netcdf::datafusion::{NetcdfFormat, ReaderBackend};
+use beacon_common::FileStatsConfig;
 use beacon_datafusion_ext::format_ext::try_file_format_factory_ext;
 use beacon_datafusion_ext::listing_factory::try_listing_factory_from_session;
-use beacon_common::FileStatsConfig;
 use beacon_file_stats::segment::ColumnStat;
 use beacon_file_stats::{
     CollectorConfig, FileAnalysis, FileAnalyzer, FileRecord, FileStatsError, FileStatsStore,
@@ -66,9 +66,9 @@ use datafusion::datasource::listing::ListingTableUrl;
 use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::prelude::SessionContext;
 use futures::StreamExt;
-use object_store::{ObjectMeta, ObjectStore, path::Path};
+use object_store::{path::Path, ObjectMeta, ObjectStore};
 
-use crate::statement_plan::{SessionCell, upgrade_session};
+use crate::statement_plan::{upgrade_session, SessionCell};
 
 /// A latch that fires once in a pass, however many files ask it.
 ///
@@ -149,10 +149,16 @@ impl FormatFileAnalyzer {
 #[async_trait::async_trait]
 impl FileAnalyzer for FormatFileAnalyzer {
     fn begin_pass(&self) {
+        tracing::debug!("beginning a file statistics pass");
         self.netcdf_c_reason.reset();
     }
 
     async fn analyze(&self, record: &FileRecord) -> beacon_file_stats::Result<FileAnalysis> {
+        // The entry line is TRACE and the outcome below is DEBUG. A file that
+        // hangs shows an entry with no outcome, which is the only thing the entry
+        // line tells you that the outcome line does not.
+        tracing::trace!(path = record.path.as_str(), "analyzing file");
+        let started = std::time::Instant::now();
         let session = self.session()?;
         let state = session.state();
 
@@ -173,18 +179,28 @@ impl FileAnalyzer for FormatFileAnalyzer {
         let schema = format
             .infer_schema(&state, &store, std::slice::from_ref(&object))
             .await
-            .map_err(|e| {
-                FileStatsError::Format(format!("schema for {}: {e}", record.path))
-            })?;
+            .map_err(|e| FileStatsError::Format(format!("schema for {}: {e}", record.path)))?;
 
         let statistics = format
             .infer_stats(&state, &store, schema.clone(), &object)
             .await
-            .map_err(|e| {
-                FileStatsError::Format(format!("statistics for {}: {e}", record.path))
-            })?;
+            .map_err(|e| FileStatsError::Format(format!("statistics for {}: {e}", record.path)))?;
 
-        Ok(to_analysis(&format_name, &schema, &statistics))
+        let analysis = to_analysis(&format_name, &schema, &statistics);
+        tracing::debug!(
+            path = record.path.as_str(),
+            format = format_name.as_str(),
+            rows = analysis.num_rows,
+            // `columns` counts the columns that got a range; `fields` counts the
+            // columns the file has. `columns = 0` against a non-zero `fields` is
+            // the signature of a reader that records no ranges, so the file
+            // analyzes cleanly and prunes nothing.
+            columns = analysis.columns.len(),
+            fields = schema.fields().len(),
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "analyzed a file"
+        );
+        Ok(analysis)
     }
 }
 
@@ -243,14 +259,12 @@ fn resolve_format(
         FileStatsError::Format(format!("no file extension on {}", object.location))
     })?;
 
-    let factory = try_file_format_factory_ext(&state, &key).ok_or_else(|| {
-        FileStatsError::Format(format!("no format registered for '{key}'"))
-    })?;
+    let factory = try_file_format_factory_ext(&state, &key)
+        .ok_or_else(|| FileStatsError::Format(format!("no format registered for '{key}'")))?;
     let name = factory.file_format_name();
 
-    let listing = try_listing_factory_from_session(&state).ok_or_else(|| {
-        FileStatsError::Format("the session has no listing factory".to_string())
-    })?;
+    let listing = try_listing_factory_from_session(&state)
+        .ok_or_else(|| FileStatsError::Format("the session has no listing factory".to_string()))?;
     let url = ListingTableUrl::parse(format!("{}{}", datasets_url.as_str(), object.location))
         .map_err(|e| FileStatsError::Format(format!("bad listing url: {e}")))?;
 
@@ -346,7 +360,6 @@ fn to_column_stat(
     ))
 }
 
-
 // ── the background service ──────────────────────────────────────────────────
 
 /// Shared, late-filled handle to the service, registered as a session extension
@@ -384,7 +397,9 @@ pub struct FileStatsService {
     session: SessionCell,
     datasets_url: ObjectStoreUrl,
     config: FileStatsConfig,
-    task: parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// The timer, and the startup collection when one was asked for. Both are
+    /// aborted on drop.
+    tasks: parking_lot::Mutex<Vec<tokio::task::JoinHandle<()>>>,
 }
 
 impl FileStatsService {
@@ -412,7 +427,7 @@ impl FileStatsService {
             session,
             datasets_url,
             config,
-            task: parking_lot::Mutex::new(None),
+            tasks: parking_lot::Mutex::new(Vec::new()),
         })
     }
 
@@ -420,11 +435,21 @@ impl FileStatsService {
         &self.store
     }
 
-    /// Start the timer. The first pass runs one interval from now, so startup is
-    /// not competing with a backfill.
+    /// Start the timer, and the startup collection when `on_startup` asks for
+    /// one.
+    ///
+    /// The timer's first pass runs one interval from now, so startup is not
+    /// competing with a backfill by default. `on_startup` is the opt-out of that
+    /// trade: it collects immediately instead, which is what a short-lived or
+    /// frequently restarted server needs, since the interval starts again on
+    /// every boot.
     pub fn start(self: &Arc<Self>) {
         let weak = Arc::downgrade(self);
         let interval = Duration::from_secs(self.config.interval_secs.max(1));
+        tracing::debug!(
+            interval_secs = interval.as_secs(),
+            "file statistics timer started; the first pass runs one interval from now"
+        );
         let handle = tokio::spawn(async move {
             let mut ticker = tokio::time::interval(interval);
             ticker.tick().await; // consume the immediate first tick
@@ -438,7 +463,77 @@ impl FileStatsService {
                 }
             }
         });
-        *self.task.lock() = Some(handle);
+        self.tasks.lock().push(handle);
+
+        if self.config.on_startup {
+            self.collect_on_startup();
+        }
+    }
+
+    /// Collect now, in the background, until the queue is empty.
+    ///
+    /// What `BEACON_FILE_STATS_ON_STARTUP` turns on. It drains rather than taking
+    /// one batch: a restart is exactly when the store is behind, and a single
+    /// `batch_files` pass would leave a large archive short until the timer had
+    /// ticked its way through the rest.
+    ///
+    /// Spawned, never awaited, so boot is not held up by it. Queries run against
+    /// whatever statistics exist meanwhile; a file with none is read, as it was
+    /// before the subsystem existed.
+    fn collect_on_startup(self: &Arc<Self>) {
+        let weak = Arc::downgrade(self);
+        let handle = tokio::spawn(async move {
+            tracing::info!("collecting file statistics at startup");
+
+            // Discover once, not once per batch: a listing of a large store is
+            // the expensive half, and nothing new appears mid-backfill that the
+            // timer will not pick up afterwards.
+            let discovered = {
+                let Some(service) = weak.upgrade() else {
+                    return; // the runtime went away before this got a turn
+                };
+                match service.discover().await {
+                    Ok(discovered) => discovered,
+                    Err(error) => {
+                        tracing::warn!(%error, "startup file statistics discovery failed");
+                        return;
+                    }
+                }
+            };
+
+            // Then drain, one batch at a time, holding the service only for the
+            // batch. A backfill runs for minutes; keeping the handle across all
+            // of it would stop a dropped runtime from ever tearing this down.
+            let mut analyzed = 0;
+            let mut failed = 0;
+            let mut segments = 0;
+            for _ in 0..MAX_ON_DEMAND_PASSES {
+                let Some(service) = weak.upgrade() else {
+                    return;
+                };
+                match service.collector.run_once().await {
+                    Ok(report) if report.is_idle() => break,
+                    Ok(report) => {
+                        analyzed += report.analyzed;
+                        failed += report.failed;
+                        segments += report.segments;
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "startup file statistics collection failed");
+                        break;
+                    }
+                }
+            }
+
+            tracing::info!(
+                discovered,
+                analyzed,
+                failed,
+                segments,
+                "startup file statistics collection finished"
+            );
+        });
+        self.tasks.lock().push(handle);
     }
 
     /// Run to completion now, rather than waiting for the timer.
@@ -456,6 +551,7 @@ impl FileStatsService {
         prefix: Option<&str>,
         force: bool,
     ) -> anyhow::Result<AnalyzePass> {
+        tracing::debug!(prefix = ?prefix, force, "ANALYZE FILES started");
         let requeued = if force {
             self.store.registry().requeue(prefix)?
         } else {
@@ -495,7 +591,17 @@ impl FileStatsService {
             segments: report.segments,
             pending: self.store.registry().num_pending().unwrap_or(0),
         };
-        if !report.is_idle() || discovered > 0 {
+        // `discovered` counts every file the listing reported, not just the new
+        // ones, so it is above zero on every pass over a store that holds
+        // anything. Only work is worth an INFO line; an idle tick is a DEBUG
+        // heartbeat, which is what tells you the timer is still running.
+        if report.is_idle() {
+            tracing::debug!(
+                discovered = pass.discovered,
+                pending = pass.pending,
+                "file statistics pass found nothing to do"
+            );
+        } else {
             tracing::info!(
                 discovered = pass.discovered,
                 analyzed = pass.analyzed,
@@ -554,6 +660,12 @@ impl FileStatsService {
             total += batch.len();
             self.store.registry().intern_files(&batch)?;
         }
+        tracing::debug!(
+            listed = total,
+            scan_prefix,
+            pending = self.store.registry().num_pending().unwrap_or(0),
+            "listed the datasets store"
+        );
         Ok(total)
     }
 
@@ -564,7 +676,7 @@ impl FileStatsService {
 
 impl Drop for FileStatsService {
     fn drop(&mut self) {
-        if let Some(task) = self.task.lock().take() {
+        for task in self.tasks.lock().drain(..) {
             task.abort();
         }
     }

--- a/beacon-db/beacon-core/src/runtime_builder.rs
+++ b/beacon-db/beacon-core/src/runtime_builder.rs
@@ -464,7 +464,12 @@ async fn init_file_stats(
     tracing::info!(
         interval_secs = builder.file_stats.interval_secs,
         concurrency = builder.file_stats.concurrency,
-        "file statistics subsystem started"
+        // The timer consumes its first tick, so nothing happens for one whole
+        // interval. Say so here: on the 900-second default, a quiet quarter of an
+        // hour otherwise reads as a subsystem that never started.
+        first_pass_in_secs = builder.file_stats.interval_secs,
+        on_startup = builder.file_stats.on_startup,
+        "file statistics subsystem started; run ANALYZE FILES to fill it now"
     );
     Ok(Some(service))
 }
@@ -726,12 +731,24 @@ fn register_system_schema(
         .config()
         .get_extension::<std::sync::OnceLock<Arc<beacon_file_stats::FileStatsStore>>>()
         .unwrap_or_else(beacon_file_stats::new_file_stats_handle);
-    let provider = Arc::new(SystemSchemaProvider::new(session_cell, auth, file_stats));
+    let provider = Arc::new(SystemSchemaProvider::new(
+        session_cell,
+        auth,
+        file_stats.clone(),
+    ));
 
     session_ctx
         .catalog("beacon")
         .ok_or_else(|| anyhow::anyhow!("Failed to get catalog 'beacon'"))?
         .register_schema(SYSTEM_SCHEMA_NAME, provider)?;
+
+    // `file_statistics(path)` reads the same handle. It is a function rather than
+    // a table because it takes the file to report on; the authorization walk
+    // covers it by its provider, since a function carries no schema name.
+    session_ctx.register_udtf(
+        crate::system_schema::FILE_STATISTICS_FUNCTION,
+        Arc::new(crate::system_schema::FileStatisticsFunc::new(file_stats)),
+    );
 
     Ok(())
 }

--- a/beacon-db/beacon-core/src/statement_plan/authz.rs
+++ b/beacon-db/beacon-core/src/statement_plan/authz.rs
@@ -51,10 +51,8 @@ pub(crate) fn authorize_logical_plan(
     // they enumerate the catalog through `Runtime::visible_tables`, which returns
     // only the tables their roles grant.
     if !identity.is_super_user {
-        if let Some(schema) = metadata_schema_touched(plan) {
-            anyhow::bail!(
-                "permission denied: the '{schema}' schema is restricted to the super-user"
-            );
+        if let Some(surface) = metadata_surface_touched(plan) {
+            anyhow::bail!("permission denied: {surface} is restricted to the super-user");
         }
     }
 
@@ -82,20 +80,36 @@ pub(crate) fn authorize_logical_plan(
 }
 
 /// The name of the first metadata schema (`beacon.system` / `information_schema`)
-/// any table scan in `plan` reads, or `None`.
+/// any table scan in `plan` reads, as a noun phrase for the error, or `None`.
 ///
 /// Matched on the scan's schema so it catches the read however it is reached —
 /// through a subquery, a view, or a rewrite (`SHOW TABLES` becomes a scan of
-/// `information_schema.tables`).
-fn metadata_schema_touched(plan: &LogicalPlan) -> Option<String> {
+/// `information_schema.tables`) — and on the provider for the one metadata
+/// surface that has no schema name, the `file_statistics` table function.
+fn metadata_surface_touched(plan: &LogicalPlan) -> Option<String> {
     let mut found = None;
     let _ = plan.apply_with_subqueries(|node| {
         if let LogicalPlan::TableScan(scan) = node {
             if let Some(schema) = scan.table_name.schema() {
                 if crate::system_schema::is_metadata_schema(schema) {
-                    found = Some(schema.to_string());
+                    found = Some(format!("the '{schema}' schema"));
                     return Ok(TreeNodeRecursion::Stop);
                 }
+            }
+            // `file_statistics(...)` is the same metadata, reached through a
+            // table function. A function has no schema in the plan — its scan is
+            // named after the function itself — so the check above cannot see it
+            // and the provider is matched instead.
+            if source_as_provider(&scan.source).is_ok_and(|provider| {
+                provider
+                    .as_any()
+                    .is::<crate::system_schema::FileStatisticsTable>()
+            }) {
+                found = Some(format!(
+                    "the {} table function",
+                    crate::system_schema::FILE_STATISTICS_FUNCTION
+                ));
+                return Ok(TreeNodeRecursion::Stop);
             }
         }
         Ok(TreeNodeRecursion::Continue)

--- a/beacon-db/beacon-core/src/system_schema/file_stats.rs
+++ b/beacon-db/beacon-core/src/system_schema/file_stats.rs
@@ -1,5 +1,6 @@
-//! `beacon.system.file_stats` and `beacon.system.file_stats_segments` — the
-//! background statistics subsystem as SQL.
+//! `beacon.system.file_stats`, `beacon.system.file_stats_segments`, and the
+//! `file_statistics(path)` table function — the background statistics subsystem
+//! as SQL.
 //!
 //! The subsystem runs on a timer, in the background, and every way it can
 //! underperform is quiet by construction. A format that computes no ranges
@@ -33,12 +34,19 @@
 use std::sync::Arc;
 
 use arrow::{
-    array::{ArrayRef, StringArray, UInt32Array, UInt64Array},
+    array::{Array, ArrayRef, StringArray, UInt32Array, UInt64Array},
     datatypes::{DataType, Field, Schema, SchemaRef},
     record_batch::RecordBatch,
+    util::display::{ArrayFormatter, FormatOptions},
 };
+use beacon_common::table_function::parse_glob_paths_arg;
 use beacon_file_stats::FileState;
-use datafusion::common::Result as DFResult;
+use datafusion::{
+    catalog::{TableFunctionImpl, TableProvider},
+    common::{plan_err, Result as DFResult},
+    error::DataFusionError,
+    prelude::Expr,
+};
 
 use super::table::{Snapshot, SystemTable};
 
@@ -179,4 +187,264 @@ pub(super) fn segments_table(handle: beacon_file_stats::FileStatsHandle) -> Syst
 /// pretending it is an error.
 fn empty(schema: SchemaRef) -> DFResult<RecordBatch> {
     Ok(RecordBatch::new_empty(schema))
+}
+
+// ── file_statistics(path) ───────────────────────────────────────────────────
+
+/// Files one call may report on.
+///
+/// A segment holds a row per file per column, so a wide glob multiplies out fast
+/// — 10K files of 200 columns is two million rows materialized in one batch.
+/// The cap turns that into an error naming the count, rather than an instance
+/// that stops answering.
+const MAX_FILES_PER_CALL: usize = 1_000;
+
+fn file_statistics_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("path", DataType::Utf8, false),
+        Field::new("column", DataType::Utf8, false),
+        // The type the range is held in, which is the file's own type for that
+        // column rather than any merged table type.
+        Field::new("data_type", DataType::Utf8, false),
+        // Rendered from the column's own type. Null means the recorded bound is
+        // null, which is what a column of only nulls produces.
+        Field::new("min", DataType::Utf8, true),
+        Field::new("max", DataType::Utf8, true),
+        Field::new("null_count", DataType::UInt64, true),
+        Field::new("row_count", DataType::UInt64, true),
+        // Which segment answered. Two segments can hold the same file; the newest
+        // wins, and this says which one that was.
+        Field::new("segment", DataType::Utf8, false),
+    ]))
+}
+
+/// `file_statistics('path')` — every column range Beacon recorded for a file.
+///
+/// The per-file counterpart to `beacon.system.file_stats`, which summarizes one
+/// row per file. This one opens the segments and reports what is actually stored,
+/// which is the only way to answer "will this prune, and on what". Accepts a
+/// glob, so a whole dataset directory can be checked in one call:
+///
+/// ```sql
+/// SELECT * FROM file_statistics('argo/2024/01/profile_001.nc');
+/// SELECT * FROM file_statistics('argo/2024/**');
+/// ```
+pub(crate) struct FileStatisticsFunc {
+    handle: beacon_file_stats::FileStatsHandle,
+}
+
+impl std::fmt::Debug for FileStatisticsFunc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileStatisticsFunc").finish_non_exhaustive()
+    }
+}
+
+impl FileStatisticsFunc {
+    pub(crate) fn new(handle: beacon_file_stats::FileStatsHandle) -> Self {
+        Self { handle }
+    }
+}
+
+impl TableFunctionImpl for FileStatisticsFunc {
+    fn call(&self, args: &[Expr]) -> DFResult<Arc<dyn TableProvider>> {
+        let patterns = parse_glob_paths_arg(args, "file_statistics")?;
+        if patterns.is_empty() {
+            return plan_err!("file_statistics requires a path: file_statistics('argo/a.nc')");
+        }
+
+        // The subsystem is either on or it is not; the handle is filled at
+        // startup. Saying so beats returning zero rows, which reads as "this
+        // file has no statistics" and sends the operator looking in the wrong
+        // place.
+        let Some(store) = self.handle.get().cloned() else {
+            return plan_err!(
+                "file statistics are not enabled on this runtime; set BEACON_FILE_STATS_ENABLE=true"
+            );
+        };
+
+        let files = resolve_files(&store, &patterns)?;
+        let schema = file_statistics_schema();
+        let snapshot: Snapshot = {
+            let schema = schema.clone();
+            Arc::new(move || {
+                let store = store.clone();
+                let files = files.clone();
+                let schema = schema.clone();
+                Box::pin(async move { file_statistics_batch(store, files, schema).await })
+            })
+        };
+        Ok(Arc::new(FileStatisticsTable(SystemTable::new(
+            schema, snapshot,
+        ))))
+    }
+}
+
+/// The files a call covers, resolved once at planning time so a typo fails
+/// there rather than as an empty result.
+fn resolve_files(
+    store: &Arc<beacon_file_stats::FileStatsStore>,
+    patterns: &[String],
+) -> DFResult<Vec<(u64, String)>> {
+    let mut files: Vec<(u64, String)> = Vec::new();
+
+    for pattern in patterns {
+        if pattern.contains(['*', '?', '[']) {
+            let matcher = glob::Pattern::new(pattern)
+                .map_err(|e| DataFusionError::Plan(format!("invalid path pattern: {e}")))?;
+            let records = store
+                .registry()
+                .scan_records()
+                .map_err(|e| DataFusionError::Execution(format!("file statistics scan: {e}")))?;
+            files.extend(
+                records
+                    .into_iter()
+                    .filter(|(_, record)| matcher.matches(&record.path))
+                    .map(|(id, record)| (id, record.path)),
+            );
+        } else {
+            let id = store
+                .registry()
+                .file_id(pattern)
+                .map_err(|e| DataFusionError::Execution(format!("file statistics lookup: {e}")))?;
+            let Some(id) = id else {
+                return plan_err!(
+                    "no file '{pattern}' in the file statistics registry; \
+                     `SELECT path FROM beacon.system.file_stats` lists what is known"
+                );
+            };
+            files.push((id, pattern.clone()));
+        }
+    }
+
+    files.sort_by(|a, b| a.1.cmp(&b.1));
+    files.dedup_by(|a, b| a.0 == b.0);
+
+    if files.is_empty() {
+        return plan_err!(
+            "no file matches {patterns:?} in the file statistics registry; \
+             `SELECT path FROM beacon.system.file_stats` lists what is known"
+        );
+    }
+    if files.len() > MAX_FILES_PER_CALL {
+        return plan_err!(
+            "{} files match {patterns:?}; file_statistics reports on at most \
+             {MAX_FILES_PER_CALL}. Narrow the pattern.",
+            files.len()
+        );
+    }
+    Ok(files)
+}
+
+/// Reads the segments and renders one row per file per column.
+async fn file_statistics_batch(
+    store: Arc<beacon_file_stats::FileStatsStore>,
+    files: Vec<(u64, String)>,
+    schema: SchemaRef,
+) -> DFResult<RecordBatch> {
+    let mut paths: Vec<String> = Vec::new();
+    let mut columns: Vec<String> = Vec::new();
+    let mut types: Vec<String> = Vec::new();
+    let mut mins: Vec<Option<String>> = Vec::new();
+    let mut maxes: Vec<Option<String>> = Vec::new();
+    let mut null_counts: Vec<Option<u64>> = Vec::new();
+    let mut row_counts: Vec<Option<u64>> = Vec::new();
+    let mut segments: Vec<String> = Vec::new();
+
+    for (file_id, path) in files {
+        let stats = store
+            .file_column_stats(file_id)
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("file statistics for {path}: {e}")))?;
+
+        // Column names come from the registry, which is redb: a blocking read,
+        // so it is resolved off the async worker in one hop rather than per row.
+        let ids: Vec<u32> = stats.iter().map(|stat| stat.column_id).collect();
+        let names = {
+            let store = store.clone();
+            tokio::task::spawn_blocking(move || {
+                ids.into_iter()
+                    .map(|id| store.registry().column_name(id).ok().flatten())
+                    .collect::<Vec<Option<String>>>()
+            })
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("column name lookup: {e}")))?
+        };
+
+        let mut rows: Vec<usize> = (0..stats.len()).collect();
+        rows.sort_by(|a, b| names[*a].cmp(&names[*b]));
+        for row in rows {
+            let stat = &stats[row];
+            paths.push(path.clone());
+            columns.push(
+                names[row]
+                    .clone()
+                    .unwrap_or_else(|| format!("column#{}", stat.column_id)),
+            );
+            types.push(stat.data_type.to_string());
+            mins.push(render(&stat.min)?);
+            maxes.push(render(&stat.max)?);
+            null_counts.push(stat.null_count);
+            row_counts.push(stat.row_count);
+            segments.push(stat.segment.clone());
+        }
+    }
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(StringArray::from(paths)) as ArrayRef,
+            Arc::new(StringArray::from(columns)),
+            Arc::new(StringArray::from(types)),
+            Arc::new(StringArray::from(mins)),
+            Arc::new(StringArray::from(maxes)),
+            Arc::new(UInt64Array::from(null_counts)),
+            Arc::new(UInt64Array::from(row_counts)),
+            Arc::new(StringArray::from(segments)),
+        ],
+    )
+    .map_err(Into::into)
+}
+
+/// Renders a one-element bound in its own type, so a timestamp reads as a
+/// timestamp rather than as the integer underneath it.
+fn render(value: &ArrayRef) -> DFResult<Option<String>> {
+    if value.is_empty() || value.is_null(0) {
+        return Ok(None);
+    }
+    let options = FormatOptions::default();
+    let formatter = ArrayFormatter::try_new(value.as_ref(), &options)?;
+    Ok(Some(formatter.value(0).to_string()))
+}
+
+/// The provider `file_statistics(...)` returns.
+///
+/// A newtype over [`SystemTable`] purely so the authorization walk can recognize
+/// it: the function has no schema in the plan, so the name-based metadata gate
+/// cannot see it. Everything else delegates.
+#[derive(Debug)]
+pub(crate) struct FileStatisticsTable(SystemTable);
+
+#[async_trait::async_trait]
+impl TableProvider for FileStatisticsTable {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.0.schema()
+    }
+
+    fn table_type(&self) -> datafusion::logical_expr::TableType {
+        self.0.table_type()
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn datafusion::catalog::Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DFResult<Arc<dyn datafusion::physical_plan::ExecutionPlan>> {
+        self.0.scan(state, projection, filters, limit).await
+    }
 }

--- a/beacon-db/beacon-core/src/system_schema/mod.rs
+++ b/beacon-db/beacon-core/src/system_schema/mod.rs
@@ -30,6 +30,11 @@ mod auth;
 mod file_stats;
 mod table;
 
+pub(crate) use file_stats::{FileStatisticsFunc, FileStatisticsTable};
+
+/// The name `file_statistics(path)` is registered under.
+pub const FILE_STATISTICS_FUNCTION: &str = "file_statistics";
+
 use std::{any::Any, collections::HashMap, sync::Arc};
 
 use datafusion::{

--- a/beacon-db/beacon-core/tests/file_stats_service.rs
+++ b/beacon-db/beacon-core/tests/file_stats_service.rs
@@ -26,6 +26,8 @@ fn enabled() -> FileStatsConfig {
     FileStatsConfig {
         enable: true,
         interval_secs: 3_600,
+        // Each test drives its own passes; the flag has its own test.
+        on_startup: false,
         concurrency: 2,
         batch_files: 100,
         target_group_files: 100,
@@ -483,6 +485,69 @@ async fn a_pass_discovers_analyzes_and_stores() {
     assert_eq!(rows, 3, "every file contributed a TEMP row");
 }
 
+/// `on_startup` is what a restarted server needs: the timer's first pass is one
+/// interval away and the interval starts again on every boot, so a server that
+/// restarts more often than that never collects anything.
+///
+/// The collection is spawned, not awaited, so the runtime is usable immediately
+/// and the test waits for the queue to drain rather than for `build`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn on_startup_collects_without_waiting_for_the_timer() {
+    let root = tempfile::tempdir().unwrap();
+    write_parquet(&root.path().join("datasets/argo/a.parquet"), 0.0, 5.0);
+    write_parquet(&root.path().join("datasets/argo/b.parquet"), 90.0, 100.0);
+
+    let config = FileStatsConfig {
+        on_startup: true,
+        // An hour away, so nothing but the startup collection can do this work.
+        interval_secs: 3_600,
+        ..enabled()
+    };
+    let runtime = builder(root.path(), config).build().await.unwrap();
+    let store = runtime.file_stats().unwrap().store().clone();
+
+    // Poll rather than sleep a fixed time: the pass is a spawned task.
+    let mut analyzed = 0;
+    for _ in 0..100 {
+        analyzed = store
+            .registry()
+            .scan_records()
+            .unwrap()
+            .iter()
+            .filter(|(_, record)| record.state == beacon_file_stats::FileState::Analyzed)
+            .count();
+        if analyzed == 2 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    assert_eq!(
+        analyzed, 2,
+        "both files analyzed without a tick of the timer"
+    );
+    assert_eq!(store.num_segments().await, 1);
+}
+
+/// Without the flag, boot collects nothing: the first pass is one interval away.
+/// This is the default, and it keeps startup free for queries.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn without_the_flag_boot_collects_nothing() {
+    let root = tempfile::tempdir().unwrap();
+    write_parquet(&root.path().join("datasets/argo/a.parquet"), 0.0, 5.0);
+
+    let runtime = builder(root.path(), enabled()).build().await.unwrap();
+    let store = runtime.file_stats().unwrap().store().clone();
+
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    assert!(
+        store.registry().scan_records().unwrap().is_empty(),
+        "discovery runs inside a pass, and no pass has run"
+    );
+    assert_eq!(store.num_segments().await, 0);
+}
+
 /// A second pass over an unchanged store does nothing. The registry recognises
 /// the files, so nothing re-queues and no segment is written.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -858,6 +923,133 @@ async fn the_segments_view_shows_the_batching() {
     .await;
     // Two roots, so two segments, each holding one file's columns.
     assert_eq!(rows.matches("segment-").count(), 2, "{rows}");
+}
+
+/// Runs `sql` and returns the error it produced. Panics if it succeeded.
+async fn query_error(runtime: &Runtime, sql: &str) -> String {
+    match runtime
+        .run_query(Query::sql(sql.to_string()), AuthIdentity::system())
+        .await
+    {
+        Ok(_) => panic!("{sql} should have failed"),
+        Err(error) => error.to_string(),
+    }
+}
+
+/// `beacon.system.file_stats` counts a file's columns; this shows their ranges.
+/// A `column_count` of 200 says nothing about whether the bounds are usable, and
+/// the bounds are what pruning runs on.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_function_reports_the_recorded_range_of_one_file() {
+    let root = tempfile::tempdir().unwrap();
+    write_parquet(&root.path().join("datasets/obs/a.parquet"), 0.0, 5.0);
+
+    let runtime = builder(root.path(), enabled()).build().await.unwrap();
+    runtime.file_stats().unwrap().run_once().await.unwrap();
+
+    let rows = query(
+        &runtime,
+        "SELECT column, data_type, min, max, row_count \
+         FROM file_statistics('obs/a.parquet') ORDER BY column",
+    )
+    .await;
+
+    assert!(rows.contains("TEMP"), "{rows}");
+    assert!(rows.contains("DEPTH"), "{rows}");
+    // The range the file was written with, rendered in the column's own type.
+    assert!(rows.contains("0.0"), "the recorded minimum:\n{rows}");
+    assert!(rows.contains("5.0"), "the recorded maximum:\n{rows}");
+}
+
+/// A dataset is usually a directory, so the function takes a glob and reports
+/// every file it matches, keeping the path on each row.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_function_globs_a_dataset_directory() {
+    let root = tempfile::tempdir().unwrap();
+    write_parquet(&root.path().join("datasets/obs/a.parquet"), 0.0, 5.0);
+    write_parquet(&root.path().join("datasets/obs/b.parquet"), 90.0, 100.0);
+    write_parquet(&root.path().join("datasets/other/c.parquet"), 0.0, 1.0);
+
+    let runtime = builder(root.path(), enabled()).build().await.unwrap();
+    runtime.file_stats().unwrap().run_once().await.unwrap();
+
+    let rows = query(
+        &runtime,
+        "SELECT path, count(*) AS columns FROM file_statistics('obs/*') \
+         GROUP BY path ORDER BY path",
+    )
+    .await;
+
+    assert!(rows.contains("obs/a.parquet"), "{rows}");
+    assert!(rows.contains("obs/b.parquet"), "{rows}");
+    assert!(
+        !rows.contains("other/c.parquet"),
+        "the glob must not widen:\n{rows}"
+    );
+}
+
+/// A path the registry never saw is a typo far more often than it is a question,
+/// and an empty result would read as "this file has no statistics".
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_function_rejects_a_path_it_does_not_know() {
+    let root = tempfile::tempdir().unwrap();
+    write_parquet(&root.path().join("datasets/obs/a.parquet"), 0.0, 5.0);
+
+    let runtime = builder(root.path(), enabled()).build().await.unwrap();
+    runtime.file_stats().unwrap().run_once().await.unwrap();
+
+    let error = query_error(
+        &runtime,
+        "SELECT * FROM file_statistics('obs/nope.parquet')",
+    )
+    .await;
+    assert!(error.contains("nope.parquet"), "{error}");
+    assert!(error.contains("beacon.system.file_stats"), "{error}");
+}
+
+/// With the subsystem off the function says so, rather than returning the empty
+/// result the views correctly return. The views describe a state; a call asks a
+/// question, and "no statistics exist anywhere" is the answer to a different one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_function_says_so_when_the_subsystem_is_off() {
+    let root = tempfile::tempdir().unwrap();
+    write_parquet(&root.path().join("datasets/obs/a.parquet"), 0.0, 5.0);
+
+    let runtime = builder(root.path(), FileStatsConfig::default())
+        .build()
+        .await
+        .unwrap();
+
+    let error = query_error(&runtime, "SELECT * FROM file_statistics('obs/a.parquet')").await;
+    assert!(error.contains("BEACON_FILE_STATS_ENABLE"), "{error}");
+}
+
+/// The function reports the value ranges of files, which is data. It belongs to
+/// the super-user for the same reason `beacon.system` does — and, like that gate,
+/// it cannot wait for grant enforcement to be turned on. A function carries no
+/// schema name, so the name-based gate cannot see it: this pins the provider one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_function_is_super_user_only() {
+    let root = tempfile::tempdir().unwrap();
+    write_parquet(&root.path().join("datasets/obs/a.parquet"), 0.0, 5.0);
+
+    // Enforcement off, the default posture: an ordinary read would be allowed.
+    let runtime = builder(root.path(), enabled()).build().await.unwrap();
+    runtime.file_stats().unwrap().run_once().await.unwrap();
+
+    let denied = runtime
+        .run_query(
+            Query::sql("SELECT * FROM file_statistics('obs/a.parquet')".to_string()),
+            AuthIdentity::empty(),
+        )
+        .await;
+    assert!(
+        denied
+            .as_ref()
+            .is_err_and(|e| e.to_string().contains("restricted to the super-user")),
+        "a non-super-user must not read recorded ranges, got: {:?}",
+        denied.as_ref().err().map(|e| e.to_string())
+    );
 }
 
 /// Both views are empty rather than an error when the subsystem never started.

--- a/beacon-db/beacon-file-stats/src/collector.rs
+++ b/beacon-db/beacon-file-stats/src/collector.rs
@@ -162,8 +162,15 @@ impl StatsCollector {
             .registry()
             .next_pending(self.config.batch_files)?;
         if pending.is_empty() {
+            tracing::trace!("no files are pending analysis");
             return Ok(CollectReport::default());
         }
+        tracing::debug!(
+            files = pending.len(),
+            batch_files = self.config.batch_files,
+            concurrency = self.config.concurrency,
+            "taking a batch of pending files"
+        );
         // A pass with work in it. An idle one is not a pass, so a server that
         // ticks all night does not repeat a condition nothing acted on.
         self.analyzer.begin_pass();
@@ -179,6 +186,12 @@ impl StatsCollector {
                 self.config.min_group_files,
             ),
         };
+
+        tracing::debug!(
+            groups = groups.len(),
+            target_group_files = self.config.target_group_files,
+            "grouped the batch by prefix; one group becomes one segment"
+        );
 
         let mut report = CollectReport::default();
         for (prefix, files) in groups {
@@ -224,30 +237,34 @@ impl StatsCollector {
         // parse and scan. Measured on eight cores, `buffer_unordered(8)` alone
         // managed 296 files/s against 287 serial. Spawning the same work reached
         // 1193 -- see `statistics_backfill_cost` in beacon-arrow-netcdf.
+        tracing::debug!(prefix, files = files.len(), "analyzing a group");
+
         // The crate's `Result` alias fixes the error type, so the join result is spelled out.
-        type Joined = std::result::Result<(FileId, Result<FileAnalysis>), tokio::task::JoinError>;
-        let outcomes: Vec<Joined> =
-            stream::iter(files)
-                .map(|(id, record)| {
-                    let analyzer = self.analyzer.clone();
-                    tokio::spawn(async move {
-                        let outcome = analyzer.analyze(&record).await;
-                        (id, outcome)
-                    })
+        // The path travels with the outcome: a failure names the file, not an id
+        // the operator has no way to look up.
+        type Joined =
+            std::result::Result<(FileId, String, Result<FileAnalysis>), tokio::task::JoinError>;
+        let outcomes: Vec<Joined> = stream::iter(files)
+            .map(|(id, record)| {
+                let analyzer = self.analyzer.clone();
+                tokio::spawn(async move {
+                    let outcome = analyzer.analyze(&record).await;
+                    (id, record.path, outcome)
                 })
-                .buffer_unordered(self.config.concurrency)
-                .collect()
-                .await;
+            })
+            .buffer_unordered(self.config.concurrency)
+            .collect()
+            .await;
 
         let mut analyzed: Vec<(FileId, FileAnalysis)> = Vec::with_capacity(outcomes.len());
         let mut failed: Vec<FileId> = Vec::new();
         for outcome in outcomes {
             match outcome {
-                Ok((id, Ok(analysis))) => analyzed.push((id, analysis)),
-                Ok((id, Err(error))) => {
+                Ok((id, _, Ok(analysis))) => analyzed.push((id, analysis)),
+                Ok((id, path, Err(error))) => {
                     // A bad file must not stop the batch, and it must leave the
                     // queue: a failure that stays pending is retried forever.
-                    tracing::warn!(file_id = id, %error, "file statistics analysis failed");
+                    tracing::warn!(file_id = id, path, %error, "file statistics analysis failed");
                     failed.push(id);
                 }
                 Err(error) => {
@@ -264,6 +281,12 @@ impl StatsCollector {
             .set_state_batch(&failed, FileState::Failed)?;
 
         if analyzed.is_empty() {
+            // Every file of the group failed, so there is no segment to write.
+            tracing::debug!(
+                prefix,
+                failed = failed.len(),
+                "the group produced no statistics"
+            );
             return Ok(());
         }
 
@@ -318,6 +341,10 @@ impl StatsCollector {
         tracing::debug!(
             prefix,
             analyzed = analyzed.len(),
+            failed = failed.len(),
+            // Columns with a recorded range. Zero here, against a file that has
+            // columns, means the reader produced no ranges to prune on.
+            columns = column_ids.len(),
             "committed a file statistics segment"
         );
         Ok(())

--- a/beacon-db/beacon-file-stats/src/lib.rs
+++ b/beacon-db/beacon-file-stats/src/lib.rs
@@ -68,5 +68,5 @@ pub use handle::{FileStatsHandle, new_file_stats_handle, try_file_stats_from_ses
 pub use registry::{AnalyzedFile, ReconcileReport, Registry};
 pub use scalar::{StatScalar, super_type};
 pub use segment::{ColumnStat, ColumnStats, SegmentBuilder, SegmentReader};
-pub use store::FileStatsStore;
+pub use store::{FileColumnStat, FileStatsStore};
 pub use types::{ColumnId, FileId, FileRecord, FileState, ObservedFile};

--- a/beacon-db/beacon-file-stats/src/store.rs
+++ b/beacon-db/beacon-file-stats/src/store.rs
@@ -2,6 +2,8 @@
 
 use std::sync::Arc;
 
+use arrow::array::{Array, ArrayRef, UInt64Array};
+use arrow::datatypes::DataType;
 use futures::stream::{self, StreamExt};
 use object_store::{ObjectStore, ObjectStoreExt, path::Path};
 use tokio::sync::RwLock;
@@ -25,6 +27,31 @@ type Joined = std::result::Result<
     std::result::Result<(usize, Option<ColumnStats>), crate::FileStatsError>,
     tokio::task::JoinError,
 >;
+
+/// One column's recorded statistics for one file.
+///
+/// What [`FileStatsStore::file_column_stats`] returns: a single row of the
+/// segment, kept in the column's own Arrow type rather than rendered, so the
+/// caller decides how to present it. `min` and `max` are one-element arrays.
+#[derive(Debug, Clone)]
+pub struct FileColumnStat {
+    pub column_id: ColumnId,
+    /// The segment this row came from.
+    pub segment: String,
+    pub data_type: DataType,
+    pub min: ArrayRef,
+    pub max: ArrayRef,
+    /// `None` where the format reported no count.
+    pub null_count: Option<u64>,
+    /// `None` for a format that reports no row count, such as netCDF.
+    pub row_count: Option<u64>,
+}
+
+/// Reads one count out of a nullable `UInt64` column.
+fn count_at(counts: &ArrayRef, row: usize) -> Option<u64> {
+    let counts = counts.as_any().downcast_ref::<UInt64Array>()?;
+    (!counts.is_null(row)).then(|| counts.value(row))
+}
 
 /// Statistics for every known file, split across immutable segments.
 pub struct FileStatsStore {
@@ -163,6 +190,79 @@ impl FileStatsStore {
         }
     }
 
+    /// Every column statistic recorded for one file.
+    ///
+    /// The inverse of [`Self::column_stats`], which reads one column across many
+    /// files. Pruning never needs this direction; an operator asking "what does
+    /// Beacon actually hold for this file" does, and answering it from the
+    /// segments is the only honest way to answer it.
+    ///
+    /// Segments are folded in manifest order, so a file that appears in more than
+    /// one is reported from the newest — the same resolution the pruning reader
+    /// applies. A column with no recorded range is absent rather than null: the
+    /// segment holds nothing for it.
+    pub async fn file_column_stats(&self, file_id: FileId) -> Result<Vec<FileColumnStat>> {
+        let covering: Vec<SegmentEntry> = {
+            let manifest = self.manifest.read().await;
+            manifest
+                .segments
+                .iter()
+                .filter(|entry| entry.min_file_id <= file_id && file_id <= entry.max_file_id)
+                .cloned()
+                .collect()
+        };
+
+        // Keyed by column so a newer segment replaces an older one's row.
+        let mut newest: std::collections::BTreeMap<ColumnId, FileColumnStat> =
+            std::collections::BTreeMap::new();
+
+        for entry in covering {
+            let path = self.prefix.clone().join(entry.name.as_str());
+            let reader = SegmentReader::open(self.store.clone(), path).await?;
+
+            // The segment's columns are read concurrently but not spawned: the
+            // reader is borrowed, and one file's columns are a bounded set.
+            let rows: Vec<(ColumnId, Option<ColumnStats>)> =
+                stream::iter(entry.column_ids.iter().copied())
+                    .map(|column_id| {
+                        let reader = &reader;
+                        async move {
+                            Ok::<_, crate::FileStatsError>((
+                                column_id,
+                                reader.column(column_id).await?,
+                            ))
+                        }
+                    })
+                    .buffer_unordered(SEGMENT_READ_CONCURRENCY)
+                    .collect::<Vec<_>>()
+                    .await
+                    .into_iter()
+                    .collect::<Result<Vec<_>>>()?;
+
+            for (column_id, stats) in rows {
+                let Some(stats) = stats else { continue };
+                // A segment holds many files; find this one's row, if it has one.
+                let Some(row) = stats.file_ids.iter().position(|id| *id == file_id) else {
+                    continue;
+                };
+                newest.insert(
+                    column_id,
+                    FileColumnStat {
+                        column_id,
+                        segment: entry.name.clone(),
+                        data_type: stats.data_type.clone(),
+                        min: stats.min.slice(row, 1),
+                        max: stats.max.slice(row, 1),
+                        null_count: count_at(&stats.null_count, row),
+                        row_count: count_at(&stats.row_count, row),
+                    },
+                );
+            }
+        }
+
+        Ok(newest.into_values().collect())
+    }
+
     /// A snapshot of the manifest, for diagnostics.
     pub async fn segments(&self) -> Vec<SegmentEntry> {
         self.manifest.read().await.segments.clone()
@@ -241,6 +341,73 @@ mod tests {
 
         let psal = store.column_stats_by_name("PSAL", (0, 2)).await.unwrap();
         assert_eq!(psal[0].file_ids, vec![1, 2]);
+    }
+
+    /// The per-file direction: every column of one file, which is what an
+    /// operator asking "what does Beacon hold for this file" needs. A column the
+    /// file never declared is absent rather than null.
+    #[tokio::test]
+    async fn one_file_reports_only_the_columns_it_declares() {
+        let (store, _dir) = store().await;
+
+        let files: Vec<ObservedFile> = (0..3)
+            .map(|i| ObservedFile::new(format!("argo/{i}.nc"), 10, 1))
+            .collect();
+        let file_ids = store.registry().intern_files(&files).unwrap();
+        let columns = store.registry().intern_columns(&["TEMP", "PSAL"]).unwrap();
+
+        let mut builder = SegmentBuilder::new();
+        builder.push_file(file_ids[0], [(columns[0], stat(0.0, 10.0))]);
+        builder.push_file(
+            file_ids[1],
+            [
+                (columns[0], stat(20.0, 30.0)),
+                (columns[1], stat(34.0, 35.0)),
+            ],
+        );
+        store.commit_segment(builder).await.unwrap().unwrap();
+
+        // The file that declared both.
+        let both = store.file_column_stats(file_ids[1]).await.unwrap();
+        assert_eq!(both.len(), 2);
+        assert_eq!(both[0].min.as_primitive::<Float64Type>().value(0), 20.0);
+        assert_eq!(both[0].max.as_primitive::<Float64Type>().value(0), 30.0);
+        assert_eq!(both[0].null_count, Some(1));
+        assert_eq!(both[0].row_count, Some(100));
+        assert_eq!(both[1].max.as_primitive::<Float64Type>().value(0), 35.0);
+
+        // The file that declared one; PSAL is missing, not null.
+        let one = store.file_column_stats(file_ids[0]).await.unwrap();
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0].column_id, columns[0]);
+
+        // A file the segment covers by id range but holds no row for.
+        assert!(store.file_column_stats(file_ids[2]).await.unwrap().is_empty());
+    }
+
+    /// A file analyzed twice appears in two segments. The newest wins, exactly as
+    /// it does for the pruning reader.
+    #[tokio::test]
+    async fn a_re_analyzed_file_reports_its_newest_range() {
+        let (store, _dir) = store().await;
+        let ids = store
+            .registry()
+            .intern_files(&[ObservedFile::new("a.nc", 1, 1)])
+            .unwrap();
+        let columns = store.registry().intern_columns(&["TEMP"]).unwrap();
+
+        let mut first = SegmentBuilder::new();
+        first.push_file(ids[0], [(columns[0], stat(0.0, 1.0))]);
+        store.commit_segment(first).await.unwrap().unwrap();
+
+        let mut second = SegmentBuilder::new();
+        second.push_file(ids[0], [(columns[0], stat(50.0, 60.0))]);
+        store.commit_segment(second).await.unwrap().unwrap();
+
+        let stats = store.file_column_stats(ids[0]).await.unwrap();
+        assert_eq!(stats.len(), 1, "one row per column, not one per segment");
+        assert_eq!(stats[0].min.as_primitive::<Float64Type>().value(0), 50.0);
+        assert_eq!(stats[0].segment, "segment-00000001.bfs");
     }
 
     #[tokio::test]

--- a/beacon-server/beacon-server-config/src/error.rs
+++ b/beacon-server/beacon-server-config/src/error.rs
@@ -25,6 +25,10 @@ pub enum ConfigError {
     #[error("invalid storage configuration: {0}")]
     InvalidStorage(String),
 
+    /// `BEACON_LOG_LEVEL` was set to something other than a known log level.
+    #[error("invalid BEACON_LOG_LEVEL: {0}")]
+    InvalidLogLevel(String),
+
     /// `BEACON_SECRETS_KEY` was set but is not a base64-encoded 32-byte key.
     #[error("invalid BEACON_SECRETS_KEY: {0}")]
     InvalidSecretsKey(String),

--- a/beacon-server/beacon-server-config/src/lib.rs
+++ b/beacon-server/beacon-server-config/src/lib.rs
@@ -90,6 +90,10 @@ pub struct ServerConfig {
     /// Maximum size, in bytes, accepted for a single dataset upload. `0` disables
     /// the cap. From `BEACON_MAX_UPLOAD_BYTES`.
     pub max_upload_bytes: u64,
+    /// Log level for Beacon's own crates, lowercase and already validated: one of
+    /// `trace`, `debug`, `info`, `warn`, `error`, `off`. From `BEACON_LOG_LEVEL`.
+    /// `RUST_LOG` overrides it when set.
+    pub log_level: String,
 }
 
 #[derive(Debug, Clone)]
@@ -300,6 +304,10 @@ struct RawConfig {
     port: u16,
     #[envconfig(from = "BEACON_HOST", default = "0.0.0.0")]
     host: String,
+    /// Level for Beacon's own crates. Validated in [`Config::load`], so a typo
+    /// stops the process instead of silently logging at the default level.
+    #[envconfig(from = "BEACON_LOG_LEVEL", default = "info")]
+    log_level: String,
 
     //VM Settings
     /// Query memory pool size, in **megabytes**.
@@ -486,6 +494,10 @@ struct RawConfig {
     file_stats_enable: bool,
     #[envconfig(from = "BEACON_FILE_STATS_INTERVAL_SECS", default = "900")]
     file_stats_interval_secs: u64,
+    /// Collect at boot rather than one interval later. Off by default, so
+    /// enabling statistics does not turn the next restart into a backfill.
+    #[envconfig(from = "BEACON_FILE_STATS_ON_STARTUP", default = "false")]
+    file_stats_on_startup: bool,
     /// Files analyzed at once. Empty takes a quarter of the cores, which leaves
     /// room for queries. Raise it well above the core count for datasets in
     /// object storage, where the work is waiting rather than parsing.
@@ -557,6 +569,7 @@ impl From<RawConfig> for Config {
                 base_path: raw.base_path,
                 web_ui_dir: raw.web_ui_dir,
                 max_upload_bytes: raw.max_upload_bytes,
+                log_level: raw.log_level,
             },
             runtime: RuntimeConfig {
                 vm_memory_size: raw.vm_memory_size,
@@ -618,6 +631,7 @@ impl From<RawConfig> for Config {
             file_stats: FileStatsConfig {
                 enable: raw.file_stats_enable,
                 interval_secs: raw.file_stats_interval_secs,
+                on_startup: raw.file_stats_on_startup,
                 concurrency: raw
                     .file_stats_concurrency
                     .filter(|n| *n > 0)
@@ -681,6 +695,26 @@ fn validate_storage(s3: &S3Config) -> Result<()> {
     Ok(())
 }
 
+/// Levels accepted by `BEACON_LOG_LEVEL`, in the spelling `tracing` expects.
+const LOG_LEVELS: [&str; 6] = ["trace", "debug", "info", "warn", "error", "off"];
+
+/// Lowercases and validates `BEACON_LOG_LEVEL`, so `DEBUG`, `Debug`, and `debug`
+/// all work.
+///
+/// Errors on an unknown level instead of falling back to the default: a typo that
+/// silently keeps the server at `info` is the failure this variable exists to
+/// avoid.
+fn normalize_log_level(raw: &str) -> std::result::Result<String, String> {
+    let level = raw.trim().to_ascii_lowercase();
+    if LOG_LEVELS.contains(&level.as_str()) {
+        return Ok(level);
+    }
+    Err(format!(
+        "`{raw}` is not a log level; expected one of {}",
+        LOG_LEVELS.join(", ")
+    ))
+}
+
 /// Decode a base64-encoded 32-byte master key from `BEACON_SECRETS_KEY`.
 fn decode_master_key(b64: &str) -> std::result::Result<[u8; 32], String> {
     use base64::Engine;
@@ -734,6 +768,8 @@ impl Config {
         }
         config.server.base_path =
             normalize_base_path(&config.server.base_path).map_err(ConfigError::InvalidBasePath)?;
+        config.server.log_level =
+            normalize_log_level(&config.server.log_level).map_err(ConfigError::InvalidLogLevel)?;
 
         validate_storage(&config.s3)?;
 
@@ -826,7 +862,8 @@ fn create_dir(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        decode_master_key, normalize_base_path, validate_storage, Config, PathBuf, RawConfig,
+        decode_master_key, normalize_base_path, normalize_log_level, validate_storage, Config,
+        PathBuf, RawConfig,
     };
     use envconfig::Envconfig;
     use std::collections::HashMap;
@@ -1039,6 +1076,37 @@ mod tests {
             !printed.contains("ab, ab"),
             "raw key bytes leaked: {printed}"
         );
+    }
+
+    /// The startup collection is opt-in: enabling statistics alone must not turn
+    /// the next restart of a large archive into a backfill.
+    #[test]
+    fn collecting_at_startup_is_opt_in() {
+        assert!(!config(&[]).file_stats.on_startup);
+        assert!(
+            config(&[("BEACON_FILE_STATS_ON_STARTUP", "true")])
+                .file_stats
+                .on_startup
+        );
+    }
+
+    #[test]
+    fn log_level_defaults_to_info() {
+        assert_eq!(config(&[]).server.log_level, "info");
+    }
+
+    #[test]
+    fn log_level_accepts_any_case() {
+        assert_eq!(normalize_log_level("DEBUG"), Ok("debug".to_string()));
+        assert_eq!(normalize_log_level("Trace"), Ok("trace".to_string()));
+        assert_eq!(normalize_log_level(" warn "), Ok("warn".to_string()));
+    }
+
+    /// A typo must stop the server, not leave it quietly at `info`.
+    #[test]
+    fn unknown_log_level_is_an_error() {
+        assert!(normalize_log_level("verbose").is_err());
+        assert!(normalize_log_level("").is_err());
     }
 
     #[test]

--- a/beacon-server/beacon-server/src/axum/client/query.rs
+++ b/beacon-server/beacon-server/src/axum/client/query.rs
@@ -15,7 +15,7 @@ use beacon_core::{
     query_result::QueryOutputFile,
     AuthIdentity,
 };
-use futures::TryStreamExt;
+use futures::{StreamExt, TryStreamExt};
 use std::sync::Arc;
 
 /// Executes a query against the runtime and streams the result to the client.
@@ -106,10 +106,34 @@ pub(crate) async fn query(
 
             let schema = arrow_output_stream.schema();
 
+            // Pull the first item before committing to a status code.
+            //
+            // The stream is lazy, so a plan that cannot run fails on its first
+            // poll — and by then the 200 is already on the wire. All the server
+            // can do at that point is drop the connection, which reaches the
+            // caller as a broken socket with no message at all. `ANALYZE FILES`
+            // on a runtime without file statistics is the case that found this:
+            // the same statement returns a clean 400 when the output is a file,
+            // because that path runs eagerly.
+            //
+            // Peeking costs one batch of buffering and delays the headers until
+            // the query produces something. An error *after* the first batch is
+            // still unreportable as a status; no HTTP response can take that
+            // back.
+            let mut arrow_output_stream = arrow_output_stream;
+            let first = match arrow_output_stream.next().await {
+                Some(Err(err)) => {
+                    tracing::error!("Error running beacon query: {}", err);
+                    return Err((StatusCode::BAD_REQUEST, Json(err.to_string())));
+                }
+                first => first,
+            };
+            let batches = futures::stream::iter(first).chain(arrow_output_stream);
+
             // Stream Arrow IPC directly so large result sets do not need to be buffered in memory.
             let axum_stream = axum_streams::StreamBodyAs::arrow_ipc_with_options_errors(
                 schema,
-                arrow_output_stream.map_err(|e| ::axum::Error::new(Box::new(e))),
+                batches.map_err(|e| ::axum::Error::new(Box::new(e))),
                 ipc_options,
             )
             .header("x-beacon-query-id", query_id_header)

--- a/beacon-server/beacon-server/src/main.rs
+++ b/beacon-server/beacon-server/src/main.rs
@@ -40,10 +40,12 @@ fn main() -> anyhow::Result<()> {
 
 /// Initializes shared services and starts all configured API transports.
 async fn async_main(config: Arc<beacon_server_config::Config>) -> anyhow::Result<()> {
-    setup_tracing();
+    let log_filter = setup_tracing(&config);
     install_panic_hook();
 
     tracing::info!("Beacon v{}", BEACON_VERSION);
+    // This line only prints when DEBUG is on, so it confirms the level took effect.
+    tracing::debug!(filter = %log_filter, "debug logging is on");
     // The server owns the datasets store and hosts the runtime that queries it.
     let server = Arc::new(Server::open(config.clone()).await?);
     // Keep both transports on the same server so metadata and access rules stay aligned.
@@ -95,23 +97,77 @@ fn install_panic_hook() {
     }));
 }
 
+/// Third-party crates whose `DEBUG`/`TRACE` events bury Beacon's own logs. They
+/// stay at `INFO` when `BEACON_LOG_LEVEL` asks for `debug` or `trace`. Set
+/// `RUST_LOG` to see them.
+const NOISY_DEPENDENCIES: &[&str] = &[
+    "arrow",
+    "aws_config",
+    "aws_smithy_runtime",
+    "datafusion",
+    "deltalake",
+    "h2",
+    "hyper",
+    "hyper_util",
+    "iceberg",
+    "lance",
+    "mio",
+    "object_store",
+    "parquet",
+    "reqwest",
+    "rustls",
+    "sqlparser",
+    "tokio_util",
+    "tonic",
+    "want",
+    "zarrs",
+];
+
+/// Builds the tracing filter for a validated `BEACON_LOG_LEVEL` value.
+///
+/// The level is the global directive, so it covers every Beacon crate, including
+/// crates added later. The filter names no Beacon crate, which is what keeps it
+/// from going stale.
+fn log_filter(level: &str) -> String {
+    match level {
+        // Beacon logs at the requested level; the loud dependencies do not.
+        "debug" | "trace" => {
+            let mut filter = String::from(level);
+            for dependency in NOISY_DEPENDENCIES {
+                filter.push_str(&format!(",{dependency}=info"));
+            }
+            filter
+        }
+        // Axum logs rejections from built-in extractors on the `axum::rejection`
+        // target at `TRACE`.
+        "info" => String::from("info,tower_http=debug,axum::rejection=trace"),
+        // `warn`, `error`, and `off` ask for less, so nothing is raised here.
+        _ => String::from(level),
+    }
+}
+
 /// Configures stdout and rolling-file tracing subscribers for the API process.
-fn setup_tracing() {
+///
+/// `RUST_LOG` takes precedence when it is set, for the full `EnvFilter` syntax.
+/// `BEACON_LOG_LEVEL` (through `config`) sets the level otherwise. Returns the
+/// filter it applied, for the startup log.
+fn setup_tracing(config: &beacon_server_config::Config) -> String {
     let file_appender = tracing_appender::rolling::daily("logs", "beacon.log");
     let (file_writer, _guard) = tracing_appender::non_blocking(file_appender);
 
+    let default_filter = log_filter(&config.server.log_level);
+    let filter = match std::env::var("RUST_LOG") {
+        Ok(rust_log) => tracing_subscriber::EnvFilter::try_new(&rust_log).unwrap_or_else(|err| {
+            // Tracing is not up yet, so this warning goes straight to stderr.
+            eprintln!("ignoring invalid RUST_LOG (`{rust_log}`): {err}");
+            tracing_subscriber::EnvFilter::new(&default_filter)
+        }),
+        Err(_) => tracing_subscriber::EnvFilter::new(&default_filter),
+    };
+
+    let applied = filter.to_string();
     tracing_subscriber::registry()
-        .with(
-            // Fallback filter is only used when `RUST_LOG` is unset. Axum logs rejections from
-            // built-in extractors with the `axum::rejection` target at `TRACE` level.
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                format!(
-                    "info,{}=debug,tower_http=debug,axum::rejection=trace,beacon_core=debug,beacon_arrow_odv=debug,beacon_arrow_netcdf=debug,beacon_server=debug,beacon_arrow_ipc=debug,beacon_arrow_csv=debug,beacon_arrow_parquet=debug,beacon_arrow_geoparquet=debug,beacon_arrow_bbf=debug,beacon_common=debug,beacon_functions=debug,beacon_nd_array=debug,beacon_arrow_atlas=debug",
-                    env!("CARGO_CRATE_NAME")
-                )
-                .into()
-            }),
-        )
+        .with(filter)
         .with(tracing_subscriber::fmt::layer())
         .with(tracing_subscriber::fmt::layer().with_writer(file_writer).with_ansi(false))
         .init();
@@ -119,4 +175,26 @@ fn setup_tracing() {
     // The non-blocking writer must outlive the subscriber, so keep the guard for the
     // lifetime of the process.
     std::mem::forget(_guard);
+
+    applied
+}
+
+#[cfg(test)]
+mod tests {
+    use super::log_filter;
+
+    #[test]
+    fn debug_level_covers_every_beacon_crate() {
+        let filter = log_filter("debug");
+        // A global `debug` directive, so a new Beacon crate needs no filter change.
+        assert!(filter.starts_with("debug,"));
+        assert!(!filter.contains("beacon_"));
+        assert!(filter.contains("datafusion=info"));
+    }
+
+    #[test]
+    fn quiet_levels_raise_nothing() {
+        assert_eq!(log_filter("warn"), "warn");
+        assert_eq!(log_filter("off"), "off");
+    }
 }

--- a/beacon-server/beacon-server/tests/client_endpoints_http.rs
+++ b/beacon-server/beacon-server/tests/client_endpoints_http.rs
@@ -193,6 +193,35 @@ async fn query_rejects_malformed_body() {
     assert_eq!(res.status, StatusCode::BAD_REQUEST);
 }
 
+/// A statement that fails on the first poll of its stream must still answer with
+/// a status and a message.
+///
+/// The Arrow output is lazy, so this class of failure used to arrive after the
+/// 200 was already sent. The server could then only drop the connection, and
+/// every client — the admin UI included — saw a broken socket carrying no
+/// reason. `ANALYZE FILES` against a runtime with no file statistics is exactly
+/// that shape.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_stream_that_fails_before_its_first_batch_is_a_400_with_a_message() {
+    let (router, _lake, _cfg) = app(config(false)).await;
+    // The statement is super-user only, so anonymous stops at the privilege gate
+    // long before the stream this test is about.
+    let admin = basic(ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    let res = send(
+        &router,
+        post_json("/api/query", json!({ "sql": "ANALYZE FILES" }), Some(&admin)),
+    )
+    .await;
+
+    assert_eq!(res.status, StatusCode::BAD_REQUEST);
+    let body = String::from_utf8_lossy(&res.body);
+    assert!(
+        body.contains("BEACON_FILE_STATS_ENABLE"),
+        "the response must carry the reason, got: {body}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn sql_over_http_is_gated_by_sql_enable() {
     let mut cfg = config(false);

--- a/docs/docs/2.0.0-rc2/internals/file-statistics.md
+++ b/docs/docs/2.0.0-rc2/internals/file-statistics.md
@@ -47,6 +47,7 @@ No row in them can match the query.
 
 ```bash
 BEACON_FILE_STATS_ENABLE=true
+BEACON_FILE_STATS_ON_STARTUP=true    # collect at each boot, see below
 BEACON_NETCDF_USE_RUST_READER=true   # netCDF servers only
 BEACON_HDF5_USE_RUST_READER=true     # HDF5 servers only
 ```
@@ -54,12 +55,54 @@ BEACON_HDF5_USE_RUST_READER=true     # HDF5 servers only
 Beacon then starts a pass every 15 minutes. Each pass finds new files and reads them.
 [Configuration](/docs/2.0.0-rc2/server/configuration#file-statistics) lists each variable.
 
+The **first pass runs one interval after startup**, not at startup. A new server does nothing for
+15 minutes. It finds no file, and `beacon.system.file_stats` holds no row. This is correct. Beacon
+keeps startup free for your queries.
+
+:::warning A restart resets the timer
+Beacon starts the interval again on each boot, and records no due time. A server that restarts more
+often than the interval never runs a pass. A build-and-run loop has this shape. Set
+`BEACON_FILE_STATS_ON_STARTUP=true` there, which is what the next section covers.
+:::
+
+## Collect at every boot
+
+```bash
+BEACON_FILE_STATS_ON_STARTUP=true
+```
+
+Beacon then collects as soon as the runtime is up. It finds the files, reads every one that has no
+statistics, and stops when the queue is empty. The timer continues afterwards.
+
+The collection runs in the background. It does not hold up startup, and the server answers queries
+while it works. A file with no statistics yet is read in full, as it was before this feature.
+
+```
+INFO collecting file statistics at startup
+INFO startup file statistics collection finished discovered=2 analyzed=2 failed=0 segments=1
+```
+
+The work is not repeated. The registry survives a restart, so the next boot reads only the files
+that are new or changed. The first boot over a large archive is the expensive one.
+
+:::tip Which one do you need
+Set this flag for a server that restarts often, or for a fresh instance that must be useful at once.
+Leave it off for a long-lived server over a large archive, where an unattended backfill at boot
+competes with your queries. `ANALYZE FILES` covers that case, at a time you choose.
+:::
+
 Do not wait for the timer. Start a pass with SQL:
 
 ```sql
 ANALYZE FILES;              -- read every file now
 ANALYZE FILES 'argo/';      -- read one prefix only
+ANALYZE FILES FORCE;        -- read every file again, after a reader change
 ```
+
+`ANALYZE FILES` runs to completion and returns one row of counts: `discovered`, `requeued`,
+`analyzed`, `failed`, `segments`, and `pending`. A second run reports `analyzed=0`, because the
+files carry their statistics already. `discovered` counts every file of the listing, new or known,
+so it stays above zero.
 
 Beacon reads one million netCDF files in about 15 minutes on 8 cores. Parquet is faster. Parquet
 holds its ranges in the file footer, so Beacon reads no data.
@@ -71,7 +114,7 @@ your data before you enable the timer.
 
 ## Check the result
 
-Two tables show what Beacon knows. Use them. This feature fails quietly.
+Two tables and one function show what Beacon knows. Use them. This feature fails quietly.
 
 A format that supplies no ranges gives no error. Beacon reads the file and records nothing. Queries
 continue to read every file.
@@ -104,6 +147,51 @@ The `beacon.system.file_stats` table holds one row for each file:
 | `column_count` | The columns this file supplied. **A value of zero is important.** |
 | `num_rows`, `total_byte_size` | The values that the reader reported |
 | `stats_epoch` | The number of times that Beacon read this file |
+
+### One file, column by column
+
+`column_count` counts the columns of a file. It does not show their values. The `file_statistics`
+function opens the segments and reports each range that Beacon holds:
+
+```sql
+SELECT column, data_type, min, max, null_count, row_count
+FROM file_statistics('obs/2025/baltic_timeseries.parquet')
+ORDER BY column;
+```
+
+```
+JULD | Float64 | 24837.5 | 24838.0 |   0 | 2042
+PSAL | Float64 | 31.2    | 38.1    | 118 | 2042
+TEMP | Float64 | -1.84   | 29.7    |  12 | 2042
+```
+
+A netCDF file reports no counts, so `null_count` and `row_count` are empty for one. The bounds are
+there just the same.
+
+A dataset is usually a directory, so the function also takes a glob. Each row keeps its `path`:
+
+```sql
+-- The columns of a dataset that hold no usable bound
+SELECT path, count(*) AS columns, sum(CASE WHEN min IS NULL THEN 1 ELSE 0 END) AS no_range
+FROM file_statistics('argo/2024/**')
+GROUP BY path
+ORDER BY path;
+```
+
+| Column | Meaning |
+| --- | --- |
+| `path` | The file the row belongs to |
+| `column` | The column name, as the file declares it |
+| `data_type` | The type of the file's own column, not of a merged table |
+| `min`, `max` | The recorded bounds, in the type of that column. `NULL` means the bound is null |
+| `null_count`, `row_count` | The counts the reader reported. `NULL` where it reported none |
+| `segment` | The segment that holds this row |
+
+The function needs the super-user, like the `beacon.system` tables: a range is data. It reports on
+at most 1000 files in one call, so a wide glob returns an error instead of a very large result.
+
+An unknown path is an error, not an empty result. A file with no recorded range gives zero rows.
+The two conditions are different, and this keeps them apart.
 
 Two more queries:
 

--- a/docs/docs/2.0.0-rc2/server/configuration.md
+++ b/docs/docs/2.0.0-rc2/server/configuration.md
@@ -21,7 +21,8 @@ See [S3 object storage](#s3-object-storage).
 | `BEACON_HOST` | `0.0.0.0` | IP address the HTTP API listens on. |
 | `BEACON_PORT` | `5001` | Port the HTTP API listens on. |
 | `BEACON_WORKER_THREADS` | `8` | Number of worker threads for the async runtime. |
-| `RUST_LOG` | _(see below)_ | Log filter, in [`tracing-subscriber` EnvFilter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) syntax (e.g. `info`, `debug`, `beacon_core=trace`). When unset, Beacon applies a built-in filter of `info` with its own crates at `debug`. |
+| `BEACON_LOG_LEVEL` | `info` | Log level: `trace`, `debug`, `info`, `warn`, `error`, or `off`. Case does not matter. The level applies to all Beacon crates. At `debug` and `trace`, loud dependencies such as DataFusion, Arrow, `object_store`, and hyper stay at `info`. An unknown value stops the server at startup. |
+| `RUST_LOG` | _(unset)_ | Full log filter, in [`tracing-subscriber` EnvFilter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) syntax (e.g. `debug,datafusion=trace`). It replaces `BEACON_LOG_LEVEL`. Use it to see the dependency logs that `BEACON_LOG_LEVEL` holds back. An invalid value prints a warning, and Beacon uses `BEACON_LOG_LEVEL`. |
 | `BEACON_BASE_PATH` | _(empty)_ | Optional URL path prefix for the HTTP API, OpenAPI document, and Swagger UI (e.g. `/beacon`). Useful behind a reverse proxy. Normalized to exactly one leading slash and no trailing slash, so `beacon`, `/beacon`, and `/beacon/` are equivalent. Only URL-safe characters are allowed (letters, digits, `-`, `_`, `.`, `~`, and `/` as a separator); any other character causes Beacon to exit at startup with a descriptive error. |
 | `BEACON_WEB_UI_DIR` | `web` | Directory holding the built admin web UI. Served at `{BEACON_BASE_PATH}/admin` when the directory exists, and skipped otherwise. Resolved relative to the working directory (`/beacon/web` in the Docker image). |
 
@@ -184,7 +185,8 @@ records no ranges.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `BEACON_FILE_STATS_ENABLE` | `false` | Master switch. When `false`, Beacon finds nothing, reads nothing and starts no background task. |
-| `BEACON_FILE_STATS_INTERVAL_SECS` | `900` | The seconds between two passes. |
+| `BEACON_FILE_STATS_INTERVAL_SECS` | `900` | The seconds between two passes. The first pass runs one interval after startup, not at startup. A restart starts the interval again, so a server that restarts more often than this never runs a pass. Set `BEACON_FILE_STATS_ON_STARTUP=true` there. |
+| `BEACON_FILE_STATS_ON_STARTUP` | `false` | Collect at each boot, and do not wait for the first tick. Beacon finds the files and reads every one that has no statistics, in the background. The server answers queries while this runs. The timer continues after it. |
 | `BEACON_FILE_STATS_CONCURRENCY` | one quarter of the cores, minimum 2 | The files that Beacon reads at the same time. A pass uses part of the machine, so it does not compete with queries. Increase this value above your core count for data in object storage. |
 | `BEACON_FILE_STATS_BATCH_FILES` | `10000` | The files that Beacon reads in one pass. This value limits the memory of one pass. |
 | `BEACON_FILE_STATS_TARGET_GROUP_FILES` | `10000` | The files that one segment covers. A small value prunes more for a rare column. It also adds segments to read for a common column. |


### PR DESCRIPTION
The file-statistics subsystem was hard to observe and hard to start. Every way it can underperform is quiet by construction, and three of the quiet paths turned out to be bugs.

## Logging

`BEACON_LOG_LEVEL` works again. It is a 1.x variable that 2.0 dropped, so only `RUST_LOG` was read and the documented knob did nothing. The fallback filter also named its crates by hand and had gone stale: `beacon_file_stats`, `beacon_arrow_zarr`, `beacon_iceberg` and every crate added since sat at `INFO` whatever the level. The filter now sets one global level and pins the loud dependencies to `INFO` instead, so a crate added later needs no filter change. `RUST_LOG` still wins when set, and an invalid value warns rather than silently falling back.

A pass now traces itself at `DEBUG`:

```
DEBUG listed the datasets store listed=3 scan_prefix="" pending=3
DEBUG taking a batch of pending files files=3 batch_files=10000 concurrency=6
DEBUG analyzing a group prefix="" files=3
DEBUG analyzed a file path="wod_ctd_2021.nc" format="nc" columns=54 fields=295 elapsed_ms=103
DEBUG committed a file statistics segment prefix="" analyzed=3 failed=0 columns=298
INFO  file statistics pass discovered=3 analyzed=3 failed=0 segments=1 pending=0
```

`columns` against `fields` is the line that earns its place: 54 of 295 means the reader recorded bounds for 54 columns and the other 241 prune nothing. A failed file now names its path rather than only its id, and an idle pass drops to `DEBUG` — `discovered` counts every listed file, so it was logging an `INFO` line every interval forever.

## A streaming error is now a status and a message

A query whose stream fails before its first batch answers `400` with the reason. The Arrow output is lazy, so the `200` was already on the wire when the failure arrived and the server could only drop the connection. Every client saw a broken socket carrying no message — this is why `ANALYZE FILES` looked like it did nothing in the admin UI:

```
before: {"sql":"ANALYZE FILES"}  -> no response, connection dropped
after:  {"sql":"ANALYZE FILES"}  -> 400 ["Error during planning: file statistics are not
                                    enabled on this runtime; set BEACON_FILE_STATS_ENABLE=true"]
```

The same statement always worked with `output.format=csv`, because a file output runs eagerly. An error *after* the first batch still cannot become a status; nothing in HTTP can take that back.

## `file_statistics('path')`

`beacon.system.file_stats` counts a file's columns. This shows their bounds, which is what pruning actually runs on:

```sql
SELECT column, data_type, min, max, null_count, row_count
FROM file_statistics('obs/2025/baltic_timeseries.parquet') ORDER BY column;
```

It takes a glob, since a dataset is usually a directory, and each row keeps its `path`:

```sql
SELECT path, count(*) AS columns, sum(CASE WHEN min IS NULL THEN 1 ELSE 0 END) AS no_range
FROM file_statistics('parquet/*') GROUP BY path;

parquet/atlantic_timeseries_2025.parquet | 219 | 7
parquet/baltic_timeseries_2025.parquet   | 184 | 16
```

An unknown path is an error naming `beacon.system.file_stats`; a known file with no bounds is zero rows. Keeping those apart is the point. It reports on at most 1000 files per call, because a segment holds a row per file per column and a wide glob multiplies out fast.

Super-user only, for the reason `beacon.system` is: a min/max pair is data, not just metadata. A table function carries no schema name, so the authorization walk matches its provider instead. A test pins that it fails closed with grant enforcement off.

## `BEACON_FILE_STATS_ON_STARTUP`

Off by default. When on, Beacon collects at every boot in the background: one listing, then the queue drained batch by batch, with the timer taking over afterwards.

This exists because the timer's first pass lands one whole interval after boot and the interval starts again on each boot — so a server that restarts more often than 15 minutes never collected anything. Verified on a fresh instance at the default interval: both files analyzed 46 ms after boot instead of never.

It stays opt-in so that enabling statistics does not turn the next restart of a large archive into an unattended backfill. The registry survives a restart, so only the first boot is expensive.
