### PR TITLE
fix: keep the case of a table name in every statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,16 @@ tag. Releases before 2.0.0 are recorded in the
 
 ### Fixed
 
+- **Seven statements lowercased a table name.** Beacon turns identifier normalization off, so the
+  catalog holds a table under the exact name the statement writes. `INSERT`, `CREATE TABLE AS
+  SELECT`, `ALTER TABLE`, `CREATE INDEX`, `DROP INDEX`, `SHOW INDEXES`, `REFRESH`, the table
+  extension statements and the admin `table-config` route rebuilt the reference from a string with
+  `TableReference::parse_str`, which lowercases every unquoted part. Each one asked for a name the
+  catalog does not hold, so `CREATE TABLE MyManaged` was followed by `No table named 'mymanaged'`.
+  `CREATE MATERIALIZED VIEW MyView` was worse: it registered `myview` but persisted `MyView`, so a
+  restart renamed the view and broke every query that used the old spelling. A new `table_name`
+  module builds the reference and keeps the case, and every path uses it. A new
+  [identifiers page](docs/docs/2.0.0-rc3/sql/identifiers.md) states the rule and its limits.
 - **`OPTIONS` on a NetCDF, HDF5, Zarr or BBF external table had no effect**
   ([#421](https://github.com/maris-development/beacon/issues/421)). DataFusion's SQL planner
   renames an `OPTIONS` key without a `.` to `format.<key>`. Those four factories read the bare key

--- a/beacon-db/beacon-core/src/extensions.rs
+++ b/beacon-db/beacon-core/src/extensions.rs
@@ -350,7 +350,7 @@ pub fn show_extensions_arrow_schema() -> SchemaRef {
 /// The table's live Arrow schema, erroring if the table is not registered.
 async fn table_schema(ctx: &Arc<SessionContext>, name: &str) -> anyhow::Result<SchemaRef> {
     let provider = ctx
-        .table_provider(name)
+        .table_provider(crate::table_name::table_reference(name))
         .await
         .map_err(|_| anyhow::anyhow!("table '{name}' not found"))?;
     Ok(provider.schema())
@@ -365,7 +365,10 @@ pub async fn get_table_extensions(
     ctx: &Arc<SessionContext>,
     name: &str,
 ) -> anyhow::Result<TableExtensions> {
-    anyhow::ensure!(ctx.table_exist(name)?, "table '{name}' not found");
+    anyhow::ensure!(
+        ctx.table_exist(crate::table_name::table_reference(name))?,
+        "table '{name}' not found"
+    );
     match persistence(ctx).load_table_extensions_json(name).await? {
         Some(json) => {
             Ok(serde_json::from_str(&json).context("stored table extensions are not valid")?)
@@ -417,7 +420,10 @@ pub async fn set_table_extensions(
 
 /// Remove all extensions for a table.
 pub async fn delete_table_extensions(ctx: &Arc<SessionContext>, name: &str) -> anyhow::Result<()> {
-    anyhow::ensure!(ctx.table_exist(name)?, "table '{name}' not found");
+    anyhow::ensure!(
+        ctx.table_exist(crate::table_name::table_reference(name))?,
+        "table '{name}' not found"
+    );
     persistence(ctx).remove_table_extensions_json(name).await?;
     Ok(())
 }

--- a/beacon-db/beacon-core/src/lib.rs
+++ b/beacon-db/beacon-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod schema_persistence;
 pub(crate) mod secret_persistence;
 pub mod settings;
 mod statement_plan;
+mod table_name;
 pub(crate) mod system_schema;
 
 // Re-export the auth types the transports (HTTP, Flight SQL) need, so they depend

--- a/beacon-db/beacon-core/src/statement_plan/actions.rs
+++ b/beacon-db/beacon-core/src/statement_plan/actions.rs
@@ -539,7 +539,7 @@ pub(crate) async fn create_table(
     session.register_table(name.clone(), provider)?;
 
     if is_ctas {
-        let stream = insert_into(session, &table_name, InsertOp::Append, child).await?;
+        let stream = insert_into(session, name, InsertOp::Append, child).await?;
         Ok(Some(build_default_indexes_after(
             stream,
             warehouse,
@@ -588,11 +588,11 @@ fn build_default_indexes_after(
 /// inserted-row count stream.
 pub(crate) async fn insert_into(
     session: &Arc<SessionContext>,
-    table: &str,
+    table: &TableReference,
     op: InsertOp,
     child: Arc<dyn ExecutionPlan>,
 ) -> anyhow::Result<SendableRecordBatchStream> {
-    let provider = session.table_provider(table).await?;
+    let provider = session.table_provider(table.clone()).await?;
     let state = session.state();
     let insert_plan = provider.insert_into(&state, child, op).await?;
     let stream = execute_stream(insert_plan, session.task_ctx())?;
@@ -654,7 +654,7 @@ pub(crate) async fn alter_table(
     session: &Arc<SessionContext>,
     spec: &AlterTableSpec,
 ) -> anyhow::Result<()> {
-    let table_ref = TableReference::parse_str(&spec.name.to_string());
+    let table_ref = crate::table_name::object_name_table_reference(&spec.name);
 
     let provider = session.table_provider(table_ref.clone()).await?;
     let definition = provider
@@ -745,7 +745,9 @@ async fn lance_table_location(
     session: &Arc<SessionContext>,
     table: &str,
 ) -> anyhow::Result<String> {
-    let provider = session.table_provider(table).await?;
+    let provider = session
+        .table_provider(crate::table_name::table_reference(table))
+        .await?;
     provider
         .as_any()
         .downcast_ref::<beacon_lance::LanceTable>()

--- a/beacon-db/beacon-core/src/statement_plan/materialized_view.rs
+++ b/beacon-db/beacon-core/src/statement_plan/materialized_view.rs
@@ -20,7 +20,6 @@ use datafusion::{
     dataframe::DataFrameWriteOptions,
     parquet::arrow::ArrowWriter,
     prelude::{DataFrame, SessionContext},
-    sql::TableReference,
 };
 use futures::StreamExt;
 use object_store::{GetOptions, ObjectStore, ObjectStoreExt};
@@ -42,7 +41,7 @@ pub(crate) async fn create_materialized_view(
     name: &str,
     query_sql: &str,
 ) -> anyhow::Result<()> {
-    let table_ref = TableReference::parse_str(name);
+    let table_ref = crate::table_name::table_reference(name);
 
     if session_ctx.table_exist(table_ref.clone())? {
         return Err(anyhow::anyhow!("Materialized view '{name}' already exists"));
@@ -86,7 +85,7 @@ pub(crate) async fn refresh_table(
     session_ctx: &Arc<SessionContext>,
     name: &str,
 ) -> anyhow::Result<()> {
-    let table_ref = TableReference::parse_str(name);
+    let table_ref = crate::table_name::table_reference(name);
     let provider = session_ctx
         .table_provider(table_ref)
         .await
@@ -201,7 +200,7 @@ pub(crate) async fn refresh_materialized_view(
     session_ctx: &Arc<SessionContext>,
     name: &str,
 ) -> anyhow::Result<()> {
-    let table_ref = TableReference::parse_str(name);
+    let table_ref = crate::table_name::table_reference(name);
 
     let provider = session_ctx
         .table_provider(table_ref.clone())

--- a/beacon-db/beacon-core/src/statement_plan/physical.rs
+++ b/beacon-db/beacon-core/src/statement_plan/physical.rs
@@ -864,7 +864,9 @@ impl ExecutionPlan for InsertExec {
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let session = upgrade_session(&self.session)?;
-        let table = self.table.table().to_string();
+        // The planner's reference, not its table name: rebuilding one from a
+        // string lowercases it, and the catalog holds the name as written.
+        let table = self.table.clone();
         let op = self.op;
         let child = self.child.clone();
         Ok(forward_stream(count_arrow_schema(), async move {

--- a/beacon-db/beacon-core/src/table_name.rs
+++ b/beacon-db/beacon-core/src/table_name.rs
@@ -1,0 +1,117 @@
+//! Table references that keep the case the statement writes.
+//!
+//! Beacon turns DataFusion's identifier normalization off (see
+//! [`crate::runtime_builder`]), so the catalog registers a table under the exact
+//! name the user spells. `TableReference::parse_str` lowercases every unquoted
+//! part, so a reference built that way asks the catalog for a name it does not
+//! hold: `CREATE TABLE MyTable` then `No table named 'mytable'`.
+//!
+//! Every path that rebuilds a reference from a name outside the SQL planner goes
+//! through this module.
+
+use datafusion::sql::TableReference;
+use datafusion::sql::sqlparser::ast::ObjectName;
+
+/// The reference for a name that is already a bare value, not SQL text.
+///
+/// Splits a qualified `schema.table` the way `parse_str` does, and keeps the
+/// case of every part.
+pub(crate) fn table_reference(name: &str) -> TableReference {
+    TableReference::parse_str_normalized(name, true)
+}
+
+/// The reference a parsed object name denotes, with the case kept.
+///
+/// Reads the identifier values straight from the AST, so a quoted part needs no
+/// second parse and keeps any character that quoting allows.
+pub(crate) fn object_name_table_reference(name: &ObjectName) -> TableReference {
+    let mut parts: Vec<String> = name
+        .0
+        .iter()
+        .map(|part| match part.as_ident() {
+            Some(ident) => ident.value.clone(),
+            None => part.to_string(),
+        })
+        .collect();
+
+    match parts.len() {
+        1 => TableReference::bare(parts.pop().expect("one part")),
+        2 => {
+            let table = parts.pop().expect("two parts");
+            let schema = parts.pop().expect("two parts");
+            TableReference::partial(schema, table)
+        }
+        3 => {
+            let table = parts.pop().expect("three parts");
+            let schema = parts.pop().expect("three parts");
+            let catalog = parts.pop().expect("three parts");
+            TableReference::full(catalog, schema, table)
+        }
+        // The parser never yields zero parts, and the catalog gives no meaning to
+        // more than three. Both keep the whole text as one name, so the failure
+        // names what the user wrote.
+        _ => TableReference::bare(parts.join(".")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::sql::sqlparser::ast::Ident;
+
+    fn object_name(parts: &[&str]) -> ObjectName {
+        ObjectName::from(parts.iter().map(|p| Ident::new(*p)).collect::<Vec<_>>())
+    }
+
+    #[test]
+    fn a_value_keeps_its_case() {
+        assert_eq!(table_reference("MyTable"), TableReference::bare("MyTable"));
+        assert_eq!(table_reference("MYTABLE"), TableReference::bare("MYTABLE"));
+        assert_eq!(
+            table_reference("MySchema.MyTable"),
+            TableReference::partial("MySchema", "MyTable")
+        );
+    }
+
+    /// The bug this module exists for: DataFusion's own parse lowercases.
+    #[test]
+    fn parse_str_lowercases_and_this_module_does_not() {
+        assert_eq!(TableReference::parse_str("MyTable").table(), "mytable");
+        assert_eq!(table_reference("MyTable").table(), "MyTable");
+    }
+
+    /// A name that needs quoting cannot be re-parsed, so it stays one name.
+    #[test]
+    fn a_value_that_is_not_an_identifier_stays_whole() {
+        assert_eq!(
+            table_reference("my table"),
+            TableReference::bare("my table")
+        );
+    }
+
+    #[test]
+    fn an_object_name_keeps_its_case() {
+        assert_eq!(
+            object_name_table_reference(&object_name(&["MyTable"])),
+            TableReference::bare("MyTable")
+        );
+        assert_eq!(
+            object_name_table_reference(&object_name(&["MySchema", "MyTable"])),
+            TableReference::partial("MySchema", "MyTable")
+        );
+        assert_eq!(
+            object_name_table_reference(&object_name(&["Cat", "MySchema", "MyTable"])),
+            TableReference::full("Cat", "MySchema", "MyTable")
+        );
+    }
+
+    /// A quoted part reaches the catalog whole, dot included.
+    #[test]
+    fn an_object_name_part_is_never_split() {
+        let name = ObjectName::from(vec![Ident::with_quote('"', "My.Table")]);
+        assert_eq!(
+            object_name_table_reference(&name),
+            TableReference::bare("My.Table")
+        );
+    }
+}

--- a/beacon-db/beacon-core/tests/table_name_case.rs
+++ b/beacon-db/beacon-core/tests/table_name_case.rs
@@ -1,0 +1,216 @@
+//! Beacon keeps the case of every identifier.
+//!
+//! The session sets `enable_ident_normalization = false`, so the catalog holds a
+//! table under the exact name the statement writes. Several statements used to
+//! rebuild a `TableReference` from a string with `TableReference::parse_str`,
+//! which lowercases every unquoted part. `CREATE TABLE MyTable` then answered
+//! `No table named 'mytable'` to the very next statement.
+//!
+//! These tests pin both halves: the case-sensitive rule itself, and each
+//! statement that used to break it.
+
+mod common;
+
+use common::{
+    TestRuntime, column_strings, restartable_runtime, runtime, scalar_i64, total_rows, write_file,
+};
+
+/// A two-row CSV whose column names are not lowercase either.
+fn write_obs(rt: &TestRuntime) {
+    write_file(
+        &rt.datasets_dir().join("obs.csv"),
+        "Depth,TEMP,value\n1,2.0,3\n4,5.0,6\n",
+    );
+}
+
+/// The user-facing table names, in catalog order.
+async fn table_names(rt: &TestRuntime) -> Vec<String> {
+    let batches = rt.sql("SHOW TABLES").await;
+    column_strings(&batches, 2)
+}
+
+fn assert_missing(result: anyhow::Result<Vec<arrow::record_batch::RecordBatch>>, name: &str) {
+    let error = format!(
+        "{:#}",
+        result.expect_err("the lowercase name must not resolve")
+    );
+    assert!(
+        error.contains(name),
+        "the error must name what was looked up, got: {error}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_table_name_keeps_its_case() {
+    let rt = runtime("case-table-name").await;
+    write_obs(&rt);
+    rt.sql("CREATE EXTERNAL TABLE MyTable STORED AS CSV LOCATION 'obs.csv'")
+        .await;
+
+    assert_eq!(total_rows(&rt.sql("SELECT * FROM MyTable").await), 2);
+    assert_eq!(total_rows(&rt.sql("SELECT * FROM \"MyTable\"").await), 2);
+    assert!(table_names(&rt).await.contains(&"MyTable".to_string()));
+
+    // The mirror image holds too: a lowercase spelling is a different name.
+    assert_missing(rt.try_sql("SELECT * FROM mytable").await, "mytable");
+    assert_missing(rt.try_sql("SELECT * FROM MYTABLE").await, "MYTABLE");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_column_name_keeps_its_case() {
+    let rt = runtime("case-column-name").await;
+    write_obs(&rt);
+    rt.sql("CREATE EXTERNAL TABLE MyTable STORED AS CSV LOCATION 'obs.csv'")
+        .await;
+
+    assert_eq!(
+        total_rows(&rt.sql("SELECT TEMP, Depth FROM MyTable").await),
+        2
+    );
+    assert!(rt.try_sql("SELECT temp FROM MyTable").await.is_err());
+    assert!(rt.try_sql("SELECT depth FROM MyTable").await.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn drop_table_matches_the_case() {
+    let rt = runtime("case-drop-table").await;
+    write_obs(&rt);
+    rt.sql("CREATE EXTERNAL TABLE MyTable STORED AS CSV LOCATION 'obs.csv'")
+        .await;
+
+    assert!(rt.try_sql("DROP TABLE mytable").await.is_err());
+    rt.sql("DROP TABLE MyTable").await;
+    assert!(!table_names(&rt).await.contains(&"MyTable".to_string()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_table_name_keeps_its_case_over_a_restart() {
+    let rt = restartable_runtime("case-restart", |b| b).await;
+    write_obs(&rt);
+    rt.sql("CREATE EXTERNAL TABLE MyTable STORED AS CSV LOCATION 'obs.csv'")
+        .await;
+
+    let rt = rt.restart().await;
+    assert!(table_names(&rt).await.contains(&"MyTable".to_string()));
+    assert_eq!(total_rows(&rt.sql("SELECT * FROM MyTable").await), 2);
+    assert_missing(rt.try_sql("SELECT * FROM mytable").await, "mytable");
+}
+
+/// `INSERT INTO` used to look up the lowercased name and fail.
+#[tokio::test(flavor = "multi_thread")]
+async fn insert_into_reaches_a_mixed_case_table() {
+    let rt = runtime("case-insert").await;
+    rt.sql("CREATE TABLE MyManaged (Id BIGINT, Name VARCHAR)")
+        .await;
+
+    rt.sql("INSERT INTO MyManaged VALUES (1, 'a'), (2, 'b')")
+        .await;
+
+    assert_eq!(
+        scalar_i64(&rt.sql("SELECT count(*) FROM MyManaged").await),
+        2
+    );
+}
+
+/// `CREATE TABLE AS SELECT` used to register the table and then fail its insert,
+/// which left an empty table behind.
+#[tokio::test(flavor = "multi_thread")]
+async fn create_table_as_select_fills_a_mixed_case_table() {
+    let rt = runtime("case-ctas").await;
+
+    rt.sql("CREATE TABLE MyManaged AS SELECT 1 AS Id, 'a' AS Name")
+        .await;
+
+    assert_eq!(
+        scalar_i64(&rt.sql("SELECT count(*) FROM MyManaged").await),
+        1
+    );
+}
+
+/// `ALTER TABLE` used to look up the lowercased name and fail.
+#[tokio::test(flavor = "multi_thread")]
+async fn alter_table_reaches_a_mixed_case_table() {
+    let rt = runtime("case-alter").await;
+    rt.sql("CREATE TABLE MyManaged (Id BIGINT)").await;
+
+    rt.sql("ALTER TABLE MyManaged ADD COLUMN Extra BIGINT")
+        .await;
+
+    let columns = column_strings(&rt.sql("DESCRIBE MyManaged").await, 0);
+    assert!(columns.contains(&"Extra".to_string()), "got {columns:?}");
+}
+
+/// `CREATE INDEX`, `SHOW INDEXES` and `DROP INDEX` share one lookup, which used
+/// to lowercase the table name.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_index_statements_reach_a_mixed_case_table() {
+    let rt = runtime("case-index").await;
+    rt.sql("CREATE TABLE MyManaged AS SELECT 1 AS Id").await;
+
+    rt.sql("CREATE INDEX id_idx ON MyManaged (Id)").await;
+    let indexes = column_strings(&rt.sql("SHOW INDEXES ON MyManaged").await, 0);
+    assert!(indexes.contains(&"id_idx".to_string()), "got {indexes:?}");
+
+    rt.sql("DROP INDEX id_idx ON MyManaged").await;
+    // `CREATE TABLE AS SELECT` builds a default zone map per column, so the
+    // listing keeps `zm_Id` after the named index goes.
+    let indexes = column_strings(&rt.sql("SHOW INDEXES ON MyManaged").await, 0);
+    assert!(!indexes.contains(&"id_idx".to_string()), "got {indexes:?}");
+}
+
+/// `REFRESH` used to look up the lowercased name and fail for every name that
+/// was not already lowercase.
+#[tokio::test(flavor = "multi_thread")]
+async fn refresh_reaches_a_mixed_case_table() {
+    let rt = runtime("case-refresh").await;
+    write_obs(&rt);
+    rt.sql("CREATE EXTERNAL TABLE MyTable STORED AS CSV LOCATION 'obs.csv'")
+        .await;
+
+    rt.sql("REFRESH TABLE MyTable").await;
+
+    assert_eq!(total_rows(&rt.sql("SELECT * FROM MyTable").await), 2);
+    assert!(rt.try_sql("REFRESH TABLE mytable").await.is_err());
+}
+
+/// The worst of the set: the view registered under the lowercased name, while
+/// its persisted definition kept the written one, so a restart renamed it.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_materialized_view_keeps_one_name_over_a_restart() {
+    let rt = restartable_runtime("case-materialized-view", |b| b).await;
+    write_obs(&rt);
+    rt.sql("CREATE EXTERNAL TABLE MyTable STORED AS CSV LOCATION 'obs.csv'")
+        .await;
+
+    rt.sql("CREATE MATERIALIZED VIEW MyView AS SELECT * FROM MyTable")
+        .await;
+
+    assert!(table_names(&rt).await.contains(&"MyView".to_string()));
+    assert_eq!(total_rows(&rt.sql("SELECT * FROM MyView").await), 2);
+    assert_missing(rt.try_sql("SELECT * FROM myview").await, "myview");
+
+    rt.sql("REFRESH TABLE MyView").await;
+    assert_eq!(total_rows(&rt.sql("SELECT * FROM MyView").await), 2);
+
+    let rt = rt.restart().await;
+    assert!(table_names(&rt).await.contains(&"MyView".to_string()));
+    assert_eq!(total_rows(&rt.sql("SELECT * FROM MyView").await), 2);
+    assert_missing(rt.try_sql("SELECT * FROM myview").await, "myview");
+}
+
+/// The table-extension statements share the lookup that the admin `table-config`
+/// endpoint uses, and it lowercased the name too.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_extension_statements_reach_a_mixed_case_table() {
+    let rt = runtime("case-extensions").await;
+    write_obs(&rt);
+    rt.sql("CREATE EXTERNAL TABLE MyTable STORED AS CSV LOCATION 'obs.csv'")
+        .await;
+
+    rt.sql("SET EXTENSION 'preset' FOR MyTable TO '{\"presets\":[]}'")
+        .await;
+    assert_eq!(total_rows(&rt.sql("SHOW EXTENSIONS FOR MyTable").await), 1);
+
+    rt.sql("DROP EXTENSION 'preset' FOR MyTable").await;
+    assert!(rt.try_sql("SHOW EXTENSIONS FOR mytable").await.is_err());
+}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -254,6 +254,7 @@ export default defineConfig({
           collapsed: true,
           items: [
             { text: 'Overview', link: '/docs/2.0.0-rc3/sql/' },
+            { text: 'Identifiers & Case', link: '/docs/2.0.0-rc3/sql/identifiers' },
             { text: 'SELECT', link: '/docs/2.0.0-rc3/sql/select' },
             { text: 'WHERE', link: '/docs/2.0.0-rc3/sql/where' },
             { text: 'GROUP BY', link: '/docs/2.0.0-rc3/sql/group-by' },

--- a/docs/docs/2.0.0-rc3/sql/create-external-table.md
+++ b/docs/docs/2.0.0-rc3/sql/create-external-table.md
@@ -22,6 +22,11 @@ LOCATION '<path>'
 [OPTIONS ('<key>' '<value>', ...)]
 ```
 
+::: tip Names keep their case
+`<table_name>` means exactly what you write. `MyTable` and `mytable` are two different tables.
+See [Identifiers and case](/docs/2.0.0-rc3/sql/identifiers).
+:::
+
 Beacon resolves `LOCATION` against its storage root. Give a folder or a glob pattern:
 
 ```sql

--- a/docs/docs/2.0.0-rc3/sql/identifiers.md
+++ b/docs/docs/2.0.0-rc3/sql/identifiers.md
@@ -1,0 +1,101 @@
+---
+description: Beacon keeps the case of every table, column and alias name. MyTable and mytable are two different names. Keywords and built-in functions stay case-insensitive.
+---
+
+# Identifiers and case
+
+Beacon keeps the case of every identifier. A table name, a column name and an alias mean exactly
+what you write. `MyTable` and `mytable` are two different names.
+
+```sql
+CREATE EXTERNAL TABLE MyTable STORED AS CSV LOCATION 'obs.csv';
+
+SELECT * FROM MyTable   -- 2 rows
+SELECT * FROM mytable   -- Error during planning: table 'beacon.public.mytable' not found
+```
+
+Most SQL databases fold an unquoted name to one case. PostgreSQL folds to lowercase. Oracle folds
+to uppercase. Beacon folds nothing.
+
+::: tip Pick one spelling
+Lowercase names with underscores need no quotes and no thought. Use `ocean_profiles`, not
+`OceanProfiles`.
+:::
+
+## Quotes change nothing
+
+A quoted name and an unquoted name follow the same rule. `"MyTable"` and `MyTable` are the same
+table.
+
+Use quotes only for a name that the parser cannot read as one word: a name with a space, a name
+that starts with a digit, or a reserved word.
+
+```sql
+CREATE EXTERNAL TABLE "My Table" STORED AS CSV LOCATION 'obs.csv';
+
+SELECT * FROM "My Table"
+```
+
+## Columns keep the case of the source
+
+A column name comes from the file, not from Beacon. A netCDF variable `TEMP` stays `TEMP`. A CSV
+header `Depth` stays `Depth`.
+
+```sql
+SELECT TEMP FROM MyTable   -- 2 rows
+SELECT temp FROM MyTable   -- Schema error: No field named temp
+```
+
+`DESCRIBE <table>` prints the exact spelling of every column:
+
+```sql
+DESCRIBE MyTable
+```
+
+| column_name | data_type |
+| ----------- | --------- |
+| Depth       | Int64     |
+| TEMP        | Float64   |
+| value       | Int64     |
+
+An alias follows the same rule:
+
+```sql
+SELECT TEMP AS Celsius FROM MyTable ORDER BY Celsius   -- 2 rows
+SELECT TEMP AS Celsius FROM MyTable ORDER BY celsius   -- Schema error: No field named celsius
+```
+
+## Every statement follows the rule
+
+`DROP TABLE`, `ALTER TABLE`, `INSERT`, `UPDATE`, `DELETE`, `REFRESH`, `CREATE INDEX` and
+`SET EXTENSION` all name the table the same way as `SELECT`:
+
+```sql
+DROP TABLE mytable   -- Table 'mytable' does not exist
+DROP TABLE MyTable   -- dropped
+```
+
+A grant names one exact table too:
+
+```sql
+GRANT SELECT ON TABLE mytable TO ROLE reader   -- does not cover MyTable
+```
+
+## What stays case-insensitive
+
+| Element | Rule | Example |
+| ------- | ---- | ------- |
+| Keywords | Case-insensitive | `select`, `SELECT`, `SeLeCt` |
+| Format after `STORED AS` | Case-insensitive | `STORED AS csv`, `STORED AS CSV` |
+| Built-in functions | Case-insensitive | `count(*)`, `COUNT(*)` |
+| [Table functions](/docs/2.0.0-rc3/sql/table-functions) | **Case-sensitive.** Always lowercase | `read_csv(…)`, never `READ_CSV(…)` |
+| Table, column and alias names | **Case-sensitive** | `MyTable` ≠ `mytable` |
+
+## Find the exact name
+
+The catalog holds the spelling. Ask it before you guess:
+
+```sql
+SHOW TABLES              -- every table name
+DESCRIBE ocean_profiles  -- every column name
+```

--- a/docs/docs/2.0.0-rc3/sql/index.md
+++ b/docs/docs/2.0.0-rc3/sql/index.md
@@ -33,6 +33,7 @@ SELECT * FROM read_netcdf(['argo/**/*.nc']) LIMIT 100
 
 ## Reference
 
+- Rules: [Identifiers and case](/docs/2.0.0-rc3/sql/identifiers)
 - Query: [SELECT](/docs/2.0.0-rc3/sql/select) · [WHERE](/docs/2.0.0-rc3/sql/where) · [GROUP BY](/docs/2.0.0-rc3/sql/group-by) · [JOIN](/docs/2.0.0-rc3/sql/join) · [UNION BY NAME](/docs/2.0.0-rc3/sql/union-by-name)
 - Tables and views: [CREATE TABLE](/docs/2.0.0-rc3/sql/managed-tables) · [CREATE EXTERNAL TABLE](/docs/2.0.0-rc3/sql/create-external-table) · [CREATE VIEW](/docs/2.0.0-rc3/sql/create-view) · [CREATE MATERIALIZED VIEW](/docs/2.0.0-rc3/sql/create-materialized-view) · [Remote tables and `ATTACH`](/docs/2.0.0-rc3/sql/remote-tables)
 - Functions: [Table functions](/docs/2.0.0-rc3/sql/table-functions) · [Utility table functions](/docs/2.0.0-rc3/sql/table-functions-utility) · [Function reference](/docs/2.0.0-rc3/sql/function-reference) · [Spatial functions](/docs/2.0.0-rc3/sql/spatial-functions)

--- a/docs/docs/2.0.0-rc3/sql/managed-tables.md
+++ b/docs/docs/2.0.0-rc3/sql/managed-tables.md
@@ -15,6 +15,11 @@ The table definition and the data survive a restart.
 A managed table needs write access. `CREATE`, `INSERT`, `UPDATE`, `DELETE`, `ALTER`, `CREATE INDEX`
 and `DROP INDEX` need admin credentials. Anonymous access stays read-only.
 
+::: tip Names keep their case
+A table name means exactly what you write. `MyTable` and `mytable` are two different tables.
+See [Identifiers and case](/docs/2.0.0-rc3/sql/identifiers).
+:::
+
 ## Storage engine
 
 **[Lance](https://lancedb.github.io/lance/)** holds a managed table. Lance is a columnar format with


### PR DESCRIPTION
### What changes does this PR make?

Beacon keeps the case of a table name in every statement.

### Why do you make these changes?

Beacon turns identifier normalization off. The catalog holds the exact name that the user writes.
Seven paths rebuilt the reference with `TableReference::parse_str`, which lowercases the name.

`CREATE TABLE MyManaged` then broke `INSERT`, `CREATE TABLE AS SELECT`, `ALTER TABLE` and
`CREATE INDEX`. `REFRESH` broke too. `CREATE MATERIALIZED VIEW` registered a
lowercase name but persisted the written name, so a restart renamed the view.

### How do you make these changes?

A new `beacon-core::table_name` module builds the reference and keeps the case. Every path uses it.
`insert_into` takes a `TableReference`. `ALTER TABLE` reads the name from the AST.

### Does this PR change a public interface or a configuration?

No. Each statement now obeys the rule that `SELECT` always obeyed.

### How do you test these changes?

`beacon-db/beacon-core/tests/table_name_case.rs` holds 11 tests. Seven fail without the fix.

```
cargo test --workspace --lib --bins --tests   # 2024 pass, 0 fail
cargo clippy -p beacon-core --lib --tests     # no new warnings
```

`cargo fmt --all --check` fails on files that this PR does not touch. The new files pass.

### Checklist
- [x] The title of the PR describes the change, and it ends with the issue number if one exists.
- [ ] The code follows the style of the project, and `cargo fmt --all --check` passes.
- [x] `cargo clippy --workspace --lib --bins --tests` reports no new warnings.
- [x] `cargo test --workspace --lib --bins --tests` passes.
- [x] The new code has tests, or the PR explains why it does not.
- [x] The documentation, the README, and the CHANGELOG show the change.
- [x] The PR contains no unrelated changes.

### Was this patch authored or co-authored using generative AI tooling?

Assisted-by: Claude:claude-opus-5
