### PR TITLE
feat: name the source file of a failed schema merge

### DIFF
--- a/beacon-db/beacon-datafusion-ext/src/fast_object/schema.rs
+++ b/beacon-db/beacon-datafusion-ext/src/fast_object/schema.rs
@@ -57,7 +57,7 @@ use futures::{StreamExt, TryStreamExt, future};
 use object_store::{ObjectMeta, ObjectStore};
 
 use crate::format_ext::{FileFormatFactoryExt, SchemaUnit, try_file_format_factory_ext};
-use crate::type_widening::{ArrowTypeWidening, session_widening};
+use crate::type_widening::{ArrowTypeWidening, LabeledSchema, label_by_object, session_widening};
 
 /// One schema per URL, cached where the cache can answer.
 ///
@@ -65,11 +65,14 @@ use crate::type_widening::{ArrowTypeWidening, session_widening};
 /// rule, and an external table has one URL and takes it as it is — so the split
 /// stays here rather than being folded into one schema, and neither caller's
 /// merge changes.
+///
+/// Each schema names its URL. A merge across URLs that refuses a column then
+/// names both URLs. A merge inside one URL names the two files. See issue #424.
 pub async fn infer_url_schemas(
     state: &dyn Session,
     options: &ListingOptions,
     urls: &[ListingTableUrl],
-) -> Result<Vec<SchemaRef>, DataFusionError> {
+) -> Result<Vec<LabeledSchema>, DataFusionError> {
     let cached = CachedInference::for_session(state, &options.format);
 
     let mut schemas = Vec::with_capacity(urls.len());
@@ -81,7 +84,8 @@ pub async fn infer_url_schemas(
                 options.infer_schema(state, url).await
             }
         };
-        schemas.push(name_the_path_if_nothing_matched(state, options, url, outcome).await?);
+        let schema = name_the_path_if_nothing_matched(state, options, url, outcome).await?;
+        schemas.push(LabeledSchema::new(schema, url.as_str()));
     }
     Ok(schemas)
 }
@@ -241,7 +245,16 @@ impl CachedInference {
             .into_iter()
             .map(|schema| schema.expect("every miss was just inferred"))
             .collect();
-        merge_in_listing_order(&session_widening(state), &resolved)
+        // One unit per source object, in listing order, so a refused column names
+        // the two files it came from.
+        let sources: Vec<ObjectMeta> = units
+            .iter()
+            .map(|unit| objects[unit.source].clone())
+            .collect();
+        merge_in_listing_order(
+            &session_widening(state),
+            &label_by_object(&sources, &resolved),
+        )
     }
 
     /// What to ask the cache, one entry per unit, in listing order.
