### PR TITLE
fix: stop the admin query editor race, and remove the query timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,25 @@ tag. Releases before 2.0.0 are recorded in the
 
 ### Fixed
 
+- **A long query in the admin UI failed after a minute.** `@beacon/client` put a 60-second deadline
+  on every request, query execution included, and reported the abort as a `TimeoutError`. Analyze
+  was the visible victim: `/api/explain-analyze-query` runs the query to completion before it
+  answers, so a query slower than a minute never returned a plan. A query has no bounded duration,
+  so the query endpoints (`/api/query`, `/api/explain-query`, `/api/explain-analyze-query`) now run
+  without a deadline. Stop the work with the Stop button, which cancels it on the server too. The
+  60-second default still guards the bounded endpoints — metadata, schemas, admin calls — and a new
+  `queryTimeoutMs` client option puts a deadline back on query execution for a caller that wants
+  one.
+- **Run and Analyze fought over the query editor.** The workbench started an action without
+  stopping the one before it, so an Analyze and a Run raced over the same result panel and the
+  server ran the query twice. Whichever finished last won: an Analyze that failed after a Run had
+  already drawn its rows replaced them with its own error, and the panel stayed on that error
+  because only a *new* action clears it. The editor looked stuck. Run, Explain, Analyze and
+  Download now cancel whatever is still running and take the panel for themselves, and a superseded
+  action writes nothing when it ends. Switching tabs cancels the query filling the panel instead of
+  leaving it to land under another tab's SQL. A second Explain or Analyze also clears the old plan,
+  so the panel shows progress rather than the previous answer, and the panel header names the
+  action that is running.
 - **Seven statements lowercased a table name.** Beacon turns identifier normalization off, so the
   catalog holds a table under the exact name the statement writes. `INSERT`, `CREATE TABLE AS
   SELECT`, `ALTER TABLE`, `CREATE INDEX`, `DROP INDEX`, `SHOW INDEXES`, `REFRESH`, the table

