### PR TITLE
feat: show the disk space of the datasets store in the admin UI (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ tag. Releases before 2.0.0 are recorded in the
 
 ### Added
 
+- **The admin UI shows the disk space of the datasets store.** An operator sees the total space,
+  the used space, the free space and the used percent on the Server page and on the Datasets page,
+  and no longer opens a shell to read them. The bar turns amber at 70% and red at 85%. The values
+  come from `GET /api/admin/datasets/storage`, which reads the disk that holds the datasets
+  directory through `sysinfo`; `client.admin.datasetStorage()` calls it from the TypeScript SDK. An
+  S3 bucket has no disk limit, so it answers with the bucket name, the total size of the objects
+  and the object count, and reads `n/a` for the total space, the free space and the used percent.
+  That answer needs a full bucket listing, so poll the endpoint at a low rate.
 - **122 spatial functions with PostGIS names.** `ST_Distance`, `ST_Intersects`, `ST_Buffer`,
   `ST_Centroid`, `ST_Simplify` and the rest now run in SQL — 117 scalar functions, 3 aggregate
   functions (`ST_Extent`, `ST_Collect`, `ST_MemUnion`) and 2 window functions

--- a/beacon-clients/beacon-ts/src/admin.ts
+++ b/beacon-clients/beacon-ts/src/admin.ts
@@ -184,6 +184,20 @@ export class AdminClient {
     await this.http.fetchRaw("DELETE", "/api/admin/datasets", { query: { path } });
   }
 
+  /**
+   * Reports the disk space of the datasets store
+   * (`GET /api/admin/datasets/storage`).
+   *
+   * A local store answers with the space of the disk that holds the datasets
+   * directory. An S3 bucket has no capacity, so `total_space`, `free_space` and
+   * `used_percent` are `null` and `used_space` is the total size of the objects.
+   * The bucket listing makes the call slow on a large bucket; poll it at a low
+   * rate.
+   */
+  datasetStorage(): Promise<DatasetStorage> {
+    return this.http.fetchJson<DatasetStorage>("GET", "/api/admin/datasets/storage");
+  }
+
   // -- users & roles ----------------------------------------------------------
 
   /** Lists all users (the super-user plus stored local users) with their roles. */
@@ -289,6 +303,31 @@ export interface AuthRole {
   name: string;
   grants: AuthRule[];
   denies: AuthRule[];
+}
+
+/** Which store backs the datasets, and therefore which values are present. */
+export type StorageKind = "local" | "s3";
+
+/**
+ * Disk space of the datasets store. `total_space`, `free_space` and
+ * `used_percent` are `null` for an S3 bucket, which has no capacity.
+ */
+export interface DatasetStorage {
+  kind: StorageKind;
+  /** The datasets directory, or the bucket name for S3. */
+  location: string;
+  /** The mount point of the disk that holds the directory. `null` for S3. */
+  mount_point: string | null;
+  /** The capacity of the disk, in bytes. `null` for S3. */
+  total_space: number | null;
+  /** The used space, in bytes. For S3, the total size of the objects. */
+  used_space: number | null;
+  /** The free space of the disk, in bytes. `null` for S3. */
+  free_space: number | null;
+  /** The used space as a percent of the capacity. `null` for S3. */
+  used_percent: number | null;
+  /** The number of objects in the bucket. `null` for a local directory. */
+  object_count: number | null;
 }
 
 /** Result of a successful dataset upload. */

--- a/beacon-clients/beacon-ts/src/index.ts
+++ b/beacon-clients/beacon-ts/src/index.ts
@@ -11,6 +11,8 @@ export type {
   AuthUser,
   AuthRule,
   AuthRole,
+  DatasetStorage,
+  StorageKind,
 } from "./admin.js";
 export { Http, basicAuthHeader, ADMIN_API_PREFIX } from "./http.js";
 export type { ClientOptions, FetchLike } from "./http.js";

--- a/beacon-clients/beacon-ts/test/admin.test.ts
+++ b/beacon-clients/beacon-ts/test/admin.test.ts
@@ -117,3 +117,63 @@ describe("AdminClient.uploadDataset", () => {
     expect(calls).toContain("DELETE /api/admin/datasets/upload");
   });
 });