@@ -349,7 +362,7 @@ fn stamp_unit(objects: &[ObjectMeta], unit: &SchemaUnit) -> Stamp {
 /// order still sets the column order. See the [module docs](self).
 fn merge_in_listing_order(
     widening: &ArrowTypeWidening,
-    schemas: &[SchemaRef],
+    schemas: &[LabeledSchema],
 ) -> Result<SchemaRef, DataFusionError> {
     widening
         .merge_schemas(schemas)
@@ -361,13 +374,13 @@ mod tests {
     use super::*;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
 
-    fn schema(fields: &[(&str, DataType)]) -> SchemaRef {
-        Arc::new(Schema::new(
+    fn schema(fields: &[(&str, DataType)]) -> LabeledSchema {
+        LabeledSchema::unlabeled(Arc::new(Schema::new(
             fields
                 .iter()
                 .map(|(name, kind)| Field::new(*name, kind.clone(), true))
                 .collect::<Vec<_>>(),
-        ))
+        )))
     }
 
     fn names(schema: &Schema) -> Vec<&str> {
@@ -382,7 +395,7 @@ mod tests {
 
     /// One flat fold over every schema, in order. It skips and splits nothing.
     /// The tests below compare the merge against this result.
-    fn flat_merge(listing: &[SchemaRef]) -> SchemaRef {
+    fn flat_merge(listing: &[LabeledSchema]) -> SchemaRef {
         use crate::type_widening::{ArrowTypeWideningStrategy, DefaultArrowTypeWidening};
         DefaultArrowTypeWidening.merge_schemas(listing).unwrap()
     }
@@ -396,12 +409,12 @@ mod tests {
 
         // A collection with repeats, as a real collection has.
         let listing = vec![
-            Arc::clone(&a),
-            Arc::clone(&a),
-            Arc::clone(&b),
-            Arc::clone(&a),
-            Arc::clone(&c),
-            Arc::clone(&b),
+            a.clone(),
+            a.clone(),
+            b.clone(),
+            a.clone(),
+            c.clone(),
+            b.clone(),
         ];
 
         let merged = merge_in_listing_order(&widening(), &listing).unwrap();
@@ -420,14 +433,13 @@ mod tests {
         let one = schema(&[("TEMP", DataType::Int32)]);
         let two = schema(&[("PSAL", DataType::Float64)]);
 
-        let once =
-            merge_in_listing_order(&widening(), &[Arc::clone(&one), Arc::clone(&two)]).unwrap();
+        let once = merge_in_listing_order(&widening(), &[one.clone(), two.clone()]).unwrap();
         let repeated = merge_in_listing_order(
             &widening(),
             &[
-                Arc::clone(&one),
+                one.clone(),
                 two,
-                Arc::clone(&one),
+                one.clone(),
                 schema(&[("TEMP", DataType::Int32)]),
             ],
         )
@@ -444,8 +456,7 @@ mod tests {
         let a = schema(&[("A", DataType::Int32)]);
         let b = schema(&[("B", DataType::Int32)]);
 
-        let forward =
-            merge_in_listing_order(&widening(), &[Arc::clone(&a), Arc::clone(&b)]).unwrap();
+        let forward = merge_in_listing_order(&widening(), &[a.clone(), b.clone()]).unwrap();
         let backward = merge_in_listing_order(&widening(), &[b, a]).unwrap();
         assert_eq!(names(&forward), vec!["A", "B"]);
         assert_eq!(names(&backward), vec!["B", "A"]);
@@ -496,7 +507,7 @@ mod tests {
 
     /// A pool of schemas over one set of column names. The merges then get fields
     /// to union and fields to skip.
-    fn schema_pool(rng: &mut Rng) -> Vec<SchemaRef> {
+    fn schema_pool(rng: &mut Rng) -> Vec<LabeledSchema> {
         let columns = column_types();
         (0..6)
             .map(|_| {
@@ -513,7 +524,7 @@ mod tests {
                         }
                         kept
                     });
-                Arc::new(Schema::new(fields))
+                LabeledSchema::unlabeled(Arc::new(Schema::new(fields)))
             })
             .collect()
     }
@@ -530,8 +541,8 @@ mod tests {
         for case in 0..500 {
             let pool = schema_pool(&mut rng);
             let length = 1 + rng.next(40);
-            let listing: Vec<SchemaRef> = (0..length)
-                .map(|_| Arc::clone(&pool[rng.next(pool.len())]))
+            let listing: Vec<LabeledSchema> = (0..length)
+                .map(|_| pool[rng.next(pool.len())].clone())
                 .collect();
 
             assert_eq!(
@@ -553,14 +564,15 @@ mod tests {
         for case in 0..500 {
             let pool = schema_pool(&mut rng);
             let length = 2 + rng.next(20);
-            let listing: Vec<SchemaRef> = (0..length)
-                .map(|_| Arc::clone(&pool[rng.next(pool.len())]))
+            let listing: Vec<LabeledSchema> = (0..length)
+                .map(|_| pool[rng.next(pool.len())].clone())
                 .collect();
 
             let split = 1 + rng.next(listing.len() - 1);
-            let combined: Vec<SchemaRef> = std::iter::once(flat_merge(&listing[..split]))
-                .chain(listing[split..].iter().cloned())
-                .collect();
+            let combined: Vec<LabeledSchema> =
+                std::iter::once(LabeledSchema::unlabeled(flat_merge(&listing[..split])))
+                    .chain(listing[split..].iter().cloned())
+                    .collect();
 
             assert_eq!(
                 flat_merge(&combined),
@@ -588,10 +600,13 @@ mod tests {
         // Every order, every group boundary and every repeat count gives the same
         // fields with the same types.
         for listing in [
-            vec![Arc::clone(&temp), Arc::clone(&psal)],
-            vec![Arc::clone(&psal), Arc::clone(&temp)],
-            vec![Arc::clone(&both), Arc::clone(&temp), Arc::clone(&psal)],
-            vec![flat_merge(&[Arc::clone(&temp)]), Arc::clone(&psal)],
+            vec![temp.clone(), psal.clone()],
+            vec![psal.clone(), temp.clone()],
+            vec![both.clone(), temp.clone(), psal.clone()],
+            vec![
+                LabeledSchema::unlabeled(flat_merge(std::slice::from_ref(&temp))),
+                psal.clone(),
+            ],
         ] {
             let merged = merge_in_listing_order(&widening(), &listing).unwrap();
             assert_eq!(merged.fields().len(), 2);

--- a/beacon-db/beacon-datafusion-ext/src/fast_object/table.rs
+++ b/beacon-db/beacon-datafusion-ext/src/fast_object/table.rs
@@ -75,9 +75,9 @@ impl FastObjectTable {
             .with_target_partitions(state.config_options().execution.target_partitions)
             .with_collect_stat(false); // We rely on the statistics store, not the listing table, to collect stats.
 
-        // One schema per URL. The schema cache answers where it can. The merge
-        // below does not change. The cache decides the source of a schema. It
-        // does not decide how the URLs combine.
+        // One schema per URL, each named after its URL. The schema cache answers
+        // where it can. The merge below does not change. The cache decides the
+        // source of a schema. It does not decide how the URLs combine.
         let schemas = super::schema::infer_url_schemas(state, &options, &urls).await?;
 
         let schema = widening

--- a/beacon-db/beacon-datafusion-ext/src/table_ext.rs
+++ b/beacon-db/beacon-datafusion-ext/src/table_ext.rs
@@ -98,7 +98,7 @@ pub(crate) async fn build_listing_table(
             std::slice::from_ref(&spec.listing_table_url),
         )
         .await
-        .map(|mut schemas| schemas.remove(0))
+        .map(|mut schemas| schemas.remove(0).schema)
         {
             Ok(schema) => schema,
             Err(error) => {

--- a/beacon-db/beacon-datafusion-ext/src/type_widening.rs
+++ b/beacon-db/beacon-datafusion-ext/src/type_widening.rs
@@ -16,7 +16,7 @@
 //! | --- | --- |
 //! | the same type | that type |
 //! | two types of one family | the member that holds both, from the tables below |
-//! | two families (a number and a string) | an error that names the column and both types |
+//! | two families (a number and a string) | an error that names the column, both types and both files |
 //! | `Null` and any type | that type, because a null column holds no value |
 //! | one nullable field, one not | a nullable field |
 //! | the column in one file only | a nullable field, because the scan fills the other file with nulls |
@@ -83,6 +83,23 @@
 //! [`RuntimeBuilder::with_type_widening`]. Every merge in the process takes the
 //! new strategy.
 //!
+//! # The source of a conflict
+//!
+//! A merge that refuses a column names the source of each type. A table over
+//! 10000 files is otherwise a search:
+//!
+//! ```text
+//! Incompatible types for field 'depth': Utf8 in 'argo/a.nc' vs Float64 in 'argo/b.nc'
+//! ```
+//!
+//! Each caller passes one [`LabeledSchema`] per source. [`label_by_object`] builds
+//! them from a listing. A caller that holds no name passes
+//! [`LabeledSchema::unlabeled`], and the error reports the two types alone.
+//!
+//! A widened column takes the name of the source that states its current type. A
+//! join that equals neither operand leaves that side without a name: `Int64`
+//! beside `UInt64` gives `Float64`, and no file states `Float64`.
+//!
 //! # How the merge does less work
 //!
 //! The rules above are a semilattice join. The numeric order is a lattice, and a
@@ -99,6 +116,12 @@
 //! A strategy that answers `false` gets one fold over every schema, repeats
 //! included.
 //!
+//! Both steps hide the source of a field. A repeat loses its own name, and a
+//! chunk result names no source at all. A merge that fails therefore folds the
+//! distinct schemas once more, in one thread, to name both sources. The fold
+//! stops at the same pair, because the join is associative. A merge that succeeds
+//! pays nothing for it.
+//!
 //! [`is_order_independent`]: ArrowTypeWideningStrategy::is_order_independent
 //! [`RuntimeBuilder::with_type_widening`]: ../../beacon_core/runtime_builder/struct.RuntimeBuilder.html#method.with_type_widening
 
@@ -109,6 +132,7 @@ use std::sync::{Arc, LazyLock};
 
 use arrow_schema::{ArrowError, DataType, FieldRef, Schema, SchemaRef, TimeUnit};
 use datafusion::catalog::Session;
+use object_store::ObjectMeta;
 
 /// Below this count, one fold costs less than a split. A merge walks field
 /// names, so a thread must earn its start cost.
@@ -116,6 +140,59 @@ const SEQUENTIAL_MERGE_LIMIT: usize = 64;
 
 /// The least work for one thread.
 const MIN_SCHEMAS_PER_THREAD: usize = 32;
+
+/// A schema and the name of the source it was read from.
+///
+/// A merge that refuses a column reports the name of both sources. The name is
+/// the object path of a file, the URL of a table, or the group path of a Zarr
+/// leaf. See the [module docs](self).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabeledSchema {
+    /// The schema of one source.
+    pub schema: SchemaRef,
+    /// What an error calls that source. `None` for a caller that holds no name,
+    /// and the error then reports the two types alone.
+    pub label: Option<Arc<str>>,
+}
+
+impl LabeledSchema {
+    /// A schema with the name of its source.
+    pub fn new(schema: SchemaRef, label: impl Into<Arc<str>>) -> Self {
+        Self {
+            schema,
+            label: Some(label.into()),
+        }
+    }
+
+    /// A schema without a name.
+    pub fn unlabeled(schema: SchemaRef) -> Self {
+        Self {
+            schema,
+            label: None,
+        }
+    }
+}
+
+impl From<SchemaRef> for LabeledSchema {
+    fn from(schema: SchemaRef) -> Self {
+        Self::unlabeled(schema)
+    }
+}
+
+/// Name each schema after the object it was read from.
+///
+/// A format reads one schema per object, in listing order, so the two lists line
+/// up. A schema past the end of `objects` gets no name.
+pub fn label_by_object(objects: &[ObjectMeta], schemas: &[SchemaRef]) -> Vec<LabeledSchema> {
+    schemas
+        .iter()
+        .enumerate()
+        .map(|(index, schema)| match objects.get(index) {
+            Some(object) => LabeledSchema::new(Arc::clone(schema), object.location.as_ref()),
+            None => LabeledSchema::unlabeled(Arc::clone(schema)),
+        })
+        .collect()
+}
 
 pub struct ArrowTypeWidening {
     pub strategy: Arc<dyn ArrowTypeWideningStrategy>,
@@ -135,17 +212,25 @@ impl ArrowTypeWidening {
         Arc::new(Self::new(Arc::new(DefaultArrowTypeWidening)))
     }
 
-    /// Merge `schema_refs` into the schema a query plans against.
+    /// Merge `schemas` into the schema a query plans against.
     ///
     /// The strategy decides the result. This method decides the cost: an
     /// order-independent strategy loses its repeats, and threads merge the rest.
-    /// See the [module docs](self).
-    pub fn merge_schemas(&self, schema_refs: &[SchemaRef]) -> Result<SchemaRef, ArrowError> {
+    /// Each schema names its source, and a failed merge reports both names. See
+    /// the [module docs](self).
+    pub fn merge_schemas(&self, schemas: &[LabeledSchema]) -> Result<SchemaRef, ArrowError> {
         let strategy = self.strategy.as_ref();
         if !strategy.is_order_independent() {
-            return strategy.merge_schemas(schema_refs);
+            return strategy.merge_schemas(schemas);
         }
-        merge_distinct(strategy, &distinct_schemas(schema_refs))
+        let distinct = distinct_schemas(schemas);
+        match merge_distinct(strategy, &distinct) {
+            Ok(schema) => Ok(schema),
+            // The dropped repeats and the chunk results hide the source of a
+            // field. Fold the named schemas once to name both sources. The fold
+            // stops at the same pair, because the join is associative.
+            Err(error) => Err(strategy.merge_schemas(&distinct).err().unwrap_or(error)),
+        }
     }
 }
 
@@ -166,7 +251,10 @@ pub fn session_widening(session: &dyn Session) -> Arc<ArrowTypeWidening> {
 
 pub trait ArrowTypeWideningStrategy: Send + Sync {
     /// Merge these schemas into one, in the order given.
-    fn merge_schemas(&self, schema_refs: &[SchemaRef]) -> Result<SchemaRef, ArrowError>;
+    ///
+    /// Each schema names its source. Report both names for a column that two
+    /// sources describe with two types. See [`LabeledSchema`].
+    fn merge_schemas(&self, schemas: &[LabeledSchema]) -> Result<SchemaRef, ArrowError>;
 
     /// State whether this merge is a semilattice join: **idempotent, commutative
     /// and associative**. The schema order, the group boundaries and the repeat
@@ -195,23 +283,28 @@ pub trait ArrowTypeWideningStrategy: Send + Sync {
 pub struct DefaultArrowTypeWidening;
 
 impl ArrowTypeWideningStrategy for DefaultArrowTypeWidening {
-    fn merge_schemas(&self, schema_refs: &[SchemaRef]) -> Result<SchemaRef, ArrowError> {
-        if schema_refs.is_empty() {
+    fn merge_schemas(&self, schemas: &[LabeledSchema]) -> Result<SchemaRef, ArrowError> {
+        if schemas.is_empty() {
             return Err(ArrowError::SchemaError(
                 "No schemas provided for merging".to_string(),
             ));
         }
 
         let mut merged_fields: Vec<FieldRef> = Vec::new();
+        // The source that gave each merged field its type, at the same index.
+        let mut sources: Vec<Option<Arc<str>>> = Vec::new();
         // The position of each field in `merged_fields`, and its schema count.
         let mut field_map: HashMap<String, (usize, usize)> = HashMap::new();
 
-        for schema_ref in schema_refs {
-            for field in schema_ref.fields() {
+        for labeled in schemas {
+            for field in labeled.schema.fields() {
                 let field_name = field.name().clone();
                 if let Some((at, held_by)) = field_map.get_mut(&field_name) {
                     *held_by += 1;
-                    let existing_field = &merged_fields[*at];
+                    let at = *at;
+                    // An `Arc` clone. It ends the borrow of `merged_fields`, so
+                    // the write below needs no second lookup.
+                    let existing_field = Arc::clone(&merged_fields[at]);
                     // Two types for one column. A numeric pair widens. Every
                     // other pair is an error.
                     let widened = if existing_field.data_type() == field.data_type() {
@@ -220,17 +313,22 @@ impl ArrowTypeWideningStrategy for DefaultArrowTypeWidening {
                         match super_type(existing_field.data_type(), field.data_type()) {
                             Some(data_type) => Some(data_type),
                             None => {
-                                return Err(ArrowError::SchemaError(format!(
-                                    "Incompatible types for field '{}': {:?} vs {:?}",
-                                    field_name,
+                                return Err(ArrowError::SchemaError(incompatible_types(
+                                    &field_name,
                                     existing_field.data_type(),
-                                    field.data_type()
+                                    sources[at].as_deref(),
+                                    field.data_type(),
+                                    labeled.label.as_deref(),
                                 )));
                             }
                         }
                     };
                     // One file that permits nulls makes the column nullable.
                     let nullable = field.is_nullable() && !existing_field.is_nullable();
+                    if let Some(data_type) = &widened {
+                        sources[at] =
+                            source_of(data_type, &existing_field, &sources[at], field, labeled);
+                    }
                     if widened.is_some() || nullable {
                         let mut merged = existing_field.as_ref().clone();
                         if let Some(data_type) = widened {
@@ -239,12 +337,13 @@ impl ArrowTypeWideningStrategy for DefaultArrowTypeWidening {
                         if nullable {
                             merged = merged.with_nullable(true);
                         }
-                        merged_fields[*at] = Arc::new(merged);
+                        merged_fields[at] = Arc::new(merged);
                     }
                 } else {
                     // If the field does not exist, add it to the map and merged fields
                     field_map.insert(field_name.clone(), (merged_fields.len(), 1));
                     merged_fields.push(field.clone());
+                    sources.push(labeled.label.clone());
                 }
             }
         }
@@ -253,12 +352,57 @@ impl ArrowTypeWideningStrategy for DefaultArrowTypeWidening {
         // lack must therefore be nullable.
         for field in merged_fields.iter_mut() {
             let (_, held_by) = field_map[field.name()];
-            if held_by < schema_refs.len() && !field.is_nullable() {
+            if held_by < schemas.len() && !field.is_nullable() {
                 *field = Arc::new(field.as_ref().clone().with_nullable(true));
             }
         }
 
         Ok(Arc::new(arrow_schema::Schema::new(merged_fields)))
+    }
+}
+
+/// The text for a column that two sources describe with two types.
+///
+/// Each type takes the name of the source that states it. A side without a name
+/// reports its type alone. See the [module docs](self).
+fn incompatible_types(
+    field_name: &str,
+    left: &DataType,
+    left_source: Option<&str>,
+    right: &DataType,
+    right_source: Option<&str>,
+) -> String {
+    fn describe(data_type: &DataType, source: Option<&str>) -> String {
+        match source {
+            Some(source) => format!("{data_type:?} in '{source}'"),
+            None => format!("{data_type:?}"),
+        }
+    }
+    format!(
+        "Incompatible types for field '{field_name}': {} vs {}",
+        describe(left, left_source),
+        describe(right, right_source)
+    )
+}
+
+/// The source that states `widened`, which is the type the column now holds.
+///
+/// One operand equals the result, so that source states it. A join that equals
+/// neither operand has no such source: `Int64` beside `UInt64` gives `Float64`,
+/// and no file states `Float64`.
+fn source_of(
+    widened: &DataType,
+    existing_field: &FieldRef,
+    existing_source: &Option<Arc<str>>,
+    field: &FieldRef,
+    labeled: &LabeledSchema,
+) -> Option<Arc<str>> {
+    if widened == existing_field.data_type() {
+        existing_source.clone()
+    } else if widened == field.data_type() {
+        labeled.label.clone()
+    } else {
+        None
     }
 }
 
@@ -540,23 +684,25 @@ impl Numeric {
 /// An idempotent join gives the same answer without the repeats, and a collection
 /// holds far fewer distinct schemas than files. The check uses a fingerprint. A
 /// full compare runs only for two equal fingerprints.
-fn distinct_schemas(schemas: &[SchemaRef]) -> Cow<'_, [SchemaRef]> {
+fn distinct_schemas(schemas: &[LabeledSchema]) -> Cow<'_, [LabeledSchema]> {
     if schemas.len() < 2 {
         return Cow::Borrowed(schemas);
     }
 
-    let mut kept: Vec<SchemaRef> = Vec::new();
+    let mut kept: Vec<LabeledSchema> = Vec::new();
     let mut seen: HashMap<u64, Vec<usize>> = HashMap::new();
-    for schema in schemas {
-        let candidates = seen.entry(fingerprint(schema)).or_default();
-        if candidates
-            .iter()
-            .any(|index| Arc::ptr_eq(&kept[*index], schema) || kept[*index] == *schema)
-        {
+    for labeled in schemas {
+        let candidates = seen.entry(fingerprint(&labeled.schema)).or_default();
+        // The first of a repeat stays, with its own name. A later copy names the
+        // same types, so the name it drops adds nothing to an error.
+        if candidates.iter().any(|index| {
+            Arc::ptr_eq(&kept[*index].schema, &labeled.schema)
+                || kept[*index].schema == labeled.schema
+        }) {
             continue;
         }
         candidates.push(kept.len());
-        kept.push(Arc::clone(schema));
+        kept.push(labeled.clone());
     }
 
     if kept.len() == schemas.len() {
@@ -588,7 +734,7 @@ fn fingerprint(schema: &Schema) -> u64 {
 /// The chunks combine in order, so the columns keep the order of the listing.
 fn merge_distinct(
     strategy: &dyn ArrowTypeWideningStrategy,
-    schemas: &[SchemaRef],
+    schemas: &[LabeledSchema],
 ) -> Result<SchemaRef, ArrowError> {
     let threads = std::thread::available_parallelism()
         .map(|threads| threads.get())
@@ -619,7 +765,10 @@ fn merge_distinct(
     // first conflict, as one fold does.
     let mut partial = Vec::with_capacity(results.len());
     for result in results {
-        partial.push(result?);
+        // A chunk result holds the fields of every schema in that chunk, so it
+        // names no single source. `ArrowTypeWidening::merge_schemas` folds the
+        // named schemas again when such a merge fails.
+        partial.push(LabeledSchema::unlabeled(result?));
     }
     // `per_thread` is 32 or more. This call therefore gets at most one part in 32
     // of the input, and the recursion stops.
@@ -632,7 +781,17 @@ mod tests {
 
     use super::*;
 
-    fn schema(fields: &[(&str, DataType)]) -> SchemaRef {
+    /// A schema without a source name. Most tests read the types alone.
+    fn schema(fields: &[(&str, DataType)]) -> LabeledSchema {
+        LabeledSchema::unlabeled(schema_ref(fields))
+    }
+
+    /// A schema with the name of the file it came from.
+    fn from_file(label: &str, fields: &[(&str, DataType)]) -> LabeledSchema {
+        LabeledSchema::new(schema_ref(fields), label)
+    }
+
+    fn schema_ref(fields: &[(&str, DataType)]) -> SchemaRef {
         Arc::new(Schema::new(
             fields
                 .iter()
@@ -704,6 +863,124 @@ mod tests {
                 }
                 other => panic!("expected SchemaError, got {other:?}"),
             }
+        }
+    }
+
+    // ── naming the source of a conflict ────────────────────────────────
+
+    /// The error names the file of each type. A table over 10000 files is
+    /// otherwise a search. See issue #424.
+    #[test]
+    fn a_refused_column_names_both_files() {
+        let widening = ArrowTypeWidening::default_extension();
+        let text = from_file("argo/a.nc", &[("depth", DataType::Utf8)]);
+        let number = from_file("argo/b.nc", &[("depth", DataType::Float64)]);
+
+        let message = message_of(widening.merge_schemas(&[text, number]).unwrap_err());
+        assert_eq!(
+            message,
+            "Incompatible types for field 'depth': Utf8 in 'argo/a.nc' vs \
+             Float64 in 'argo/b.nc'"
+        );
+    }
+
+    /// A caller without a name gets the types alone, as before issue #424.
+    #[test]
+    fn a_schema_without_a_name_reports_its_type_alone() {
+        let widening = ArrowTypeWidening::default_extension();
+        let text = schema(&[("depth", DataType::Utf8)]);
+        let number = from_file("argo/b.nc", &[("depth", DataType::Float64)]);
+
+        assert_eq!(
+            message_of(widening.merge_schemas(&[text, number]).unwrap_err()),
+            "Incompatible types for field 'depth': Utf8 vs Float64 in 'argo/b.nc'"
+        );
+    }
+
+    /// A widened column names the file that states the type it now holds, not the
+    /// file that first held the column.
+    #[test]
+    fn a_widened_column_names_the_file_of_its_current_type() {
+        let widening = ArrowTypeWidening::default_extension();
+        let narrow = from_file("a.nc", &[("depth", DataType::Int32)]);
+        let wide = from_file("b.nc", &[("depth", DataType::Int64)]);
+        let text = from_file("c.nc", &[("depth", DataType::Utf8)]);
+
+        assert_eq!(
+            message_of(widening.merge_schemas(&[narrow, wide, text]).unwrap_err()),
+            "Incompatible types for field 'depth': Int64 in 'b.nc' vs Utf8 in 'c.nc'"
+        );
+    }
+
+    /// A join that equals neither operand has no file behind it. `Int64` beside
+    /// `UInt64` gives `Float64`, and no file states `Float64`.
+    #[test]
+    fn a_join_of_two_files_names_neither() {
+        let widening = ArrowTypeWidening::default_extension();
+        let signed = from_file("a.nc", &[("depth", DataType::Int64)]);
+        let unsigned = from_file("b.nc", &[("depth", DataType::UInt64)]);
+        let text = from_file("c.nc", &[("depth", DataType::Utf8)]);
+
+        assert_eq!(
+            message_of(
+                widening
+                    .merge_schemas(&[signed, unsigned, text])
+                    .unwrap_err()
+            ),
+            "Incompatible types for field 'depth': Float64 vs Utf8 in 'c.nc'"
+        );
+    }
+
+    /// A repeated schema keeps the name of its first file. The merge drops the
+    /// later copies, which state the same types.
+    #[test]
+    fn a_repeated_schema_keeps_the_name_of_its_first_file() {
+        let widening = ArrowTypeWidening::default_extension();
+        let first = from_file("a.nc", &[("depth", DataType::Utf8)]);
+        let copy = from_file("z.nc", &[("depth", DataType::Utf8)]);
+        let number = from_file("b.nc", &[("depth", DataType::Float64)]);
+
+        assert_eq!(
+            message_of(widening.merge_schemas(&[first, copy, number]).unwrap_err()),
+            "Incompatible types for field 'depth': Utf8 in 'a.nc' vs Float64 in 'b.nc'"
+        );
+    }
+
+    /// A merge that splits over threads still names both files. A chunk result
+    /// names no file, so the failed merge folds the named schemas once more.
+    #[test]
+    fn a_split_merge_names_both_files() {
+        // Enough distinct schemas to reach the threads, and a conflict in the
+        // last chunk.
+        let mut schemas: Vec<LabeledSchema> = (0..300)
+            .map(|index| {
+                from_file(
+                    &format!("argo/{index}.nc"),
+                    &[
+                        ("depth", DataType::Utf8),
+                        (&format!("own_{index}"), DataType::Int32),
+                    ],
+                )
+            })
+            .collect();
+        schemas.push(from_file("argo/bad.nc", &[("depth", DataType::Float64)]));
+
+        let message = message_of(
+            ArrowTypeWidening::default_extension()
+                .merge_schemas(&schemas)
+                .unwrap_err(),
+        );
+        assert_eq!(
+            message,
+            "Incompatible types for field 'depth': Utf8 in 'argo/0.nc' vs \
+             Float64 in 'argo/bad.nc'"
+        );
+    }
+
+    fn message_of(error: ArrowError) -> String {
+        match error {
+            ArrowError::SchemaError(message) => message,
+            other => panic!("expected SchemaError, got {other:?}"),
         }
     }
 
@@ -1074,7 +1351,7 @@ mod tests {
     #[test]
     fn a_field_keeps_its_metadata() {
         let geometry = || {
-            Arc::new(Schema::new(vec![
+            LabeledSchema::unlabeled(Arc::new(Schema::new(vec![
                 Field::new("geometry", DataType::Float64, false).with_metadata(
                     [(
                         "ARROW:extension:name".to_string(),
@@ -1082,7 +1359,7 @@ mod tests {
                     )]
                     .into(),
                 ),
-            ])) as SchemaRef
+            ])))
         };
 
         let merged = ArrowTypeWidening::default_extension()
@@ -1105,11 +1382,11 @@ mod tests {
     #[test]
     fn a_column_some_files_lack_comes_out_nullable() {
         let required = |name: &str| {
-            Arc::new(Schema::new(vec![Field::new(
+            LabeledSchema::unlabeled(Arc::new(Schema::new(vec![Field::new(
                 name,
                 DataType::Float64,
                 false,
-            )])) as SchemaRef
+            )])))
         };
 
         let merged = ArrowTypeWidening::default_extension()
@@ -1121,14 +1398,14 @@ mod tests {
         // A column that every file holds keeps the declared nullability. One file
         // that permits nulls makes the column nullable. No such file leaves the
         // column required.
-        let both_required = Arc::new(Schema::new(vec![
+        let both_required = LabeledSchema::unlabeled(Arc::new(Schema::new(vec![
             Field::new("TEMP", DataType::Float64, false),
             Field::new("DEPTH", DataType::Int64, false),
-        ])) as SchemaRef;
-        let depth_optional = Arc::new(Schema::new(vec![
+        ])));
+        let depth_optional = LabeledSchema::unlabeled(Arc::new(Schema::new(vec![
             Field::new("TEMP", DataType::Float64, false),
             Field::new("DEPTH", DataType::Int64, true),
-        ])) as SchemaRef;
+        ])));
 
         for order in [
             vec![both_required.clone(), depth_optional.clone()],
@@ -1158,17 +1435,11 @@ mod tests {
         // fingerprint must catch it, because the pointers differ.
         let a_again = schema(&[("a", DataType::Int32)]);
 
-        let listing = [
-            Arc::clone(&a),
-            Arc::clone(&a),
-            Arc::clone(&b),
-            a_again,
-            Arc::clone(&b),
-        ];
+        let listing = [a.clone(), a.clone(), b.clone(), a_again, b.clone()];
         let distinct = distinct_schemas(&listing);
         assert_eq!(distinct.len(), 2);
-        assert_eq!(names(&distinct[0]), vec!["a"]);
-        assert_eq!(names(&distinct[1]), vec!["b"]);
+        assert_eq!(names(&distinct[0].schema), vec!["a"]);
+        assert_eq!(names(&distinct[1].schema), vec!["b"]);
 
         // The input holds no repeat, so the function returns it unchanged.
         let no_repeats = [a, b];
@@ -1180,14 +1451,18 @@ mod tests {
     /// drop one schema and report the other.
     #[test]
     fn schemas_that_differ_in_more_than_types_stay_distinct() {
-        let nullable = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
-        let required = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let nullable = schema(&[("a", DataType::Int32)]);
+        let required = LabeledSchema::unlabeled(Arc::new(Schema::new(vec![Field::new(
+            "a",
+            DataType::Int32,
+            false,
+        )])));
         assert_eq!(distinct_schemas(&[nullable.clone(), required]).len(), 2);
 
-        let with_metadata: SchemaRef = Arc::new(
+        let with_metadata = LabeledSchema::unlabeled(Arc::new(
             Schema::new(vec![Field::new("a", DataType::Int32, true)])
                 .with_metadata([("k".to_string(), "v".to_string())].into()),
-        );
+        ));
         assert_eq!(distinct_schemas(&[nullable, with_metadata]).len(), 2);
     }
 
@@ -1204,7 +1479,7 @@ mod tests {
             DataType::UInt8,
             DataType::Float32,
         ];
-        let schemas: Vec<SchemaRef> = (0..300)
+        let schemas: Vec<LabeledSchema> = (0..300)
             .map(|index| {
                 schema(&[
                     ("shared", widths[index % widths.len()].clone()),
@@ -1233,8 +1508,13 @@ mod tests {
     /// first chunk, gives back the order dependence of issue #377.
     #[test]
     fn a_split_merge_reports_a_conflict_wherever_it_falls() {
-        let schemas: Vec<SchemaRef> = (0..300)
-            .map(|index| schema(&[("shared", DataType::Int32), (&format!("own_{index}"), DataType::Utf8)]))
+        let schemas: Vec<LabeledSchema> = (0..300)
+            .map(|index| {
+                schema(&[
+                    ("shared", DataType::Int32),
+                    (&format!("own_{index}"), DataType::Utf8),
+                ])
+            })
             .collect();
         let widening = ArrowTypeWidening::default_extension();
         assert!(widening.merge_schemas(&schemas).is_ok());
@@ -1250,7 +1530,7 @@ mod tests {
         }
 
         // A second copy of every schema does not change a clean merge.
-        let doubled: Vec<SchemaRef> = schemas.iter().chain(schemas.iter()).cloned().collect();
+        let doubled: Vec<LabeledSchema> = schemas.iter().chain(schemas.iter()).cloned().collect();
         assert_eq!(
             widening.merge_schemas(&doubled).unwrap(),
             widening.merge_schemas(&schemas).unwrap()
@@ -1269,10 +1549,10 @@ mod tests {
         }
 
         impl ArrowTypeWideningStrategy for CountingStrategy {
-            fn merge_schemas(&self, schema_refs: &[SchemaRef]) -> Result<SchemaRef, ArrowError> {
+            fn merge_schemas(&self, schemas: &[LabeledSchema]) -> Result<SchemaRef, ArrowError> {
                 self.calls.fetch_add(1, Ordering::SeqCst);
-                self.seen.fetch_add(schema_refs.len(), Ordering::SeqCst);
-                DefaultArrowTypeWidening.merge_schemas(schema_refs)
+                self.seen.fetch_add(schemas.len(), Ordering::SeqCst);
+                DefaultArrowTypeWidening.merge_schemas(schemas)
             }
 
             fn is_order_independent(&self) -> bool {
@@ -1286,7 +1566,7 @@ mod tests {
         });
         let widening = ArrowTypeWidening::new(strategy.clone());
         let one = schema(&[("a", DataType::Int32)]);
-        let repeated: Vec<SchemaRef> = (0..200).map(|_| Arc::clone(&one)).collect();
+        let repeated: Vec<LabeledSchema> = (0..200).map(|_| one.clone()).collect();
 
         widening.merge_schemas(&repeated).unwrap();
         assert_eq!(strategy.calls.load(Ordering::SeqCst), 1, "one fold");

--- a/beacon-db/beacon-datafusion-ext/tests/fast_object_table.rs
+++ b/beacon-db/beacon-datafusion-ext/tests/fast_object_table.rs
@@ -566,7 +566,9 @@ async fn a_projection_that_names_nothing_leaves_the_schema_alone() {
 /// files that disagree behaves the same however the URLs are spelled.
 #[tokio::test(flavor = "multi_thread")]
 async fn the_caller_can_name_the_merge_rule() {
-    use beacon_datafusion_ext::type_widening::{ArrowTypeWideningStrategy, DefaultArrowTypeWidening};
+    use beacon_datafusion_ext::type_widening::{
+        ArrowTypeWideningStrategy, DefaultArrowTypeWidening, LabeledSchema,
+    };
     use datafusion::arrow::array::{Int32Array, Int64Array};
     use datafusion::arrow::datatypes::SchemaRef;
 
@@ -578,11 +580,11 @@ async fn the_caller_can_name_the_merge_rule() {
     impl ArrowTypeWideningStrategy for FirstTypeWins {
         fn merge_schemas(
             &self,
-            schema_refs: &[SchemaRef],
+            schemas: &[LabeledSchema],
         ) -> Result<SchemaRef, datafusion::arrow::error::ArrowError> {
             let mut fields: Vec<datafusion::arrow::datatypes::FieldRef> = Vec::new();
-            for schema in schema_refs {
-                for field in schema.fields() {
+            for labeled in schemas {
+                for field in labeled.schema.fields() {
                     if !fields.iter().any(|kept| kept.name() == field.name()) {
                         fields.push(field.clone());
                     }

--- a/beacon-db/beacon-datafusion-ext/tests/schema_cache.rs
+++ b/beacon-db/beacon-datafusion-ext/tests/schema_cache.rs
@@ -97,7 +97,9 @@ impl FileFormat for CountingFormat {
             return Ok(Arc::new(Schema::empty()));
         }
         beacon_datafusion_ext::type_widening::session_widening(state)
-            .merge_schemas(&schemas)
+            .merge_schemas(&beacon_datafusion_ext::type_widening::label_by_object(
+                objects, &schemas,
+            ))
             .map_err(|e| datafusion::error::DataFusionError::Execution(e.to_string()))
     }
 

--- a/beacon-db/beacon-file-formats/beacon-arrow-atlas/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-atlas/src/datafusion/mod.rs
@@ -13,7 +13,7 @@ use arrow::datatypes::SchemaRef;
 use beacon_datafusion_ext::format_ext::{
     DatasetMetadata, FileFormatFactoryExt, SchemaOptions, SchemaUnit, units_over_stores,
 };
-use beacon_datafusion_ext::type_widening::session_widening;
+use beacon_datafusion_ext::type_widening::{LabeledSchema, session_widening};
 use datafusion::{
     catalog::{Session, memory::DataSourceExec},
     common::{GetExt, Statistics, exec_datafusion_err},
@@ -310,7 +310,11 @@ impl FileFormat for AtlasFormat {
             let merged = atlas.merged_schema();
             let schema =
                 crate::compat::atlas_merged_schema_to_arrow(&merged, read_dimensions.as_deref());
-            schemas.push(Arc::new(schema));
+            // The marker names the store, so a refused column names both stores.
+            schemas.push(LabeledSchema::new(
+                Arc::new(schema),
+                marker.location.as_ref(),
+            ));
         }
 
         // Union the stores with the rule of the session. One store is the common

--- a/beacon-db/beacon-file-formats/beacon-arrow-bbf/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-bbf/src/datafusion/mod.rs
@@ -7,7 +7,7 @@ use beacon_binary_format::{
 use beacon_common::file_descriptors::file_open_parallelism;
 use beacon_datafusion_ext::format_ext::{DatasetMetadata, FileFormatFactoryExt, SchemaOptions};
 use beacon_datafusion_ext::format_options::format_option;
-use beacon_datafusion_ext::type_widening::session_widening;
+use beacon_datafusion_ext::type_widening::{label_by_object, session_widening};
 use datafusion::{
     catalog::{Session, memory::DataSourceExec},
     common::{GetExt, Statistics},
@@ -180,9 +180,10 @@ impl FileFormat for BBFFormat {
             .try_collect::<Vec<_>>()
             .await?;
 
-        // Merge & widen types across all files, using the session's type widening rules.
+        // Merge & widen types across all files, using the session's type widening
+        // rules. Each schema names its file, so a refused column names both files.
         session_widening(state)
-            .merge_schemas(&schemas)
+            .merge_schemas(&label_by_object(objects, &schemas))
             .map_err(|e| {
                 datafusion::error::DataFusionError::Execution(format!(
                     "Failed to infer schema: {}",

--- a/beacon-db/beacon-file-formats/beacon-arrow-csv/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-csv/src/datafusion/mod.rs
@@ -20,7 +20,7 @@ use futures::{StreamExt, TryStreamExt, stream};
 
 use beacon_common::file_descriptors::file_open_parallelism;
 use beacon_datafusion_ext::format_ext::{FileFormatFactoryExt, SchemaOptions};
-use beacon_datafusion_ext::type_widening::session_widening;
+use beacon_datafusion_ext::type_widening::{label_by_object, session_widening};
 
 pub const DEFAULT_CSV_EXTENSION: &str = "csv";
 pub const DEFAULT_TSV_EXTENSION: &str = "tsv";
@@ -193,9 +193,10 @@ impl FileFormat for CsvFormat {
             .await?;
 
         // The rule of the session decides the result for a column that two
-        // files describe differently.
+        // files describe differently. Each schema names its file, so a refused
+        // column names both files.
         session_widening(state)
-            .merge_schemas(&schemas)
+            .merge_schemas(&label_by_object(objects, &schemas))
             .map_err(|e| {
                 datafusion::error::DataFusionError::Execution(format!(
                     "Failed to infer schema: {}",
@@ -393,6 +394,28 @@ mod tests {
             .expect("agreeing files merge");
         let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
         assert_eq!(names, vec!["value", "other"]);
+    }
+
+    /// A column that two files give two types names both files. A collection of
+    /// 10000 files is otherwise a search. See issue #424.
+    #[tokio::test]
+    async fn infer_schema_names_the_file_of_each_type() {
+        let store = Arc::new(InMemory::new());
+        let object_store: Arc<dyn ObjectStore> = store.clone();
+        let numbers = put(&store, &Path::from("argo/a.csv"), "depth\n1.5\n").await;
+        let words = put(&store, &Path::from("argo/b.csv"), "depth\nsurface\n").await;
+
+        let ctx = SessionContext::new();
+        let error = CsvFormat::new(b',', 1000)
+            .infer_schema(&ctx.state(), &object_store, &[numbers, words])
+            .await
+            .expect_err("a number beside a string has no common type");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("'argo/a.csv'") && message.contains("'argo/b.csv'"),
+            "the error must name both files: {message}"
+        );
     }
 
     /// A non-default delimiter must reach the wrapped DataFusion format, otherwise

--- a/beacon-db/beacon-file-formats/beacon-arrow-geoparquet/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-geoparquet/src/datafusion/mod.rs
@@ -3,7 +3,7 @@ use std::{any::Any, fmt::Debug, sync::Arc};
 use arrow::datatypes::SchemaRef;
 use beacon_common::file_descriptors::file_open_parallelism;
 use beacon_datafusion_ext::format_ext::{DatasetMetadata, FileFormatFactoryExt, SchemaOptions};
-use beacon_datafusion_ext::type_widening::session_widening;
+use beacon_datafusion_ext::type_widening::{label_by_object, session_widening};
 use datafusion::{
     catalog::{Session, memory::DataSourceExec},
     common::{ColumnStatistics, GetExt, Statistics, exec_datafusion_err},
@@ -173,9 +173,10 @@ impl FileFormat for GeoParquetFormat {
         }
 
         // The rule of the session decides the result for a column that two
-        // files describe differently.
+        // files describe differently. Each schema names its file, so a refused
+        // column names both files.
         let super_schema = session_widening(state)
-            .merge_schemas(&schemas)
+            .merge_schemas(&label_by_object(objects, &schemas))
             .map_err(|e| {
                 exec_datafusion_err!("Failed to merge the schemas of the GeoParquet files: {}", e)
             })?;
@@ -763,9 +764,17 @@ mod tests {
         )])) as SchemaRef;
 
         let extension = |schemas: &[SchemaRef]| {
+            let labeled: Vec<_> = schemas
+                .iter()
+                .map(|schema| {
+                    beacon_datafusion_ext::type_widening::LabeledSchema::unlabeled(Arc::clone(
+                        schema,
+                    ))
+                })
+                .collect();
             let merged =
                 beacon_datafusion_ext::type_widening::ArrowTypeWidening::default_extension()
-                    .merge_schemas(schemas)
+                    .merge_schemas(&labeled)
                     .expect("merge");
             reconcile_field_metadata(&merged, schemas)
                 .field_with_name("geometry")

--- a/beacon-db/beacon-file-formats/beacon-arrow-hdf5/src/format.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-hdf5/src/format.rs
@@ -15,7 +15,7 @@ use beacon_arrow_netcdf::datafusion::{statistics, NetCDFFormatFactory, NetcdfFor
 use beacon_datafusion_ext::format_ext::{DatasetMetadata, FileFormatFactoryExt, SchemaOptions};
 use beacon_datafusion_ext::format_options::format_option;
 use beacon_datafusion_ext::listing_factory::ListingFactory;
-use beacon_datafusion_ext::type_widening::session_widening;
+use beacon_datafusion_ext::type_widening::{label_by_object, session_widening};
 use datafusion::{
     catalog::{memory::DataSourceExec, Session},
     common::{exec_datafusion_err, GetExt, Statistics},
@@ -428,9 +428,10 @@ impl FileFormat for Hdf5Format {
             return Ok(Arc::new(arrow::datatypes::Schema::empty()));
         }
         // The rule of the session decides the result for a column that two
-        // files describe differently.
+        // files describe differently. Each schema names its file, so a refused
+        // column names both files.
         session_widening(state)
-            .merge_schemas(&schemas)
+            .merge_schemas(&label_by_object(objects, &schemas))
             .map_err(|e| {
                 exec_datafusion_err!(
                     "Failed to merge the schemas of the HDF5 datasets: {}",

--- a/beacon-db/beacon-file-formats/beacon-arrow-ipc/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-ipc/src/datafusion/mod.rs
@@ -21,7 +21,7 @@ use futures::{StreamExt, TryStreamExt, stream};
 
 use beacon_common::file_descriptors::file_open_parallelism;
 use beacon_datafusion_ext::format_ext::{FileFormatFactoryExt, SchemaOptions};
-use beacon_datafusion_ext::type_widening::session_widening;
+use beacon_datafusion_ext::type_widening::{label_by_object, session_widening};
 
 pub const DEFAULT_ARROW_EXTENSION: &str = "arrow";
 
@@ -153,9 +153,10 @@ impl FileFormat for ArrowFormat {
             .await?;
 
         // The rule of the session decides the result for a column that two
-        // files describe differently.
+        // files describe differently. Each schema names its file, so a refused
+        // column names both files.
         session_widening(state)
-            .merge_schemas(&schemas)
+            .merge_schemas(&label_by_object(objects, &schemas))
             .map_err(|e| {
                 datafusion::error::DataFusionError::Execution(format!(
                     "Failed to infer schema: {}",

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -6,7 +6,7 @@ use arrow::datatypes::SchemaRef;
 use beacon_datafusion_ext::format_ext::{DatasetMetadata, FileFormatFactoryExt, SchemaOptions};
 use beacon_datafusion_ext::format_options::format_option;
 use beacon_datafusion_ext::listing_factory::ListingFactory;
-use beacon_datafusion_ext::type_widening::session_widening;
+use beacon_datafusion_ext::type_widening::{label_by_object, session_widening};
 use beacon_datafusion_ext::unique_values::UniqueValuesExec;
 use datafusion::{
     catalog::{memory::DataSourceExec, Session},
@@ -447,9 +447,10 @@ impl FileFormat for NetcdfFormat {
             return Ok(Arc::new(arrow::datatypes::Schema::empty()));
         }
         // The rule of the session decides the result for a column that two
-        // files describe differently.
+        // files describe differently. Each schema names its file, so a refused
+        // column names both files.
         session_widening(state)
-            .merge_schemas(&schemas)
+            .merge_schemas(&label_by_object(objects, &schemas))
             .map_err(|e| {
                 exec_datafusion_err!(
                     "Failed to merge the schemas of the NetCDF datasets: {}",

--- a/beacon-db/beacon-file-formats/beacon-arrow-odv/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-odv/src/datafusion/mod.rs
@@ -1,7 +1,7 @@
 use std::{any::Any, sync::Arc};
 
 use arrow::datatypes::SchemaRef;
-use beacon_datafusion_ext::type_widening::session_widening;
+use beacon_datafusion_ext::type_widening::{label_by_object, session_widening};
 use datafusion::{
     catalog::{memory::DataSourceExec, Session},
     common::{Column, DFSchema, GetExt, Statistics},
@@ -196,9 +196,10 @@ impl FileFormat for OdvFormat {
             .await?;
 
         // The rule of the session decides the result for a column that two
-        // files describe differently.
+        // files describe differently. Each schema names its file, so a refused
+        // column names both files.
         session_widening(state)
-            .merge_schemas(&schemas)
+            .merge_schemas(&label_by_object(objects, &schemas))
             .map_err(|e| {
                 datafusion::error::DataFusionError::Execution(format!(
                     "Failed to infer schema: {}",

--- a/beacon-db/beacon-file-formats/beacon-arrow-parquet/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-parquet/src/datafusion/mod.rs
@@ -19,7 +19,7 @@ use futures::{StreamExt, TryStreamExt, stream};
 
 use beacon_common::file_descriptors::file_open_parallelism;
 use beacon_datafusion_ext::format_ext::{FileFormatFactoryExt, SchemaOptions};
-use beacon_datafusion_ext::type_widening::session_widening;
+use beacon_datafusion_ext::type_widening::{label_by_object, session_widening};
 
 #[derive(Debug)]
 pub struct ParquetFormatFactory;
@@ -142,9 +142,10 @@ impl FileFormat for ParquetFormat {
             .await?;
 
         // The rule of the session decides the result for a column that two
-        // files describe differently.
+        // files describe differently. Each schema names its file, so a refused
+        // column names both files.
         session_widening(state)
-            .merge_schemas(&schemas)
+            .merge_schemas(&label_by_object(objects, &schemas))
             .map_err(|e| {
                 datafusion::error::DataFusionError::Execution(format!(
                     "Failed to infer schema: {}",

--- a/beacon-db/beacon-file-formats/beacon-arrow-tiff/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-tiff/src/datafusion/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::SchemaRef;
 use beacon_datafusion_ext::format_ext::{DatasetMetadata, FileFormatFactoryExt, SchemaOptions};
-use beacon_datafusion_ext::type_widening::session_widening;
+use beacon_datafusion_ext::type_widening::{label_by_object, session_widening};
 use datafusion::{
     catalog::{memory::DataSourceExec, Session},
     common::{exec_datafusion_err, GetExt, Statistics},
@@ -154,9 +154,10 @@ impl FileFormat for TiffFormat {
         }
 
         // The rule of the session decides the result for a column that two
-        // files describe differently.
+        // files describe differently. Each schema names its file, so a refused
+        // column names both files.
         session_widening(state)
-            .merge_schemas(&schemas)
+            .merge_schemas(&label_by_object(objects, &schemas))
             .map_err(|e| {
                 exec_datafusion_err!(
                     "Failed to merge the schemas of the TIFF datasets: {}",

--- a/beacon-db/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-zarr/src/datafusion/mod.rs
@@ -12,7 +12,7 @@ use beacon_datafusion_ext::format_ext::{
     DatasetMetadata, FileFormatFactoryExt, SchemaOptions, SchemaUnit, units_over_stores,
 };
 use beacon_datafusion_ext::format_options::format_option;
-use beacon_datafusion_ext::type_widening::session_widening;
+use beacon_datafusion_ext::type_widening::{LabeledSchema, session_widening};
 use datafusion::{
     catalog::{Session, memory::DataSourceExec},
     common::{GetExt, Statistics},
@@ -356,7 +356,9 @@ impl FileFormat for ZarrFormat {
             )
             .await
             .map_err(|e| datafusion::error::DataFusionError::Execution(e.to_string()))?;
-            schemas.push(schema);
+            // The store path names the schema, so a refused column names both
+            // stores.
+            schemas.push(LabeledSchema::new(schema, object.location.as_ref()));
         }
 
         if schemas.is_empty() {

--- a/beacon-db/beacon-file-formats/beacon-arrow-zarr/src/reader.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-zarr/src/reader.rs
@@ -13,7 +13,7 @@
 use std::sync::Arc;
 
 use arrow::datatypes::SchemaRef;
-use beacon_datafusion_ext::type_widening::ArrowTypeWidening;
+use beacon_datafusion_ext::type_widening::{ArrowTypeWidening, LabeledSchema};
 use beacon_nd_array::{
     NdArrayD,
     arrow::schema::any_dataset_to_arrow_schema,
@@ -72,6 +72,8 @@ pub async fn schema_from_group_path(
 
     let mut schemas = Vec::new();
     for leaf in leaves {
+        // The group path names the leaf, so a refused column names both leaves.
+        let leaf_path = leaf.path().as_str().to_string();
         let dataset = dataset_from_group(&leaf, None)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to read Zarr group as dataset: {e}"))?;
@@ -79,7 +81,7 @@ pub async fn schema_from_group_path(
         let dataset = project_read_dimensions(dataset, read_dimensions.clone(), log_label)?;
         let schema = any_dataset_to_arrow_schema(&dataset)
             .map_err(|e| anyhow::anyhow!("Failed to derive Zarr Arrow schema: {e}"))?;
-        schemas.push(Arc::new(schema));
+        schemas.push(LabeledSchema::new(Arc::new(schema), leaf_path));
     }
 
     if schemas.is_empty() {


### PR DESCRIPTION
Closes #424.

## Problem

A schema merge that refused a column named the column and the two types:

```
Failed to infer schema: Schema error: Incompatible types for field 'depth': Utf8 vs Float64
```

A table over 10000 files gave the same text, so the user had to search for the bad file.

## What changes

`ArrowTypeWideningStrategy::merge_schemas` now takes `&[LabeledSchema]` instead of `&[SchemaRef]`. A `LabeledSchema` holds a schema and the name of its source. The error reports both names:

```
Incompatible types for field 'depth': Utf8 in 'argo/a.nc' vs Float64 in 'argo/b.nc'
```

Each caller supplies the name:

| Caller | The name |
| --- | --- |
| every file format (`infer_schema`) | the object path, through the new `label_by_object` |
| `FastObjectTable` / `infer_url_schemas` | the table URL |
| Zarr and Icechunk leaf groups | the group path |
| Atlas stores | the marker path |

A caller with no name passes `LabeledSchema::unlabeled`, and the error then reports the two types alone, as before.

## The two steps that hid the source

- **A repeated schema drops out.** `distinct_schemas` keeps the first copy, so it keeps the first file name.
- **A thread merges a chunk.** A chunk result holds the fields of every schema in the chunk, so it names no single file. A failed merge therefore folds the named schemas once more, in one thread, to name both sources. The fold stops at the same pair, because the join is associative, and a merge that succeeds pays nothing for it.

## The name of a widened column

A widened column keeps the name of the source that states its current type. `Int32` in `a.nc` beside `Int64` in `b.nc` gives `Int64`, and a later `Utf8` names `b.nc`. A join that equals neither operand names neither source: `Int64` beside `UInt64` gives `Float64`, and no file states `Float64`.

## Compatibility

The trait is public. A custom strategy registered through `RuntimeBuilder::with_type_widening` takes the same signature change.

## Tests

Six unit tests in `type_widening.rs` cover the exact text, an unnamed schema, a widened column, a join that names neither file, a repeated schema, and a split merge over 301 schemas. One end-to-end test in `beacon-arrow-csv` reads two real files and checks that both paths reach the message.
