### PR TITLE
Render admin UI results from Arrow columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,14 @@ tag. Releases before 2.0.0 are recorded in the
 
 ### Changed
 
+- **The admin UI renders a result from the Arrow columns.** The query workbench reads each record
+  batch as it arrives and shows it. It no longer builds a JS object for each row first, which cost
+  one object per row and one property per column — on a beacon table that carries 100K+ columns,
+  the decode was the wait, not the query. The grid now reads one value as `column.get(row)`, and
+  the preview and dataset pages take the same path. Duplicate column names survive, because the
+  columns come from the Arrow schema and not from the keys of a decoded row. The SDK types state
+  the columnar access the UI uses: `ArrowTable` and `ArrowRecordBatch` declare `schema` and
+  `getChildAt`, with the new `ArrowVector`, `ArrowField` and `ArrowSchema`.
 - **Minimum supported Rust is 1.94**, up from 1.91. `iceberg` and `iceberg-datafusion` 0.10 — the
   only release line built against the DataFusion 53 and Arrow 58 this workspace unifies on —
   declare `rust-version = "1.94"`, so the workspace floor follows. Beacon's own code uses no

--- a/beacon-clients/beacon-ts/README.md
+++ b/beacon-clients/beacon-ts/README.md
@@ -142,8 +142,28 @@ alternative.
 | `queryArrow()` | default Arrow stream | an `apache-arrow` `Table` |
 | `queryStream()` | default Arrow stream | `AsyncGenerator<RecordBatch>` — streamed, unbuffered |
 | `queryArrowTableStream()` | default Arrow stream | `AsyncGenerator<Table>` — one Table per batch, unbuffered |
+| `queryBatches()` | default Arrow stream | `{ queryId, batches }` — the query id, plus the batches as they arrive |
 | `queryCsv()` | `csv` | `{ rows, queryId }` — string-valued rows |
 | `queryRaw(query, format?)` | any (or default stream) | the raw `fetch` `Response` |
+
+Every batch and table also gives its columns directly, which costs no JS object
+per row. Beacon produces rows while the query still runs, so a consumer can read
+the batches as they arrive and stop at the rows it needs:
+
+```ts
+const controller = new AbortController();
+const { batches } = await beacon.queryBatches("SELECT * FROM ctd", controller.signal);
+let seen = 0;
+for await (const batch of batches) {
+  const temp = batch.getChildAt(batch.schema.fields.findIndex((f) => f.name === "TEMP"));
+  for (let i = 0; i < batch.numRows; i++) console.log(temp?.get(i));
+  seen += batch.numRows;
+  if (seen >= 500) {
+    controller.abort(); // enough rows; stop the query on the server
+    break;
+  }
+}
+```
 
 `getArrowDecoder()` exposes the same decoder the methods above use — a loaded,
 zstd-enabled `apache-arrow` — so you can decode Beacon's Arrow output yourself:

--- a/beacon-clients/beacon-ts/src/arrow.ts
+++ b/beacon-clients/beacon-ts/src/arrow.ts
@@ -11,10 +11,37 @@
  * Arrow into their bundle until the first query.
  */
 
-/** Minimal structural view of an apache-arrow `Table`, to avoid a type dependency. */
+/** Minimal structural view of an apache-arrow `Vector` — one decoded column. */
+export interface ArrowVector {
+  readonly length: number;
+  /** The value at `index`, already converted to a JS value (number, string, Date, …). */
+  get(index: number): unknown;
+}
+
+/** One field of an Arrow schema. `String(type)` renders it, e.g. `Timestamp<MICROSECOND>`. */
+export interface ArrowField {
+  readonly name: string;
+  readonly type: unknown;
+}
+
+/** Minimal structural view of an apache-arrow `Schema`. */
+export interface ArrowSchema {
+  readonly fields: readonly ArrowField[];
+}
+
+/**
+ * Minimal structural view of an apache-arrow `Table`, to avoid a type dependency.
+ *
+ * `getChildAt` reads a column without materializing rows — the cheap path for a
+ * consumer that renders or aggregates columnwise. `toArray()` is the row path,
+ * which builds one JS object per row.
+ */
 export interface ArrowTable {
   readonly numRows: number;
   readonly numCols: number;
+  readonly schema: ArrowSchema;
+  /** The column at `index` (in `schema.fields` order), or null when out of range. */
+  getChildAt(index: number): ArrowVector | null;
   toArray(): unknown[];
 }
 
