### PR TITLE
feat: support PARTITIONED BY for netCDF, HDF5 and TIFF tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ tag. Releases before 2.0.0 are recorded in the
 
 ### Added
 
+- **`PARTITIONED BY` works for netCDF, HDF5 and GeoTIFF tables.** `CREATE EXTERNAL TABLE
+  observations STORED AS NC LOCATION 'obs/' PARTITIONED BY (year, month)` used to fail with a
+  `NotImplemented` error naming the format and the columns; it now plans and runs, and a filter on
+  a partition column still prunes whole directories out of the listing. A partition value is in the
+  *path* of a file rather than inside it, and DataFusion's `FileStream` appends it per plan entry —
+  which it can do only because an entry is a file. These three formats read a whole collection
+  behind one entry, so each file's values now travel on the queue with that file, and the reader
+  appends them itself: as one value on no axis, which broadcasts over whatever grid the file's own
+  columns define, so nothing is built per row. A query for nothing but the partition column
+  (`SELECT year, count(*) … GROUP BY year`) states the value over the rows of the read instead,
+  because there is no other column to define a grid. `ZARR` still refuses the clause: a Zarr table
+  holds groups inside one store, not files in directories, so a path holds no value to read.
 - **122 spatial functions with PostGIS names.** `ST_Distance`, `ST_Intersects`, `ST_Buffer`,
   `ST_Centroid`, `ST_Simplify` and the rest now run in SQL — 117 scalar functions, 3 aggregate
   functions (`ST_Extent`, `ST_Collect`, `ST_MemUnion`) and 2 window functions

--- a/beacon-db/beacon-core/tests/external_table_partitioned_netcdf.rs
+++ b/beacon-db/beacon-core/tests/external_table_partitioned_netcdf.rs
@@ -1,0 +1,115 @@
+//! `PARTITIONED BY` over a netCDF collection, through the runtime.
+//!
+//! A partition column is in the *path* of a file rather than inside it, and
+//! DataFusion's `FileStream` appends its value per plan entry — which it can do
+//! only because an entry is a file. A netCDF scan reads a whole collection
+//! behind one entry, so the reader appends the values itself, per file. These
+//! tests drive the statement a user writes and read what comes back.
+
+mod common;
+
+use common::{column_strings, runtime, scalar_i64, total_rows};
+
+/// The WOD CTD fixture shipped with the netCDF reader.
+fn netcdf_fixture() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("beacon-file-formats/beacon-arrow-netcdf/test_files/wod_ctd_1964.nc")
+}
+
+/// One copy of the fixture per `year=` directory, under `obs/`.
+fn write_collection(datasets: &std::path::Path, years: &[&str]) {
+    for year in years {
+        let dir = datasets.join("obs").join(format!("year={year}"));
+        std::fs::create_dir_all(&dir).expect("the partition directory is created");
+        std::fs::copy(netcdf_fixture(), dir.join("ctd.nc")).expect("the fixture is copied");
+    }
+}
+
+/// The statement from the issue plans, runs, and gives every row the value of
+/// its own file's path.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_partitioned_netcdf_table_reads_every_directory() {
+    let rt = runtime("partitioned-nc-reads").await;
+    write_collection(rt.datasets_dir(), &["1964", "1965"]);
+
+    rt.sql(
+        "CREATE EXTERNAL TABLE observations \
+         STORED AS NC \
+         LOCATION 'obs/' \
+         PARTITIONED BY (year)",
+    )
+    .await;
+
+    // `SELECT *` carries the partition column beside the file's own columns.
+    let star = rt.sql("SELECT * FROM observations LIMIT 5").await;
+    assert!(
+        star[0].schema().index_of("year").is_ok(),
+        "the partition column stands in the table's schema"
+    );
+    assert!(total_rows(&star) > 0, "and the scan returns rows");
+
+    // The column is in the table, and holds the directory names.
+    let years = rt
+        .sql("SELECT DISTINCT CAST(year AS VARCHAR) AS y FROM observations ORDER BY y")
+        .await;
+    assert_eq!(
+        column_strings(&years, 0),
+        vec!["1964".to_string(), "1965".to_string()],
+        "both directories are read, and each keeps its own value"
+    );
+
+    // The two copies are the same file, so they hold the same number of rows,
+    // and the table holds both.
+    let counted = rt
+        .sql(
+            "SELECT CAST(year AS VARCHAR) AS y, count(*) AS n \
+             FROM observations GROUP BY y ORDER BY y",
+        )
+        .await;
+    let per_directory = scalar_i64(&rt.sql("SELECT count(*) FROM observations").await) / 2;
+    assert!(per_directory > 0, "the fixture holds rows");
+
+    let counts =
+        arrow::array::AsArray::as_primitive::<arrow::datatypes::Int64Type>(counted[0].column(1));
+    assert_eq!(counted[0].num_rows(), 2, "one row per directory");
+    assert_eq!(
+        (counts.value(0), counts.value(1)),
+        (per_directory, per_directory),
+        "each directory counts its own copy of the fixture"
+    );
+}
+
+/// A filter on the partition column reads one directory and leaves the other.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_filter_on_the_partition_column_reads_one_directory() {
+    let rt = runtime("partitioned-nc-prunes").await;
+    write_collection(rt.datasets_dir(), &["1964", "1965"]);
+
+    rt.sql(
+        "CREATE EXTERNAL TABLE observations \
+         STORED AS NC \
+         LOCATION 'obs/' \
+         PARTITIONED BY (year)",
+    )
+    .await;
+
+    let whole = scalar_i64(&rt.sql("SELECT count(*) FROM observations").await);
+    let one = scalar_i64(
+        &rt.sql("SELECT count(*) FROM observations WHERE year = '1965'")
+            .await,
+    );
+
+    assert!(one > 0, "the matching directory is read");
+    assert_eq!(one * 2, whole, "and the other one is not");
+
+    // The rows that come back carry the value that selected them.
+    let selected = rt
+        .sql(
+            "SELECT DISTINCT CAST(year AS VARCHAR) AS y \
+             FROM observations WHERE year = '1965'",
+        )
+        .await;
+    assert_eq!(column_strings(&selected, 0), vec!["1965".to_string()]);
+}

--- a/beacon-db/beacon-datafusion-ext/src/nd/encoding.rs
+++ b/beacon-db/beacon-datafusion-ext/src/nd/encoding.rs
@@ -242,11 +242,24 @@ pub fn encode_flat_batch_as_nd(batch: &RecordBatch) -> Result<RecordBatch> {
 
 /// The logical (decoded) schema of an nd-encoded schema: each `beacon.nd`
 /// struct column becomes its element type.
+///
+/// Nullability follows the encoded field. [`nd_encoded_field`] makes every
+/// column of a file nullable, because a file a collection is not obliged to be
+/// uniform over is null-filled for the columns it lacks. A `PARTITIONED BY`
+/// column is not read from a file at all — its value is in the path, and the
+/// scan always has it — so a format may encode it as the table declared it, and
+/// the table gets that column back exactly as it declared it.
 pub fn logical_schema(encoded: &Schema) -> Result<SchemaRef> {
     let fields = encoded
         .fields()
         .iter()
-        .map(|field| Ok(Field::new(field.name(), nd_value_type(field.data_type())?, true)))
+        .map(|field| {
+            Ok(Field::new(
+                field.name(),
+                nd_value_type(field.data_type())?,
+                field.is_nullable(),
+            ))
+        })
         .collect::<Result<Vec<_>>>()?;
     Ok(Arc::new(Schema::new(fields)))
 }

--- a/beacon-db/beacon-file-formats/beacon-arrow-hdf5/src/format.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-hdf5/src/format.rs
@@ -485,17 +485,24 @@ impl FileFormat for Hdf5Format {
         _state: &dyn Session,
         conf: FileScanConfig,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        beacon_nd_array::arrow::morsel::reject_partition_columns("HDF5", &conf)?;
-
         // The scan carries nd data as `beacon.nd`-encoded struct columns, so
         // the file source's schema is the encoded form of the logical table
         // schema. `NdSourceExec` decodes it and `NdBroadcastExec` broadcasts it
         // back to the logical schema above the scan.
+        //
+        // The `PARTITIONED BY` columns are encoded with it. Their values come
+        // from a file's path rather than its contents, and the reader appends
+        // them per file, but they reach the plan the same way every other column
+        // does — so that one decoder reads the whole batch.
         let encoded_file_schema = Arc::new(beacon_datafusion_ext::nd::encoded_schema(
             conf.file_schema(),
         ));
-        let table_schema =
-            TableSchema::new(encoded_file_schema, conf.table_partition_cols().clone());
+        let table_schema = TableSchema::new(
+            encoded_file_schema,
+            beacon_nd_array::arrow::partition::encoded_partition_cols(
+                conf.table_partition_cols(),
+            ),
+        );
         // Preserve a projection that the scan pushed down into the incoming
         // source — rebuilding the source below would otherwise drop it.
         let projection = conf.file_source().projection().cloned();

--- a/beacon-db/beacon-file-formats/beacon-arrow-hdf5/src/source.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-hdf5/src/source.rs
@@ -12,12 +12,16 @@
 use std::sync::Arc;
 
 use crate::ReadOptions;
-use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use arrow::{
+    datatypes::{FieldRef, SchemaRef},
+    record_batch::RecordBatch,
+};
 use beacon_nd_array::{
     arrow::{
         file_read::FileRead,
         metrics::ReadMetrics,
         morsel::{morsel_scan, MorselSource, OpenFile},
+        partition::FilePartitions,
     },
     projection::DatasetProjection,
 };
@@ -105,6 +109,7 @@ impl FileSource for Hdf5Source {
             partition,
             object_store,
             self.morsel.clone(),
+            base_config.table_partition_cols().clone(),
         )))
     }
 
