### PR TITLE
deps: bump datafusion-spatial to 0.2.0 (#438)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4595,8 +4595,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-spatial"
-version = "0.1.0"
-source = "git+https://github.com/robinskil/datafusion-spatial.git?rev=20a416ff473192f47082dd4b3dcf19340aed3c77#20a416ff473192f47082dd4b3dcf19340aed3c77"
+version = "0.2.0"
+source = "git+https://github.com/robinskil/datafusion-spatial.git?rev=92245ff8e2eaad939425993cff7fa9180d471ec1#92245ff8e2eaad939425993cff7fa9180d471ec1"
 dependencies = [
  "datafusion 53.1.0",
  "datafusion 54.1.0",
@@ -4609,8 +4609,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-spatial-kernels"
-version = "0.1.0"
-source = "git+https://github.com/robinskil/datafusion-spatial.git?rev=20a416ff473192f47082dd4b3dcf19340aed3c77#20a416ff473192f47082dd4b3dcf19340aed3c77"
+version = "0.2.0"
+source = "git+https://github.com/robinskil/datafusion-spatial.git?rev=92245ff8e2eaad939425993cff7fa9180d471ec1#92245ff8e2eaad939425993cff7fa9180d471ec1"
 dependencies = [
  "arrow-array 58.4.0",
  "arrow-buffer 58.4.0",
@@ -4630,8 +4630,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-spatial-udf"
-version = "0.1.0"
-source = "git+https://github.com/robinskil/datafusion-spatial.git?rev=20a416ff473192f47082dd4b3dcf19340aed3c77#20a416ff473192f47082dd4b3dcf19340aed3c77"
+version = "0.2.0"
+source = "git+https://github.com/robinskil/datafusion-spatial.git?rev=92245ff8e2eaad939425993cff7fa9180d471ec1#92245ff8e2eaad939425993cff7fa9180d471ec1"
 dependencies = [
  "arrow-array 58.4.0",
  "arrow-buffer 58.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,9 +77,9 @@ datafusion-federation = { version = "=0.5.3", features = ["sql"] }
 
 datafusion-table-providers = { version = "=0.11.2", default-features = false }
 
-datafusion-spatial = { git = "https://github.com/robinskil/datafusion-spatial.git", rev = "20a416ff473192f47082dd4b3dcf19340aed3c77", default-features = false, features = ["df53", "sql"] }
+datafusion-spatial = { git = "https://github.com/robinskil/datafusion-spatial.git", rev = "92245ff8e2eaad939425993cff7fa9180d471ec1", default-features = false, features = ["df53", "sql"] }
 
-datafusion-spatial-kernels = { git = "https://github.com/robinskil/datafusion-spatial.git", rev = "20a416ff473192f47082dd4b3dcf19340aed3c77" }
+datafusion-spatial-kernels = { git = "https://github.com/robinskil/datafusion-spatial.git", rev = "92245ff8e2eaad939425993cff7fa9180d471ec1" }
 object_store = { version = "0.13.1", features = ["aws", "gcp", "azure", "http"] }
 
 oxcdf = { git = "https://github.com/robinskil/oxcdf.git", version = "0.4.0", features = ["async", "object-store", "ndarray"] }


### PR DESCRIPTION
### Change

Set `datafusion-spatial` and `datafusion-spatial-kernels` to rev `92245ff` (0.2.0). Version 0.2.0 adds a point in polygon index. The index groups the ring edges by y interval. No Beacon source changes.

### Test

`cargo +1.94 build --locked --workspace` passes.
`cargo +1.94 test --locked --workspace` passes. 2044 pass. 0 fail.

### Benchmark

`within_point`, 50000 rows:

| Case | 0.1.0 | 0.2.0 |
|---|--:|--:|
| `ST_Within` box | 1.11 ms | 1.11 ms |
| `ST_Within` ring256 | 1.65 ms | 1.52 ms |

The bench ring holds 256 vertices. A ring with more vertices shows a larger gain.

Closes #438