+
+describe("AdminClient.datasetStorage", () => {
+  it("reads the disk space of a local datasets directory", async () => {
+    const calls: string[] = [];
+    const fn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push(`${(init?.method ?? "GET").toUpperCase()} ${String(url)}`);
+      return new Response(
+        JSON.stringify({
+          kind: "local",
+          location: "/beacon/data/datasets",
+          mount_point: "/",
+          total_space: 400,
+          used_space: 100,
+          free_space: 300,
+          used_percent: 25,
+          object_count: null,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    const client = adminClient(fn as unknown as typeof fetch);
+
+    const info = await client.admin.datasetStorage();
+
+    expect(calls).toEqual(["GET http://beacon.test/api/admin/datasets/storage"]);
+    expect(info.kind).toBe("local");
+    expect(info.used_percent).toBe(25);
+    expect(info.object_count).toBeNull();
+  });
+
+  it("keeps the S3 values that a bucket cannot answer null", async () => {
+    const fn = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            kind: "s3",
+            location: "my-bucket",
+            mount_point: null,
+            total_space: null,
+            used_space: 2048,
+            free_space: null,
+            used_percent: null,
+            object_count: 7,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const client = adminClient(fn as unknown as typeof fetch);
+
+    const info = await client.admin.datasetStorage();
+
+    expect(info.kind).toBe("s3");
+    expect(info.location).toBe("my-bucket");
+    expect(info.used_space).toBe(2048);
+    expect(info.total_space).toBeNull();
+    expect(info.free_space).toBeNull();
+    expect(info.used_percent).toBeNull();
+    expect(info.object_count).toBe(7);
+  });
+});

--- a/beacon-clients/beacon-web/src/components/dataset-storage.tsx
+++ b/beacon-clients/beacon-web/src/components/dataset-storage.tsx
@@ -1,0 +1,135 @@
+/**
+ * Disk space of the datasets store, shown on the Server page and the Datasets
+ * page.
+ *
+ * An S3 bucket has no capacity, so the total space, the free space and the used
+ * percent read `n/a` there; the used space is the total size of the objects.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { HardDrive } from "lucide-react";
+
+import { useBeacon } from "@/lib/beacon-context";
+import { errorMessage } from "@/lib/errors";
+import { formatBytes } from "@/lib/format";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Meter } from "@/components/ui/meter";
+
+/** What a bucket cannot answer. */
+const NOT_AVAILABLE = "n/a";
+
+/**
+ * Reads the disk space. The listing behind an S3 bucket is slow, so this polls
+ * far slower than the host gauges and stays fresh for a minute.
+ */
+export function useDatasetStorage() {
+  const beacon = useBeacon();
+  return useQuery({
+    queryKey: ["dataset-storage"],
+    queryFn: () => beacon.admin.datasetStorage(),
+    refetchInterval: 60_000,
+    staleTime: 60_000,
+  });
+}
+
+/** A byte count, or `n/a` when the store cannot report it. */
+function bytes(value: number | null | undefined): string {
+  return value == null ? NOT_AVAILABLE : formatBytes(value);
+}
+
+/** A percent with one decimal, or `n/a` when the store has no capacity. */
+function percent(value: number | null | undefined): string {
+  return value == null ? NOT_AVAILABLE : `${value.toFixed(1)}%`;
+}
+
+/** The full card for the Server page: a usage bar plus the four values. */
+export function DatasetStorageCard() {
+  const { data, isLoading, isError, error } = useDatasetStorage();
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <HardDrive className="h-4 w-4 text-primary" /> Datasets storage
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {isLoading && <div className="text-sm text-muted-foreground">Loading…</div>}
+        {isError && <div className="text-sm text-destructive">{errorMessage(error)}</div>}
+        {data && (
+          <>
+            <div className="truncate font-mono text-xs text-muted-foreground" title={data.location}>
+              {data.kind === "s3" ? `s3://${data.location}` : data.location}
+              {data.mount_point && ` (on ${data.mount_point})`}
+            </div>
+            {data.used_percent != null ? (
+              <Meter
+                label={`${bytes(data.used_space)} used`}
+                detail={`of ${bytes(data.total_space)}`}
+                pct={data.used_percent}
+              />
+            ) : (
+              <div className="text-sm text-muted-foreground">
+                An S3 bucket has no disk limit. Only the size of the objects is known
+                {data.object_count != null && ` (${data.object_count} objects)`}.
+              </div>
+            )}
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+              <Value label="Total" text={bytes(data.total_space)} />
+              <Value label="Used" text={bytes(data.used_space)} />
+              <Value label="Free" text={bytes(data.free_space)} />
+              <Value label="Used percent" text={percent(data.used_percent)} />
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Value({ label, text }: { label: string; text: string }) {
+  return (
+    <div>
+      <div className="text-sm font-semibold tabular-nums">{text}</div>
+      <div className="text-xs text-muted-foreground">{label}</div>
+    </div>
+  );
+}
+
+/**
+ * The one-line form for the Datasets page header: the four values, and a bar
+ * that turns amber then red as the disk fills.
+ */
+export function DatasetStorageBar() {
+  const { data, isError } = useDatasetStorage();
+  if (isError || !data) return null;
+
+  return (
+    <div className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-1 rounded-md border px-3 py-2 text-xs">
+      <span className="flex items-center gap-1.5 font-medium">
+        <HardDrive className="h-3.5 w-3.5 text-primary" />
+        <span className="max-w-[18rem] truncate font-mono" title={data.location}>
+          {data.kind === "s3" ? `s3://${data.location}` : data.location}
+        </span>
+      </span>
+      <span className="text-muted-foreground">
+        Total <span className="tabular-nums text-foreground">{bytes(data.total_space)}</span>
+      </span>
+      <span className="text-muted-foreground">
+        Used <span className="tabular-nums text-foreground">{bytes(data.used_space)}</span>
+      </span>
+      <span className="text-muted-foreground">
+        Free <span className="tabular-nums text-foreground">{bytes(data.free_space)}</span>
+      </span>
+      <span className="text-muted-foreground">
+        Used percent{" "}
+        <span className="tabular-nums text-foreground">{percent(data.used_percent)}</span>
+      </span>
+      {data.used_percent != null && (
+        <span className="ml-auto w-40">
+          <Meter pct={data.used_percent} compact />
+        </span>
+      )}
+    </div>
+  );
+}

--- a/beacon-clients/beacon-web/src/components/ui/meter.tsx
+++ b/beacon-clients/beacon-web/src/components/ui/meter.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * A small horizontal usage bar. The colour follows the load: green below 70%,
+ * amber from 70%, red from 85%. Shared by the host gauges on the Server page
+ * and the datasets disk space. Without a label and a detail the bar stands on
+ * its own, for a row that already names the values.
+ */
+export function Meter({
+  label,
+  detail,
+  pct,
+  compact,
+}: {
+  label?: string;
+  detail?: string;
+  pct: number;
+  compact?: boolean;
+}) {
+  const clamped = Math.max(0, Math.min(100, pct));
+  const color = clamped >= 85 ? "bg-destructive" : clamped >= 70 ? "bg-amber-500" : "bg-primary";
+  return (
+    <div>
+      {(label || detail) && (
+        <div
+          className={cn(
+            "mb-1 flex items-baseline justify-between gap-2",
+            compact ? "text-[11px]" : "text-xs",
+          )}
+        >
+          <span className="truncate font-medium">{label}</span>
+          {detail && <span className="shrink-0 text-muted-foreground">{detail}</span>}
+        </div>
+      )}
+      <div className={cn("w-full overflow-hidden rounded bg-secondary", compact ? "h-1.5" : "h-2")}>
+        <div
+          className={cn("h-full rounded transition-all", color)}
+          style={{ width: `${clamped}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/beacon-clients/beacon-web/src/pages/datasets.tsx
+++ b/beacon-clients/beacon-web/src/pages/datasets.tsx
@@ -27,6 +27,7 @@ import { useBeacon } from "@/lib/beacon-context";
 import { COLUMN_PAGE_SIZE, parseSchema } from "@/lib/schema";
 import { errorMessage } from "@/lib/errors";
 import { PageContainer } from "@/components/app-shell";
+import { DatasetStorageBar } from "@/components/dataset-storage";
 import { InfoBanner } from "@/components/info-banner";
 import { ResultsGrid } from "@/components/results-grid";
 import { Card } from "@/components/ui/card";
@@ -268,6 +269,8 @@ export function DatasetsPage() {
   const refreshDatasets = React.useCallback(() => {
     qc.invalidateQueries({ queryKey: ["datasets-all"] });
     qc.invalidateQueries({ queryKey: ["total-datasets"] });
+    // An upload or a delete moves the used space, so the disk values are stale.
+    qc.invalidateQueries({ queryKey: ["dataset-storage"] });
   }, [qc]);
 
   const deleteMutation = useMutation({
@@ -546,6 +549,7 @@ export function DatasetsPage() {
         adds files at any path you choose &mdash; type a destination folder to drop them into an
         existing folder or create a new one.
       </InfoBanner>
+      <DatasetStorageBar />
       {banner && (
         <div
           className={cn(

--- a/beacon-clients/beacon-web/src/pages/server-info.tsx
+++ b/beacon-clients/beacon-web/src/pages/server-info.tsx
@@ -20,8 +20,10 @@ import { useBeacon } from "@/lib/beacon-context";
 import { errorMessage } from "@/lib/errors";
 import { formatBytes } from "@/lib/format";
 import { PageContainer } from "@/components/app-shell";
+import { DatasetStorageCard } from "@/components/dataset-storage";
 import { JsonView } from "@/components/json-view";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Meter } from "@/components/ui/meter";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -141,6 +143,12 @@ export function ServerInfoPage() {
           value={host?.cpus?.[0]?.brand ?? "—"}
           detail={host?.physical_core_count != null ? `${host.physical_core_count} cores` : undefined}
         />
+      </div>
+
+      {/* Datasets store disk space. The datasets store is the server's own, so
+          this does not depend on BEACON_ENABLE_SYS_INFO. */}
+      <div className="mt-4">
+        <DatasetStorageCard />
       </div>
 
       {host == null && !infoQuery.isLoading && (
@@ -291,38 +299,6 @@ export function ServerInfoPage() {
 function ratio(used?: number, total?: number): number {
   if (!used || !total) return 0;
   return (used / total) * 100;
-}
-
-/** A small labelled horizontal usage bar, coloured by load. */
-function Meter({
-  label,
-  detail,
-  pct,
-  compact,
-}: {
-  label: string;
-  detail?: string;
-  pct: number;
-  compact?: boolean;
-}) {
-  const clamped = Math.max(0, Math.min(100, pct));
-  const color = clamped >= 85 ? "bg-destructive" : clamped >= 70 ? "bg-amber-500" : "bg-primary";
-  return (
-    <div>
-      <div
-        className={cn(
-          "mb-1 flex items-baseline justify-between gap-2",
-          compact ? "text-[11px]" : "text-xs",
-        )}
-      >
-        <span className="truncate font-medium">{label}</span>
-        {detail && <span className="shrink-0 text-muted-foreground">{detail}</span>}
-      </div>
-      <div className={cn("w-full overflow-hidden rounded bg-secondary", compact ? "h-1.5" : "h-2")}>
-        <div className={cn("h-full rounded transition-all", color)} style={{ width: `${clamped}%` }} />
-      </div>
-    </div>
-  );
 }
 
 function StatTile({

--- a/beacon-server/beacon-server/src/axum/admin/datasets.rs
+++ b/beacon-server/beacon-server/src/axum/admin/datasets.rs
@@ -15,6 +15,7 @@ use ::axum::{
 };
 use crate::server::{
     files::{FileError, UploadResult},
+    storage::DatasetStorageInfo,
     Server,
 };
 use futures::TryStreamExt;
@@ -113,6 +114,25 @@ pub(crate) async fn download_dataset(
         body,
     )
         .into_response())
+}
+
+/// Reports the disk space of the datasets store.
+///
+/// A local store answers with the space of the disk that holds the datasets
+/// directory. An S3 bucket has no capacity, so it answers with the bucket name
+/// and the total size of the objects; the free space and the used percent stay
+/// `null`. The bucket listing makes this call slow on a large bucket, so poll it
+/// at a low rate.
+#[tracing::instrument(level = "info", skip(state))]
+#[utoipa::path(
+    tag = "admin",
+    get,
+    path = "/api/admin/datasets/storage",
+    responses((status = 200, description = "Disk space of the datasets store", body = DatasetStorageInfo)),
+    security(("basic-auth" = []))
+)]
+pub(crate) async fn dataset_storage(State(state): State<Arc<Server>>) -> Json<DatasetStorageInfo> {
+    Json(state.dataset_storage().await)
 }
 
 /// Query parameters identifying a chunked upload and a part within it.

--- a/beacon-server/beacon-server/src/axum/admin/mod.rs
+++ b/beacon-server/beacon-server/src/axum/admin/mod.rs
@@ -52,6 +52,7 @@ pub(crate) fn setup_admin_router() -> (Router<Arc<Server>>, utoipa::openapi::Ope
         .routes(routes!(datasets::upload_part))
         .routes(routes!(datasets::complete_upload))
         .routes(routes!(datasets::abort_upload))
+        .routes(routes!(datasets::dataset_storage))
         .routes(routes!(tables::list_table_config))
         .routes(routes!(auth::list_users))
         .routes(routes!(auth::list_roles))

--- a/beacon-server/beacon-server/src/server/mod.rs
+++ b/beacon-server/beacon-server/src/server/mod.rs
@@ -16,6 +16,7 @@
 pub mod catalog;
 pub mod files;
 pub mod sql;
+pub mod storage;
 pub mod sys;
 pub mod uploads;
 
@@ -74,6 +75,19 @@ impl Server {
     /// Host and build information for `GET /api/info`.
     pub fn system_info(&self) -> sys::SystemInfo {
         sys::SystemInfo::new(self.config.runtime.enable_sys_info)
+    }
+
+    /// Disk space of the datasets store, for `GET /api/admin/datasets/storage`.
+    ///
+    /// A local store reads the disk that holds the datasets directory. An S3
+    /// store has no capacity, so it lists the bucket to get the used space —
+    /// which makes this call slow on a large bucket.
+    pub async fn dataset_storage(&self) -> storage::DatasetStorageInfo {
+        let s3 = &self.config.s3;
+        match (s3.datasets_on_s3, s3.bucket.as_deref()) {
+            (true, Some(bucket)) => storage::s3_storage(self.store.as_ref(), bucket).await,
+            _ => storage::local_storage(&self.config.data.datasets),
+        }
     }
 
     /// The cap on a single upload, in bytes. `0` means unlimited.

--- a/beacon-server/beacon-server/src/server/storage.rs
+++ b/beacon-server/beacon-server/src/server/storage.rs
@@ -1,0 +1,197 @@
+//! Disk space of the datasets store, for `GET /api/admin/datasets/storage`.
+//!
+//! An operator must see when the store fills up without opening a shell. The two
+//! store backings answer that question differently:
+//!
+//! - A local directory sits on a disk with a fixed capacity. `sysinfo` reports
+//!   the capacity of the mount that holds the directory.
+//! - An S3 bucket has no capacity. Only the size of the objects is known, so the
+//!   free space and the used percent stay empty.
+
+use std::path::{Path, PathBuf};
+
+use futures::StreamExt;
+use object_store::ObjectStore;
+
+/// Which store backs the datasets, and therefore which values are available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum StorageKind {
+    /// A directory on a local disk. Every value is present.
+    Local,
+    /// An S3 bucket. A bucket has no capacity, so only the used space is present.
+    S3,
+}
+
+/// Disk space of the datasets store.
+///
+/// `total_space`, `free_space` and `used_percent` are `null` for an S3 bucket.
+/// The web UI shows `n/a` for each of them.
+#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+pub struct DatasetStorageInfo {
+    /// Which store holds the datasets.
+    pub kind: StorageKind,
+    /// The datasets directory, or the bucket name for S3.
+    #[schema(example = "/beacon/data/datasets")]
+    pub location: String,
+    /// The mount point of the disk that holds the directory. `null` for S3.
+    #[schema(example = "/")]
+    pub mount_point: Option<String>,
+    /// The capacity of the disk, in bytes. `null` for S3.
+    pub total_space: Option<u64>,
+    /// The used space of the disk, in bytes. For S3, the total size of the objects.
+    pub used_space: Option<u64>,
+    /// The free space of the disk, in bytes. `null` for S3.
+    pub free_space: Option<u64>,
+    /// The used space as a percent of the capacity. `null` for S3.
+    pub used_percent: Option<f64>,
+    /// The number of objects in the bucket. `null` for a local directory.
+    pub object_count: Option<u64>,
+}
+
+/// Read the space of the disk that holds `dir`.
+///
+/// The directory does not have to exist yet: the nearest parent that does exist
+/// sits on the same disk. A path that matches no mount point at all yields
+/// `None` rather than an error, because the space is a display value.
+pub fn local_storage(dir: &Path) -> DatasetStorageInfo {
+    let mut info = DatasetStorageInfo {
+        kind: StorageKind::Local,
+        location: dir.display().to_string(),
+        mount_point: None,
+        total_space: None,
+        used_space: None,
+        free_space: None,
+        used_percent: None,
+        object_count: None,
+    };
+
+    let Some(target) = existing_ancestor(dir) else {
+        return info;
+    };
+
+    let disks = sysinfo::Disks::new_with_refreshed_list_specifics(
+        sysinfo::DiskRefreshKind::nothing().with_storage(),
+    );
+
+    // Several mounts can be a prefix of the path (`/` and `/data` both hold
+    // `/data/datasets`). The longest one is the disk the directory is on.
+    let disk = disks
+        .list()
+        .iter()
+        .filter(|disk| target.starts_with(disk.mount_point()))
+        .max_by_key(|disk| disk.mount_point().as_os_str().len());
+
+    if let Some(disk) = disk {
+        let total = disk.total_space();
+        let free = disk.available_space();
+        info.mount_point = Some(disk.mount_point().display().to_string());
+        info.total_space = Some(total);
+        info.free_space = Some(free);
+        info.used_space = Some(total.saturating_sub(free));
+        info.used_percent = percent(total.saturating_sub(free), total);
+    }
+
+    info
+}
+
+/// Sum the size and the count of every object in the bucket.
+///
+/// A bucket has no capacity, so a listing is the only measure of the used space.
+/// The listing is a paged request per 1000 objects; a large bucket makes this
+/// call slow. The caller must not put it on a fast refresh interval.
+pub async fn s3_storage(store: &dyn ObjectStore, bucket: &str) -> DatasetStorageInfo {
+    let mut used: u64 = 0;
+    let mut count: u64 = 0;
+    let mut stream = store.list(None);
+    while let Some(entry) = stream.next().await {
+        match entry {
+            Ok(meta) => {
+                used += meta.size;
+                count += 1;
+            }
+            Err(error) => {
+                tracing::warn!(%error, "failed to list the datasets bucket");
+                break;
+            }
+        }
+    }
+
+    DatasetStorageInfo {
+        kind: StorageKind::S3,
+        location: bucket.to_string(),
+        mount_point: None,
+        total_space: None,
+        used_space: Some(used),
+        free_space: None,
+        used_percent: None,
+        object_count: Some(count),
+    }
+}
+
+/// The nearest ancestor of `dir` that exists, canonicalized.
+///
+/// A datasets directory is created on first write, so it can still be absent.
+/// Its parent is on the same disk, which makes the space the same value.
+fn existing_ancestor(dir: &Path) -> Option<PathBuf> {
+    let mut current = dir;
+    loop {
+        if let Ok(path) = current.canonicalize() {
+            return Some(path);
+        }
+        current = current.parent()?;
+    }
+}
+
+/// `used` as a percent of `total`, or `None` when the capacity is unknown.
+fn percent(used: u64, total: u64) -> Option<f64> {
+    (total > 0).then(|| (used as f64 / total as f64) * 100.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_storage_reads_the_disk_of_an_existing_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let info = local_storage(dir.path());
+
+        assert_eq!(info.kind, StorageKind::Local);
+        assert_eq!(info.location, dir.path().display().to_string());
+        assert!(
+            info.total_space.unwrap() > 0,
+            "the disk must have a capacity"
+        );
+        assert_eq!(
+            info.used_space.unwrap() + info.free_space.unwrap(),
+            info.total_space.unwrap()
+        );
+        let pct = info.used_percent.unwrap();
+        assert!(
+            (0.0..=100.0).contains(&pct),
+            "used percent out of range: {pct}"
+        );
+        assert!(info.mount_point.is_some());
+        assert_eq!(info.object_count, None);
+    }
+
+    #[test]
+    fn local_storage_falls_back_to_an_existing_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("datasets");
+        let info = local_storage(&missing);
+
+        assert_eq!(info.location, missing.display().to_string());
+        assert!(
+            info.total_space.is_some(),
+            "the parent disk answers instead"
+        );
+    }
+
+    #[test]
+    fn percent_of_an_unknown_capacity_is_none() {
+        assert_eq!(percent(0, 0), None);
+        assert_eq!(percent(1, 4), Some(25.0));
+    }
+}

--- a/beacon-server/beacon-server/tests/admin_datasets_http.rs
+++ b/beacon-server/beacon-server/tests/admin_datasets_http.rs
@@ -340,3 +340,37 @@ async fn chunked_upload_rejects_unknown_session_and_out_of_order() {
     .await;
     assert_eq!(status, StatusCode::NO_CONTENT);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dataset_storage_reports_the_local_disk_and_needs_the_super_user() {
+    let (harness, config) = app(temp_config(1024)).await;
+    let router = setup_router(harness.server.clone(), config.clone()).unwrap();
+    let admin = basic(&config.admin.username, &config.admin.password);
+    let uri = "/api/admin/datasets/storage";
+
+    // No credentials → 401.
+    let (status, _) = send(&router, request("GET", uri, None, Body::empty())).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    let (status, body) = send(&router, request("GET", uri, Some(&admin), Body::empty())).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let info: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(info["kind"], "local");
+    assert_eq!(
+        info["location"].as_str().unwrap(),
+        config.data.datasets.display().to_string()
+    );
+    assert!(info["mount_point"].is_string());
+
+    let total = info["total_space"].as_u64().unwrap();
+    let used = info["used_space"].as_u64().unwrap();
+    let free = info["free_space"].as_u64().unwrap();
+    assert!(total > 0, "a local disk must report a capacity");
+    assert_eq!(used + free, total);
+
+    let percent = info["used_percent"].as_f64().unwrap();
+    assert!((0.0..=100.0).contains(&percent), "used percent: {percent}");
+    // A local directory reports no object count; only a bucket does.
+    assert!(info["object_count"].is_null());
+}

--- a/beacon-server/beacon-server/tests/api_contract_http.rs
+++ b/beacon-server/beacon-server/tests/api_contract_http.rs
@@ -80,6 +80,7 @@ const CLIENT_ENDPOINTS: &[(&str, &str)] = &[
     ("put", "/api/admin/datasets/upload/part"),
     ("post", "/api/admin/datasets/upload/complete"),
     ("delete", "/api/admin/datasets/upload"),
+    ("get", "/api/admin/datasets/storage"),
 ];
 
 async fn app() -> (Router, common::TestServer) {


### PR DESCRIPTION
Closes #432

## Problem

The admin UI does not show the disk space of the datasets store. An operator opens a shell to read it.

## Solution

Add `GET /api/admin/datasets/storage`. The endpoint reports the total space, the used space, the free space and the used percent.

A local store reads the disk that holds the datasets directory. `sysinfo` supplies the values. The directory does not have to exist. The nearest parent that exists sits on the same disk.

An S3 bucket has no capacity. The endpoint lists the objects and reports their total size and count. The other three values stay `null`.

The Server page shows a card. The Datasets page shows one row above the files. Both show `n/a` for each value that a bucket cannot answer. The bar turns amber at 70% and red at 85%.

`client.admin.datasetStorage()` calls the endpoint from the SDK.

## Verification

I ran the server against a local directory and a MinIO bucket. Both show the correct values. The change adds 3 unit tests, 1 HTTP test and 2 SDK tests.

## Limit

The SDK aborts a request after 60 seconds. A large bucket then reports an error. A server-side cache repairs this.