@@ -181,10 +186,8 @@ impl FileSource for Hdf5Source {
             return Ok(Some(config));
         }
 
-        // The queue declined, which it only does for a partitioned table: its
-        // `PARTITIONED BY` values live on each file and only `FileStream` can
-        // apply them. Such a scan keeps the grouping the listing gave it, which
-        // is what it had before any of this and is correct.
+        // The queue declined: one partition, or no files. Keeping the scan as it
+        // was planned is the answer to both.
         Ok(None)
     }
 
@@ -263,6 +266,9 @@ struct Hdf5Opener {
     morsel: Option<Arc<MorselSource>>,
     /// How one file is opened, for the queue to call.
     files: Arc<dyn OpenFile>,
+    /// The table's `PARTITIONED BY` columns, nd-encoded as the scan carries
+    /// them. A file's values for them travel on its `PartitionedFile`.
+    partition_fields: Vec<FieldRef>,
 }
 
 /// How one HDF5 file becomes a planned [`FileRead`].
@@ -276,6 +282,8 @@ struct Hdf5Files {
     batch_size: usize,
     predicate: Option<Arc<dyn PhysicalExpr>>,
     metrics: ReadMetrics,
+    /// The table's `PARTITIONED BY` columns. Each file brings its own values.
+    partition_fields: Vec<FieldRef>,
 }
 
 impl std::fmt::Debug for Hdf5Files {
@@ -300,6 +308,7 @@ impl OpenFile for Hdf5Files {
             self.projected_schema.clone(),
             self.batch_size,
             self.predicate.clone(),
+            FilePartitions::new(self.partition_fields.clone(), file.partition_values.clone()),
             Some(&self.metrics),
         )
         .await
@@ -318,6 +327,7 @@ impl Hdf5Opener {
         partition: usize,
         object_store: Arc<dyn ObjectStore>,
         morsel: Option<Arc<MorselSource>>,
+        partition_fields: Vec<FieldRef>,
     ) -> Self {
         let read_metrics = ReadMetrics::new(&metrics, partition);
         let files = Arc::new(Hdf5Files {
@@ -328,6 +338,7 @@ impl Hdf5Opener {
             batch_size,
             predicate: predicate.clone(),
             metrics: read_metrics.clone(),
+            partition_fields: partition_fields.clone(),
         });
 
         Self {
@@ -341,6 +352,7 @@ impl Hdf5Opener {
             read_metrics,
             partition,
             object_store,
+            partition_fields,
         }
     }
 
@@ -365,6 +377,7 @@ impl Hdf5Opener {
         batch_size: usize,
         metrics: ReadMetrics,
         predicate: Option<Arc<dyn PhysicalExpr>>,
+        partitions: FilePartitions,
     ) -> datafusion::error::Result<BoxStream<'static, datafusion::error::Result<RecordBatch>>> {
         let planning = metrics.clone();
         let plan = async move || {
@@ -374,14 +387,16 @@ impl Hdf5Opener {
                 projected_schema,
                 batch_size,
                 predicate,
+                partitions,
                 Some(&planning),
             )
             .await
         };
 
         // This partition's own file. Nothing is shared here: a scan that can be
-        // divided goes through the queue, and one that cannot — a partitioned
-        // table — reads each file whole, as `FileStream` hands it over.
+        // divided goes through the queue, and one that cannot — a single
+        // partition, or no files — reads each file whole, as `FileStream` hands
+        // it over.
         let dataset = plan().await?;
 
         Ok(dataset.stream(Some(metrics)))
@@ -444,6 +459,8 @@ impl FileOpener for Hdf5Opener {
         // holds. Testing them again per opener would repeat that work on the one
         // file that survived it.
         let metrics = self.read_metrics.clone();
+        let partitions =
+            FilePartitions::new(self.partition_fields.clone(), file.partition_values.clone());
         Ok(Self::read(
             self.object_store.clone(),
             file.object_meta,
@@ -453,6 +470,7 @@ impl FileOpener for Hdf5Opener {
             self.batch_size,
             metrics,
             self.predicate.clone(),
+            partitions,
         )
         .boxed())
     }

--- a/beacon-db/beacon-file-formats/beacon-arrow-hdf5/tests/backend_parity.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-hdf5/tests/backend_parity.rs
@@ -495,6 +495,68 @@ async fn a_nested_group_reads_end_to_end() {
     assert_eq!(batch.num_columns(), 3);
 }
 
+/// A partitioned table reads, and every row holds the value of its own file's
+/// path.
+///
+/// A `PARTITIONED BY` column is in the *path* of a file, and an HDF5 scan reads
+/// a whole collection behind one plan entry, so `FileStream` cannot append it:
+/// it does not know which file a batch came from. The reader appends it itself
+/// instead — per file, which is per morsel.
+#[tokio::test]
+async fn a_partitioned_table_gives_every_row_the_value_of_its_path() {
+    use datafusion::datasource::listing::{ListingOptions, ListingTable, ListingTableConfig};
+
+    let dir = tempfile::tempdir().unwrap();
+    for site in ["north", "south"] {
+        let part = dir.path().join(format!("site={site}"));
+        std::fs::create_dir_all(&part).unwrap();
+        std::fs::copy(hdf5_file(NESTED_FILE), part.join("obs.h5")).unwrap();
+    }
+
+    let ctx = session();
+    let url = ListingTableUrl::parse(dir.path().to_string_lossy()).unwrap();
+    let listing = Arc::new(ListingFactory::dynamic());
+    let format = factory(Backend::Rust)
+        .create_with_native_root(&ctx.state(), &Backend::Rust.options(), &url, &listing)
+        .expect("the HDF5 format builds");
+
+    let options = ListingOptions::new(format)
+        // The format finds its own files, as `CREATE EXTERNAL TABLE` leaves it.
+        .with_file_extension("")
+        .with_collect_stat(false)
+        .with_table_partition_cols(vec![("site".to_string(), arrow::datatypes::DataType::Utf8)]);
+
+    let config = ListingTableConfig::new(url)
+        .with_listing_options(options)
+        .infer_schema(&ctx.state())
+        .await
+        .expect("the partitioned collection infers a schema");
+    ctx.register_table("obs", Arc::new(ListingTable::try_new(config).unwrap()))
+        .unwrap();
+
+    let batch = collect(
+        &ctx,
+        r#"SELECT site, station_id, "observations/temperature"
+           FROM obs ORDER BY site, station_id, "observations/temperature""#,
+    )
+    .await;
+
+    // Twelve rows per copy: 3 stations x 4 samples, as the fixture holds.
+    assert_eq!(batch.num_rows(), 24, "both copies are read, whole");
+    let sites = arrow::array::AsArray::as_string::<i32>(batch.column(0));
+    let seen: Vec<&str> = (0..batch.num_rows()).map(|row| sites.value(row)).collect();
+    assert_eq!(
+        seen.iter().filter(|site| **site == "north").count(),
+        12,
+        "one copy's rows carry north"
+    );
+    assert_eq!(
+        seen.iter().filter(|site| **site == "south").count(),
+        12,
+        "and the other's carry south"
+    );
+}
+
 /// A dataset of one group carries the rows of a dataset of another.
 ///
 /// [`oxcdf`] names the axes of one group apart from those of another, so the

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/mod.rs
@@ -516,18 +516,23 @@ impl FileFormat for NetcdfFormat {
         _state: &dyn Session,
         conf: FileScanConfig,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        beacon_nd_array::arrow::morsel::reject_partition_columns("netCDF", &conf)?;
-
         // The scan carries nd data as `beacon.nd`-encoded struct columns, so
         // the file source's schema is the encoded form of the logical table
         // schema. `NdSourceExec` decodes it and `NdBroadcastExec` broadcasts it
         // back to the logical schema above the scan.
+        //
+        // The `PARTITIONED BY` columns are encoded with it. Their values come
+        // from a file's path rather than its contents, and the reader appends
+        // them per file, but they reach the plan the same way every other column
+        // does — so that one decoder reads the whole batch.
         let encoded_file_schema = Arc::new(beacon_datafusion_ext::nd::encoded_schema(
             conf.file_schema(),
         ));
         let table_schema = datafusion::datasource::table_schema::TableSchema::new(
             encoded_file_schema,
-            conf.table_partition_cols().clone(),
+            beacon_nd_array::arrow::partition::encoded_partition_cols(
+                conf.table_partition_cols(),
+            ),
         );
         // Preserve a projection that the scan pushed down into the incoming
         // source — rebuilding the source below would otherwise drop it.
@@ -1288,51 +1293,213 @@ mod reader_backend_tests {
         }
     }
 
-    /// A partitioned table is refused, naming the reader and the column.
-    ///
-    /// A `PARTITIONED BY` column is part of a file's *path*, and `FileStream`
-    /// appends its value to that file's batches — which it can do only because
-    /// it knows which file each batch came from. An nd scan reads a collection
-    /// as one unit, so it does not.
-    ///
-    /// The alternative to refusing is returning the column silently empty, and a
-    /// query that quietly drops a column it was asked for is worse than one that
-    /// says it cannot do this yet.
-    #[tokio::test]
-    async fn a_partitioned_table_is_refused() {
-        use datafusion::datasource::listing::PartitionedFile;
-        use datafusion::datasource::table_schema::TableSchema;
-        use datafusion::execution::object_store::ObjectStoreUrl;
+    /// A hive-partitioned table over copies of `GRIDDED_FILE`: one file per
+    /// `year=` directory, and `year` as a `PARTITIONED BY` column.
+    async fn register_partitioned(
+        ctx: &SessionContext,
+        table: &str,
+        dir: &std::path::Path,
+        years: &[&str],
+    ) {
+        use datafusion::datasource::listing::{ListingOptions, ListingTable, ListingTableConfig};
 
-        let table_schema = TableSchema::new(
-            Arc::new(arrow::datatypes::Schema::empty()),
-            vec![Arc::new(arrow::datatypes::Field::new(
-                "year",
+        for year in years {
+            let part = dir.join(format!("year={year}"));
+            std::fs::create_dir_all(&part).unwrap();
+            std::fs::copy(test_file(GRIDDED_FILE), part.join("obs.nc")).unwrap();
+        }
+
+        let options = ListingOptions::new(Arc::new(format_on(ReaderBackend::Oxcdf)))
+            // The format finds its own files, so a suffix here would have to
+            // match it. This is what `CREATE EXTERNAL TABLE` passes too.
+            .with_file_extension("")
+            .with_collect_stat(false)
+            .with_table_partition_cols(vec![(
+                "year".to_string(),
                 arrow::datatypes::DataType::Utf8,
-                false,
-            ))],
-        );
-        let source = NetCDFSource::new(access_on(ReaderBackend::Oxcdf), None, table_schema);
-        let config = FileScanConfigBuilder::new(
-            ObjectStoreUrl::local_filesystem(),
-            Arc::new(source) as Arc<dyn FileSource>,
-        )
-        .with_file(PartitionedFile::new("year=2023/one.nc", 1024))
-        .build();
+            )]);
 
-        let ctx = session();
-        let error = format_on(ReaderBackend::Oxcdf)
-            .create_physical_plan(&ctx.state(), config)
+        let url = ListingTableUrl::parse(dir.to_string_lossy()).unwrap();
+        let config = ListingTableConfig::new(url)
+            .with_listing_options(options)
+            .infer_schema(&ctx.state())
             .await
-            .expect_err("a partitioned table is refused");
+            .unwrap_or_else(|e| panic!("the partitioned collection infers a schema: {e}"));
 
-        let message = error.to_string();
-        assert!(message.contains("netCDF"), "it names the reader: {message}");
-        assert!(message.contains("year"), "and the column: {message}");
-        assert!(
-            message.contains("PARTITIONED BY"),
-            "in the words the user wrote: {message}"
+        ctx.register_table(table, Arc::new(ListingTable::try_new(config).unwrap()))
+            .unwrap();
+    }
+
+    /// The rows one copy of `GRIDDED_FILE` contributes to `column`.
+    async fn rows_in_one_file(ctx: &SessionContext, column: &str) -> usize {
+        register(ctx, "one", ReaderBackend::Oxcdf, GRIDDED_FILE).await;
+        let batches = ctx
+            .sql(&format!("SELECT {column} FROM one"))
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        batches.iter().map(|batch| batch.num_rows()).sum()
+    }
+
+    /// A partitioned table reads, and every row holds the value of its own
+    /// file's path.
+    ///
+    /// The value is in the *path*, and an nd scan reads a whole collection
+    /// behind one plan entry, so `FileStream` cannot append it: it does not know
+    /// which file a batch came from. The reader appends it itself instead —
+    /// per file, which is per morsel.
+    #[tokio::test]
+    async fn a_partitioned_table_gives_every_row_the_value_of_its_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = session();
+        register_partitioned(&ctx, "obs", dir.path(), &["2023", "2024"]).await;
+        let per_file = rows_in_one_file(&ctx, "analysed_sst").await;
+
+        let rows = ctx
+            .sql("SELECT year FROM obs WHERE analysed_sst IS NOT NULL OR analysed_sst IS NULL")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let mut years: Vec<String> = Vec::new();
+        for batch in &rows {
+            let column = batch
+                .column_by_name("year")
+                .expect("the partition column is in the scan");
+            let values = arrow::array::AsArray::as_string::<i32>(column);
+            years.extend((0..batch.num_rows()).map(|row| values.value(row).to_string()));
+        }
+
+        assert_eq!(
+            years.len(),
+            2 * per_file,
+            "both files are read, whole: {} rows each",
+            per_file
         );
+        assert_eq!(
+            years.iter().filter(|year| *year == "2023").count(),
+            per_file,
+            "and one file's worth of rows carries 2023"
+        );
+        assert_eq!(
+            years.iter().filter(|year| *year == "2024").count(),
+            per_file,
+            "and the other's carries 2024"
+        );
+    }
+
+    /// A scan of nothing but the partition column still counts the file's rows.
+    ///
+    /// It reads no column of the file, so there is no grid for the value to
+    /// spread over. The read is driven by a column of its own and the value is
+    /// stated over the rows it produces — see `FilePartitions::row_columns`.
+    #[tokio::test]
+    async fn a_group_by_on_the_partition_column_counts_every_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = session();
+        register_partitioned(&ctx, "obs", dir.path(), &["2023", "2024"]).await;
+        let per_file = rows_in_one_file(&ctx, "analysed_sst").await;
+
+        let counted = ctx
+            .sql("SELECT year, count(*) AS n FROM obs GROUP BY year ORDER BY year")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let batch = &counted[0];
+        assert_eq!(batch.num_rows(), 2, "one row per partition directory");
+        let years = arrow::array::AsArray::as_string::<i32>(batch.column(0));
+        let counts = arrow::array::AsArray::as_primitive::<arrow::datatypes::Int64Type>(
+            batch.column(1),
+        );
+        assert_eq!((years.value(0), years.value(1)), ("2023", "2024"));
+        assert_eq!(
+            (counts.value(0), counts.value(1)),
+            (per_file as i64, per_file as i64),
+            "each directory counts one file's rows"
+        );
+    }
+
+    /// A filter on the partition column leaves the other directory unlisted.
+    ///
+    /// Pruning happens where it does for every other format — in the listing,
+    /// before a scan exists — so the plan holds only the files that can match.
+    #[tokio::test]
+    async fn a_filter_on_the_partition_column_prunes_files() {
+        use datafusion::physical_plan::displayable;
+
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = session();
+        register_partitioned(&ctx, "obs", dir.path(), &["2023", "2024"]).await;
+
+        let plan = ctx
+            .sql("SELECT analysed_sst FROM obs WHERE year = '2024'")
+            .await
+            .unwrap()
+            .create_physical_plan()
+            .await
+            .unwrap();
+
+        let shown = displayable(plan.as_ref()).indent(false).to_string();
+        assert!(
+            shown.contains("year=2024"),
+            "the matching directory is scanned: {shown}"
+        );
+        assert!(
+            !shown.contains("year=2023"),
+            "and the other one is not listed at all: {shown}"
+        );
+    }
+
+    /// The same values come back when the scan divides over many partitions.
+    ///
+    /// That is the morsel path: every partition draws from one queue, and the
+    /// entry it is handed stands for the scan rather than for a file. The values
+    /// travel on the queued files instead.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_parallel_partitioned_scan_keeps_the_values_apart() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = SessionStateBuilder::new()
+            .with_config(
+                SessionConfig::new()
+                    .with_target_partitions(4)
+                    .with_extension(
+                        beacon_datafusion_ext::type_widening::ArrowTypeWidening::default_extension(
+                        ),
+                    ),
+            )
+            .with_default_features()
+            .build();
+        let ctx = SessionContext::new_with_state(state);
+        register_partitioned(&ctx, "obs", dir.path(), &["2023", "2024"]).await;
+
+        let counted = ctx
+            .sql("SELECT year, count(*) AS n FROM obs GROUP BY year ORDER BY year")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let batch = &counted[0];
+        let years = arrow::array::AsArray::as_string::<i32>(batch.column(0));
+        let counts = arrow::array::AsArray::as_primitive::<arrow::datatypes::Int64Type>(
+            batch.column(1),
+        );
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!((years.value(0), years.value(1)), ("2023", "2024"));
+        assert_eq!(
+            counts.value(0),
+            counts.value(1),
+            "the two copies of one file hold the same number of rows"
+        );
+        assert!(counts.value(0) > 0, "and the scan read them");
     }
 
     /// An ordered scan is left alone: a partition holding an arbitrary subset of

--- a/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/source.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-netcdf/src/datafusion/source.rs
@@ -1,11 +1,15 @@
 use std::sync::Arc;
 
-use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use arrow::{
+    datatypes::{FieldRef, SchemaRef},
+    record_batch::RecordBatch,
+};
 use beacon_nd_array::{
     arrow::{
         file_read::FileRead,
         metrics::ReadMetrics,
         morsel::{morsel_scan, MorselSource, OpenFile},
+        partition::FilePartitions,
     },
     projection::DatasetProjection,
 };
@@ -101,6 +105,7 @@ impl FileSource for NetCDFSource {
             partition,
             object_store,
             self.morsel.clone(),
+            base_config.table_partition_cols().clone(),
         )))
     }
 
