### PR TITLE
feat: keep the first type of a column that no type holds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,6 +2124,7 @@ dependencies = [
  "beacon-arrow-netcdf",
  "beacon-arrow-zarr",
  "beacon-common",
+ "beacon-datafusion-ext",
  "envconfig",
  "object_store 0.13.2",
  "thiserror 2.0.20",

--- a/beacon-db/beacon-core/src/embedded.rs
+++ b/beacon-db/beacon-core/src/embedded.rs
@@ -35,6 +35,7 @@ use std::sync::Arc;
 use beacon_auth::{AuthIdentity, Credential, ANONYMOUS_USERNAME};
 use beacon_common::FileStatsConfig;
 use beacon_datafusion_ext::listing_factory::DefaultStore;
+use beacon_datafusion_ext::type_widening::TypeConflict;
 use datafusion::scalar::ScalarValue;
 use tokio::runtime::Handle;
 
@@ -233,6 +234,10 @@ pub struct OpenOptions {
     /// The container file is still opened with an exclusive lock, so this is a per-connection
     /// writability guarantee, not (yet) multi-process concurrent access.
     pub read_only: bool,
+    /// What a schema merge does with a column that no type holds, e.g. a number
+    /// in one file and a string in another. Defaults to [`TypeConflict::Fail`],
+    /// which refuses such a collection.
+    pub type_conflict: TypeConflict,
 }
 
 impl OpenOptions {
@@ -279,6 +284,15 @@ impl OpenOptions {
 
     pub fn with_nd_pipeline(mut self, enabled: bool) -> Self {
         self.nd_pipeline = enabled;
+        self
+    }
+
+    /// Set what a schema merge does with a column that no type holds.
+    ///
+    /// [`TypeConflict::KeepFirst`] reads the type of the first file, and null
+    /// for every value that type cannot hold.
+    pub fn with_type_conflict(mut self, on_conflict: TypeConflict) -> Self {
+        self.type_conflict = on_conflict;
         self
     }
 
@@ -378,6 +392,7 @@ impl Database {
         if options.nd_pipeline {
             builder = builder.with_nd_pipeline();
         }
+        builder = builder.with_type_conflict(options.type_conflict);
         if let Some(datasets) = &options.datasets {
             builder = builder.with_default_store(datasets.url.clone(), datasets.root.clone());
         }

--- a/beacon-db/beacon-core/src/runtime_builder.rs
+++ b/beacon-db/beacon-core/src/runtime_builder.rs
@@ -28,7 +28,9 @@ use beacon_datafusion_ext::{
     object_store_registry::LazyObjectStoreRegistry,
     secrets::SecretStore,
     stats_cache::BeaconFileStatisticsCache,
-    type_widening::{ArrowTypeWidening, ArrowTypeWideningStrategy, DefaultArrowTypeWidening},
+    type_widening::{
+        ArrowTypeWidening, ArrowTypeWideningStrategy, DefaultArrowTypeWidening, TypeConflict,
+    },
 };
 use beacon_functions::register_functions;
 use beacon_redb_store::RedbStore;
@@ -255,6 +257,18 @@ impl RuntimeBuilder {
     pub fn with_type_widening(mut self, strategy: Arc<dyn ArrowTypeWideningStrategy>) -> Self {
         self.type_widening = Some(strategy);
         self
+    }
+
+    /// Set what a schema merge does with a column that no type holds.
+    ///
+    /// The default is [`TypeConflict::Fail`], which refuses such a table. Take
+    /// [`TypeConflict::KeepFirst`] to read the type of the first file instead,
+    /// and null for every value that type cannot hold.
+    ///
+    /// This replaces the rule of [`with_type_widening`](Self::with_type_widening),
+    /// so call one or the other.
+    pub fn with_type_conflict(self, on_conflict: TypeConflict) -> Self {
+        self.with_type_widening(Arc::new(DefaultArrowTypeWidening { on_conflict }))
     }
 
     pub fn with_tmp_dir_path(mut self, path: PathBuf) -> Self {
@@ -911,7 +925,7 @@ fn build_session_config(
             builder
                 .type_widening
                 .clone()
-                .unwrap_or_else(|| Arc::new(DefaultArrowTypeWidening)),
+                .unwrap_or_else(|| Arc::new(DefaultArrowTypeWidening::new())),
         )))
         // Resolves user-supplied dataset paths (a `LOCATION`, a `read_*` argument)
         // to object-store URLs and to native reader paths. Configured against the

--- a/beacon-db/beacon-datafusion-ext/src/fast_object/schema.rs
+++ b/beacon-db/beacon-datafusion-ext/src/fast_object/schema.rs
@@ -397,7 +397,7 @@ mod tests {
     /// The tests below compare the merge against this result.
     fn flat_merge(listing: &[LabeledSchema]) -> SchemaRef {
         use crate::type_widening::{ArrowTypeWideningStrategy, DefaultArrowTypeWidening};
-        DefaultArrowTypeWidening.merge_schemas(listing).unwrap()
+        DefaultArrowTypeWidening::new().merge_schemas(listing).unwrap()
     }
 
     /// The merge equals the earlier fold of the format, over the same sequence.

--- a/beacon-db/beacon-datafusion-ext/src/scan_adapt.rs
+++ b/beacon-db/beacon-datafusion-ext/src/scan_adapt.rs
@@ -14,26 +14,60 @@
 //! A scan that skips this step reports a schema it cannot produce. The reader
 //! then fails on the first batch, and `LIMIT 0` still succeeds, because it reads
 //! no batch.
+//!
+//! # A column the merge could not join
+//!
+//! [`TypeConflict::KeepFirst`] lets the merge settle a column that two files
+//! type in two families. The table then reports the type of the first file, and
+//! the merge marks the column with
+//! [`TYPE_CONFLICT_KEY`](crate::type_widening::TYPE_CONFLICT_KEY). The files
+//! disagree on what such a column holds, so its cast may not fail:
+//!
+//! - A value the type cannot hold reads as null. `Utf8` "abc" to `Float64`
+//!   gives null, not an error.
+//! - A type no cast reaches reads as null for the whole file. A list beside a
+//!   number is one such pair.
+//!
+//! Every other cast stays strict, and a value it cannot hold is an error. The
+//! merged schema carries the mark, so no scan reads the setting itself.
+//!
+//! [`TypeConflict::KeepFirst`]: crate::type_widening::TypeConflict::KeepFirst
 
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, RecordBatch, RecordBatchOptions, new_null_array};
-use arrow::compute::{CastOptions, cast_with_options};
+use arrow::compute::{CastOptions, can_cast_types, cast_with_options};
 use arrow::datatypes::{DataType, Schema, SchemaRef};
 use arrow::util::display::FormatOptions;
+use datafusion::common::ScalarValue;
+use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion::datasource::listing::PartitionedFile;
 use datafusion::datasource::physical_plan::{FileOpenFuture, FileOpener};
 use datafusion::error::{DataFusionError, Result};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::{CastColumnExpr, Column, lit};
+use datafusion::physical_expr_adapter::{
+    BatchAdapterFactory, DefaultPhysicalExprAdapterFactory, PhysicalExprAdapter,
+    PhysicalExprAdapterFactory,
+};
 use futures::StreamExt;
+
+use crate::type_widening::is_type_conflict;
 
 /// Where one column of the target schema comes from.
 #[derive(Debug, Clone)]
 enum Source {
     /// The file holds this column, with this type. Take it as it is.
     Column(usize),
-    /// The file holds this column with another type. Cast it.
-    Cast(usize, DataType),
-    /// The file lacks this column. Read nulls of this type.
+    /// The file holds this column with another type. Cast it. `lenient` reads a
+    /// value the type cannot hold as null; see the [module docs](self).
+    Cast {
+        at: usize,
+        data_type: DataType,
+        lenient: bool,
+    },
+    /// The file lacks this column, or no cast reaches its type. Read nulls of
+    /// this type.
     Missing(DataType),
 }
 
@@ -54,6 +88,14 @@ const CAST_OPTIONS: CastOptions<'static> = CastOptions {
     format_options: FormatOptions::new(),
 };
 
+/// The cast for a column the merge could not join, where a null is the answer.
+/// The files state two families, so no value of the other family is a value of
+/// this one. See the [module docs](self).
+const LENIENT_CAST_OPTIONS: CastOptions<'static> = CastOptions {
+    safe: true,
+    format_options: FormatOptions::new(),
+};
+
 impl BatchAdapter {
     /// The map from `source` onto `target`.
     ///
@@ -69,7 +111,28 @@ impl BatchAdapter {
                 Ok(at) if source.field(at).data_type() == field.data_type() => {
                     Ok(Source::Column(at))
                 }
-                Ok(at) => Ok(Source::Cast(at, field.data_type().clone())),
+                // A column the merge could not join reads null where the cast
+                // cannot answer, and null for the whole file where no cast
+                // reaches its type.
+                Ok(at) if is_type_conflict(field) => {
+                    let data_type = field.data_type().clone();
+                    Ok(
+                        if can_cast_types(source.field(at).data_type(), &data_type) {
+                            Source::Cast {
+                                at,
+                                data_type,
+                                lenient: true,
+                            }
+                        } else {
+                            Source::Missing(data_type)
+                        },
+                    )
+                }
+                Ok(at) => Ok(Source::Cast {
+                    at,
+                    data_type: field.data_type().clone(),
+                    lenient: false,
+                }),
                 Err(_) if field.is_nullable() => Ok(Source::Missing(field.data_type().clone())),
                 Err(_) => Err(DataFusionError::Execution(format!(
                     "Non-nullable column '{}' is missing from a file of this collection",
@@ -89,8 +152,17 @@ impl BatchAdapter {
             .map(|source| -> Result<ArrayRef> {
                 Ok(match source {
                     Source::Column(at) => Arc::clone(batch.column(*at)),
-                    Source::Cast(at, data_type) => {
-                        cast_with_options(batch.column(*at), data_type, &CAST_OPTIONS)?
+                    Source::Cast {
+                        at,
+                        data_type,
+                        lenient,
+                    } => {
+                        let options = if *lenient {
+                            &LENIENT_CAST_OPTIONS
+                        } else {
+                            &CAST_OPTIONS
+                        };
+                        cast_with_options(batch.column(*at), data_type, options)?
                     }
                     Source::Missing(data_type) => new_null_array(data_type, rows),
                 })
@@ -160,10 +232,116 @@ impl FileOpener for AdaptingOpener {
     }
 }
 
+/// A [`BatchAdapterFactory`] that reads a column the merge could not join as
+/// null.
+///
+/// Every format that maps its batches with DataFusion's factory builds it here.
+/// The rule reads the mark on the target field, so a schema without a marked
+/// column gets what `BatchAdapterFactory::new` gives: a strict cast, and an
+/// error for a value the type cannot hold. See the [module docs](self).
+pub fn batch_adapter_factory(target: SchemaRef) -> BatchAdapterFactory {
+    BatchAdapterFactory::new(target).with_adapter_factory(Arc::new(LenientCastAdapterFactory))
+}
+
+/// Builds [`LenientCastAdapter`] for one file.
+#[derive(Debug)]
+struct LenientCastAdapterFactory;
+
+impl PhysicalExprAdapterFactory for LenientCastAdapterFactory {
+    fn create(
+        &self,
+        logical_file_schema: SchemaRef,
+        physical_file_schema: SchemaRef,
+    ) -> Result<Arc<dyn PhysicalExprAdapter>> {
+        Ok(Arc::new(LenientCastAdapter {
+            inner: DefaultPhysicalExprAdapterFactory.create(
+                Arc::clone(&logical_file_schema),
+                Arc::clone(&physical_file_schema),
+            )?,
+            logical_file_schema,
+            physical_file_schema,
+        }))
+    }
+}
+
+/// DataFusion's rule, with a null for a column the merge could not join.
+///
+/// Two passes wrap the inner rewrite, because the inner rule refuses a pair no
+/// cast reaches before it builds any cast at all:
+///
+/// 1. Before: a marked column that no cast reaches becomes a null literal. The
+///    inner rule then sees a literal and builds no cast.
+/// 2. After: the cast of a marked column takes [`LENIENT_CAST_OPTIONS`].
+#[derive(Debug)]
+struct LenientCastAdapter {
+    inner: Arc<dyn PhysicalExprAdapter>,
+    /// The schema the table reports, which carries the mark.
+    logical_file_schema: SchemaRef,
+    /// The schema of the file being read.
+    physical_file_schema: SchemaRef,
+}
+
+impl LenientCastAdapter {
+    /// The target field of `column`, when the merge could not join it.
+    fn conflicted(&self, column: &Column) -> Option<&arrow::datatypes::Field> {
+        let at = self.logical_file_schema.index_of(column.name()).ok()?;
+        let field = self.logical_file_schema.field(at);
+        is_type_conflict(field).then_some(field)
+    }
+}
+
+impl PhysicalExprAdapter for LenientCastAdapter {
+    fn rewrite(&self, expr: Arc<dyn PhysicalExpr>) -> Result<Arc<dyn PhysicalExpr>> {
+        let expr = expr
+            .transform_down(|expr| {
+                let Some(column) = expr.as_any().downcast_ref::<Column>() else {
+                    return Ok(Transformed::no(expr));
+                };
+                let Some(field) = self.conflicted(column) else {
+                    return Ok(Transformed::no(expr));
+                };
+                let Ok(at) = self.physical_file_schema.index_of(column.name()) else {
+                    // The file lacks the column. The inner rule fills the null.
+                    return Ok(Transformed::no(expr));
+                };
+                if can_cast_types(
+                    self.physical_file_schema.field(at).data_type(),
+                    field.data_type(),
+                ) {
+                    return Ok(Transformed::no(expr));
+                }
+                // No cast reaches this type. The file reads null for the column.
+                Ok(Transformed::yes(lit(ScalarValue::try_new_null(
+                    field.data_type(),
+                )?)))
+            })
+            .data()?;
+
+        self.inner
+            .rewrite(expr)?
+            .transform_down(|expr| {
+                let Some(cast) = expr.as_any().downcast_ref::<CastColumnExpr>() else {
+                    return Ok(Transformed::no(expr));
+                };
+                if !is_type_conflict(cast.target_field()) {
+                    return Ok(Transformed::no(expr));
+                }
+                Ok(Transformed::yes(Arc::new(CastColumnExpr::new(
+                    Arc::clone(cast.expr()),
+                    Arc::clone(cast.input_field()),
+                    Arc::clone(cast.target_field()),
+                    Some(LENIENT_CAST_OPTIONS),
+                )) as Arc<dyn PhysicalExpr>))
+            })
+            .data()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Float64Array, Int32Array, Int64Array, StringArray};
+    use crate::type_widening::{TYPE_CONFLICT_FIRST_TYPE, TYPE_CONFLICT_KEY};
+    use arrow::array::{Array, Float64Array, Int32Array, Int64Array, StringArray};
     use arrow::datatypes::Field;
 
     fn batch(fields: Vec<Field>, columns: Vec<ArrayRef>) -> RecordBatch {
@@ -279,5 +457,151 @@ mod tests {
 
         let adapter = BatchAdapter::try_new(target, source.schema().as_ref()).expect("map");
         assert!(adapter.adapt(&source).is_err(), "an overflow must be told");
+    }
+
+    // ── a column the merge could not join ──────────────────────────────
+
+    /// `field`, marked as `TypeConflict::KeepFirst` marks it.
+    fn conflicted(name: &str, data_type: DataType) -> Field {
+        Field::new(name, data_type, true).with_metadata(
+            [(
+                TYPE_CONFLICT_KEY.to_string(),
+                TYPE_CONFLICT_FIRST_TYPE.to_string(),
+            )]
+            .into_iter()
+            .collect(),
+        )
+    }
+
+    /// A value the target type cannot hold reads as null, not as an error,
+    /// because the files disagree on what the column holds.
+    #[test]
+    fn a_kept_column_reads_a_value_it_cannot_hold_as_null() {
+        let target = Arc::new(Schema::new(vec![conflicted("v", DataType::Float64)]));
+        let source = batch(
+            vec![Field::new("v", DataType::Utf8, true)],
+            vec![Arc::new(StringArray::from(vec!["1.5", "abc"]))],
+        );
+
+        let adapter = BatchAdapter::try_new(target, source.schema().as_ref()).expect("map");
+        let adapted = adapter.adapt(&source).expect("a marked column may not fail");
+        let values = adapted
+            .column(0)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("Float64");
+        assert_eq!(values.value(0), 1.5, "a value the type holds is read");
+        assert!(values.is_null(1), "a value it cannot hold reads null");
+    }
+
+    /// A type no cast reaches reads null for the whole file, rather than
+    /// failing the scan.
+    #[test]
+    fn a_kept_column_no_cast_reaches_reads_null() {
+        let list = DataType::List(Arc::new(Field::new("item", DataType::Int32, true)));
+        let target = Arc::new(Schema::new(vec![conflicted("v", DataType::Float64)]));
+        let source = batch(
+            vec![Field::new("v", list, true)],
+            vec![Arc::new(
+                arrow::array::ListArray::from_iter_primitive::<arrow::datatypes::Int32Type, _, _>(
+                    vec![Some(vec![Some(1)]), Some(vec![Some(2)])],
+                ),
+            )],
+        );
+
+        let adapter = BatchAdapter::try_new(target, source.schema().as_ref()).expect("map");
+        let adapted = adapter.adapt(&source).expect("no cast reaches this type");
+        assert_eq!(adapted.num_rows(), 2);
+        assert_eq!(adapted.column(0).null_count(), 2);
+    }
+
+    /// The mark reaches only the column that carries it. Every other cast stays
+    /// strict, so an overflow is still an error.
+    #[test]
+    fn the_mark_leaves_every_other_column_strict() {
+        let target = Arc::new(Schema::new(vec![
+            conflicted("kept", DataType::Float64),
+            Field::new("plain", DataType::Int32, true),
+        ]));
+        let source = batch(
+            vec![
+                Field::new("kept", DataType::Utf8, true),
+                Field::new("plain", DataType::Int64, true),
+            ],
+            vec![
+                Arc::new(StringArray::from(vec!["abc"])),
+                Arc::new(Int64Array::from(vec![i64::MAX])),
+            ],
+        );
+
+        let adapter = BatchAdapter::try_new(target, source.schema().as_ref()).expect("map");
+        assert!(
+            adapter.adapt(&source).is_err(),
+            "the unmarked column still reports its overflow"
+        );
+    }
+
+    /// DataFusion's own adapter reads the mark the same way. Every format that
+    /// maps its batches with `batch_adapter_factory` gets this.
+    #[test]
+    fn the_datafusion_adapter_reads_the_mark() {
+        let target = Arc::new(Schema::new(vec![conflicted("v", DataType::Float64)]));
+        let source = batch(
+            vec![Field::new("v", DataType::Utf8, true)],
+            vec![Arc::new(StringArray::from(vec!["1.5", "abc"]))],
+        );
+
+        let adapted = batch_adapter_factory(target)
+            .make_adapter(&source.schema())
+            .expect("map")
+            .adapt_batch(&source)
+            .expect("a marked column may not fail");
+        let values = adapted
+            .column(0)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("Float64");
+        assert_eq!(values.value(0), 1.5);
+        assert!(values.is_null(1), "a value it cannot hold reads null");
+    }
+
+    /// The same, for a type no cast reaches. DataFusion's rule refuses such a
+    /// pair before it builds a cast, so the null comes from the pass above it.
+    #[test]
+    fn the_datafusion_adapter_reads_an_unreachable_type_as_null() {
+        let list = DataType::List(Arc::new(Field::new("item", DataType::Int32, true)));
+        let target = Arc::new(Schema::new(vec![conflicted("v", DataType::Float64)]));
+        let source = batch(
+            vec![Field::new("v", list, true)],
+            vec![Arc::new(
+                arrow::array::ListArray::from_iter_primitive::<arrow::datatypes::Int32Type, _, _>(
+                    vec![Some(vec![Some(1)]), Some(vec![Some(2)])],
+                ),
+            )],
+        );
+
+        let adapted = batch_adapter_factory(target)
+            .make_adapter(&source.schema())
+            .expect("map")
+            .adapt_batch(&source)
+            .expect("no cast reaches this type");
+        assert_eq!(adapted.num_rows(), 2);
+        assert_eq!(adapted.column(0).null_count(), 2);
+    }
+
+    /// An unmarked column keeps DataFusion's strict cast.
+    #[test]
+    fn the_datafusion_adapter_leaves_an_unmarked_column_strict() {
+        let target = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, true)]));
+        let source = batch(
+            vec![Field::new("v", DataType::Int64, true)],
+            vec![Arc::new(Int64Array::from(vec![i64::MAX]))],
+        );
+
+        let adapted = batch_adapter_factory(target)
+            .make_adapter(&source.schema())
+            .expect("map")
+            .adapt_batch(&source);
+        assert!(adapted.is_err(), "an overflow must be told");
     }
 }

--- a/beacon-db/beacon-datafusion-ext/src/type_widening.rs
+++ b/beacon-db/beacon-datafusion-ext/src/type_widening.rs
@@ -16,7 +16,7 @@
 //! | --- | --- |
 //! | the same type | that type |
 //! | two types of one family | the member that holds both, from the tables below |
-//! | two families (a number and a string) | an error that names the column, both types and both files |
+//! | two families (a number and a string) | an error that names the column, both types and both files, or the first type: see the setting below |
 //! | `Null` and any type | that type, because a null column holds no value |
 //! | one nullable field, one not | a nullable field |
 //! | the column in one file only | a nullable field, because the scan fills the other file with nulls |
@@ -79,9 +79,34 @@
 //! The GeoParquet reader states the extension name and drops the system, so the
 //! merge sees two equal fields and joins them.
 //!
+//! # The setting for a column that no type holds
+//!
+//! [`TypeConflict`] settles a column that two sources type in two families. The
+//! default is [`Fail`], which is the error above. A deployment that reads a
+//! collection of many years takes [`KeepFirst`] instead:
+//!
+//! ```text
+//! BEACON_TYPE_WIDENING_ON_CONFLICT=keep_first
+//! ```
+//!
+//! The table then reports the type of the first source, and the scan casts
+//! every other source to it. A value the type cannot hold reads as null, and so
+//! does a column no cast reaches. The merge marks such a column with
+//! [`TYPE_CONFLICT_KEY`], and `scan_adapt` reads that mark. The merged schema
+//! carries the decision, so no scan needs the setting itself.
+//!
+//! Two costs follow. **The merge reads the order**, so it drops no repeat and
+//! starts no thread: a collection of 100000 files takes one fold. **The first
+//! type is the first in listing order**, which is the disk answer order of issue
+//! #377, so a store that lists in two orders reports two types. A column that
+//! widens keeps the rules above either way.
+//!
 //! A deployment replaces the rules through
 //! [`RuntimeBuilder::with_type_widening`]. Every merge in the process takes the
 //! new strategy.
+//!
+//! [`Fail`]: TypeConflict::Fail
+//! [`KeepFirst`]: TypeConflict::KeepFirst
 //!
 //! # The source of a conflict
 //!
@@ -130,7 +155,7 @@ use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::{Arc, LazyLock};
 
-use arrow_schema::{ArrowError, DataType, FieldRef, Schema, SchemaRef, TimeUnit};
+use arrow_schema::{ArrowError, DataType, Field, FieldRef, Schema, SchemaRef, TimeUnit};
 use datafusion::catalog::Session;
 use object_store::ObjectMeta;
 
@@ -209,7 +234,7 @@ impl ArrowTypeWidening {
     /// falls back to this value, so a test or an embedded use gets the same rule
     /// and no error.
     pub fn default_extension() -> Arc<Self> {
-        Arc::new(Self::new(Arc::new(DefaultArrowTypeWidening)))
+        Arc::new(Self::new(Arc::new(DefaultArrowTypeWidening::new())))
     }
 
     /// Merge `schemas` into the schema a query plans against.
@@ -280,9 +305,119 @@ pub trait ArrowTypeWideningStrategy: Send + Sync {
 /// The scan fills a missing column with nulls, and a non-nullable column holds no
 /// nulls. Such a table fails with "Non-nullable column X is missing from the
 /// physical schema".
-pub struct DefaultArrowTypeWidening;
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DefaultArrowTypeWidening {
+    /// What the merge does with a column that two sources type in two families.
+    pub on_conflict: TypeConflict,
+}
+
+impl DefaultArrowTypeWidening {
+    /// The rule that refuses a column two sources type in two families.
+    pub const fn new() -> Self {
+        Self {
+            on_conflict: TypeConflict::Fail,
+        }
+    }
+
+    /// The rule that keeps the first type of such a column.
+    ///
+    /// See [`TypeConflict::KeepFirst`] for what the table then reports and what
+    /// the scan then reads.
+    pub const fn keeping_first_type() -> Self {
+        Self {
+            on_conflict: TypeConflict::KeepFirst,
+        }
+    }
+}
+
+/// What the merge does with a column that no type holds.
+///
+/// A column that two sources type in one family widens either way. This setting
+/// covers the rest: a number beside a string, a list beside a scalar. See the
+/// [module docs](self).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TypeConflict {
+    /// Refuse the merge. The error names the column, both types and both
+    /// sources. The table then answers no query at all.
+    #[default]
+    Fail,
+    /// Keep the type the merge met first, and mark the column with
+    /// [`TYPE_CONFLICT_KEY`].
+    ///
+    /// The table reports that type, and the scan casts every other source to
+    /// it. A value the type cannot hold reads as null, and so does a column no
+    /// cast reaches. The column is nullable for that reason.
+    ///
+    /// **The first type is the first in listing order.** The merge therefore
+    /// reads the order, and [`is_order_independent`] answers `false` for it:
+    /// the merge drops no repeat and starts no thread. A store that lists in
+    /// two orders also reports two types. See the [module docs](self).
+    ///
+    /// [`is_order_independent`]: ArrowTypeWideningStrategy::is_order_independent
+    KeepFirst,
+}
+
+impl TypeConflict {
+    /// The setting one option value names.
+    ///
+    /// `BEACON_TYPE_WIDENING_ON_CONFLICT` holds the value.
+    ///
+    /// # Errors
+    ///
+    /// Returns the offending value when it names no setting.
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "fail" | "error" | "" => Ok(Self::Fail),
+            "keep_first" | "keep-first" | "first" => Ok(Self::KeepFirst),
+            other => Err(other.to_string()),
+        }
+    }
+}
+
+/// The field metadata key that marks a column [`TypeConflict::KeepFirst`]
+/// settled.
+///
+/// The scan reads it. A cast of such a column may not fail, because the sources
+/// disagree on what the column holds. `beacon_datafusion_ext::scan_adapt` casts
+/// it to null instead. The merged schema carries the decision, so no scan needs
+/// the setting itself.
+pub const TYPE_CONFLICT_KEY: &str = "beacon.type_conflict";
+
+/// The value of [`TYPE_CONFLICT_KEY`]. The column holds the type of the first
+/// source, and every other source casts to it.
+pub const TYPE_CONFLICT_FIRST_TYPE: &str = "first_type";
+
+/// Whether [`TypeConflict::KeepFirst`] settled this column.
+///
+/// A cast onto such a column reads a value it cannot hold as null. Every other
+/// cast reports that value as an error.
+pub fn is_type_conflict(field: &Field) -> bool {
+    field
+        .metadata()
+        .get(TYPE_CONFLICT_KEY)
+        .is_some_and(|value| value == TYPE_CONFLICT_FIRST_TYPE)
+}
+
+/// `field`, marked as a column [`TypeConflict::KeepFirst`] settled.
+///
+/// The field turns nullable. The cast of a source the type cannot hold reads
+/// null, and a non-nullable column holds no null.
+fn mark_type_conflict(field: Field) -> Field {
+    let mut metadata = field.metadata().clone();
+    metadata.insert(
+        TYPE_CONFLICT_KEY.to_string(),
+        TYPE_CONFLICT_FIRST_TYPE.to_string(),
+    );
+    field.with_nullable(true).with_metadata(metadata)
+}
 
 impl ArrowTypeWideningStrategy for DefaultArrowTypeWidening {
+    fn is_order_independent(&self) -> bool {
+        // `KeepFirst` reads the order. `Int64` then `Utf8` then `Float64` gives
+        // `Float64`, and the same three in one other grouping give `Int64`.
+        matches!(self.on_conflict, TypeConflict::Fail)
+    }
+
     fn merge_schemas(&self, schemas: &[LabeledSchema]) -> Result<SchemaRef, ArrowError> {
         if schemas.is_empty() {
             return Err(ArrowError::SchemaError(
@@ -305,22 +440,32 @@ impl ArrowTypeWideningStrategy for DefaultArrowTypeWidening {
                     // An `Arc` clone. It ends the borrow of `merged_fields`, so
                     // the write below needs no second lookup.
                     let existing_field = Arc::clone(&merged_fields[at]);
-                    // Two types for one column. A numeric pair widens. Every
-                    // other pair is an error.
+                    // Two types for one column. A numeric pair widens. The
+                    // setting settles every other pair.
+                    let mut conflict = false;
                     let widened = if existing_field.data_type() == field.data_type() {
                         None
                     } else {
                         match super_type(existing_field.data_type(), field.data_type()) {
                             Some(data_type) => Some(data_type),
-                            None => {
-                                return Err(ArrowError::SchemaError(incompatible_types(
-                                    &field_name,
-                                    existing_field.data_type(),
-                                    sources[at].as_deref(),
-                                    field.data_type(),
-                                    labeled.label.as_deref(),
-                                )));
-                            }
+                            None => match self.on_conflict {
+                                TypeConflict::Fail => {
+                                    return Err(ArrowError::SchemaError(incompatible_types(
+                                        &field_name,
+                                        existing_field.data_type(),
+                                        sources[at].as_deref(),
+                                        field.data_type(),
+                                        labeled.label.as_deref(),
+                                    )));
+                                }
+                                // Keep the type the merge met first, and leave
+                                // the source that states it. The mark tells the
+                                // scan to read this source as null.
+                                TypeConflict::KeepFirst => {
+                                    conflict = true;
+                                    None
+                                }
+                            },
                         }
                     };
                     // One file that permits nulls makes the column nullable.
@@ -329,13 +474,16 @@ impl ArrowTypeWideningStrategy for DefaultArrowTypeWidening {
                         sources[at] =
                             source_of(data_type, &existing_field, &sources[at], field, labeled);
                     }
-                    if widened.is_some() || nullable {
+                    if widened.is_some() || nullable || conflict {
                         let mut merged = existing_field.as_ref().clone();
                         if let Some(data_type) = widened {
                             merged = merged.with_data_type(data_type);
                         }
                         if nullable {
                             merged = merged.with_nullable(true);
+                        }
+                        if conflict {
+                            merged = mark_type_conflict(merged);
                         }
                         merged_fields[at] = Arc::new(merged);
                     }
@@ -864,6 +1012,136 @@ mod tests {
                 other => panic!("expected SchemaError, got {other:?}"),
             }
         }
+    }
+
+    // ── the setting for a column that no type holds ────────────────────
+
+    /// The merge rule that keeps the first type of a refused column.
+    fn keeping_first() -> ArrowTypeWidening {
+        ArrowTypeWidening::new(Arc::new(DefaultArrowTypeWidening::keeping_first_type()))
+    }
+
+    /// The column of a merge, by name.
+    fn field_of<'a>(schema: &'a Schema, name: &str) -> &'a FieldRef {
+        schema
+            .fields()
+            .iter()
+            .find(|field| field.name() == name)
+            .unwrap_or_else(|| panic!("the merge holds '{name}'"))
+    }
+
+    /// `KeepFirst` reports the type of the first file instead of an error.
+    #[test]
+    fn the_setting_keeps_the_type_of_the_first_file() {
+        let text = from_file("argo/a.nc", &[("depth", DataType::Utf8)]);
+        let number = from_file("argo/b.nc", &[("depth", DataType::Float64)]);
+
+        let merged = keeping_first()
+            .merge_schemas(&[text, number])
+            .expect("the setting settles the column");
+        assert_eq!(field_of(&merged, "depth").data_type(), &DataType::Utf8);
+    }
+
+    /// The first file is the first in listing order, so the two orders report
+    /// two types. `Fail` refuses both orders alike.
+    #[test]
+    fn the_setting_reads_the_order() {
+        let text = from_file("argo/a.nc", &[("depth", DataType::Utf8)]);
+        let number = from_file("argo/b.nc", &[("depth", DataType::Float64)]);
+
+        let first = keeping_first()
+            .merge_schemas(&[text.clone(), number.clone()])
+            .expect("merge");
+        let second = keeping_first().merge_schemas(&[number, text]).expect("merge");
+        assert_eq!(field_of(&first, "depth").data_type(), &DataType::Utf8);
+        assert_eq!(field_of(&second, "depth").data_type(), &DataType::Float64);
+    }
+
+    /// The merge marks the column, so the scan reads a value the type cannot
+    /// hold as null. The column turns nullable for that reason.
+    #[test]
+    fn a_kept_column_is_marked_and_nullable() {
+        let text = LabeledSchema::unlabeled(Arc::new(Schema::new(vec![Field::new(
+            "depth",
+            DataType::Utf8,
+            false,
+        )])));
+        let number = LabeledSchema::unlabeled(Arc::new(Schema::new(vec![Field::new(
+            "depth",
+            DataType::Float64,
+            false,
+        )])));
+
+        let merged = keeping_first().merge_schemas(&[text, number]).expect("merge");
+        let field = field_of(&merged, "depth");
+        assert!(is_type_conflict(field), "the merge marks the column");
+        assert!(field.is_nullable(), "a null needs a nullable column");
+    }
+
+    /// A column that widens takes the rules of the module either way, and the
+    /// merge leaves it unmarked.
+    #[test]
+    fn the_setting_changes_no_column_that_widens() {
+        let narrow = schema(&[("v", DataType::Int32)]);
+        let wide = schema(&[("v", DataType::Float64)]);
+
+        let merged = keeping_first().merge_schemas(&[narrow, wide]).expect("merge");
+        let field = field_of(&merged, "v");
+        assert_eq!(field.data_type(), &DataType::Float64);
+        assert!(
+            !is_type_conflict(field),
+            "a widened column needs no lenient cast"
+        );
+    }
+
+    /// The mark outlives a later widening. `Utf8` still needs a lenient cast
+    /// after `Int64` and `Float64` join above it.
+    #[test]
+    fn the_mark_survives_a_later_widening() {
+        let schemas = [
+            schema(&[("v", DataType::Int64)]),
+            schema(&[("v", DataType::Utf8)]),
+            schema(&[("v", DataType::Float64)]),
+        ];
+
+        let merged = keeping_first().merge_schemas(&schemas).expect("merge");
+        let field = field_of(&merged, "v");
+        assert_eq!(field.data_type(), &DataType::Float64);
+        assert!(is_type_conflict(field), "the `Utf8` file still casts to null");
+    }
+
+    /// The default refuses the column, as before the setting existed.
+    #[test]
+    fn the_default_still_refuses_a_column_that_no_type_holds() {
+        let widening = ArrowTypeWidening::default_extension();
+        let text = from_file("argo/a.nc", &[("depth", DataType::Utf8)]);
+        let number = from_file("argo/b.nc", &[("depth", DataType::Float64)]);
+
+        assert!(widening.merge_schemas(&[text, number]).is_err());
+    }
+
+    /// `KeepFirst` reads the order, so it gets one fold over every schema.
+    /// `Fail` is a semilattice join and keeps the threads.
+    #[test]
+    fn only_the_default_is_order_independent() {
+        assert!(DefaultArrowTypeWidening::new().is_order_independent());
+        assert!(!DefaultArrowTypeWidening::keeping_first_type().is_order_independent());
+    }
+
+    /// The names `BEACON_TYPE_WIDENING_ON_CONFLICT` takes.
+    #[test]
+    fn the_setting_parses_its_option_names() {
+        for name in ["fail", "FAIL", " error ", ""] {
+            assert_eq!(TypeConflict::parse(name), Ok(TypeConflict::Fail), "{name}");
+        }
+        for name in ["keep_first", "keep-first", "First"] {
+            assert_eq!(
+                TypeConflict::parse(name),
+                Ok(TypeConflict::KeepFirst),
+                "{name}"
+            );
+        }
+        assert_eq!(TypeConflict::parse("widen"), Err("widen".to_string()));
     }
 
     // ── naming the source of a conflict ────────────────────────────────
@@ -1491,7 +1769,7 @@ mod tests {
         let merged = ArrowTypeWidening::default_extension()
             .merge_schemas(&schemas)
             .unwrap();
-        let folded = DefaultArrowTypeWidening.merge_schemas(&schemas).unwrap();
+        let folded = DefaultArrowTypeWidening::new().merge_schemas(&schemas).unwrap();
         assert_eq!(merged, folded, "the split changed the answer");
 
         // Int32 v Float32 needs a Float64, and it reaches every chunk.
@@ -1552,7 +1830,7 @@ mod tests {
             fn merge_schemas(&self, schemas: &[LabeledSchema]) -> Result<SchemaRef, ArrowError> {
                 self.calls.fetch_add(1, Ordering::SeqCst);
                 self.seen.fetch_add(schemas.len(), Ordering::SeqCst);
-                DefaultArrowTypeWidening.merge_schemas(schemas)
+                DefaultArrowTypeWidening::new().merge_schemas(schemas)
             }
 
             fn is_order_independent(&self) -> bool {

--- a/beacon-db/beacon-datafusion-ext/tests/fast_object_table.rs
+++ b/beacon-db/beacon-datafusion-ext/tests/fast_object_table.rs
@@ -677,7 +677,7 @@ async fn the_caller_can_name_the_merge_rule() {
             &state,
             Arc::new(ParquetFormat::default()),
             urls.clone(),
-            &DefaultArrowTypeWidening,
+            &DefaultArrowTypeWidening::new(),
         )
         .await
         .unwrap(),

--- a/beacon-db/beacon-file-formats/beacon-arrow-atlas/src/datafusion/source.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-atlas/src/datafusion/source.rs
@@ -23,7 +23,7 @@ use beacon_nd_array::{
     dataset::resolve_read_dimensions,
     projection::DatasetProjection,
 };
-use datafusion::physical_expr_adapter::BatchAdapterFactory;
+use beacon_datafusion_ext::scan_adapt::batch_adapter_factory;
 use datafusion::{
     config::ConfigOptions,
     datasource::{
@@ -454,7 +454,7 @@ fn stream_adapted(
             "Failed to derive Arrow schema for atlas dataset: {e}"
         ))
     })?);
-    let adapter = BatchAdapterFactory::new(projected_schema).make_adapter(&source_schema)?;
+    let adapter = batch_adapter_factory(projected_schema).make_adapter(&source_schema)?;
 
     let pushdown_filter: Option<PushdownFilter> = predicate.map(PushdownFilter::new);
     let stream = any_dataset_as_record_batch_stream(dataset, batch_size, pushdown_filter, metrics)
@@ -599,7 +599,7 @@ mod repartition_tests {
 mod adapter_tests {
     //! The per-dataset schema adaptation contract, exercised directly.
     //!
-    //! [`stream_adapted`] leans entirely on `BatchAdapterFactory`: a dataset is
+    //! [`stream_adapted`] leans entirely on `batch_adapter_factory`: a dataset is
     //! read at its own native dtypes and every batch is mapped onto the merged
     //! table schema. These pin that mapping — cast up, null-fill by name — without
     //! building an atlas store or a DataFusion session, so a behaviour change in
@@ -610,7 +610,7 @@ mod adapter_tests {
     use arrow::array::{Array, Int16Array, Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
-    use datafusion::physical_expr_adapter::BatchAdapterFactory;
+    use beacon_datafusion_ext::scan_adapt::batch_adapter_factory;
 
     /// Map `batch` (in `source`) onto `target`, exactly as `stream_adapted` does.
     fn adapt(
@@ -618,7 +618,7 @@ mod adapter_tests {
         target: Arc<Schema>,
         batch: RecordBatch,
     ) -> datafusion::error::Result<RecordBatch> {
-        BatchAdapterFactory::new(target)
+        batch_adapter_factory(target)
             .make_adapter(&source)?
             .adapt_batch(&batch)
     }

--- a/beacon-db/beacon-file-formats/beacon-arrow-bbf/src/datafusion/opener.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-bbf/src/datafusion/opener.rs
@@ -14,7 +14,7 @@ use beacon_binary_format::{
     object_store::ArrowBBFObjectReader,
     reader::async_reader::{AsyncBBFReader, AsyncPruningIndexReader},
 };
-use datafusion::physical_expr_adapter::BatchAdapterFactory;
+use beacon_datafusion_ext::scan_adapt::batch_adapter_factory;
 use datafusion::{
     common::pruning::PruningStatistics,
     datasource::{
@@ -91,7 +91,7 @@ impl FileOpener for BBFOpener {
                         .collect();
                     let source_schema: SchemaRef = Arc::new(file_schema.project(&projection)?);
                     let schema_mapper = Arc::new(
-                        BatchAdapterFactory::new(fut_projected_schema.clone())
+                        batch_adapter_factory(fut_projected_schema.clone())
                             .make_adapter(&source_schema)?,
                     );
                     let mut selection: Option<BooleanArray> = None;
@@ -150,7 +150,7 @@ impl FileOpener for BBFOpener {
                         });
                         let batch_schema = arrow_batch.schema();
                         // Map the batch schema to the table schema.
-                        let schema_mapper = BatchAdapterFactory::new(projected_schema.clone())
+                        let schema_mapper = batch_adapter_factory(projected_schema.clone())
                             .make_adapter(&batch_schema)?;
                         let mapped_batch = schema_mapper
                             .adapt_batch(&arrow_batch)

--- a/beacon-db/beacon-file-formats/beacon-arrow-csv/src/datafusion/source.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-csv/src/datafusion/source.rs
@@ -15,6 +15,16 @@
 //! Such a file keeps the positional reading, and so does a file whose header
 //! shares no name with the table. The second case is a table whose schema
 //! renames the columns of its files, which only a positional reading serves.
+//!
+//! # A column the merge could not join
+//!
+//! The parser reads each column straight into the type the table reports, so a
+//! type the value does not hold fails the parse itself. A column that
+//! `TypeConflict::KeepFirst` settled holds one family in one file and another
+//! family in the next, so no such type exists. This source reads that column as
+//! text and leaves the type to `AdaptingOpener`, which reads a value the type
+//! cannot hold as null. See
+//! [`scan_adapt`](beacon_datafusion_ext::scan_adapt).
 
 use std::any::Any;
 use std::io::{Cursor, Read};
@@ -22,6 +32,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use beacon_datafusion_ext::scan_adapt::AdaptingOpener;
+use beacon_datafusion_ext::type_widening::is_type_conflict;
 use datafusion::common::config::CsvOptions;
 use datafusion::datasource::file_format::file_compression_type::FileCompressionType;
 use datafusion::datasource::listing::PartitionedFile;
@@ -254,22 +265,25 @@ async fn file_read_schema(
     file_schema: &SchemaRef,
 ) -> Result<SchemaRef> {
     if !options.has_header.unwrap_or(true) {
-        return Ok(Arc::clone(file_schema));
+        return Ok(positional_schema(file_schema));
     }
 
     let Some(names) = header_names(store, file, options, compression).await? else {
-        return Ok(Arc::clone(file_schema));
+        return Ok(positional_schema(file_schema));
     };
     if !names
         .iter()
         .any(|name| file_schema.field_with_name(name).is_ok())
     {
-        return Ok(Arc::clone(file_schema));
+        return Ok(positional_schema(file_schema));
     }
 
     let fields: Vec<Field> = names
         .iter()
         .map(|name| match file_schema.field_with_name(name) {
+            // A column the merge could not join reads as text. No type parses
+            // every file of it, and the adapter above casts the text.
+            Ok(field) if is_type_conflict(field) => Field::new(name, DataType::Utf8, true),
             // Every column is read as nullable. A file states no null count
             // before it is read, and the merge already widened the type.
             Ok(field) => Field::new(name, field.data_type().clone(), true),
@@ -277,6 +291,29 @@ async fn file_read_schema(
         })
         .collect();
     Ok(Arc::new(Schema::new(fields)))
+}
+
+/// The merged schema, with text for every column the merge could not join.
+///
+/// The positional reading takes this where no header can be matched. The parser
+/// would otherwise read a column into a type that no file of it holds. See the
+/// [module docs](self).
+fn positional_schema(file_schema: &SchemaRef) -> SchemaRef {
+    if !file_schema.fields().iter().any(|f| is_type_conflict(f)) {
+        return Arc::clone(file_schema);
+    }
+    let fields: Vec<Field> = file_schema
+        .fields()
+        .iter()
+        .map(|field| {
+            if is_type_conflict(field) {
+                Field::new(field.name(), DataType::Utf8, true)
+            } else {
+                field.as_ref().clone()
+            }
+        })
+        .collect();
+    Arc::new(Schema::new(fields))
 }
 
 /// The column names the first record of `file` holds, or `None` when it names

--- a/beacon-db/beacon-file-formats/beacon-arrow-csv/tests/merged_schema_scan.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-csv/tests/merged_schema_scan.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::DataType;
 use beacon_arrow_csv::datafusion::CsvFormat;
+use beacon_datafusion_ext::type_widening::{ArrowTypeWidening, DefaultArrowTypeWidening};
 use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
 };
@@ -270,4 +271,69 @@ async fn a_split_file_reads_its_header_for_every_part() {
         .downcast_ref::<arrow::array::Int64Array>()
         .expect("sum");
     assert_eq!(total.value(0), (0..4000i64).sum::<i64>() + 7);
+}
+
+/// The default merge refuses a column that one file types as a number and
+/// another as a string. The table then answers no query at all.
+#[tokio::test]
+async fn a_column_of_two_families_is_refused_by_default() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("a.csv"), "v\n1.5\n2.5\n").expect("write a");
+    std::fs::write(dir.path().join("b.csv"), "v\nabc\ndef\n").expect("write b");
+
+    let ctx = SessionContext::new();
+    let url = ListingTableUrl::parse(format!("file://{}/", dir.path().display())).expect("url");
+    let format = Arc::new(CsvFormat::new(b',', 1000));
+    let options = ListingOptions::new(format).with_file_extension(".csv");
+    let error = options
+        .infer_schema(&ctx.state(), &url)
+        .await
+        .expect_err("a number and a string share no type")
+        .to_string();
+    assert!(error.contains("Incompatible types for field 'v'"), "{error}");
+}
+
+/// `TypeConflict::KeepFirst` reports the type of the first file instead, and a
+/// value that type cannot hold reads as null.
+#[tokio::test]
+async fn a_column_of_two_families_reads_null_under_the_setting() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // `a.csv` is listed first, so the column reads as `Float64`.
+    std::fs::write(dir.path().join("a.csv"), "v\n1.5\n2.5\n").expect("write a");
+    std::fs::write(dir.path().join("b.csv"), "v\nabc\ndef\n").expect("write b");
+
+    let config = datafusion::prelude::SessionConfig::new().with_extension(Arc::new(
+        ArrowTypeWidening::new(Arc::new(DefaultArrowTypeWidening::keeping_first_type())),
+    ));
+    let ctx = SessionContext::new_with_config(config);
+    let url = ListingTableUrl::parse(format!("file://{}/", dir.path().display())).expect("url");
+    let format = Arc::new(CsvFormat::new(b',', 1000));
+    let options = ListingOptions::new(format).with_file_extension(".csv");
+    let schema = options
+        .infer_schema(&ctx.state(), &url)
+        .await
+        .expect("the setting settles the column");
+    assert_eq!(
+        schema.field_with_name("v").unwrap().data_type(),
+        &DataType::Float64,
+        "the first file states the type"
+    );
+
+    let config = ListingTableConfig::new(url)
+        .with_listing_options(options)
+        .with_schema(schema);
+    ctx.register_table("t", Arc::new(ListingTable::try_new(config).expect("table")))
+        .expect("register");
+
+    let batches = ctx
+        .sql("SELECT v FROM t")
+        .await
+        .expect("plan")
+        .collect()
+        .await
+        .expect("a value the type cannot hold may not fail the scan");
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 4, "both files contribute their rows");
+    let nulls: usize = batches.iter().map(|b| b.column(0).null_count()).sum();
+    assert_eq!(nulls, 2, "the two strings read as null");
 }

--- a/beacon-db/beacon-file-formats/beacon-arrow-geoparquet/src/datafusion/opener.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-geoparquet/src/datafusion/opener.rs
@@ -5,13 +5,13 @@ use std::sync::Arc;
 
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
+use beacon_datafusion_ext::scan_adapt::batch_adapter_factory;
 use datafusion::{
     datasource::{
         listing::{FileRange, PartitionedFile},
         physical_plan::{FileOpenFuture, FileOpener},
     },
     error::{DataFusionError, Result},
-    physical_expr_adapter::BatchAdapterFactory,
     physical_plan::metrics::{Count, ExecutionPlanMetricsSet, MetricBuilder},
 };
 use futures::{FutureExt, StreamExt, TryStreamExt, stream::BoxStream};
@@ -177,7 +177,7 @@ impl GeoParquetOpener {
         // Adapt the file's own fields onto the table's: cast a column whose type
         // this file states differently, and null-fill one it does not hold. The
         // column *selection* is already done, above and in the reader.
-        let adapter = BatchAdapterFactory::new(read_schema).make_adapter(&read_file_schema)?;
+        let adapter = batch_adapter_factory(read_schema).make_adapter(&read_file_schema)?;
 
         let stream = batches
             .map(move |batch| {

--- a/beacon-db/beacon-file-formats/beacon-arrow-odv/src/datafusion/source.rs
+++ b/beacon-db/beacon-file-formats/beacon-arrow-odv/src/datafusion/source.rs
@@ -5,6 +5,7 @@
 
 use std::{any::Any, sync::Arc};
 
+use beacon_datafusion_ext::scan_adapt::batch_adapter_factory;
 use datafusion::{
     common::exec_datafusion_err,
     datasource::{
@@ -14,7 +15,6 @@ use datafusion::{
         table_schema::TableSchema,
     },
     physical_expr::{LexOrdering, projection::ProjectionExprs},
-    physical_expr_adapter::BatchAdapterFactory,
     physical_plan::metrics::ExecutionPlanMetricsSet,
 };
 use futures::{StreamExt, TryFutureExt, TryStreamExt};
@@ -196,7 +196,7 @@ impl FileOpener for OdvOpener {
             // cast, and null-fill columns the file lacks.
             let source_schema: SchemaRef = Arc::new(file_schema.project(&projection)?);
             let adapter =
-                BatchAdapterFactory::new(projected_schema).make_adapter(&source_schema)?;
+                batch_adapter_factory(projected_schema).make_adapter(&source_schema)?;
 
             // Open and decode the file body
             let body_stream = object_store

--- a/beacon-db/beacon-file-formats/beacon-nd-array/src/arrow/file_read.rs
+++ b/beacon-db/beacon-file-formats/beacon-nd-array/src/arrow/file_read.rs
@@ -6,7 +6,8 @@ use arrow::record_batch::RecordBatch;
 use crossbeam::queue::ArrayQueue;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::physical_expr::PhysicalExpr;
-use datafusion::physical_expr_adapter::{BatchAdapter, BatchAdapterFactory};
+use beacon_datafusion_ext::scan_adapt::batch_adapter_factory;
+use datafusion::physical_expr_adapter::BatchAdapter;
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use indexmap::IndexMap;
@@ -461,7 +462,7 @@ impl FileRead {
 
             let partition_columns = partitions.scalar_columns(&projected_schema)?;
             let adapter =
-                BatchAdapterFactory::new(projected_schema).make_adapter(&source_schema)?;
+                batch_adapter_factory(projected_schema).make_adapter(&source_schema)?;
             (
                 Output::Columns {
                     adapter: Arc::new(adapter),

--- a/beacon-server/beacon-server-config/Cargo.toml
+++ b/beacon-server/beacon-server-config/Cargo.toml
@@ -17,6 +17,7 @@ base64 = { workspace = true }
 # Per-format and storage config types are owned by their crates; beacon-config
 # composes them and fills them from the environment.
 beacon-common = { path = "../../beacon-db/beacon-common" }
+beacon-datafusion-ext = { path = "../../beacon-db/beacon-datafusion-ext" }
 beacon-arrow-netcdf = { path = "../../beacon-db/beacon-file-formats/beacon-arrow-netcdf" }
 beacon-arrow-hdf5 = { path = "../../beacon-db/beacon-file-formats/beacon-arrow-hdf5" }
 beacon-arrow-zarr = { path = "../../beacon-db/beacon-file-formats/beacon-arrow-zarr" }

--- a/beacon-server/beacon-server-config/src/lib.rs
+++ b/beacon-server/beacon-server-config/src/lib.rs
@@ -15,6 +15,7 @@ pub use beacon_arrow_hdf5::{Hdf5Config, Hdf5Convention};
 pub use beacon_arrow_netcdf::datafusion::NetcdfConfig;
 pub use beacon_arrow_zarr::ZarrConfig;
 pub use beacon_common::CrawlerConfig;
+pub use beacon_datafusion_ext::type_widening::TypeConflict;
 pub use beacon_common::FileStatsConfig;
 
 #[derive(Debug, Clone)]
@@ -100,6 +101,11 @@ pub struct RuntimeConfig {
     pub vm_memory_size: usize,
     pub enable_sys_info: bool,
     pub batch_size: usize,
+    /// What a schema merge does with a column that no type holds, e.g. a number
+    /// in one file and a string in another. From
+    /// `BEACON_TYPE_WIDENING_ON_CONFLICT`. Defaults to [`TypeConflict::Fail`],
+    /// which refuses such a collection and names both files.
+    pub type_conflict: TypeConflict,
 }
 
 #[derive(Debug, Clone)]
@@ -404,6 +410,18 @@ struct RawConfig {
     #[envconfig(from = "BEACON_ENABLE_ND_PIPELINE", default = "true")]
     enable_nd_pipeline: bool,
 
+    /// What a schema merge does with a column that two files type in two
+    /// families, e.g. a number and a string.
+    ///
+    /// `fail`, the default, refuses the collection and names the column, both
+    /// types and both files.
+    ///
+    /// `keep_first` reads the type of the first file. Every other file casts to
+    /// it, and a value that type cannot hold reads as null. The merge then
+    /// reads the listing order, so it drops no repeat and starts no thread.
+    #[envconfig(from = "BEACON_TYPE_WIDENING_ON_CONFLICT", default = "fail")]
+    type_widening_on_conflict: String,
+
     /// Root directory for Beacon's local data (datasets, tables, tmp, etc.).
     #[envconfig(from = "BEACON_DATA_DIR", default = "./data")]
     data_dir: String,
@@ -605,6 +623,17 @@ impl From<RawConfig> for Config {
                 vm_memory_size: raw.vm_memory_size,
                 enable_sys_info: raw.enable_sys_info,
                 batch_size: raw.beacon_batch_size,
+                // An unknown name reads as `fail`, which is the rule a server
+                // ran before this setting existed. A server that cannot start
+                // over a typo is worse than one that names the column.
+                type_conflict: TypeConflict::parse(&raw.type_widening_on_conflict).unwrap_or_else(
+                    |value| {
+                        tracing::warn!(
+                            "BEACON_TYPE_WIDENING_ON_CONFLICT names no setting: '{value}'.                              The settings are 'fail' and 'keep_first'. Refusing a conflict."
+                        );
+                        TypeConflict::Fail
+                    },
+                ),
             },
             sql: SqlConfig {
                 enable: raw.enable_sql,

--- a/beacon-server/beacon-server/src/server/mod.rs
+++ b/beacon-server/beacon-server/src/server/mod.rs
@@ -295,6 +295,8 @@ async fn build_runtime(
     if config.sql.enable_nd_pipeline {
         builder = builder.with_nd_pipeline();
     }
+    // The rule for a column that no type holds. Every schema merge takes it.
+    builder = builder.with_type_conflict(config.runtime.type_conflict);
     if config.auth.anonymous_enabled {
         builder = builder.with_anonymous_user(ANONYMOUS_USERNAME);
     }


### PR DESCRIPTION
## Problem

A schema merge refuses a column that two files type in two families. A number in one file and a string in the next give an error. The table then answers no query.

## Change

`TypeConflict::KeepFirst` keeps the type of the first file. Set it two ways:

- `BEACON_TYPE_WIDENING_ON_CONFLICT=keep_first`
- `RuntimeBuilder::with_type_conflict`, or `OpenOptions::with_type_conflict`

The default stays `Fail`. An unknown name reads as `fail` and logs a warning.

## How a scan reads such a column

The merge marks the column with `beacon.type_conflict`. Each scan reads that mark:

- A value the type cannot hold reads as null.
- A type no cast reaches reads as null for the whole file.
- The column turns nullable.
- Every other cast stays strict.

`scan_adapt::BatchAdapter` applies this. `batch_adapter_factory` applies it for the formats that map with DataFusion's adapter. CSV reads a marked column as text, because its parser reads straight into the type the table reports.

The merged schema carries the mark, so no scan reads the setting.