--- a/beacon-clients/beacon-ts/src/client.ts
+++ b/beacon-clients/beacon-ts/src/client.ts
@@ -178,7 +178,11 @@ export class BeaconClient {
    */
   queryRaw(query: QueryInput, format?: OutputFormat, signal?: AbortSignal): Promise<Response> {
     const output = format === undefined ? undefined : { format };
-    return this.http.fetchRaw("POST", "/api/query", { json: buildBody(query, output), signal });
+    return this.http.fetchRaw("POST", "/api/query", {
+      json: buildBody(query, output),
+      signal,
+      timeoutMs: this.http.queryTimeoutMs,
+    });
   }
 
   /**
@@ -196,7 +200,11 @@ export class BeaconClient {
 
   /** Returns the planner's explanation of a query without running it. */
   explainQuery<T = unknown>(query: QueryInput, signal?: AbortSignal): Promise<T> {
-    return this.http.fetchJson<T>("POST", "/api/explain-query", { json: buildBody(query), signal });
+    return this.http.fetchJson<T>("POST", "/api/explain-query", {
+      json: buildBody(query),
+      signal,
+      timeoutMs: this.http.queryTimeoutMs,
+    });
   }
 
   /**
@@ -204,11 +212,16 @@ export class BeaconClient {
    * (`EXPLAIN ANALYZE`), as a PostgreSQL-style JSON plan. Unlike `explainQuery`,
    * this executes the query to collect actual row counts and timings. Pass a
    * `signal` to cancel the (potentially long-running) execution.
+   *
+   * The server answers only once the query has run to completion, so this call
+   * takes as long as the query does. It is therefore not subject to the default
+   * request timeout — see {@link ClientOptions.queryTimeoutMs}.
    */
   explainAnalyzeQuery<T = unknown>(query: QueryInput, signal?: AbortSignal): Promise<T> {
     return this.http.fetchJson<T>("POST", "/api/explain-analyze-query", {
       json: buildBody(query),
       signal,
+      timeoutMs: this.http.queryTimeoutMs,
     });
   }
 

--- a/beacon-clients/beacon-ts/src/http.ts
+++ b/beacon-clients/beacon-ts/src/http.ts
@@ -35,8 +35,24 @@ export interface ClientOptions {
    * {@link ADMIN_API_PREFIX} to call the admin-gated alias instead.
    */
   apiPrefix?: string;
-  /** Per-request timeout in milliseconds. Defaults to 60000. Set to 0 to disable. */
+  /**
+   * Per-request timeout in milliseconds for the bounded endpoints — metadata,
+   * schemas, admin calls. Defaults to 60000. Set to 0 to disable.
+   *
+   * Query execution is *not* covered by this: see {@link queryTimeoutMs}.
+   */
   timeoutMs?: number;
+  /**
+   * Timeout in milliseconds for the endpoints that execute a query
+   * (`/api/query`, `/api/explain-query`, `/api/explain-analyze-query`).
+   *
+   * Defaults to 0 — no timeout. A query has no bounded duration: a scan over a
+   * large dataset, or an `EXPLAIN ANALYZE` that runs the query to collect its
+   * metrics, may legitimately take minutes. Cancel one with an `AbortSignal`
+   * instead, which also stops the work on the server. Set a positive value to
+   * impose a deadline.
+   */
+  queryTimeoutMs?: number;
   /** Custom fetch implementation (e.g. for testing or a proxy). */
   fetch?: FetchLike;
   /** Extra headers attached to every request. */
@@ -70,6 +86,8 @@ export class Http {
   readonly baseUrl: string;
   private readonly fetchImpl: FetchLike;
   private readonly timeoutMs: number;
+  /** Timeout applied to the query-execution endpoints (0 = none). */
+  readonly queryTimeoutMs: number;
   private readonly authHeader?: string;
   private readonly extraHeaders: Record<string, string>;
 
@@ -89,6 +107,7 @@ export class Http {
     // invocation" in browsers, where `fetch` must run with `this === window`.
     this.fetchImpl = options.fetch ?? fetchImpl.bind(globalThis);
     this.timeoutMs = options.timeoutMs ?? 60_000;
+    this.queryTimeoutMs = options.queryTimeoutMs ?? 0;
     this.extraHeaders = options.headers ?? {};
     if (options.username != null && options.password != null) {
       this.authHeader = basicAuthHeader(options.username, options.password);

--- a/beacon-clients/beacon-ts/test/http.test.ts
+++ b/beacon-clients/beacon-ts/test/http.test.ts
@@ -21,7 +21,7 @@ const hangingFetch = ((_url: string | URL | Request, init?: RequestInit) =>
 describe("abort classification", () => {
   it("raises TimeoutError when the request times out", async () => {
     const client = new BeaconClient({ url: "http://beacon.test", fetch: hangingFetch, timeoutMs: 10 });
-    await expect(client.query("SELECT 1", { format: "csv" })).rejects.toBeInstanceOf(TimeoutError);
+    await expect(client.tables()).rejects.toBeInstanceOf(TimeoutError);
   });
 
   it("preserves the caller's AbortError on external cancellation (not a TimeoutError)", async () => {
@@ -31,5 +31,37 @@ describe("abort classification", () => {
     ac.abort();
     await expect(promise).rejects.toMatchObject({ name: "AbortError" });
     await expect(promise).rejects.not.toBeInstanceOf(TimeoutError);
+  });
+});
+
+describe("query timeout", () => {
+  /** Resolves once `fn` has settled, or to "pending" if it is still running after `ms`. */
+  const settledWithin = (fn: Promise<unknown>, ms: number) =>
+    Promise.race([
+      fn.then(
+        () => "settled",
+        () => "settled",
+      ),
+      new Promise((resolve) => setTimeout(() => resolve("pending"), ms)),
+    ]);
+
+  it("does not apply the request timeout to query execution", async () => {
+    // A query runs for as long as it runs; only an AbortSignal ends it early.
+    const client = new BeaconClient({ url: "http://beacon.test", fetch: hangingFetch, timeoutMs: 10 });
+    const ac = new AbortController();
+    const promise = client.query("SELECT 1", { format: "csv", signal: ac.signal });
+    expect(await settledWithin(promise, 40)).toBe("pending");
+    ac.abort();
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("applies `queryTimeoutMs` to query execution when one is set", async () => {
+    const client = new BeaconClient({
+      url: "http://beacon.test",
+      fetch: hangingFetch,
+      queryTimeoutMs: 10,
+    });
+    await expect(client.query("SELECT 1", { format: "csv" })).rejects.toBeInstanceOf(TimeoutError);
+    await expect(client.explainAnalyzeQuery("SELECT 1")).rejects.toBeInstanceOf(TimeoutError);
   });
 });

--- a/beacon-clients/beacon-web/src/pages/workbench.tsx
+++ b/beacon-clients/beacon-web/src/pages/workbench.tsx
@@ -84,14 +84,37 @@ const DOWNLOAD_FORMATS: DownloadFormat[] = [
  */
 const PREVIEW_ROW_LIMIT = 500;
 
+/**
+ * What the workbench is doing right now.
+ *
+ * Run, Explain, Analyze and Download all describe the SQL of the active tab and
+ * write into the one panel below it, so the workbench does one at a time: a
+ * second action cancels the first instead of racing it. Two of them in flight
+ * only doubled the work the server did, and whichever finished last took the
+ * panel — an EXPLAIN ANALYZE that failed after a Run had already drawn its rows
+ * replaced them with its own error, and the editor looked stuck.
+ */
+type Action = "run" | "explain" | "analyze" | "download";
+
+/** Tooltip note on the buttons that cancel whatever else is running. */
+const SUPERSEDES_TITLE = "Cancels the query that is still running, if any.";
+
+/** What the results header says while each action is in flight. */
+const BUSY_LABEL: Record<Action, string> = {
+  run: "Running…",
+  explain: "Explaining…",
+  analyze: "Analyzing…",
+  download: "Preparing download…",
+};
+
 export function WorkbenchPage() {
   const beacon = useBeacon();
   const location = useLocation();
   const editorRef = React.useRef<SqlEditorHandle>(null);
-  // Tracks the in-flight streaming query so it can be cancelled by the user.
-  const abortRef = React.useRef<AbortController | null>(null);
-  // Tracks the in-flight EXPLAIN ANALYZE run so it can be cancelled.
-  const analyzeAbortRef = React.useRef<AbortController | null>(null);
+  // The in-flight action, so the user (or the next action) can cancel it. Held
+  // in a ref as well as in `busy` because the async bodies below test ownership
+  // of the panel after every await, and state they closed over is stale by then.
+  const inflight = React.useRef<AbortController | null>(null);
   // Open queries, one per tab, kept in local storage so they survive leaving the
   // page (and the browser).
   const queryTabs = useQueryTabs();
@@ -102,15 +125,43 @@ export function WorkbenchPage() {
     [setTabSql, activeId],
   );
 
-  const [running, setRunning] = React.useState(false);
-  const [explaining, setExplaining] = React.useState(false);
-  const [analyzing, setAnalyzing] = React.useState(false);
-  const [downloading, setDownloading] = React.useState(false);
+  const [busy, setBusy] = React.useState<Action | null>(null);
   const [mode, setMode] = React.useState<ViewMode>("results");
   const [result, setResult] = React.useState<RunResult | null>(null);
   const [plan, setPlan] = React.useState<unknown>(null);
   const [analyzed, setAnalyzed] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+
+  const running = busy === "run";
+  const explaining = busy === "explain";
+  const analyzing = busy === "analyze";
+  const downloading = busy === "download";
+
+  /** Cancels whatever is running and hands the panel to `action`. */
+  const begin = React.useCallback((action: Action) => {
+    inflight.current?.abort();
+    const controller = new AbortController();
+    inflight.current = controller;
+    setBusy(action);
+    setError(null);
+    return controller;
+  }, []);
+
+  /**
+   * Whether `controller`'s action still owns the panel. A superseded action must
+   * write no state at all: its result belongs to SQL the user has moved on from.
+   */
+  const owns = React.useCallback(
+    (controller: AbortController) => inflight.current === controller,
+    [],
+  );
+
+  /** Releases the panel, unless a newer action has already taken it. */
+  const end = React.useCallback((controller: AbortController) => {
+    if (inflight.current !== controller) return;
+    inflight.current = null;
+    setBusy(null);
+  }, []);
 
   // Another page (e.g. Datasets → "Query") can open the editor pre-filled by
   // navigating to `/query` with `{ state: { sql } }`. It lands in a tab of its
@@ -128,8 +179,12 @@ export function WorkbenchPage() {
   const [metricsId, setMetricsId] = React.useState<string | null>(null);
 
   // Results describe the query that produced them, so switching tabs clears the
-  // panel rather than showing one tab's rows under another tab's SQL.
+  // panel — and cancels the work still filling it — rather than showing one
+  // tab's rows under another tab's SQL.
   React.useEffect(() => {
+    inflight.current?.abort();
+    inflight.current = null;
+    setBusy(null);
     setResult(null);
     setPlan(null);
     setError(null);
@@ -138,22 +193,20 @@ export function WorkbenchPage() {
 
   const run = React.useCallback(async () => {
     const text = sql.trim();
-    if (!text || running) return;
-    setRunning(true);
-    setError(null);
+    if (!text) return;
+    const controller = begin("run");
     setMode("results");
     setResult(null);
     const started = performance.now();
     // Stream record batches and render them as they arrive, stopping (and
     // aborting the server query) once the preview limit is reached — or when the
     // user cancels.
-    const controller = new AbortController();
-    abortRef.current = controller;
     try {
       const { queryId, batches } = await beacon.queryBatches(text, controller.signal);
       let view = EMPTY_RESULT;
       let truncated = false;
       for await (const batch of batches) {
+        if (!owns(controller)) return;
         // The batch is kept as Arrow columns; nothing is decoded into JS objects
         // until the grid renders a cell.
         truncated = batch.numRows > PREVIEW_ROW_LIMIT - view.numRows;
@@ -165,6 +218,7 @@ export function WorkbenchPage() {
           break;
         }
       }
+      if (!owns(controller)) return;
       // No batches arrived (DDL/DML or an empty result): surface a zero-row result.
       setResult(
         (prev) =>
@@ -176,6 +230,7 @@ export function WorkbenchPage() {
           },
       );
     } catch (err) {
+      if (!owns(controller)) return;
       if (controller.signal.aborted) {
         // User cancelled mid-stream: keep whatever rows already arrived. (Don't
         // relabel a result that stopped because it hit the preview limit.)
@@ -185,90 +240,80 @@ export function WorkbenchPage() {
         setError(errorMessage(err));
       }
     } finally {
-      if (abortRef.current === controller) abortRef.current = null;
-      setRunning(false);
+      end(controller);
     }
-  }, [beacon, sql, running]);
+  }, [beacon, sql, begin, owns, end]);
 
-  /** Aborts the in-flight query (if any); partial results stay on screen. */
+  /** Aborts the in-flight action (if any); partial results stay on screen. */
   const cancel = React.useCallback(() => {
-    abortRef.current?.abort();
-  }, []);
-
-  /** Aborts the in-flight EXPLAIN ANALYZE run (if any). */
-  const cancelAnalyze = React.useCallback(() => {
-    analyzeAbortRef.current?.abort();
+    inflight.current?.abort();
   }, []);
 
   // Abort any in-flight work if the page unmounts.
-  React.useEffect(
-    () => () => {
-      abortRef.current?.abort();
-      analyzeAbortRef.current?.abort();
-    },
-    [],
-  );
+  React.useEffect(() => () => inflight.current?.abort(), []);
 
-  async function explain() {
-    const text = sql.trim();
-    if (!text || explaining) return;
-    setExplaining(true);
-    setError(null);
-    setMode("explain");
-    setAnalyzed(false);
-    try {
-      setPlan(await beacon.explainQuery(text));
-    } catch (err) {
-      setPlan(null);
-      setError(errorMessage(err));
-    } finally {
-      setExplaining(false);
-    }
-  }
-
-  async function analyze() {
-    const text = sql.trim();
-    if (!text || analyzing) return;
-    setAnalyzing(true);
-    setError(null);
-    setMode("explain");
-    setAnalyzed(true);
-    const controller = new AbortController();
-    analyzeAbortRef.current = controller;
-    try {
-      setPlan(await beacon.explainAnalyzeQuery(text, controller.signal));
-    } catch (err) {
-      setPlan(null);
-      // Swallow user cancellation; only surface real failures.
-      if (!controller.signal.aborted) setError(errorMessage(err));
-    } finally {
-      if (analyzeAbortRef.current === controller) analyzeAbortRef.current = null;
-      setAnalyzing(false);
-    }
-  }
-
-  async function download(format: DownloadFormat["format"], ext: string) {
+  const explain = React.useCallback(async () => {
     const text = sql.trim();
     if (!text) return;
-    setDownloading(true);
-    setError(null);
+    const controller = begin("explain");
+    setMode("explain");
+    setAnalyzed(false);
+    // Drop the previous plan: leaving it up makes a second Explain look like it
+    // did nothing, because the pane shows progress only while it is empty.
+    setPlan(null);
     try {
-      const res = await beacon.queryRaw(text, format);
-      const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `beacon-result.${ext}`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
+      const explained = await beacon.explainQuery(text, controller.signal);
+      if (owns(controller)) setPlan(explained);
     } catch (err) {
-      setError(errorMessage(err));
+      // Swallow cancellation; only surface real failures.
+      if (owns(controller) && !controller.signal.aborted) setError(errorMessage(err));
     } finally {
-      setDownloading(false);
+      end(controller);
     }
-  }
+  }, [beacon, sql, begin, owns, end]);
+
+  const analyze = React.useCallback(async () => {
+    const text = sql.trim();
+    if (!text) return;
+    const controller = begin("analyze");
+    setMode("explain");
+    setAnalyzed(true);
+    setPlan(null);
+    try {
+      const analyzedPlan = await beacon.explainAnalyzeQuery(text, controller.signal);
+      if (owns(controller)) setPlan(analyzedPlan);
+    } catch (err) {
+      if (owns(controller) && !controller.signal.aborted) setError(errorMessage(err));
+    } finally {
+      end(controller);
+    }
+  }, [beacon, sql, begin, owns, end]);
+
+  const download = React.useCallback(
+    async (format: DownloadFormat["format"], ext: string) => {
+      const text = sql.trim();
+      if (!text) return;
+      const controller = begin("download");
+      try {
+        const res = await beacon.queryRaw(text, format, controller.signal);
+        const blob = await res.blob();
+        if (!owns(controller)) return;
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `beacon-result.${ext}`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+      } catch (err) {
+        if (owns(controller) && !controller.signal.aborted) setError(errorMessage(err));
+      } finally {
+        end(controller);
+      }
+    },
+    [beacon, sql, begin, owns, end],
+  );
 
   /** Closing a tab drops its editor model too, undo history and all. */
   const closeWithModel = React.useCallback(
@@ -305,12 +350,19 @@ export function WorkbenchPage() {
               Stop
             </Button>
           ) : (
-            <Button onClick={run} size="sm" className="gap-1.5">
+            <Button onClick={run} size="sm" className="gap-1.5" title={SUPERSEDES_TITLE}>
               <Play className="h-4 w-4" />
               Run
             </Button>
           )}
-          <Button onClick={explain} disabled={explaining} variant="outline" size="sm" className="gap-1.5">
+          <Button
+            onClick={explain}
+            disabled={explaining}
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            title={SUPERSEDES_TITLE}
+          >
             {explaining ? (
               <Loader2 className="h-4 w-4 animate-spin" />
             ) : (
@@ -320,7 +372,7 @@ export function WorkbenchPage() {
           </Button>
           {analyzing ? (
             <Button
-              onClick={cancelAnalyze}
+              onClick={cancel}
               variant="destructive"
               size="sm"
               className="gap-1.5"
@@ -335,7 +387,7 @@ export function WorkbenchPage() {
               variant="outline"
               size="sm"
               className="gap-1.5"
-              title="Run the query and show its plan with execution metrics"
+              title={`Run the query and show its plan with execution metrics. ${SUPERSEDES_TITLE}`}
             >
               <Gauge className="h-4 w-4" />
               Analyze
@@ -391,6 +443,14 @@ export function WorkbenchPage() {
         {/* Results / plan header */}
         <div className="flex items-center gap-3 border-b bg-secondary/40 px-4 py-1.5 text-xs">
           <span className="font-semibold">{mode === "explain" ? "Query plan" : "Results"}</span>
+          {/* One indicator for the one action in flight. It names that action, so
+              a slow query says which of them the server is still working on. */}
+          {busy && (
+            <span className="flex items-center gap-1.5 text-muted-foreground">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              {BUSY_LABEL[busy]}
+            </span>
+          )}
           {mode === "results" && result && (
             <>
               <span className="text-muted-foreground">
@@ -398,7 +458,6 @@ export function WorkbenchPage() {
                 {result.truncated && ` (first ${PREVIEW_ROW_LIMIT} — query stopped)`}
                 {result.cancelled && " (cancelled)"}
               </span>
-              {running && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
               <span className="text-muted-foreground">{result.elapsedMs.toFixed(0)} ms</span>
               {result.queryId && (
                 <button


### PR DESCRIPTION
## Problem

The query editor starts an action without a stop of the previous action. Run and
Analyze race over one result panel. The server runs the query two times. An
Analyze that fails after a Run replaces the rows with its own error. Only a new
action clears an error, so the editor looks stuck.

The SDK sets a 60 second deadline on every request, query execution included.
`/api/explain-analyze-query` answers only after the query ends. A query slower
than a minute always fails with a TimeoutError.

## Fix

- Run, Explain, Analyze and Download stop the action that still runs.
- A superseded action writes no state when it ends.
- A tab change stops the action that fills the panel.
- Explain and Analyze clear the old plan, so the panel shows progress.
- The panel header names the action that runs.
- The three query endpoints run with no deadline. An AbortSignal stops one.
- A new `queryTimeoutMs` option sets a deadline again.
- The 60 second default still guards the metadata endpoints.

## Test

- 41 SDK tests pass, three of them new.
- The SDK query paths run against a live Beacon 2.0.0-rc.4 server.
- `tsc --noEmit` and the production build are clean.