@@ -22,7 +49,9 @@ export interface ArrowTable {
 export interface ArrowRecordBatch {
   readonly numRows: number;
   /** The batch's Arrow schema (carries field names and types). */
-  readonly schema?: unknown;
+  readonly schema: ArrowSchema;
+  /** The column at `index` (in `schema.fields` order), or null when out of range. */
+  getChildAt(index: number): ArrowVector | null;
   toArray(): unknown[];
 }
 

--- a/beacon-clients/beacon-ts/src/index.ts
+++ b/beacon-clients/beacon-ts/src/index.ts
@@ -16,7 +16,14 @@ export { Http, basicAuthHeader } from "./http.js";
 export type { ClientOptions, FetchLike } from "./http.js";
 export { BeaconError, ApiError, ConnectionError, TimeoutError } from "./errors.js";
 export { getArrowDecoder, rowsFromTable, rowsFromBatch } from "./arrow.js";
-export type { ArrowDecoder, ArrowTable, ArrowRecordBatch } from "./arrow.js";
+export type {
+  ArrowDecoder,
+  ArrowTable,
+  ArrowRecordBatch,
+  ArrowVector,
+  ArrowField,
+  ArrowSchema,
+} from "./arrow.js";
 export { responseByteStream } from "./stream.js";
 export { parseCsv, parseCsvRows } from "./csv.js";
 export {

--- a/beacon-clients/beacon-ts/test/decode.test.ts
+++ b/beacon-clients/beacon-ts/test/decode.test.ts
@@ -66,4 +66,15 @@ describe("getArrowDecoder", () => {
     for await (const batch of batches) seen.push(batch.numRows);
     expect(seen).toEqual([2]);
   });
+
+  it("exposes a streamed batch as Arrow columns, without decoding rows", async () => {
+    const decoder = await getArrowDecoder();
+    const batches = await decoder.readStream(responseByteStream(new Response(ipc())));
+    for await (const batch of batches) {
+      expect(batch.schema.fields.map((f) => f.name)).toEqual(["n"]);
+      const column = batch.getChildAt(0);
+      expect(column?.length).toBe(2);
+      expect([column?.get(0), column?.get(1)]).toEqual([1, 2]);
+    }
+  });
 });

--- a/beacon-clients/beacon-web/src/components/results-grid.tsx
+++ b/beacon-clients/beacon-web/src/components/results-grid.tsx
@@ -1,24 +1,20 @@
-import { useMemo } from "react";
-import type { ArrowRecordBatch, ArrowTable, Row } from "@beacon/client";
-
-import { columnsOf, formatCell, formatTimestamp, timestampColumns } from "@/lib/format";
+import { EMPTY_RESULT, type ArrowResult } from "@/lib/arrow-result";
+import { formatCell, formatTimestamp } from "@/lib/format";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 interface ResultsGridProps {
-  rows: Row[];
-  /**
-   * Decoded Arrow table or record batch — its schema is used to render timestamp
-   * columns as date strings.
-   */
-  table?: ArrowTable | ArrowRecordBatch;
+  /** The rows to show, in Arrow's columnar form. */
+  result?: ArrowResult;
 }
 