@@ -170,10 +175,8 @@ impl FileSource for NetCDFSource {
             return Ok(Some(config));
         }
 
-        // The queue declined. It only does that for a partitioned table, and
-        // `NetcdfFormat::create_physical_plan` refuses those before a scan is
-        // built, so this is unreachable in practice. Keeping the scan as it was
-        // planned is the safe answer either way.
+        // The queue declined: one partition, or no files. Keeping the scan as it
+        // was planned is the answer to both.
         Ok(None)
     }
 
@@ -247,6 +250,9 @@ struct NetCDFOpener {
     morsel: Option<Arc<MorselSource>>,
     /// How one file is opened, for the queue to call.
     files: Arc<dyn OpenFile>,
+    /// The table's `PARTITIONED BY` columns, nd-encoded as the scan carries
+    /// them. A file's values for them travel on its `PartitionedFile`.
+    partition_fields: Vec<FieldRef>,
 }
 
 impl NetCDFOpener {
@@ -261,6 +267,7 @@ impl NetCDFOpener {
         partition: usize,
         object_store: Arc<dyn object_store::ObjectStore>,
         morsel: Option<Arc<MorselSource>>,
+        partition_fields: Vec<FieldRef>,
     ) -> Self {
         let read_metrics = ReadMetrics::new(&metrics, partition);
         let files = Arc::new(NetCDFFiles {
@@ -271,6 +278,7 @@ impl NetCDFOpener {
             batch_size,
             predicate: predicate.clone(),
             metrics: read_metrics.clone(),
+            partition_fields: partition_fields.clone(),
         });
 
         Self {
@@ -284,6 +292,7 @@ impl NetCDFOpener {
             partition,
             access,
             object_store,
+            partition_fields,
         }
     }
 
@@ -307,6 +316,7 @@ impl NetCDFOpener {
         batch_size: usize,
         metrics: ReadMetrics,
         predicate: Option<Arc<dyn PhysicalExpr>>,
+        partitions: FilePartitions,
     ) -> datafusion::error::Result<BoxStream<'static, datafusion::error::Result<RecordBatch>>> {
         let planning = metrics.clone();
         let plan = async move || {
@@ -316,14 +326,16 @@ impl NetCDFOpener {
                 projected_schema,
                 batch_size,
                 predicate,
+                partitions,
                 Some(&planning),
             )
             .await
         };
 
         // This partition's own file. Nothing is shared here: a scan that can be
-        // divided goes through the queue, and one that cannot is refused before
-        // it is planned.
+        // divided goes through the queue, and one that cannot — a single
+        // partition, or no files — reads each file whole, as `FileStream` hands
+        // it over.
         let dataset = plan().await?;
 
         Ok(dataset.stream(Some(metrics)))
@@ -376,6 +388,8 @@ struct NetCDFFiles {
     batch_size: usize,
     predicate: Option<Arc<dyn PhysicalExpr>>,
     metrics: ReadMetrics,
+    /// The table's `PARTITIONED BY` columns. Each file brings its own values.
+    partition_fields: Vec<FieldRef>,
 }
 
 impl std::fmt::Debug for NetCDFFiles {
@@ -404,6 +418,7 @@ impl OpenFile for NetCDFFiles {
             self.projected_schema.clone(),
             self.batch_size,
             self.predicate.clone(),
+            FilePartitions::new(self.partition_fields.clone(), file.partition_values.clone()),
             Some(&self.metrics),
         )
         .await
@@ -439,6 +454,8 @@ impl FileOpener for NetCDFOpener {
         let input = self
             .access
             .input_for(&self.object_store, &file.object_meta)?;
+        let partitions =
+            FilePartitions::new(self.partition_fields.clone(), file.partition_values.clone());
 
         Ok(Self::read(
             input,
@@ -448,6 +465,7 @@ impl FileOpener for NetCDFOpener {
             self.batch_size,
             metrics,
             self.predicate.clone(),
+            partitions,
         )
         .boxed())
     }

--- a/beacon-db/beacon-file-formats/beacon-arrow-tiff/src/datafusion/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-tiff/src/datafusion/mod.rs
@@ -180,18 +180,21 @@ impl FileFormat for TiffFormat {
         _state: &dyn Session,
         conf: FileScanConfig,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        beacon_nd_array::arrow::morsel::reject_partition_columns("TIFF", &conf)?;
-
         // The scan carries nd data as `beacon.nd`-encoded struct columns, so
         // the file source's schema is the encoded form of the logical table
         // schema. `NdSourceExec` decodes it and `NdBroadcastExec` broadcasts it
         // back to the logical schema above the scan.
+        //
+        // The `PARTITIONED BY` columns are encoded with it. Their values come
+        // from a file's path rather than its contents, and the reader appends
+        // them per file, but they reach the plan the same way every other column
+        // does — so that one decoder reads the whole batch.
         let encoded_file_schema = Arc::new(beacon_datafusion_ext::nd::encoded_schema(
             conf.file_schema(),
         ));
         let table_schema = datafusion::datasource::table_schema::TableSchema::new(
             encoded_file_schema,
-            conf.table_partition_cols().clone(),
+            beacon_nd_array::arrow::partition::encoded_partition_cols(conf.table_partition_cols()),
         );
         // Preserve a projection that the scan pushed down into the incoming
         // source — rebuilding the source below would otherwise drop it.
@@ -383,6 +386,69 @@ mod tests {
             let v = lon_col.value(i);
             assert!(v >= -18.0 && v <= 37.0, "lon[{i}]={v} out of range");
         }
+    }
+
+    /// A partitioned table carries the value of a raster's path on every row
+    /// that raster contributes.
+    ///
+    /// The value is in the *path*, and a TIFF scan reads a whole collection
+    /// behind one plan entry, so `FileStream` cannot append it: it does not know
+    /// which raster a batch came from. The reader appends it itself instead —
+    /// per file, which is per morsel.
+    #[tokio::test]
+    async fn a_partitioned_raster_carries_the_value_of_its_path() {
+        let store = Arc::new(InMemory::new());
+        let object_store: Arc<dyn ObjectStore> = store.clone();
+        let path = Path::from("year=2024/test.tif");
+        let object = put_fixture(&store, &path, TEST_TIF_BYTES).await;
+
+        let file_schema = reader::fetch_schema(object_store.clone(), object.clone())
+            .await
+            .expect("schema");
+
+        // What `create_physical_plan` builds for a partitioned table: the file
+        // schema encoded, and the partition column encoded beside it.
+        let year: arrow::datatypes::FieldRef = Arc::new(arrow::datatypes::Field::new(
+            "year",
+            arrow::datatypes::DataType::Utf8,
+            false,
+        ));
+        let ts = datafusion::datasource::table_schema::TableSchema::new(
+            Arc::new(beacon_datafusion_ext::nd::encoded_schema(&file_schema)),
+            beacon_nd_array::arrow::partition::encoded_partition_cols(&[year]),
+        );
+
+        let source = source::TiffSource::new(ts);
+        let file_opener = {
+            let conf = FileScanConfigBuilder::new(
+                ObjectStoreUrl::parse("memory://").expect("url"),
+                Arc::new(source.clone()) as Arc<dyn FileSource>,
+            )
+            .build();
+            source
+                .create_file_opener(object_store, &conf, 0)
+                .expect("file opener")
+        };
+
+        let mut file = datafusion::datasource::listing::PartitionedFile::from(object);
+        file.partition_values = vec![datafusion::scalar::ScalarValue::Utf8(Some(
+            "2024".to_string(),
+        ))];
+
+        let stream = file_opener.open(file).expect("open").await.expect("stream");
+        let batches = decoded(stream).await;
+        let full = arrow::compute::concat_batches(&batches[0].schema(), &batches).expect("concat");
+
+        assert!(full.num_rows() > 0, "the raster is read");
+        let years = full
+            .column(full.schema().index_of("year").expect("the partition column"))
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .expect("year is Utf8");
+        assert!(
+            (0..full.num_rows()).all(|row| years.value(row) == "2024"),
+            "every row of the raster carries the value of its directory"
+        );
     }
 
     #[tokio::test]

--- a/beacon-db/beacon-file-formats/beacon-arrow-tiff/src/datafusion/source.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-tiff/src/datafusion/source.rs
@@ -1,9 +1,13 @@
 use std::sync::Arc;
 
-use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use arrow::{
+    datatypes::{FieldRef, SchemaRef},
+    record_batch::RecordBatch,
+};
 use beacon_nd_array::arrow::{
     metrics::ReadMetrics,
     morsel::{morsel_scan, MorselSource, OpenFile},
+    partition::FilePartitions,
     file_read::FileRead,
 };
 use datafusion::{
@@ -78,6 +82,7 @@ impl FileSource for TiffSource {
             self.execution_plan_metrics.clone(),
             partition,
             self.morsel.clone(),
+            base_config.table_partition_cols().clone(),
         )))
     }
 
@@ -202,6 +207,9 @@ struct TiffOpener {
     morsel: Option<Arc<MorselSource>>,
     /// How one raster is opened, for the queue to call.
     rasters: Arc<dyn OpenFile>,
+    /// The table's `PARTITIONED BY` columns, nd-encoded as the scan carries
+    /// them. A file's values for them travel on its `PartitionedFile`.
+    partition_fields: Vec<FieldRef>,
 }
 
 /// How one GeoTIFF becomes a planned [`FileRead`].
@@ -213,6 +221,8 @@ struct TiffRasters {
     batch_size: usize,
     predicate: Option<Arc<dyn PhysicalExpr>>,
     metrics: ReadMetrics,
+    /// The table's `PARTITIONED BY` columns. Each file brings its own values.
+    partition_fields: Vec<FieldRef>,
 }
 
 impl std::fmt::Debug for TiffRasters {
@@ -239,6 +249,7 @@ impl OpenFile for TiffRasters {
             self.projected_schema.clone(),
             self.batch_size,
             self.predicate.clone(),
+            FilePartitions::new(self.partition_fields.clone(), file.partition_values.clone()),
             Some(&self.metrics),
         )
         .await
@@ -254,6 +265,7 @@ impl TiffOpener {
         metrics: ExecutionPlanMetricsSet,
         partition: usize,
         morsel: Option<Arc<MorselSource>>,
+        partition_fields: Vec<FieldRef>,
     ) -> Self {
         // Once per partition, not once per file: every call registers four
         // counters into the scan's one metrics set, behind a mutex.
@@ -264,6 +276,7 @@ impl TiffOpener {
             batch_size,
             predicate: predicate.clone(),
             metrics: read_metrics.clone(),
+            partition_fields: partition_fields.clone(),
         });
 
         Self {
@@ -275,6 +288,7 @@ impl TiffOpener {
             read_metrics,
             morsel,
             rasters,
+            partition_fields,
         }
     }
 
@@ -291,6 +305,7 @@ impl TiffOpener {
         batch_size: usize,
         predicate: Option<Arc<dyn PhysicalExpr>>,
         metrics: ReadMetrics,
+        partitions: FilePartitions,
     ) -> datafusion::error::Result<BoxStream<'static, datafusion::error::Result<RecordBatch>>> {
         let dataset = reader::open_dataset(object_store, object.clone())
             .await
@@ -306,6 +321,7 @@ impl TiffOpener {
             projected_schema,
             batch_size,
             predicate,
+            partitions,
             Some(&metrics),
         )
         .await?;
@@ -328,6 +344,8 @@ impl FileOpener for TiffOpener {
             return Ok(futures::future::ready(Ok(stream)).boxed());
         }
 
+        let partitions =
+            FilePartitions::new(self.partition_fields.clone(), file.partition_values.clone());
         Ok(Self::read(
             file.object_meta,
             self.object_store.clone(),
@@ -335,6 +353,7 @@ impl FileOpener for TiffOpener {
             self.batch_size,
             self.predicate.clone(),
             self.read_metrics.clone(),
+            partitions,
         )
         .boxed())
     }

--- a/beacon-db/beacon-file-formats/beacon-arrow-zarr/src/datafusion/source.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-zarr/src/datafusion/source.rs
@@ -12,6 +12,7 @@ use arrow::record_batch::RecordBatch;
 use beacon_nd_array::arrow::{
     metrics::ReadMetrics,
     morsel::{MorselSource, OpenFile, morsel_scan},
+    partition::FilePartitions,
     file_read::FileRead,
 };
 use datafusion::{
@@ -213,10 +214,9 @@ impl FileSource for ZarrSource {
             return Ok(Some(config));
         }
 
-        // The queue declined, which it only does for a partitioned table: its
-        // `PARTITIONED BY` values live on each entry and only `FileStream` can
-        // apply them. Such a scan keeps the grouping the listing gave it, which
-        // is what it had before any of this and is correct.
+        // The queue declined: one partition, or no groups. Keeping the scan as
+        // it was planned is the answer to both. A partitioned Zarr table never
+        // reaches here — `ZarrFormat::create_physical_plan` refuses it.
         Ok(None)
     }
 
@@ -337,11 +337,14 @@ impl OpenFile for ZarrGroups {
         )
         .await?;
 
+        // Zarr refuses a partitioned table before a scan is built — see
+        // `reject_partition_columns` — so a group never carries values.
         FileRead::plan(
             dataset,
             self.projected_schema.clone(),
             self.batch_size,
             self.predicate.clone(),
+            FilePartitions::none(),
             Some(&self.metrics),
         )
         .await
@@ -378,10 +381,9 @@ impl ZarrOpener {
 
     /// Read one group whole.
     ///
-    /// This is the path a scan the queue declined takes — a partitioned table,
-    /// where `FileStream` walks the real group list because only it can apply
-    /// the per-entry `PARTITIONED BY` values. Every other scan goes through
-    /// [`MorselSource`] and never reaches here.
+    /// This is the path a scan the queue declined takes — one partition, or no
+    /// groups — where `FileStream` walks the real group list. Every other scan
+    /// goes through [`MorselSource`] and never reaches here.
     #[allow(clippy::too_many_arguments)]
     async fn read(
         storage: ZarrStorage,
@@ -400,14 +402,16 @@ impl ZarrOpener {
                 projected_schema,
                 batch_size,
                 predicate,
+                FilePartitions::none(),
                 Some(&planning),
             )
             .await
         };
 
         // This partition's own group. Nothing is shared here: a scan that can be
-        // divided goes through the queue, and one that cannot — a partitioned
-        // table — reads each group whole, as `FileStream` hands it over.
+        // divided goes through the queue, and one that cannot — a single
+        // partition, or no groups — reads each group whole, as `FileStream`
+        // hands it over.
         let dataset = plan().await?;
 
         Ok(dataset.stream(Some(metrics)))

--- a/beacon-db/beacon-file-formats/beacon-nd-array/src/arrow/file_read.rs
+++ b/beacon-db/beacon-file-formats/beacon-nd-array/src/arrow/file_read.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use arrow::array::RecordBatchOptions;
-use arrow::datatypes::{Schema, SchemaRef};
+use arrow::array::{ArrayRef, RecordBatchOptions};
+use arrow::datatypes::{FieldRef, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use crossbeam::queue::ArrayQueue;
 use datafusion::error::{DataFusionError, Result};
@@ -22,6 +22,7 @@ use crate::arrow::batch::{
 };
 use crate::arrow::metrics::ReadMetrics;
 use crate::arrow::nd_provider::read_nd_chunk;
+use crate::arrow::partition::FilePartitions;
 use crate::arrow::pushdown_filter::PushdownFilter;
 use crate::dataset::AnyDataset;
 
@@ -36,10 +37,26 @@ use crate::dataset::AnyDataset;
 enum Output {
     /// Columns: nd-encoded batches, reordered and null-filled onto the
     /// projected schema.
-    Columns(Arc<BatchAdapter>),
+    Columns {
+        adapter: Arc<BatchAdapter>,
+        /// What the file's `PARTITIONED BY` columns are called, when the scan
+        /// projects any.
+        partition_fields: Vec<FieldRef>,
+        /// Those columns, nd-encoded as rank-0 arrays. One value each, constant
+        /// for the whole file, so they are built once here and appended to
+        /// every batch of it. See [`FilePartitions`].
+        partition_columns: Vec<ArrayRef>,
+    },
     /// `COUNT(*)`: flat batches, of which only the row count leaves, under the
     /// (empty) projected schema. See [`count_projection`].
-    Rows(SchemaRef),
+    ///
+    /// A scan of nothing but partition columns comes here too. It wants no
+    /// column of the file either, and the row count is what says how many times
+    /// each partition value repeats.
+    Rows {
+        schema: SchemaRef,
+        partitions: FilePartitions,
+    },
     /// The file holds none of the columns the query projects, so it has nothing
     /// to contribute and is not read at all.
     Nothing,
@@ -48,7 +65,7 @@ enum Output {
 impl Output {
     /// Whether the read encodes its chunks, rather than broadcasting them flat.
     fn encoded(&self) -> bool {
-        matches!(self, Output::Columns(_))
+        matches!(self, Output::Columns { .. })
     }
 }
 
@@ -350,11 +367,17 @@ impl FileRead {
     /// `metrics` belong to the partition that plans. They take the counts made
     /// here rather than per chunk: a chunk the predicate excluded is dropped
     /// before the queue exists, so no reader of the queue can account for it.
+    ///
+    /// `partitions` are the table's `PARTITIONED BY` columns and this file's
+    /// values for them. They are in the file's path rather than in the file, so
+    /// they are appended to its batches here — see [`FilePartitions`]. Pass
+    /// [`FilePartitions::none`] for an unpartitioned table.
     pub async fn plan(
         dataset: AnyDataset,
         projected_schema: SchemaRef,
         batch_size: usize,
         predicate: Option<Arc<dyn PhysicalExpr>>,
+        partitions: FilePartitions,
         metrics: Option<&ReadMetrics>,
     ) -> Result<Arc<Self>> {
         let dataset_schema: SchemaRef = Arc::new(
@@ -365,22 +388,34 @@ impl FileRead {
             })?,
         );
 
-        // The columns of this file the query needs, in file order.
+        // The `PARTITIONED BY` columns this scan projects, in the order it wants
+        // them. They are added to every batch below rather than read: the value
+        // is in the file's path, not in the file.
+        let partition_fields = partitions.projected_fields(&projected_schema);
+
+        // The columns of this file the query needs, in file order. A partition
+        // column shadows a variable of the same name — the path wins, as it does
+        // for every other format — so it never counts as one of these.
         let projection: Vec<usize> = dataset_schema
             .fields()
             .iter()
             .enumerate()
-            .filter(|(_, field)| projected_schema.index_of(field.name()).is_ok())
+            .filter(|(_, field)| {
+                !partitions.holds(field.name()) && projected_schema.index_of(field.name()).is_ok()
+            })
             .map(|(index, _)| index)
             .collect();
 
         let pushdown = predicate.clone().map(PushdownFilter::new);
 
+        // How much of the file itself the query wants, partition columns aside.
+        let wanted_file_columns = projected_schema.fields().len() - partition_fields.len();
+
         // Nothing of this file was projected. That is two different situations,
         // and they must not be confused: the query wanted no column at all, or
         // it wanted columns this file does not have.
         let (output, projection) = if projection.is_empty() {
-            if !projected_schema.fields().is_empty() {
+            if wanted_file_columns > 0 {
                 // The query named columns and this file has none of them. A
                 // collection is not obliged to be uniform — of one CORA year, 2%
                 // of the files carry no `TEMP` and 10% no `DEPH` — so this is an
@@ -401,19 +436,40 @@ impl FileRead {
                 }));
             }
 
-            // `COUNT(*)`: no column is wanted, so the read is driven by columns
-            // of its own and only the row counts leave.
+            // `COUNT(*)`, or a scan of nothing but partition columns: no column
+            // of the file is wanted, so the read is driven by columns of its own
+            // and only the row counts leave.
             let counted = count_projection(&dataset, &dataset_schema, &predicate);
-            (Output::Rows(projected_schema), counted)
+            (
+                Output::Rows {
+                    schema: projected_schema,
+                    partitions,
+                },
+                counted,
+            )
         } else {
             // The scan carries nd columns, so adaptation happens in the encoded
             // (struct) domain: reorder and null-fill onto the projected schema.
-            let source_schema: SchemaRef = Arc::new(beacon_datafusion_ext::nd::encoded_schema(
-                &dataset_schema.project(&projection)?,
-            ));
+            // The partition columns join the source there, so the adapter puts
+            // them wherever the projection asked for them.
+            let mut source_fields: Vec<FieldRef> =
+                beacon_datafusion_ext::nd::encoded_schema(&dataset_schema.project(&projection)?)
+                    .fields()
+                    .to_vec();
+            source_fields.extend(partition_fields.iter().cloned());
+            let source_schema: SchemaRef = Arc::new(Schema::new(source_fields));
+
+            let partition_columns = partitions.scalar_columns(&projected_schema)?;
             let adapter =
                 BatchAdapterFactory::new(projected_schema).make_adapter(&source_schema)?;
-            (Output::Columns(Arc::new(adapter)), projection)
+            (
+                Output::Columns {
+                    adapter: Arc::new(adapter),
+                    partition_fields,
+                    partition_columns,
+                },
+                projection,
+            )
         };
 
         let dataset = project(dataset, &dataset_schema, projection)?;
@@ -448,34 +504,33 @@ impl FileRead {
         };
         let batches = queue.stream(metrics);
         match &self.output {
-            Output::Columns(adapter) => {
+            Output::Columns {
+                adapter,
+                partition_fields,
+                partition_columns,
+            } => {
                 let adapter = adapter.clone();
+                let fields = partition_fields.clone();
+                let columns = partition_columns.clone();
                 batches
                     .and_then(move |batch| {
-                        let adapted = adapter.adapt_batch(&batch).map_err(|e| {
-                            DataFusionError::Execution(format!(
-                                "Failed to adapt the batch onto the scan's schema: {e}"
-                            ))
-                        });
+                        let adapted = with_partitions(&batch, &fields, &columns)
+                            .and_then(|batch| adapter.adapt_batch(&batch))
+                            .map_err(|e| {
+                                DataFusionError::Execution(format!(
+                                    "Failed to adapt the batch onto the scan's schema: {e}"
+                                ))
+                            });
                         futures::future::ready(adapted)
                     })
                     .boxed()
             }
-            Output::Rows(schema) => {
+            Output::Rows { schema, partitions } => {
                 let schema = schema.clone();
+                let partitions = partitions.clone();
                 batches
                     .and_then(move |batch| {
-                        let counted = RecordBatch::try_new_with_options(
-                            schema.clone(),
-                            vec![],
-                            &RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
-                        )
-                        .map_err(|e| {
-                            DataFusionError::Execution(format!(
-                                "Failed to build a count batch: {e}"
-                            ))
-                        });
-                        futures::future::ready(counted)
+                        futures::future::ready(count_batch(&schema, &partitions, batch.num_rows()))
                     })
                     .boxed()
             }
@@ -484,6 +539,68 @@ impl FileRead {
             Output::Nothing => futures::stream::empty().boxed(),
         }
     }
+}
+
+/// `batch` with the file's `PARTITIONED BY` columns appended.
+///
+/// Each is one value on no axis, so it broadcasts over whatever grid the file's
+/// own columns define and reaches every row the file contributes. Nothing is
+/// built per row, and nothing is built per batch: the columns are the file's,
+/// and [`FileRead::plan`] made them once.
+fn with_partitions(
+    batch: &RecordBatch,
+    fields: &[FieldRef],
+    columns: &[ArrayRef],
+) -> Result<RecordBatch> {
+    if fields.is_empty() {
+        return Ok(batch.clone());
+    }
+
+    let schema: Vec<FieldRef> = batch
+        .schema()
+        .fields()
+        .iter()
+        .cloned()
+        .chain(fields.iter().cloned())
+        .collect();
+    let values: Vec<ArrayRef> = batch
+        .columns()
+        .iter()
+        .cloned()
+        .chain(columns.iter().cloned())
+        .collect();
+
+    RecordBatch::try_new_with_options(
+        Arc::new(Schema::new(schema)),
+        values,
+        &RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
+    )
+    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+}
+
+/// The batch a read that wants no column of the file emits for `rows` rows.
+///
+/// A plain `COUNT(*)` emits the row count and nothing else. A scan of nothing
+/// but partition columns emits those columns instead: rank-0 columns alone
+/// would define a rank-0 grid, which holds one row, so the rows of the read are
+/// stated as an axis of their own.
+fn count_batch(
+    schema: &SchemaRef,
+    partitions: &FilePartitions,
+    rows: usize,
+) -> Result<RecordBatch> {
+    let (columns, encoded_rows) = if schema.fields().is_empty() {
+        (Vec::new(), rows)
+    } else {
+        (partitions.row_columns(schema, rows)?, 1)
+    };
+
+    RecordBatch::try_new_with_options(
+        schema.clone(),
+        columns,
+        &RecordBatchOptions::new().with_row_count(Some(encoded_rows)),
+    )
+    .map_err(|e| DataFusionError::Execution(format!("Failed to build a count batch: {e}")))
 }
 
 /// The columns a `COUNT(*)` reads, out of a file the query wants no column of.
@@ -1075,9 +1192,16 @@ mod tests {
             true,
         )]));
 
-        let planned = FileRead::plan(dataset(64).await, wanted, 16, None, None)
-            .await
-            .expect("a file without the column is planned, not rejected");
+        let planned = FileRead::plan(
+            dataset(64).await,
+            wanted,
+            16,
+            None,
+            FilePartitions::none(),
+            None,
+        )
+        .await
+        .expect("a file without the column is planned, not rejected");
 
         assert_eq!(planned.remaining(), 0, "nothing is queued to read");
         let batches: Vec<RecordBatch> = planned
@@ -1094,9 +1218,16 @@ mod tests {
     async fn a_count_over_the_same_file_still_counts_it() {
         const ROWS: usize = 64;
 
-        let planned = FileRead::plan(dataset(ROWS).await, no_columns(), 16, None, None)
-            .await
-            .expect("a count is planned");
+        let planned = FileRead::plan(
+            dataset(ROWS).await,
+            no_columns(),
+            16,
+            None,
+            FilePartitions::none(),
+            None,
+        )
+        .await
+        .expect("a count is planned");
 
         assert!(planned.remaining() > 0, "a count has work to do");
         assert_eq!(drain_flat(planned.stream(None)).await, ROWS);

--- a/beacon-db/beacon-file-formats/beacon-nd-array/src/arrow/mod.rs
+++ b/beacon-db/beacon-file-formats/beacon-nd-array/src/arrow/mod.rs
@@ -4,6 +4,7 @@ pub mod compute;
 pub mod metrics;
 pub mod morsel;
 pub mod nd_provider;
+pub mod partition;
 pub mod pushdown;
 pub mod pushdown_filter;
 pub mod schema;

--- a/beacon-db/beacon-file-formats/beacon-nd-array/src/arrow/morsel.rs
+++ b/beacon-db/beacon-file-formats/beacon-nd-array/src/arrow/morsel.rs
@@ -247,10 +247,16 @@ impl MorselSource {
 /// can do only because it knows which file each batch came from.
 ///
 /// An nd scan reads a whole collection behind one plan entry, so `FileStream`
-/// does not know. Supporting this means the morsel loop carrying the values per
-/// morsel and appending them itself. Until it does, the alternatives are to
-/// return those columns silently empty or to say so, and a query that quietly
-/// drops a column it was asked for is the worse of the two.
+/// does not know. The file readers do it themselves instead: a morsel carries
+/// its file's values and
+/// [`FilePartitions`](crate::arrow::partition::FilePartitions) appends them to
+/// its batches. That works because a morsel is a file.
+///
+/// A Zarr table is not made of files. Its entries are groups inside a store,
+/// and a group is not a path a partition value can be read off, so Zarr still
+/// refuses such a table. The alternatives are to return those columns silently
+/// empty or to say so, and a query that quietly drops a column it was asked for
+/// is the worse of the two.
 ///
 /// `format` names the reader in the error, since a user reaches this through
 /// `CREATE EXTERNAL TABLE ... PARTITIONED BY` and needs to know which format
@@ -291,14 +297,17 @@ pub fn reject_partition_columns(format: &str, config: &FileScanConfig) -> Result
 /// whatever the queue hands out. Its path says so, and its size is the scan's,
 /// so `EXPLAIN` still shows how much a partition is pointed at.
 ///
+/// A partitioned table divides the same way. A file's `PARTITIONED BY` values
+/// travel on its [`PartitionedFile`], the queue hands that whole entry to
+/// whoever opens it, and the reader appends the values to the batches it reads
+/// from it — see
+/// [`FilePartitions`](crate::arrow::partition::FilePartitions). So the standing
+/// entry below carries no values of its own, and needs none.
+///
 /// Returns `None` when the scan should keep the grouping it was planned with:
 ///
 /// - one partition, where there is nobody to divide the work with;
-/// - no files;
-/// - a partitioned table. `FileStream` appends a file's `PARTITIONED BY` values
-///   to its batches, and it can only do that because it knows which file each
-///   batch came from. Behind one entry it does not. A morsel loop would have to
-///   apply them itself, per morsel, and until it does such a scan is left alone.
+/// - no files.
 pub fn morsel_scan(
     file_groups: &[FileGroup],
     target_partitions: usize,
@@ -313,12 +322,6 @@ pub fn morsel_scan(
         .cloned()
         .collect();
     if files.is_empty() {
-        return None;
-    }
-    if files
-        .iter()
-        .any(|file| !file.partition_values.is_empty())
-    {
         return None;
     }
 
@@ -544,6 +547,7 @@ mod tests {
                 no_columns(),
                 self.batch_size,
                 None,
+                crate::arrow::partition::FilePartitions::none(),
                 None,
             )
             .await
@@ -886,25 +890,43 @@ mod tests {
         assert_eq!(entry.object_meta.size, 1_000, "the scan's bytes, not a file's");
     }
 
-    /// A partitioned table is left alone by the planner.
+    /// A partitioned table divides like any other, values and all.
     ///
-    /// The readers refuse it outright before a scan is built — see
-    /// [`reject_partition_columns`], which each of them calls from
-    /// `create_physical_plan`. This is the second line: `FileStream` appends a
-    /// file's `PARTITIONED BY` values to its batches, and it can do that only
-    /// because it knows which file a batch came from. Behind one entry it does
-    /// not.
+    /// The values travel on the [`PartitionedFile`] the queue holds, so whoever
+    /// opens that file has them and appends them to what it reads. Only the
+    /// standing entry is valueless, and nothing reads it as a file.
     #[test]
-    fn a_partitioned_table_is_left_alone() {
+    fn a_partitioned_table_divides_and_keeps_its_values() {
         use datafusion::scalar::ScalarValue;
 
-        let mut partitioned = file(0, 32);
-        partitioned.partition_values = vec![ScalarValue::Utf8(Some("2023".to_string()))];
-        let group = FileGroup::new(vec![partitioned, file(1, 32)]);
+        let year = |value: &str| vec![ScalarValue::Utf8(Some(value.to_string()))];
+        let mut first = file(0, 32);
+        first.partition_values = year("2023");
+        let mut second = file(1, 32);
+        second.partition_values = year("2024");
+        let group = FileGroup::new(vec![first, second]);
 
+        let (source, groups) =
+            morsel_scan(&[group], 8).expect("a partitioned table plans morsel-driven");
+
+        assert_eq!(groups.len(), 8, "one entry per partition, as for any scan");
+        assert_eq!(source.files(), 2, "and both files are in the queue");
+
+        let mut taken: Vec<Vec<ScalarValue>> = Vec::new();
+        while let Some(file) = source.unopened.pop() {
+            taken.push(file.partition_values.clone());
+        }
+        taken.sort_by_key(|values| format!("{values:?}"));
+        assert_eq!(
+            taken,
+            vec![year("2023"), year("2024")],
+            "each file keeps the values of its own path"
+        );
+
+        let entry = groups[0].iter().next().expect("an entry");
         assert!(
-            morsel_scan(&[group], 8).is_none(),
-            "a scan carrying partition values keeps its own grouping"
+            entry.partition_values.is_empty(),
+            "the standing entry stands for the scan, not for a file, so it holds no values"
         );
     }
 

--- a/beacon-db/beacon-file-formats/beacon-nd-array/src/arrow/partition.rs
+++ b/beacon-db/beacon-file-formats/beacon-nd-array/src/arrow/partition.rs
@@ -1,0 +1,265 @@
+//! The `PARTITIONED BY` columns of a scan, as columns of a file's batches.
+//!
+//! A partition column lives in the *path* of a file rather than inside it, so
+//! every row that file contributes carries the same value. DataFusion's
+//! `FileStream` appends that value per file, which it can do because a plan
+//! entry is a file. An nd scan reads a whole collection behind one entry, so it
+//! appends the values itself — per morsel, which is per file.
+//!
+//! The value repeats over the whole file, and an nd array of rank 0 says
+//! exactly that: one value, no axis. It broadcasts onto whatever grid the
+//! file's own columns define, so every row gets it and nothing is built per
+//! row. A scan that reads no column of the file has no such grid, so there the
+//! column is stated over the `row` axis instead. See
+//! [`FilePartitions::row_columns`].
+
+use std::sync::Arc;
+
+use arrow::array::ArrayRef;
+use arrow::datatypes::{FieldRef, Schema};
+use beacon_datafusion_ext::nd::encoding::{encode_nd_array, nd_value_type};
+use beacon_datafusion_ext::nd::{Dimension, Dimensions, NdArrowArray};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::scalar::ScalarValue;
+
+/// The axis a partition column is stated over when the scan reads no column of
+/// the file. The same name [`encode_flat_batch_as_nd`] uses, so the two agree
+/// when they meet in one batch.
+///
+/// [`encode_flat_batch_as_nd`]: beacon_datafusion_ext::nd::encode_flat_batch_as_nd
+const ROW_AXIS: &str = "row";
+
+/// A table's `PARTITIONED BY` fields, and one file's value for each of them.
+///
+/// The fields are nd-encoded, as they stand in the scan's schema: a format
+/// encodes its partition columns along with everything else, so that every
+/// column of a batch decodes the same way. The value type of each is read back
+/// off the encoding.
+#[derive(Debug, Clone, Default)]
+pub struct FilePartitions {
+    /// The scan's partition fields, nd-encoded, in table order.
+    fields: Vec<FieldRef>,
+    /// This file's value per field, in the same order.
+    values: Vec<ScalarValue>,
+}
+
+impl FilePartitions {
+    /// An unpartitioned table: no columns to add.
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// The scan's partition fields and one file's values for them.
+    ///
+    /// A value missing from `values` reads as null, which is what a path that
+    /// does not state the column means.
+    pub fn new(fields: Vec<FieldRef>, values: Vec<ScalarValue>) -> Self {
+        Self { fields, values }
+    }
+
+    /// Whether the table has any partition column at all.
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+
+    /// Whether `name` is one of the partition columns.
+    ///
+    /// A partition column shadows a variable of the same name, exactly as it
+    /// does for every other format: the value in the path wins.
+    pub fn holds(&self, name: &str) -> bool {
+        self.fields.iter().any(|field| field.name() == name)
+    }
+
+    /// The partition columns `projected` names, as rank-0 arrays.
+    ///
+    /// One value each, which broadcasts onto the grid the file's own columns
+    /// define. In the order `projected` names them, so they append to a batch
+    /// read in that same order.
+    pub fn scalar_columns(&self, projected: &Schema) -> Result<Vec<ArrayRef>> {
+        self.columns(projected, None)
+    }
+
+    /// The same columns over a `row` axis of `rows` cells.
+    ///
+    /// For a scan that reads no column of the file — `SELECT year FROM t`, where
+    /// `year` is a partition column. Rank-0 columns alone define a rank-0 grid,
+    /// which holds one row, and the file's rows would be lost. The row count of
+    /// the read says how many there are, so the axis is stated here.
+    pub fn row_columns(&self, projected: &Schema, rows: usize) -> Result<Vec<ArrayRef>> {
+        self.columns(projected, Some(rows))
+    }
+
+    /// The fields of [`scalar_columns`](Self::scalar_columns), in the same
+    /// order: what the columns it returns are called.
+    pub fn projected_fields(&self, projected: &Schema) -> Vec<FieldRef> {
+        projected
+            .fields()
+            .iter()
+            .filter(|field| self.holds(field.name()))
+            .cloned()
+            .collect()
+    }
+
+    fn columns(&self, projected: &Schema, rows: Option<usize>) -> Result<Vec<ArrayRef>> {
+        projected
+            .fields()
+            .iter()
+            .filter(|field| self.holds(field.name()))
+            .map(|field| self.column(field, rows))
+            .collect()
+    }
+
+    /// One partition column, nd-encoded.
+    fn column(&self, field: &FieldRef, rows: Option<usize>) -> Result<ArrayRef> {
+        let value_type = nd_value_type(field.data_type())?;
+        let index = self
+            .fields
+            .iter()
+            .position(|declared| declared.name() == field.name())
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "'{}' is not a partition column of this scan",
+                    field.name()
+                ))
+            })?;
+        let value = self.values.get(index).cloned().unwrap_or(ScalarValue::Null);
+
+        let values = value.to_array_of_size(rows.unwrap_or(1)).map_err(|e| {
+            DataFusionError::Execution(format!(
+                "Failed to build the partition column '{}': {e}",
+                field.name()
+            ))
+        })?;
+        // The scan declared the type; a path value that parsed to another one
+        // is made to fit rather than reaching the plan as a surprise.
+        let values = if values.data_type() == &value_type {
+            values
+        } else {
+            arrow::compute::cast(values.as_ref(), &value_type)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?
+        };
+
+        let dims = match rows {
+            None => Dimensions::scalar(),
+            Some(rows) => Dimensions::try_new(vec![Dimension::new(ROW_AXIS, rows)])?,
+        };
+        Ok(encode_nd_array(&NdArrowArray::try_new(values, dims)?))
+    }
+}
+
+/// A scan's partition fields, nd-encoded so that every column of a batch
+/// decodes the same way.
+///
+/// A format calls this where it encodes its file schema, and hands the result
+/// to `TableSchema::new`. What comes back out above the scan is the logical
+/// field again, so the table keeps the schema the user declared.
+///
+/// Nullability is kept, unlike a file column's. A file column is null-filled
+/// where a file of the collection lacks it, so it becomes nullable whatever the
+/// table said; a partition column is never read from a file, so it stays as the
+/// table declared it — and a plan built on that declaration, an aggregate for
+/// one, expects nothing else.
+pub fn encoded_partition_cols(cols: &[FieldRef]) -> Vec<FieldRef> {
+    cols.iter()
+        .map(|field| {
+            Arc::new(
+                beacon_datafusion_ext::nd::nd_encoded_field(field.name(), field.data_type())
+                    .with_nullable(field.is_nullable()),
+            )
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::array::{Array, AsArray};
+    use arrow::datatypes::{DataType, Field};
+    use beacon_datafusion_ext::nd::encoding::decode_nd_array;
+
+    use super::*;
+
+    fn year() -> FieldRef {
+        Arc::new(Field::new("year", DataType::Utf8, false))
+    }
+
+    fn partitions() -> FilePartitions {
+        FilePartitions::new(
+            encoded_partition_cols(&[year()]),
+            vec![ScalarValue::Utf8(Some("2023".to_string()))],
+        )
+    }
+
+    /// The projected schema of a scan that reads `year` and nothing else.
+    fn projected() -> Schema {
+        Schema::new(encoded_partition_cols(&[year()]))
+    }
+
+    /// A partition column carries the file's value, once, on no axis.
+    #[test]
+    fn a_scalar_column_holds_the_value_once() {
+        let columns = partitions()
+            .scalar_columns(&projected())
+            .expect("the column builds");
+
+        assert_eq!(columns.len(), 1);
+        let decoded = decode_nd_array(&columns[0], 0).expect("it decodes");
+        assert_eq!(decoded.dims().rank(), 0, "no axis: one value for the file");
+        assert_eq!(decoded.values().as_string::<i32>().value(0), "2023");
+    }
+
+    /// Over the `row` axis it holds one value per row of the read.
+    #[test]
+    fn a_row_column_holds_one_value_per_row() {
+        let columns = partitions()
+            .row_columns(&projected(), 3)
+            .expect("the column builds");
+
+        let decoded = decode_nd_array(&columns[0], 0).expect("it decodes");
+        assert_eq!(decoded.dims().shape(), vec![3]);
+        let values = decoded.values().as_string::<i32>();
+        assert_eq!(
+            (0..3).map(|i| values.value(i)).collect::<Vec<_>>(),
+            ["2023"; 3]
+        );
+    }
+
+    /// A column the scan does not project is not built.
+    #[test]
+    fn an_unprojected_partition_column_is_left_out() {
+        let month = Arc::new(Field::new("month", DataType::Utf8, false));
+        let partitions = FilePartitions::new(
+            encoded_partition_cols(&[year(), month]),
+            vec![
+                ScalarValue::Utf8(Some("2023".to_string())),
+                ScalarValue::Utf8(Some("07".to_string())),
+            ],
+        );
+
+        // The scan asks for `year` alone.
+        let columns = partitions
+            .scalar_columns(&projected())
+            .expect("the column builds");
+        assert_eq!(columns.len(), 1, "only what the projection names");
+    }
+
+    /// A path that states no value gives a null, not an error.
+    #[test]
+    fn a_missing_value_reads_as_null() {
+        let partitions = FilePartitions::new(encoded_partition_cols(&[year()]), vec![]);
+
+        let columns = partitions
+            .scalar_columns(&projected())
+            .expect("the column builds");
+        let decoded = decode_nd_array(&columns[0], 0).expect("it decodes");
+        assert!(decoded.values().is_null(0), "the value is null");
+    }
+
+    /// An unpartitioned table adds nothing.
+    #[test]
+    fn an_unpartitioned_table_adds_no_column() {
+        let none = FilePartitions::none();
+        assert!(none.is_empty());
+        assert!(!none.holds("year"));
+        assert!(none.scalar_columns(&projected()).unwrap().is_empty());
+    }
+}

--- a/docs/docs/2.0.0-rc3/sql/create-external-table.md
+++ b/docs/docs/2.0.0-rc3/sql/create-external-table.md
@@ -113,6 +113,19 @@ PARTITIONED BY (year, month)
 SELECT * FROM observations WHERE year = 2024 AND month = 6
 ```
 
+The value comes from the directory name of each file. `NC`, `HDF5` and `TIFF` read a partitioned
+collection the same way:
+
+```sql
+CREATE EXTERNAL TABLE observations
+STORED AS NC
+LOCATION 'obs/'
+PARTITIONED BY (year, month)
+```
+
+`ZARR` does not support this clause. A Zarr table holds groups inside one store, not files in
+directories, so a path holds no partition value.
+
 ## `OPTIONS`
 
 `OPTIONS` tunes the read of one table. Each format reads its own keys. Beacon stores the keys with


### PR DESCRIPTION
Closes #419

## Problem

Beacon refuses `PARTITIONED BY` on netCDF, HDF5 and TIFF tables. The scan returns a `NotImplemented` error.

A partition column is in the path of a file. It is not in the file. DataFusion appends the value for each plan entry. An entry is a file. These three readers put a whole collection behind one entry. DataFusion cannot append the value there.

## Solution

The readers append the values themselves. Each morsel carries the values of its own file. A morsel is a file.

`FilePartitions` makes one nd column for each value. The column has rank 0. It broadcasts over the grid of the file. Each row gets the value. No column grows per row.

A scan of only partition columns has no grid. That scan states the value over a row axis. The row count of the read gives the size.

Zarr keeps the refusal. A Zarr table holds groups in a store. A group has no path with a partition value.

## Tests

- netCDF: values per path, `GROUP BY`, file pruning, parallel scan.
- HDF5 and TIFF: values per path.
- beacon-core: the statement of the issue, end to end.

The workspace suite passes: 2013 tests, 0 failures.
