### PR TITLE
fix: restore BEACON_S3_DATA_LAKE and document the log files

### DIFF
--- a/beacon-server/beacon-server-config/src/lib.rs
+++ b/beacon-server/beacon-server-config/src/lib.rs
@@ -356,7 +356,7 @@ struct RawConfig {
     // Former name of `BEACON_S3_DATASETS`, kept so existing deployments keep working.
     // `Config::load` warns when it is the one that turned the S3 store on. Remove it
     // one major version after 2.0.
-    #[envconfig(from = "BEACON_S3_DATASETS", default = "false")]
+    #[envconfig(from = "BEACON_S3_DATA_LAKE", default = "false")]
     s3_data_lake_deprecated: bool,
     #[envconfig(from = "BEACON_S3_BUCKET")]
     s3_bucket: Option<String>,
@@ -759,7 +759,16 @@ impl Config {
         let raw = RawConfig::init_from_env().map_err(|e| ConfigError::EnvLoad(e.to_string()))?;
         // Capture the secrets key before `raw` is consumed; decode/validate below.
         let secrets_key_b64 = raw.secrets_key.clone();
+        // Same, for the one case the deprecation warning below has to distinguish:
+        // the S3 store turned on by the old variable alone.
+        let s3_via_deprecated_name = raw.s3_data_lake_deprecated && !raw.s3_datasets;
         let mut config: Config = raw.into();
+        if s3_via_deprecated_name {
+            tracing::warn!(
+                "BEACON_S3_DATA_LAKE is deprecated; set BEACON_S3_DATASETS=true instead. \
+                 The old name is removed one major version after 2.0."
+            );
+        }
         if let Some(b64) = secrets_key_b64 {
             config.secrets.master_key =
                 Some(decode_master_key(&b64).map_err(ConfigError::InvalidSecretsKey)?);
@@ -915,6 +924,37 @@ mod tests {
         // Path-style addressing and plain HTTP are the defaults (local MinIO).
         assert!(!s3.enable_virtual_hosting);
         assert!(s3.allow_http);
+    }
+
+    /// `BEACON_S3_DATA_LAKE` is the pre-2.0 name of `BEACON_S3_DATASETS`. A
+    /// deployment that still sets it must keep its S3 datasets store, so the two
+    /// names stay independent inputs to the same flag.
+    #[test]
+    fn the_deprecated_s3_variable_still_turns_the_store_on() {
+        let old = config(&[
+            ("BEACON_S3_DATA_LAKE", "true"),
+            ("BEACON_S3_BUCKET", "my-bucket"),
+        ])
+        .s3;
+        assert!(old.datasets_on_s3);
+        assert_eq!(old.bucket.as_deref(), Some("my-bucket"));
+
+        // The old name off and the new one on is the ordinary 2.0 deployment.
+        assert!(
+            config(&[
+                ("BEACON_S3_DATASETS", "true"),
+                ("BEACON_S3_BUCKET", "my-bucket"),
+            ])
+            .s3
+            .datasets_on_s3
+        );
+
+        // Neither name set leaves the datasets store local.
+        assert!(
+            !config(&[("BEACON_S3_BUCKET", "my-bucket")])
+                .s3
+                .datasets_on_s3
+        );
     }
 
     /// The native-reader base URL must address the same bucket the object store

--- a/docs/docs/2.0.0-rc3/getting-started.md
+++ b/docs/docs/2.0.0-rc3/getting-started.md
@@ -94,6 +94,7 @@ docker run -d \
     -e BEACON_ADMIN_PASSWORD=securepassword \
     -v ./datasets:/beacon/data/datasets \
     -v ./tables:/beacon/data/tables \
+    -v ./logs:/beacon/logs \
     ghcr.io/maris-development/beacon:latest
 ```
 
@@ -112,6 +113,7 @@ services:
         volumes:
             - ./datasets:/beacon/data/datasets
             - ./tables:/beacon/data/tables
+            - ./logs:/beacon/logs
 ```
 
 :::
@@ -120,6 +122,12 @@ For Compose, run `docker compose up -d`. Beacon now runs. Open the
 [admin UI](/docs/2.0.0-rc3/connect/web-admin-ui) at `http://localhost:5001/admin` to explore and
 query. Open `http://localhost:5001/swagger` for the API docs. You can query any file in `./datasets`
 at once.
+
+::: tip Log files
+The `./logs` volume writes the log files to your machine. Beacon starts one file each day, for
+example `beacon.log.2026-08-19`. Without the volume the files stay in the container. See
+[Log files](/docs/2.0.0-rc3/server/configuration#log-files).
+:::
 
 ::: tip Two ways to connect
 Beacon exposes two endpoints. The **HTTP API** on port `5001` serves SQL and JSON queries, the admin
@@ -155,8 +163,9 @@ docker run -d \
     -e AWS_ACCESS_KEY_ID=your-access-key \
     -e AWS_SECRET_ACCESS_KEY=your-secret-key \
     -e BEACON_S3_BUCKET=your-bucket-name \
-    -e BEACON_S3_DATA_LAKE=true \
+    -e BEACON_S3_DATASETS=true \
     -v ./tables:/beacon/data/tables \
+    -v ./logs:/beacon/logs \
     ghcr.io/maris-development/beacon:latest
 ```
 
@@ -176,9 +185,10 @@ services:
             - AWS_ACCESS_KEY_ID=your-access-key
             - AWS_SECRET_ACCESS_KEY=your-secret-key
             - BEACON_S3_BUCKET=your-bucket-name
-            - BEACON_S3_DATA_LAKE=true
+            - BEACON_S3_DATASETS=true
         volumes:
             - ./tables:/beacon/data/tables
+            - ./logs:/beacon/logs
 ```
 
 :::

--- a/docs/docs/2.0.0-rc3/server/configuration.md
+++ b/docs/docs/2.0.0-rc3/server/configuration.md
@@ -129,9 +129,58 @@ Beacon creates and uses these paths under `BEACON_DATA_DIR`:
 With Docker, mount the subdirectories that you want to keep. Two examples are
 `-v ./datasets:/beacon/data/datasets` and `-v ./tables:/beacon/data/tables`.
 
+## Log files
+
+Beacon writes each log line to two places at the same time:
+
+- **stdout**, which Docker collects. Read it with `docker logs -f beacon`.
+- a **rolling log file** in the `logs/` directory.
+
+The file name carries the date, for example `logs/beacon.log.2026-08-19`. Beacon starts a new file
+each day. Beacon never deletes an old file. Remove old files yourself.
+
+::: warning The log directory is fixed
+`BEACON_DATA_DIR` does not move the log files. The path is always `logs/`, below the working
+directory. In the Docker image the working directory is `/beacon`, so the files are in
+`/beacon/logs/`.
+:::
+
+`BEACON_LOG_LEVEL` and `RUST_LOG` control how much Beacon writes. See [Server](#server). The file
+and stdout always get the same lines. The file holds no ANSI colour codes.
+
+### Write the log files to your machine
+
+Mount a host directory on `/beacon/logs`:
+
+::: code-group
+
+```bash [docker run]
+docker run -d \
+    --name beacon \
+    -p 5001:5001 \
+    -v ./logs:/beacon/logs \
+    ghcr.io/maris-development/beacon:latest
+```
+
+```yaml [docker-compose.yml]
+services:
+    beacon:
+        image: ghcr.io/maris-development/beacon:latest
+        container_name: beacon
+        ports:
+            - "5001:5001"
+        volumes:
+            - ./logs:/beacon/logs
+```
+
+:::
+
+The dated files then appear in `./logs` on your machine. The files stay there after you remove the
+container. On Linux, give the directory write permission for the container user first.
+
 ## S3 object storage
 
-Set `BEACON_S3_DATA_LAKE=true` to put the **datasets** store on an S3-compatible
+Set `BEACON_S3_DATASETS=true` to put the **datasets** store on an S3-compatible
 bucket. Beacon then does not use the local `datasets/` directory. Beacon finds and
 queries every file in the bucket. This works like a local datasets directory.
 `tables/beacon.db` and `tmp/` stay on local disk. `BEACON_DATA_DIR` therefore
@@ -139,10 +188,11 @@ still applies.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `BEACON_S3_DATA_LAKE` | `false` | Use an S3-compatible bucket as the datasets store. When `false`, the local filesystem is used. |
-| `BEACON_S3_BUCKET` | _(none)_ | Bucket name. **Required** when `BEACON_S3_DATA_LAKE=true`; Beacon exits at startup if it is missing. Never inferred from the endpoint. |
+| `BEACON_S3_DATASETS` | `false` | Use an S3-compatible bucket as the datasets store. When `false`, the local filesystem is used. |
+| `BEACON_S3_BUCKET` | _(none)_ | Bucket name. **Required** when `BEACON_S3_DATASETS=true`; Beacon exits at startup if it is missing. Never inferred from the endpoint. |
 | `BEACON_S3_ENABLE_VIRTUAL_HOSTING` | `false` | Use virtual-hosted-style addressing (bucket in the host) instead of path-style (`{endpoint}/{bucket}/{key}`). |
 | `BEACON_S3_ALLOW_HTTP` | `true` | Allow plain `http://` endpoints (useful for local MinIO; disable for production). |
+| `BEACON_S3_DATA_LAKE` | `false` | Deprecated name of `BEACON_S3_DATASETS`. It still works. Beacon logs a warning at startup. |
 
 ### S3 credentials and endpoint (`AWS_*`)
 

--- a/docs/docs/2.0.0-rc3/server/performance-tuning.md
+++ b/docs/docs/2.0.0-rc3/server/performance-tuning.md
@@ -62,7 +62,7 @@ This flag controls the SQL parser and the SQL execution.
 
 ### Object store listings
 
-#### `BEACON_S3_DATA_LAKE`, `BEACON_S3_BUCKET`, `BEACON_S3_ENABLE_VIRTUAL_HOSTING`
+#### `BEACON_S3_DATASETS`, `BEACON_S3_BUCKET`, `BEACON_S3_ENABLE_VIRTUAL_HOSTING`
 
 These settings decide if the datasets store lives on an S3-compatible bucket. They also set the
 address form. Every listing and every read on object storage costs network latency.

--- a/docs/docs/2.0.0-rc3/troubleshooting.md
+++ b/docs/docs/2.0.0-rc3/troubleshooting.md
@@ -6,6 +6,12 @@ description: Common Beacon errors and what causes them. Missing columns, zero ro
 
 Each entry below names a symptom, its usual cause and the fix.
 
+::: tip Find the log first
+Many entries below tell you to read the log. Beacon writes to stdout and to a dated file in
+`/beacon/logs/`. Use `docker logs -f beacon`, or mount the directory to keep the files. See
+[Log files](/docs/2.0.0-rc3/server/configuration#log-files).
+:::
+
 ## Reading files
 
 ### A variable is missing from `SELECT *`


### PR DESCRIPTION
## Problem

`BEACON_S3_DATA_LAKE` did nothing. The compatibility field read the new name, `BEACON_S3_DATASETS`.
A 1.x deployment therefore lost its S3 datasets store on an upgrade to 2.0. The server fell back to
the local directory, or it stopped at startup with a missing bucket. The CHANGELOG and the docs
promise that the old name works.

The 2.0.0-rc3 docs also taught the old name as the switch.

## Changes

**Code**

- Point the compatibility field at `BEACON_S3_DATA_LAKE`.
- Add the deprecation warning that the field comment promises. It fires only when the old name alone
  turns the store on.
- Add a test for three cases: the old name, the new name, and neither name.

**Docs (2.0.0-rc3)**

- Rename the switch to `BEACON_S3_DATASETS` in `configuration.md`, `getting-started.md` and
  `performance-tuning.md`. Keep a table row for the deprecated name.
- Add a `Log files` section. It gives the log path, the daily rotation, and the Docker volume that
  writes the files to the host machine.
- Add the log location to the top of `troubleshooting.md`.