-/** A scrollable, monospaced grid over decoded query rows. */
-export function ResultsGrid({ rows, table }: ResultsGridProps) {
-  const columns = useMemo(() => columnsOf(rows), [rows]);
-  const tsColumns = useMemo(() => timestampColumns(table), [table]);
-
-  if (rows.length === 0) {
+/**
+ * A scrollable, monospaced grid over an Arrow query result.
+ *
+ * Cells are read from the Arrow vectors while rendering, so a streaming query
+ * shows each batch as it lands without first decoding it into JS row objects.
+ */
+export function ResultsGrid({ result = EMPTY_RESULT }: ResultsGridProps) {
+  if (result.numRows === 0) {
     return (
       <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
         Query returned no rows.
@@ -33,32 +29,37 @@ export function ResultsGrid({ rows, table }: ResultsGridProps) {
       <TableHeader className="sticky top-0 z-10 bg-secondary">
         <TableRow>
           <TableHead className="w-12 text-right text-muted-foreground">#</TableHead>
-          {columns.map((col) => (
-            <TableHead key={col} className="whitespace-nowrap font-mono">
-              {col}
+          {result.columns.map((col, c) => (
+            // Arrow allows duplicate field names, so columns are keyed by position.
+            <TableHead key={c} className="whitespace-nowrap font-mono">
+              {col.name}
             </TableHead>
           ))}
         </TableRow>
       </TableHeader>
       <TableBody>
-        {rows.map((row, i) => (
-          <TableRow key={i}>
-            <TableCell className="text-right text-muted-foreground">{i + 1}</TableCell>
-            {columns.map((col) => {
-              const isTimestamp = tsColumns.has(col);
-              const text = isTimestamp ? formatTimestamp(row[col]) : formatCell(row[col]);
-              return (
-                <TableCell
-                  key={col}
-                  className="max-w-[28rem] truncate whitespace-nowrap"
-                  title={text}
-                >
-                  {text}
-                </TableCell>
-              );
-            })}
-          </TableRow>
-        ))}
+        {result.chunks.map((chunk, ci) =>
+          Array.from({ length: chunk.numRows }, (_, i) => (
+            <TableRow key={`${ci}:${i}`}>
+              <TableCell className="text-right text-muted-foreground">
+                {chunk.offset + i + 1}
+              </TableCell>
+              {result.columns.map((col, c) => {
+                const value = chunk.vectors[c]?.get(i);
+                const text = col.timestamp ? formatTimestamp(value) : formatCell(value);
+                return (
+                  <TableCell
+                    key={c}
+                    className="max-w-[28rem] truncate whitespace-nowrap"
+                    title={text}
+                  >
+                    {text}
+                  </TableCell>
+                );
+              })}
+            </TableRow>
+          )),
+        )}
       </TableBody>
     </Table>
   );

--- a/beacon-clients/beacon-web/src/lib/arrow-result.ts
+++ b/beacon-clients/beacon-web/src/lib/arrow-result.ts
@@ -1,0 +1,90 @@
+/** A columnar view over the Arrow chunks a query returns. */
+
+import type { ArrowRecordBatch, ArrowTable, ArrowVector } from "@beacon/client";
+
+/** A decoded Arrow chunk: one streamed record batch, or a whole table. */
+export type ArrowChunk = ArrowTable | ArrowRecordBatch;
+
+/** A column of the result, named by the Arrow schema. */
+export interface ResultColumn {
+  name: string;
+  /** An Arrow `Timestamp` column, which the grid renders as a date. */
+  timestamp: boolean;
+}
+
+/**
+ * One chunk of the result, with its columns resolved on arrival so the grid
+ * reads cells straight out of the Arrow vectors.
+ */
+export interface ResultChunk {
+  /** Row index of this chunk's first row within the whole result. */
+  offset: number;
+  /** Rows to take from this chunk. The last chunk is clipped at the row limit. */
+  numRows: number;
+  /** One vector per entry of {@link ArrowResult.columns}; null when the chunk lacks it. */
+  vectors: Array<ArrowVector | null>;
+}
+
+/**
+ * The rows a query returned, held in Arrow's columnar form.
+ *
+ * Nothing here builds a JS object per row. The grid reads one cell as
+ * `chunk.vectors[column].get(row)`, so a result costs only the cells that are
+ * rendered — a beacon table can carry 100K+ columns, of which a preview shows a
+ * few hundred rows.
+ */
+export interface ArrowResult {
+  readonly columns: readonly ResultColumn[];
+  readonly chunks: readonly ResultChunk[];
+  readonly numRows: number;
+}
+
+/** A result with no columns and no rows. */
+export const EMPTY_RESULT: ArrowResult = { columns: [], chunks: [], numRows: 0 };
+
+/**
+ * Appends `chunk`, keeping at most `maxRows` rows in total, and returns a new
+ * result. The reference is new, so React re-renders with the rows so far while
+ * the query still streams.
+ */
+export function appendChunk(
+  result: ArrowResult,
+  chunk: ArrowChunk,
+  maxRows = Number.POSITIVE_INFINITY,
+): ArrowResult {
+  const numRows = Math.min(chunk.numRows, Math.max(0, maxRows - result.numRows));
+  if (numRows === 0) return result;
+  // Every batch of one Arrow IPC stream shares the schema of the first.
+  const columns = result.columns.length > 0 ? result.columns : columnsOf(chunk);
+  const vectors = columns.map((_, i) => chunk.getChildAt(i));
+  return {
+    columns,
+    chunks: [...result.chunks, { offset: result.numRows, numRows, vectors }],
+    numRows: result.numRows + numRows,
+  };
+}
+
+/** Builds a result from a single already-decoded table (the non-streaming path). */
+export function resultFromTable(
+  table: ArrowTable | undefined,
+  maxRows = Number.POSITIVE_INFINITY,
+): ArrowResult {
+  return table ? appendChunk(EMPTY_RESULT, table, maxRows) : EMPTY_RESULT;
+}
+
+/**
+ * Reads the column names from the chunk's Arrow schema, marking the `Timestamp`
+ * ones. The unit is not needed — apache-arrow's getters already normalize every
+ * timestamp to milliseconds (see `formatTimestamp`) — only which columns are
+ * timestamps, so the grid renders them as dates and not as bare numbers.
+ */
+function columnsOf(chunk: ArrowChunk): ResultColumn[] {
+  const fields = chunk.schema?.fields;
+  if (!Array.isArray(fields)) return [];
+  // A `Timestamp` type prints as `Timestamp<MICROSECOND>`, or with a time zone
+  // as `Timestamp<MICROSECOND, UTC>` — match the name, not the parameters.
+  return fields.map((field) => ({
+    name: String(field.name),
+    timestamp: String(field.type).startsWith("Timestamp<"),
+  }));
+}

--- a/beacon-clients/beacon-web/src/lib/format.ts
+++ b/beacon-clients/beacon-web/src/lib/format.ts
@@ -1,14 +1,5 @@
 /** Display helpers for query rows and Arrow values in the results grid. */
 
-import type { Row } from "@beacon/client";
-
-/** Derives ordered column names from the decoded rows (Arrow column order). */
-export function columnsOf(rows: Row[]): string[] {
-  const seen = new Set<string>();
-  for (const row of rows) for (const key of Object.keys(row)) seen.add(key);
-  return [...seen];
-}
-
 /** Formats an arbitrary cell value (BigInt, Date, typed-array, object) as text. */
 export function formatCell(value: unknown): string {
   if (value === null || value === undefined) return "";
@@ -22,25 +13,6 @@ export function formatCell(value: unknown): string {
     }
   }
   return String(value);
-}
-
-/**
- * Maps each Arrow `Timestamp` column to its unit (SECOND/MILLISECOND/…), read
- * from the decoded table's schema. The unit is not needed to scale the value
- * (see [`formatTimestamp`]) — it only tells us *which* columns are timestamps,
- * so the grid renders them as dates rather than as bare numbers. Defensive:
- * returns an empty map if the table or its schema is unavailable.
- */
-export function timestampColumns(table: unknown): Map<string, string> {
-  const map = new Map<string, string>();
-  const fields = (table as { schema?: { fields?: unknown[] } } | undefined)?.schema?.fields;
-  if (!Array.isArray(fields)) return map;
-  for (const f of fields) {
-    const field = f as { name?: unknown; type?: unknown };
-    const match = /^Timestamp<(\w+)>/.exec(String(field.type ?? ""));
-    if (match && typeof field.name === "string") map.set(field.name, match[1]);
-  }
-  return map;
 }
 
 /**

--- a/beacon-clients/beacon-web/src/pages/datasets.tsx
+++ b/beacon-clients/beacon-web/src/pages/datasets.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { EMPTY_RESULT, resultFromTable } from "@/lib/arrow-result";
 import { useBeacon } from "@/lib/beacon-context";
 import { COLUMN_PAGE_SIZE, parseSchema } from "@/lib/schema";
 import { errorMessage } from "@/lib/errors";
@@ -1071,13 +1072,13 @@ function DatasetPreview({ path, format }: { path: string; format?: string }) {
     queryKey: ["dataset-preview", path],
     queryFn: async () => {
       const cols = parseSchema(await beacon.datasetSchema(path)).map((c) => c.name);
-      if (cols.length === 0) return { rows: [] as Record<string, unknown>[], table: undefined };
-      const { rows, table } = await beacon.query({
+      if (cols.length === 0) return EMPTY_RESULT;
+      const table = await beacon.queryArrow({
         select: cols.map((name) => ({ column: name })),
         from: { [fromKey(format)]: { paths: [path] } },
         limit: PREVIEW_ROWS,
       });
-      return { rows, table };
+      return resultFromTable(table);
     },
   });
 
@@ -1094,14 +1095,14 @@ function DatasetPreview({ path, format }: { path: string; format?: string }) {
       </div>
     );
 
-  const rows = query.data?.rows ?? [];
+  const result = query.data ?? EMPTY_RESULT;
   return (
     <div className="space-y-2">
       <div className="max-h-[60vh] overflow-auto rounded-md border">
-        <ResultsGrid rows={rows} table={query.data?.table} />
+        <ResultsGrid result={result} />
       </div>
-      {rows.length > 0 && (
-        <p className="text-xs text-muted-foreground">First {rows.length} rows.</p>
+      {result.numRows > 0 && (
+        <p className="text-xs text-muted-foreground">First {result.numRows} rows.</p>
       )}
     </div>
   );

--- a/beacon-clients/beacon-web/src/pages/tables.tsx
+++ b/beacon-clients/beacon-web/src/pages/tables.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { EMPTY_RESULT, resultFromTable } from "@/lib/arrow-result";
 import { useBeacon } from "@/lib/beacon-context";
 import { COLUMN_PAGE_SIZE, parseSchema } from "@/lib/schema";
 import { errorMessage } from "@/lib/errors";
@@ -482,12 +483,10 @@ function TablePreview({ table, defaults }: { table: TableRef; defaults: CatalogD
   const beacon = useBeacon();
   const query = useQuery({
     queryKey: ["table-preview", refKey(table)],
-    queryFn: async () => {
-      const result = await beacon.query(
-        `SELECT * FROM ${sqlName(table, defaults)} LIMIT ${PREVIEW_ROWS}`,
-      );
-      return { rows: result.rows, table: result.table };
-    },
+    queryFn: async () =>
+      resultFromTable(
+        await beacon.queryArrow(`SELECT * FROM ${sqlName(table, defaults)} LIMIT ${PREVIEW_ROWS}`),
+      ),
   });
 
   if (query.isLoading)
@@ -503,14 +502,14 @@ function TablePreview({ table, defaults }: { table: TableRef; defaults: CatalogD
       </div>
     );
 
-  const rows = query.data?.rows ?? [];
+  const result = query.data ?? EMPTY_RESULT;
   return (
     <div className="space-y-2">
       <div className="max-h-[60vh] overflow-auto rounded-md border">
-        <ResultsGrid rows={rows} table={query.data?.table} />
+        <ResultsGrid result={result} />
       </div>
-      {rows.length > 0 && (
-        <p className="text-xs text-muted-foreground">First {rows.length} rows.</p>
+      {result.numRows > 0 && (
+        <p className="text-xs text-muted-foreground">First {result.numRows} rows.</p>
       )}
     </div>
   );

--- a/beacon-clients/beacon-web/src/pages/workbench.tsx
+++ b/beacon-clients/beacon-web/src/pages/workbench.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { useLocation } from "react-router-dom";
-import { rowsFromBatch, type ArrowRecordBatch, type ArrowTable, type Row } from "@beacon/client";
 import {
   AlertCircle,
   Bookmark,
@@ -14,6 +13,7 @@ import {
   Trash2,
 } from "lucide-react";
 
+import { appendChunk, EMPTY_RESULT, type ArrowResult } from "@/lib/arrow-result";
 import { useBeacon } from "@/lib/beacon-context";
 import { errorMessage } from "@/lib/errors";
 import { formatBytes } from "@/lib/format";
@@ -51,9 +51,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 interface RunResult {
-  rows: Row[];
-  /** First record batch (or full table) — carries the schema for timestamp rendering. */
-  table?: ArrowTable | ArrowRecordBatch;
+  /** The rows that have streamed in so far, kept in Arrow's columnar form. */
+  view: ArrowResult;
   queryId: string | null;
   elapsedMs: number;
   /** True when the preview row limit was hit and the query was stopped early. */
@@ -152,26 +151,15 @@ export function WorkbenchPage() {
     abortRef.current = controller;
     try {
       const { queryId, batches } = await beacon.queryBatches(text, controller.signal);
-      const rows: Row[] = [];
-      let schema: ArrowRecordBatch | undefined;
+      let view = EMPTY_RESULT;
       let truncated = false;
       for await (const batch of batches) {
-        if (!schema) schema = batch; // the first batch carries the Arrow schema
-        for (const row of rowsFromBatch<Row>(batch)) {
-          if (rows.length >= PREVIEW_ROW_LIMIT) {
-            truncated = true;
-            break;
-          }
-          rows.push(row);
-        }
-        // New array reference so React re-renders with the rows so far.
-        setResult({
-          rows: rows.slice(),
-          table: schema,
-          queryId,
-          elapsedMs: performance.now() - started,
-          truncated,
-        });
+        // The batch is kept as Arrow columns; nothing is decoded into JS objects
+        // until the grid renders a cell.
+        truncated = batch.numRows > PREVIEW_ROW_LIMIT - view.numRows;
+        view = appendChunk(view, batch, PREVIEW_ROW_LIMIT);
+        // A new result reference makes React render the rows so far.
+        setResult({ view, queryId, elapsedMs: performance.now() - started, truncated });
         if (truncated) {
           controller.abort(); // we have our preview; stop the query
           break;
@@ -180,7 +168,12 @@ export function WorkbenchPage() {
       // No batches arrived (DDL/DML or an empty result): surface a zero-row result.
       setResult(
         (prev) =>
-          prev ?? { rows: [], queryId, elapsedMs: performance.now() - started, truncated: false },
+          prev ?? {
+            view: EMPTY_RESULT,
+            queryId,
+            elapsedMs: performance.now() - started,
+            truncated: false,
+          },
       );
     } catch (err) {
       if (controller.signal.aborted) {
@@ -401,7 +394,7 @@ export function WorkbenchPage() {
           {mode === "results" && result && (
             <>
               <span className="text-muted-foreground">
-                {result.rows.length} rows
+                {result.view.numRows} rows
                 {result.truncated && ` (first ${PREVIEW_ROW_LIMIT} — query stopped)`}
                 {result.cancelled && " (cancelled)"}
               </span>
@@ -448,7 +441,7 @@ export function WorkbenchPage() {
               <Empty>Run Explain to see the query plan.</Empty>
             )
           ) : result ? (
-            <ResultsGrid rows={result.rows} table={result.table} />
+            <ResultsGrid result={result.view} />
           ) : running ? (
             <Empty>
               <Loader2 className="mr-2 inline h-4 w-4 animate-spin" />


### PR DESCRIPTION
## Problem

The query workbench streams record batches and shows the first 500 rows. But it decodes each batch into JS row objects first. That step makes one object per row and one property per column. A beacon table carries up to 100K+ columns, so the decode is the wait, not the query.

## Change

The workbench keeps each batch in columnar form. The grid reads one value as `column.get(row)`. The table preview and the dataset preview use the same path.

- `lib/arrow-result.ts` holds the result as Arrow chunks. It clips the last chunk at the row limit.
- Column names come from the Arrow schema, so a duplicate name survives.
- A timestamp column with a time zone renders as a date again. The old test needed `Timestamp<UNIT>` and missed `Timestamp<UNIT, UTC>`.
- The SDK types state the columnar access. `ArrowTable` and `ArrowRecordBatch` declare `schema` and `getChildAt`, next to the new `ArrowVector`, `ArrowField` and `ArrowSchema` types.

## Test

A 2,000,000 row query fills the grid in 335 ms and stops the query. Small batches number the rows 1 to 300. A result of exactly 500 rows reports no truncation. A `SET` statement reports 0 rows. All 35 SDK tests pass.