### PR TITLE
Admin-gated path alias for Admin UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,15 @@ tag. Releases before 2.0.0 are recorded in the
   creation, no `INSERT`. Virtual chunk references — chunks that stay inside a netCDF or HDF5 file
   outside the repository, as VirtualiZarr produces — are **not** followed, because that read needs
   the credentials of a different store than the one the caller was granted.
+- **Every endpoint answers on a second path below `/admin`.** `POST /admin/api/query` runs the same
+  handler as `POST /api/query`, and `/admin/api/admin/crawlers` the same as `/api/admin/crawlers`.
+  The whole alias sits behind the admin Basic auth gate, the client endpoints included: `/api/info`
+  answers any caller, `/admin/api/info` only the super-user. The
+  [admin web UI](docs/docs/2.0.0-rc3/connect/web-admin-ui.md) now calls the alias, so a deployment
+  that puts its own security in front of `/api/*` keeps a working admin panel. `@beacon/client`
+  reaches the alias with the new `apiPrefix: ADMIN_API_PREFIX` client option. The alias stays out of
+  `/openapi.json`: publishing it would list every operation twice and repeat each operation id. See
+  [the REST API reference](docs/docs/2.0.0-rc3/api/index.md#admin-path-alias).
 
 ### Changed
 

--- a/beacon-clients/beacon-ts/src/http.ts
+++ b/beacon-clients/beacon-ts/src/http.ts
@@ -5,6 +5,16 @@ import { ApiError, ConnectionError, TimeoutError } from "./errors.js";
 /** A fetch-compatible function. Defaults to the global `fetch`. */
 export type FetchLike = typeof fetch;
 
+/**
+ * Prefix of Beacon's admin-gated alias of the API, for {@link ClientOptions.apiPrefix}.
+ *
+ * Beacon serves every endpoint twice: on its own path (`/api/query`) and below
+ * `/admin` (`/admin/api/query`). Both run the same handler. Use the alias when a
+ * gateway in front of Beacon holds `/api/*`; it needs super-user credentials, so
+ * set `username` and `password` with it.
+ */
+export const ADMIN_API_PREFIX = "/admin";
+
 export interface ClientOptions {
   /** Base URL of the Beacon server, e.g. `http://localhost:5001`. */
   url: string;
@@ -19,6 +29,12 @@ export interface ClientOptions {
    * Prepended to every API path. Defaults to "".
    */
   basePath?: string;
+  /**
+   * Prefix of the API surface to call, between `basePath` and the endpoint path.
+   * Defaults to "" — the endpoints on their own paths. Set
+   * {@link ADMIN_API_PREFIX} to call the admin-gated alias instead.
+   */
+  apiPrefix?: string;
   /** Per-request timeout in milliseconds. Defaults to 60000. Set to 0 to disable. */
   timeoutMs?: number;
   /** Custom fetch implementation (e.g. for testing or a proxy). */
@@ -60,7 +76,8 @@ export class Http {
   constructor(options: ClientOptions) {
     const base = options.url.replace(/\/+$/, "");
     const prefix = (options.basePath ?? "").replace(/\/+$/, "");
-    this.baseUrl = `${base}${prefix}`;
+    const apiPrefix = (options.apiPrefix ?? "").replace(/\/+$/, "");
+    this.baseUrl = `${base}${prefix}${apiPrefix}`;
     const fetchImpl = options.fetch ?? globalThis.fetch;
     if (typeof fetchImpl !== "function") {
       throw new Error(

--- a/beacon-clients/beacon-ts/src/index.ts
+++ b/beacon-clients/beacon-ts/src/index.ts
@@ -12,7 +12,7 @@ export type {
   AuthRule,
   AuthRole,
 } from "./admin.js";
-export { Http, basicAuthHeader } from "./http.js";
+export { Http, basicAuthHeader, ADMIN_API_PREFIX } from "./http.js";
 export type { ClientOptions, FetchLike } from "./http.js";
 export { BeaconError, ApiError, ConnectionError, TimeoutError } from "./errors.js";
 export { getArrowDecoder, rowsFromTable, rowsFromBatch } from "./arrow.js";

--- a/beacon-clients/beacon-ts/test/client.test.ts
+++ b/beacon-clients/beacon-ts/test/client.test.ts
@@ -1,7 +1,13 @@
 import { Table, tableFromArrays, tableToIPC } from "apache-arrow";
 import { describe, expect, it, vi } from "vitest";
 
-import { ApiError, BeaconClient, basicAuthHeader, rowsFromTable } from "../src/index.js";
+import {
+  ADMIN_API_PREFIX,
+  ApiError,
+  BeaconClient,
+  basicAuthHeader,
+  rowsFromTable,
+} from "../src/index.js";
 
 /** Builds a fetch stub that records calls and returns a fresh `response` each time. */
 function stubFetch(makeResponse: () => Response) {
@@ -174,5 +180,28 @@ describe("BeaconClient metadata paths", () => {
     const client = new BeaconClient({ url: "http://beacon.test", basePath: "/beacon", fetch: fn });
     await client.tables();
     expect(calls[0]!.url).toBe("http://beacon.test/beacon/api/tables");
+  });
+
+  it("calls the admin alias when apiPrefix is set", async () => {
+    const { fn, calls } = stubFetch(() => jsonResponse([]));
+    const client = new BeaconClient({
+      url: "http://beacon.test",
+      apiPrefix: ADMIN_API_PREFIX,
+      fetch: fn,
+    });
+    await client.tables();
+    expect(calls[0]!.url).toBe("http://beacon.test/admin/api/tables");
+  });
+
+  it("puts apiPrefix after basePath", async () => {
+    const { fn, calls } = stubFetch(() => jsonResponse([]));
+    const client = new BeaconClient({
+      url: "http://beacon.test",
+      basePath: "/beacon",
+      apiPrefix: ADMIN_API_PREFIX,
+      fetch: fn,
+    });
+    await client.tables();
+    expect(calls[0]!.url).toBe("http://beacon.test/beacon/admin/api/tables");
   });
 });

--- a/beacon-clients/beacon-web/src/lib/auth.ts
+++ b/beacon-clients/beacon-web/src/lib/auth.ts
@@ -1,6 +1,6 @@
 /** Connection + admin-credential storage for the login-gated admin UI. */
 
-import { BeaconClient } from "@beacon/client";
+import { ADMIN_API_PREFIX, BeaconClient } from "@beacon/client";
 
 import { serverBase } from "./base-path";
 
@@ -25,7 +25,7 @@ export const SAME_ORIGIN = import.meta.env.PROD;
 /**
  * The API base URL when the UI is served by Beacon: the current origin plus any
  * deployment base path (the path in front of `/admin`). The SDK appends
- * `/api/...` to this, so an empty base path yields just the origin.
+ * `/admin/api/...` to this, so an empty base path yields just the origin.
  */
 export function sameOriginUrl(): string {
   return serverBase();
@@ -65,18 +65,27 @@ export function clearConnection(): void {
   localStorage.removeItem(STORAGE_KEY);
 }
 
-/** Builds a `BeaconClient` from a connection (credentials elevate every request). */
+/**
+ * Builds a `BeaconClient` from a connection (credentials elevate every request).
+ *
+ * The client calls Beacon's admin-gated alias of the API, so every request the UI
+ * makes sits below `/admin` — the same prefix that serves this application. A
+ * deployment can then put its own security in front of `/api/*` and this panel
+ * keeps working. The alias demands super-user credentials, which a session here
+ * always carries.
+ */
 export function makeClient(conn: Connection): BeaconClient {
   return new BeaconClient({
     url: conn.url.replace(/\/+$/, ""),
+    apiPrefix: ADMIN_API_PREFIX,
     username: conn.username,
     password: conn.password,
   });
 }
 
 /**
- * Verifies admin credentials against `GET /api/admin/check`. Throws the SDK's
- * `ApiError` (401 on bad credentials) or a `ConnectionError` if unreachable.
+ * Verifies admin credentials against `GET /admin/api/admin/check`. Throws the
+ * SDK's `ApiError` (401 on bad credentials) or a `ConnectionError` if unreachable.
  */
 export async function verifyAdmin(client: BeaconClient): Promise<void> {
   await client.admin.check();

--- a/beacon-clients/beacon-web/src/lib/base-path.ts
+++ b/beacon-clients/beacon-web/src/lib/base-path.ts
@@ -19,8 +19,8 @@ export function routerBasename(): string {
 
 /**
  * The URL of the Beacon server that serves this UI: the origin plus the prefix
- * in front of `/admin`. The SDK adds `/api/...` to it, so a server at the root
- * gives back only the origin.
+ * in front of `/admin`. The SDK adds `/admin/api/...` to it (the admin-gated
+ * alias of the API), so a server at the root gives back only the origin.
  */
 export function serverBase(): string {
   const { origin, pathname } = new URL(document.baseURI);

--- a/beacon-server/beacon-server/src/axum/router.rs
+++ b/beacon-server/beacon-server/src/axum/router.rs
@@ -2,16 +2,16 @@
 
 use std::{str::FromStr, sync::Arc, time::Duration};
 
+use crate::server::Server;
 use ::axum::{
     body::Bytes,
     extract::MatchedPath,
     http::{HeaderMap, HeaderName, HeaderValue, Method, Request},
     response::{IntoResponse, Redirect, Response},
-    routing::get,
+    routing::{any, get},
     Router,
 };
 use anyhow::Context;
-use crate::server::Server;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tower_http::services::{ServeDir, ServeFile};
 use tower_http::{classify::ServerErrorsFailureClass, trace::TraceLayer};
@@ -23,6 +23,9 @@ use utoipa_swagger_ui::{SwaggerUi, Url};
 use crate::axum::{admin::setup_admin_router, client::setup_client_router};
 
 const BEACON_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Path prefix carrying an admin-gated alias of the whole HTTP API.
+const ADMIN_ALIAS_PREFIX: &str = "/admin";
 
 /// Builds the complete HTTP router, OpenAPI docs, CORS policy, and tracing layers.
 ///
@@ -36,6 +39,19 @@ pub fn setup_router(
     let (client_router, mut api_docs_client) = setup_client_router();
     let (admin_router, api_docs_admin) = setup_admin_router();
 
+    // The alias of both surfaces (see `ADMIN_ALIAS_PREFIX`). It copies the two
+    // routers before any middleware goes on them, so the admin gate added below
+    // covers all of it — the mirrored client routes as well. `/api/health` is a
+    // plain route rather than a documented one, so it is added here by hand.
+    let alias_router = Router::new().nest(
+        ADMIN_ALIAS_PREFIX,
+        client_router
+            .clone()
+            .merge(admin_router.clone())
+            .route("/api/health", get(health))
+            .route("/api/{*rest}", any(::axum::http::StatusCode::NOT_FOUND)),
+    );
+
     // Resolve the caller's identity for every client route; gate admin routes on a super-user.
     // Both middlewares carry the runtime as their own state (independent of the router state set
     // below), so they are attached per-sub-router before the two are merged.
@@ -43,20 +59,8 @@ pub fn setup_router(
         beacon_runtime.clone(),
         crate::axum::auth::resolve_identity,
     ));
-    // `basic_auth` gates admin routes on the super-user; `resolve_identity` puts
-    // that identity in the request extensions. Admin handlers need it too, now
-    // that they read the catalog by running SQL as the caller rather than through
-    // privileged accessors. Layers apply bottom-up, so `resolve_identity` is
-    // listed second to run after the gate.
-    let admin_router = admin_router
-        .layer(::axum::middleware::from_fn_with_state(
-            beacon_runtime.clone(),
-            crate::axum::auth::resolve_identity,
-        ))
-        .layer(::axum::middleware::from_fn_with_state(
-            beacon_runtime.clone(),
-            crate::axum::auth::basic_auth,
-        ));
+    let admin_router = with_admin_auth(admin_router, &beacon_runtime);
+    let alias_router = with_admin_auth(alias_router, &beacon_runtime);
 
     api_docs_client.merge(api_docs_admin);
     api_docs_client = set_api_docs_info(api_docs_client, &config.api_docs);
@@ -87,9 +91,14 @@ pub fn setup_router(
     // calls execute under the caller's identity (or the anonymous principal when
     // enabled) and per-user RBAC applies at query time.
     let mcp_enabled = std::env::var("BEACON_MCP_ENABLED")
-        .map(|v| !matches!(v.trim().to_ascii_lowercase().as_str(), "false" | "0" | "off"))
+        .map(|v| {
+            !matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "false" | "0" | "off"
+            )
+        })
         .unwrap_or(true);
-    let mut router = client_router.merge(admin_router);
+    let mut router = client_router.merge(admin_router).merge(alias_router);
     if mcp_enabled {
         let mcp_router = ::axum::Router::new()
             .route_service(
@@ -108,10 +117,7 @@ pub fn setup_router(
             "/scalar",
             get(move || async move { Redirect::to(scalar_redirect) }),
         )
-        .route(
-            "/api/health",
-            get(|| async { Response::new("Ok".to_string()) }),
-        )
+        .route("/api/health", get(health))
         .route(
             "/",
             get(move || async move { Redirect::to(swagger_redirect) }),
@@ -142,6 +148,33 @@ pub fn setup_router(
             .nest(base_path, setup_tracing_router(router))
             .merge(swagger_ui))
     }
+}
+
+/// Liveness probe: `200 OK` once the server answers.
+///
+/// Undocumented on purpose — it is a plain route, not part of the OpenAPI
+/// surface. Served on `/api/health` and on its `ADMIN_ALIAS_PREFIX` alias.
+async fn health() -> Response<String> {
+    Response::new("Ok".to_string())
+}
+
+/// Puts the admin gate on `router`.
+///
+/// `basic_auth` rejects every caller that is not the super-user. `resolve_identity`
+/// then puts that identity in the request extensions: admin handlers need it too,
+/// now that they read the catalog by running SQL as the caller rather than through
+/// privileged accessors. Layers apply bottom-up, so the gate listed last runs
+/// first.
+fn with_admin_auth(router: Router<Arc<Server>>, runtime: &Arc<Server>) -> Router<Arc<Server>> {
+    router
+        .layer(::axum::middleware::from_fn_with_state(
+            runtime.clone(),
+            crate::axum::auth::resolve_identity,
+        ))
+        .layer(::axum::middleware::from_fn_with_state(
+            runtime.clone(),
+            crate::axum::auth::basic_auth,
+        ))
 }
 
 /// Builds a router that serves the admin web UI (a Vite single-page app) at

--- a/beacon-server/beacon-server/tests/api_contract_http.rs
+++ b/beacon-server/beacon-server/tests/api_contract_http.rs
@@ -17,6 +17,11 @@
 //! This test pins the wire contract by asserting each client-called path is
 //! present in the router's own OpenAPI document. Add a client call → add it
 //! here; intentionally retire an endpoint → remove both, deliberately.
+//!
+//! The admin UI addresses every one of them through the `/admin` alias (so a
+//! deployment can gate `/api/*` in front of Beacon and keep the panel working),
+//! which the same list checks against the router itself — the alias is not in
+//! the OpenAPI document.
 
 mod common;
 
@@ -129,6 +134,207 @@ async fn every_client_called_endpoint_is_routed() {
         "the shipped clients call endpoints the router does not serve — these 404 in the \
          admin UI:\n  {}",
         missing.join("\n  ")
+    );
+}
+
+/// Every endpoint the clients call is served a second time below `/admin`, so
+/// the admin UI can reach the whole API without touching `/api/*`. The alias is
+/// absent from the OpenAPI document on purpose (it would list every operation
+/// twice), so this asks the router instead.
+///
+/// `TRACE` is the probe. No handler registers it, so a routed path answers `405`
+/// and an unrouted one falls through to `404`. That separates routing from
+/// behaviour without running a handler — several of these endpoints write.
+#[tokio::test(flavor = "multi_thread")]
+async fn every_client_called_endpoint_is_routed_under_the_admin_alias() {
+    let (router, _lake) = app().await;
+    let auth = basic(ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    let mut wrong = Vec::new();
+    for (_, path) in CLIENT_ENDPOINTS {
+        // The probe never reaches a handler, so any value fills a path parameter.
+        let uri = format!(
+            "/admin{}",
+            path.replace("{query_id}", "x").replace("{name}", "x")
+        );
+        let (status, _) = send(
+            &router,
+            Request::builder()
+                .method("TRACE")
+                .uri(&uri)
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        if status != StatusCode::METHOD_NOT_ALLOWED {
+            wrong.push(format!("{uri} answered {status}, expected 405"));
+        }
+    }
+
+    assert!(
+        wrong.is_empty(),
+        "the admin UI calls these through the `/admin` alias — a 404 means the alias          does not route them, a 401 means the admin gate rejects the super-user:
+  {}",
+        wrong.join("
+  ")
+    );
+}
+
+/// The GETs the admin UI loads on page render must answer through the alias, not
+/// merely route: this is the path the shipped panel actually uses. `/api/health`
+/// is aliased by hand (it is a plain route), so it is in the list.
+#[tokio::test(flavor = "multi_thread")]
+async fn admin_alias_get_endpoints_answer_successfully() {
+    let (router, _lake) = app().await;
+    let auth = basic(ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    let cases = [
+        "/admin/api/health",
+        "/admin/api/info",
+        "/admin/api/tables",
+        "/admin/api/tables-with-schema",
+        "/admin/api/list-datasets",
+        "/admin/api/functions",
+        "/admin/api/admin/check",
+        "/admin/api/admin/auth/users",
+        "/admin/api/admin/crawlers",
+    ];
+
+    for uri in cases {
+        let (status, body) = send(
+            &router,
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "GET {uri} should succeed, got {status}: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+}
+
+/// The whole alias sits behind the admin gate, the mirrored client routes
+/// included. `/api/info` answers any caller; `/admin/api/info` answers the
+/// super-user only. Anything less would publish an ungated copy of the client
+/// API on a second path.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_admin_alias_gates_the_client_routes_it_mirrors() {
+    let (router, _lake) = app().await;
+
+    for uri in ["/api/info", "/api/tables"] {
+        let (status, _) = send(
+            &router,
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "GET {uri} is open to any caller");
+
+        let (status, _) = send(
+            &router,
+            Request::builder()
+                .method("GET")
+                .uri(&format!("/admin{uri}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "GET /admin{uri} must demand credentials"
+        );
+    }
+
+    // Wrong credentials are refused rather than treated as anonymous.
+    let (status, _) = send(
+        &router,
+        Request::builder()
+            .method("GET")
+            .uri("/admin/api/info")
+            .header(
+                header::AUTHORIZATION,
+                basic(ADMIN_USERNAME, "wrong-password"),
+            )
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "bad credentials are refused"
+    );
+}
+
+/// An alias path that no endpoint claims answers `404`, like the canonical path
+/// does. The web UI mounts at the same prefix and catches everything below it with
+/// its own shell, so the alias carries a catch-all of its own to stop a mistyped
+/// endpoint from returning that HTML page with a `200`.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_unclaimed_alias_path_is_a_404() {
+    let (router, _lake) = app().await;
+    let auth = basic(ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    for uri in [
+        "/admin/api/nope",
+        "/admin/api/admin/nope",
+        "/admin/api/query/nope",
+    ] {
+        let (status, _) = send(
+            &router,
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "GET {uri}");
+    }
+
+    // The catch-all must not shadow the endpoints beside it.
+    let (status, _) = send(
+        &router,
+        Request::builder()
+            .method("GET")
+            .uri("/admin/api/tables")
+            .header(header::AUTHORIZATION, &auth)
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "an exact route beats the catch-all");
+}
+
+/// The alias is not published: `/openapi.json` documents each operation once, on
+/// its own path. A second copy would double every tag in Swagger UI and repeat
+/// each operation id, which breaks code generators.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_admin_alias_stays_out_of_the_openapi_document() {
+    let (router, _lake) = app().await;
+    let spec = openapi(&router).await;
+    let paths = spec
+        .get("paths")
+        .and_then(Value::as_object)
+        .expect("the OpenAPI document should have a `paths` object");
+
+    let published: Vec<&String> = paths.keys().filter(|p| p.starts_with("/admin/")).collect();
+    assert!(
+        published.is_empty(),
+        "the `/admin` alias should not be documented, found: {published:?}"
     );
 }
 

--- a/beacon-server/beacon-server/tests/web_ui_http.rs
+++ b/beacon-server/beacon-server/tests/web_ui_http.rs
@@ -138,6 +138,40 @@ async fn the_api_stays_reachable_beside_the_web_ui() {
     assert_eq!(status, StatusCode::UNAUTHORIZED);
 }
 
+/// The API alias and the SPA share the `/admin` prefix. The alias paths are exact
+/// routes and the SPA is a catch-all below them, so `/admin/api/...` has to reach
+/// the API. A `401` proves it: the app shell answers `200` to anything it catches.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_api_alias_wins_over_the_spa_catch_all() {
+    let web = web_build();
+
+    for (base_path, alias, spa_route) in [
+        ("", "/admin/api/info", "/admin/tables"),
+        ("/beacon", "/beacon/admin/api/info", "/beacon/admin/tables"),
+    ] {
+        let (_harness, router) = app(base_path, &web).await;
+
+        let (status, _, body) = get(&router, alias).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "base path {base_path:?}: {alias} should reach the gated API"
+        );
+        assert_ne!(body, INDEX_HTML, "base path {base_path:?}");
+
+        // An unclaimed alias path is the API's 404, not the app shell. The gate
+        // in front of the alias answers first, which is already not the shell.
+        let (status, _, body) = get(&router, &format!("{alias}-nope")).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED, "base path {base_path:?}");
+        assert_ne!(body, INDEX_HTML, "base path {base_path:?}");
+
+        // A client-side route beside it still falls back to the app shell.
+        let (status, _, body) = get(&router, spa_route).await;
+        assert_eq!(status, StatusCode::OK, "base path {base_path:?}");
+        assert_eq!(body, INDEX_HTML, "base path {base_path:?}");
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn no_web_ui_directory_leaves_the_admin_path_unmounted() {
     let empty = tempfile::tempdir().expect("create temp dir");

--- a/docs/docs/2.0.0-rc3/api/index.md
+++ b/docs/docs/2.0.0-rc3/api/index.md
@@ -20,6 +20,34 @@ This documentation shows every endpoint as a relative path, for example `GET /ap
 request to the base URL of your Beacon server. The default is `http://localhost:5001`. Behind a
 reverse proxy, use the URL of that proxy.
 
+## Admin path alias
+
+Beacon serves each endpoint on two paths. The second path has the prefix `/admin`:
+
+| Endpoint | Alias |
+| -------- | ----- |
+| `POST /api/query` | `POST /admin/api/query` |
+| `GET /api/tables` | `GET /admin/api/tables` |
+| `GET /api/admin/crawlers` | `GET /admin/api/admin/crawlers` |
+| `GET /api/health` | `GET /admin/api/health` |
+
+The two paths run the same handler.
+
+Each path below `/admin` needs the admin Basic auth credentials. This also applies
+to the endpoints that answer any caller on `/api/*`. `GET /api/info` is open.
+`GET /admin/api/info` is not.
+
+Use the alias when a proxy in front of Beacon protects `/api/*`. Your proxy keeps
+control of `/api/*`. The [admin web UI](/docs/2.0.0-rc3/connect/web-admin-ui) calls
+the alias only, so the UI stays in service.
+
+```bash
+curl -u beacon-admin:beacon-password http://localhost:5001/admin/api/tables
+```
+
+The OpenAPI specification lists each endpoint one time. It shows the path without
+the prefix.
+
 ## Health check
 
 ```http

--- a/docs/docs/2.0.0-rc3/connect/typescript.md
+++ b/docs/docs/2.0.0-rc3/connect/typescript.md
@@ -102,6 +102,31 @@ The client sends the credentials on every request. The server checks them with
 `GET /api/admin/check`. The [REST API reference](/docs/2.0.0-rc3/api/) lists every
 admin endpoint.
 
+## Call the admin path alias
+
+Beacon serves each endpoint a second time below `/admin`. Set `apiPrefix` to send
+each call through that prefix:
+
+```ts
+import { ADMIN_API_PREFIX, BeaconClient } from "@beacon/client";
+
+const beacon = new BeaconClient({
+  url: "http://localhost:5001",
+  apiPrefix: ADMIN_API_PREFIX,
+  username: "beacon-admin",
+  password: "beacon-password",
+});
+
+await beacon.tables(); // GET /admin/api/tables
+```
+
+Use this when a proxy in front of Beacon protects `/api/*`. The alias needs the
+admin credentials for each endpoint. Read the
+[admin path alias](/docs/2.0.0-rc3/api/#admin-path-alias) for the rules.
+
+`basePath` and `apiPrefix` are separate. `basePath` gives the prefix that the
+server runs under (`BEACON_BASE_PATH`). `apiPrefix` comes after it.
+
 ## Use in a browser
 
 The SDK works with a bundler. It runs in the browser without a change. The

--- a/docs/docs/2.0.0-rc3/connect/web-admin-ui.md
+++ b/docs/docs/2.0.0-rc3/connect/web-admin-ui.md
@@ -28,8 +28,22 @@ BEACON_ADMIN_USERNAME=beacon-admin
 BEACON_ADMIN_PASSWORD=beacon-password
 ```
 
-The UI checks the credentials with `GET /api/admin/check`. It stores them in the
-`localStorage` of the browser. It then sends them on every request.
+The UI checks the credentials with `GET /admin/api/admin/check`. It stores them in
+the `localStorage` of the browser. It then sends them on every request.
+
+## Every call sits below `/admin`
+
+The UI calls the [admin path alias](/docs/2.0.0-rc3/api/#admin-path-alias) of the
+API. `/admin/api/query` runs the same handler as `/api/query`. Each request of the
+UI therefore uses the same prefix that serves the UI.
+
+Put your own security in front of `/api/*` with this. The UI keeps its function,
+because it sends no request to `/api/*`. Give your proxy these rules:
+
+- Keep your own rules on `/api/*`.
+- Send `/admin` and each path below it to Beacon.
+
+The alias needs the admin credentials, which the UI holds after the login.
 
 :::warning
 This login runs in the browser, over the HTTP Basic admin auth of Beacon. It


### PR DESCRIPTION
# Add an admin-gated path alias for the whole API

Beacon now answers each endpoint on a second path below `/admin`.
`POST /admin/api/query` runs the same handler as `POST /api/query`.
The alias covers the client routes and the admin routes.

Each alias path needs the admin Basic auth credentials. This also applies to
the open endpoints. `GET /api/info` answers any caller. `GET /admin/api/info`
answers the super-user only.

The alias helps a deployment that protects `/api/*` with its own proxy. The
admin web UI now calls the alias, so the panel stays in service.

## Changes

- **Server:** Build an alias router below `/admin`. Put the admin gate on it.
  Move the shared gate into `with_admin_auth`. Send unclaimed alias paths to a
  404, before the single-page app catch-all.
- **TypeScript client:** Add the `apiPrefix` option and the `ADMIN_API_PREFIX`
  constant. The prefix comes after `basePath`.
- **Web UI:** Build the client with `apiPrefix: ADMIN_API_PREFIX`.
- **Docs:** Add an "Admin path alias" section to the REST API reference.
  Update the TypeScript and web UI pages. Add a CHANGELOG entry.