### PR TITLE
feat: serve a home page at the server root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ tag. Releases before 2.0.0 are recorded in the
   running version. The documentation link is pinned to that version, so a server two releases old
   no longer sends its operator to the newest manual. The admin card appears only when the admin UI
   is mounted, and the MCP address only when MCP is enabled. Every link carries the configured
-  `BEACON_BASE_PATH`. The page carries the colors, the type and the card layout of the
+  `BEACON_BASE_PATH`, and that root now answers in both forms: `/prefix/` redirects to `/prefix`,
+  where it used to be a `404`. The page carries the colors, the type and the card layout of the
   documentation site, and it loads nothing from the network, so it also renders on a server with
   no route out. Swagger keeps its own path, so a bookmark to `/swagger` is unaffected.
 - **`BEACON_TYPE_WIDENING_ON_CONFLICT` settles a column that no type holds.** A collection can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ tag. Releases before 2.0.0 are recorded in the
 
 ### Added
 
+- **The server root is a home page instead of a jump to Swagger.** `http://localhost:5001/` sent
+  every visitor straight to the Swagger UI, which hid the admin panel, the API reference and the
+  documentation from anyone who did not know their paths. The root now answers with a small page
+  that links to all of them, plus the OpenAPI document and the health endpoint, and names the
+  running version. The documentation link is pinned to that version, so a server two releases old
+  no longer sends its operator to the newest manual. The admin card appears only when the admin UI
+  is mounted, and the MCP address only when MCP is enabled. Every link carries the configured
+  `BEACON_BASE_PATH`. The page carries the colors, the type and the card layout of the
+  documentation site, and it loads nothing from the network, so it also renders on a server with
+  no route out. Swagger keeps its own path, so a bookmark to `/swagger` is unaffected.
 - **`BEACON_TYPE_WIDENING_ON_CONFLICT` settles a column that no type holds.** A collection can
   type one column as a number in one file and as a string in another. No type holds both, so the
   schema merge refused the whole table and the table answered no query: `Incompatible types for

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -20,7 +20,8 @@ docker run -d \
   ghcr.io/maris-development/beacon:latest
 ```
 
-That's it — Beacon is now serving on <http://localhost:5001>.
+That's it — Beacon is now serving on <http://localhost:5001>. That page links to the
+admin UI, the API docs and this documentation.
 
 ## 2. Add data
 

--- a/beacon-server/beacon-server/assets/home.html
+++ b/beacon-server/beacon-server/assets/home.html
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{title}}</title>
+<style>
+/* Colors, type and card idiom follow the documentation site (VitePress default
+   theme, indigo brand). The tokens below are that theme's values, copied because
+   this page ships inside the server and loads nothing from the network. */
+:root {
+  --bg: #ffffff;
+  --bg-soft: #f6f6f7;
+  --bg-elv: #ffffff;
+  --divider: #e2e2e3;
+  --text-1: #3c3c43;
+  --text-2: #67676c;
+  --brand-1: #3451b2;
+  --brand-2: #3a5ccc;
+  --shadow: rgba(0, 0, 0, 0.1);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1b1b1f;
+    --bg-soft: #202127;
+    --bg-elv: #252529;
+    --divider: #2e2e32;
+    --text-1: #dfdfd6;
+    --text-2: #98989f;
+    --brand-1: #a8b1ff;
+    --brand-2: #5c73e7;
+    --shadow: rgba(0, 0, 0, 0.36);
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  padding: 64px 32px 80px;
+  background: var(--bg);
+  color: var(--text-1);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+main { max-width: 1152px; margin: 0 auto; }
+
+/* The documentation home page header: an accent rule, no band. */
+.dhead {
+  margin: 0 0 3.25rem;
+  padding: 0.3rem 0 0.3rem 1.35rem;
+  border-left: 3px solid var(--brand-1);
+}
+.dhead h1 {
+  margin: 0;
+  font-size: 2.6rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+}
+.dhead p {
+  margin: 0.8rem 0 0;
+  max-width: 44rem;
+  color: var(--text-2);
+  font-size: 1.12rem;
+  line-height: 1.6;
+}
+
+.dgrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.dcard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  height: 100%;
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  padding: 1rem 1.1rem;
+  background: var(--bg-soft);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.25s ease, background-color 0.25s ease,
+              transform 0.25s ease, box-shadow 0.25s ease;
+}
+.dcard:hover, .dcard:focus-visible {
+  border-color: var(--brand-1);
+  background: var(--bg-elv);
+  transform: translateY(-3px);
+  box-shadow: 0 10px 24px var(--shadow);
+}
+.dcard-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  margin-bottom: 0.15rem;
+  background: var(--bg);
+  color: var(--brand-1);
+  transition: border-color 0.25s ease;
+}
+.dcard-icon svg { width: 17px; height: 17px; }
+.dcard:hover .dcard-icon { border-color: var(--brand-1); }
+.dcard-title {
+  color: var(--text-1);
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+.dcard-body {
+  flex: 1 1 auto;
+  color: var(--text-2);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.note {
+  margin: 2.5rem 0 0;
+  color: var(--text-2);
+  font-size: 0.9rem;
+}
+code {
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  padding: 0.15rem 0.4rem;
+  background: var(--bg-soft);
+  color: var(--text-1);
+  font-family: ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.85em;
+}
+
+.foot {
+  max-width: 1152px;
+  margin: 4rem auto 0;
+  border-top: 1px solid var(--divider);
+  padding-top: 2rem;
+  color: var(--text-2);
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.7;
+  text-align: center;
+}
+.foot p { margin: 0; }
+
+@media (max-width: 860px) {
+  .dgrid { grid-template-columns: 1fr; }
+  body { padding: 40px 20px 56px; }
+  .dhead { margin-bottom: 2.5rem; padding-left: 1rem; }
+  .dhead h1 { font-size: 1.95rem; }
+  .dhead p { font-size: 1rem; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dcard, .dcard-icon { transition: none; }
+  .dcard:hover, .dcard:focus-visible { transform: none; box-shadow: none; }
+}
+</style>
+</head>
+<body>
+<main>
+<div class="dhead">
+<h1>{{title}}</h1>
+<p>Beacon {{version}}. Query the data. Read the API. Manage the server.</p>
+</div>
+<ul class="dgrid">
+<!--[admin]-->
+<li><a class="dcard" href="{{base}}/admin/">
+<span class="dcard-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/></svg></span>
+<span class="dcard-title">Admin panel</span>
+<span class="dcard-body">Write queries. Manage tables, datasets and access.</span>
+</a></li>
+<!--[/admin]-->
+<li><a class="dcard" href="{{base}}/swagger">
+<span class="dcard-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m10 8 6 4-6 4z"/></svg></span>
+<span class="dcard-title">Swagger UI</span>
+<span class="dcard-body">Send a request to any endpoint from the browser.</span>
+</a></li>
+<li><a class="dcard" href="{{base}}/scalar/">
+<span class="dcard-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg></span>
+<span class="dcard-title">API reference</span>
+<span class="dcard-body">Read every endpoint, parameter and response.</span>
+</a></li>
+<li><a class="dcard" href="{{base}}/openapi.json">
+<span class="dcard-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 21H6a2 2 0 0 1-2-2v-5a2 2 0 0 0-2-2 2 2 0 0 0 2-2V5a2 2 0 0 1 2-2h1"/><path d="M17 3h1a2 2 0 0 1 2 2v5a2 2 0 0 0 2 2 2 2 0 0 0-2 2v5a2 2 0 0 1-2 2h-1"/></svg></span>
+<span class="dcard-title">OpenAPI document</span>
+<span class="dcard-body">Generate a client from the machine-readable schema.</span>
+</a></li>
+<li><a class="dcard" href="{{docs}}" target="_blank" rel="noopener">
+<span class="dcard-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></svg></span>
+<span class="dcard-title">Documentation</span>
+<span class="dcard-body">Read the guides, the SQL reference and every setting.</span>
+</a></li>
+<li><a class="dcard" href="{{base}}/api/health">
+<span class="dcard-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/></svg></span>
+<span class="dcard-title">Health</span>
+<span class="dcard-body">Check that the server answers.</span>
+</a></li>
+</ul>
+<!--[mcp]-->
+<p class="note">MCP endpoint: <code>{{base}}/mcp</code></p>
+<!--[/mcp]-->
+</main>
+<footer class="foot">
+<p>Released under the AGPL-3.0 License.</p>
+<p>Copyright &copy; MARIS &amp; the Beacon contributors</p>
+</footer>
+</body>
+</html>

--- a/beacon-server/beacon-server/src/axum/home.rs
+++ b/beacon-server/beacon-server/src/axum/home.rs
@@ -1,0 +1,176 @@
+//! The server home page: a static index of the surfaces a Beacon server exposes.
+//!
+//! The page itself is `assets/home.html`, compiled into the binary. This module
+//! only fills in its placeholders, once at startup: every value the page shows
+//! (base path, admin UI presence, MCP state) is fixed for the life of the process.
+
+/// The page template, with `{{...}}` placeholders and optional sections.
+const TEMPLATE: &str = include_str!("../../assets/home.html");
+
+/// Root of the published documentation, one directory per released version.
+const DOCS_BASE: &str = "https://maris-development.github.io/beacon/docs";
+
+/// Landing page of a documentation version. No version directory holds an
+/// `index.md`, so a bare directory URL is a 404.
+const DOCS_ENTRY: &str = "introduction";
+
+/// Renders the home page served at the router root.
+///
+/// # Arguments
+///
+/// * `title` - Deployment title, from the API documentation configuration
+/// * `version` - Beacon version of the running binary, shown and linked to
+/// * `base_path` - Normalized path prefix, empty or `/prefix`
+/// * `web_ui` - `true` when the admin web UI is mounted, which shows its card
+/// * `mcp` - `true` when the MCP endpoint is enabled, which shows its address
+///
+/// # Returns
+///
+/// A complete HTML document. Text taken from the configuration is escaped.
+pub(crate) fn render(
+    title: &str,
+    version: &str,
+    base_path: &str,
+    web_ui: bool,
+    mcp: bool,
+) -> String {
+    let page = section(TEMPLATE, "admin", web_ui);
+    let page = section(&page, "mcp", mcp);
+    page.replace("{{title}}", &escape(title))
+        .replace("{{version}}", &escape(version))
+        .replace("{{docs}}", &docs_url(version))
+        // Links carry the base path because the root answers on both `/prefix`
+        // and `/prefix/`. Relative targets resolve one level up on the first.
+        .replace("{{base}}", base_path)
+}
+
+/// Builds the documentation URL for the running version.
+fn docs_url(version: &str) -> String {
+    format!("{DOCS_BASE}/{}/{DOCS_ENTRY}", docs_directory(version))
+}
+
+/// Names the documentation directory of `version`.
+///
+/// The directory of a pre-release drops the dot of its pre-release part: version
+/// `2.0.0-rc.5` publishes as `docs/2.0.0-rc5`. A release bump renames that
+/// directory, so the running binary and its documentation stay in step.
+fn docs_directory(version: &str) -> String {
+    // Build metadata is not part of a directory name.
+    let version = version.split('+').next().unwrap_or(version);
+    match version.split_once('-') {
+        Some((release, pre_release)) => format!("{release}-{}", pre_release.replace('.', "")),
+        None => version.to_string(),
+    }
+}
+
+/// Keeps or drops an optional section of the template.
+///
+/// A section runs from `<!--[name]-->` to `<!--[/name]-->`. `keep` removes the two
+/// markers and holds the content between them; otherwise the whole block goes.
+///
+/// The markers exclude their line break, so the template works with either line
+/// ending: Git rewrites the checked-out file on Windows.
+fn section(page: &str, name: &str, keep: bool) -> String {
+    let open = format!("<!--[{name}]-->");
+    let close = format!("<!--[/{name}]-->");
+    if keep {
+        return page.replace(&open, "").replace(&close, "");
+    }
+    let (Some(start), Some(end)) = (page.find(&open), page.find(&close)) else {
+        return page.to_string();
+    };
+    let mut out = String::with_capacity(page.len());
+    out.push_str(&page[..start]);
+    out.push_str(&page[end + close.len()..]);
+    out
+}
+
+/// Escapes the characters that carry meaning in HTML text and attributes.
+fn escape(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for character in text.chars() {
+        match character {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            _ => out.push(character),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{docs_directory, docs_url, render, DOCS_ENTRY};
+
+    #[test]
+    fn optional_sections_follow_what_the_server_mounts() {
+        let full = render("Beacon", "2.0.0", "", true, true);
+        assert!(full.contains("href=\"/admin/\""));
+        assert!(full.contains("<code>/mcp</code>"));
+
+        let bare = render("Beacon", "2.0.0", "", false, false);
+        assert!(!bare.contains("/admin/"));
+        assert!(!bare.contains("/mcp"));
+        assert!(
+            !bare.contains("<!--["),
+            "markers must not reach the browser"
+        );
+        // The rest of the page survives the cuts.
+        assert!(bare.contains("href=\"/swagger\""));
+    }
+
+    #[test]
+    fn every_link_carries_the_base_path() {
+        let page = render("Beacon", "2.0.0", "/beacon", true, true);
+        for href in [
+            "/beacon/admin/",
+            "/beacon/swagger",
+            "/beacon/scalar/",
+            "/beacon/openapi.json",
+            "/beacon/api/health",
+        ] {
+            assert!(page.contains(&format!("href=\"{href}\"")), "missing {href}");
+        }
+        assert!(!page.contains("{{"), "no placeholder may survive");
+    }
+
+    #[test]
+    fn the_docs_link_points_at_the_running_version() {
+        let page = render("Beacon", "2.0.0-rc.5", "", false, false);
+        assert!(page.contains(
+            "href=\"https://maris-development.github.io/beacon/docs/2.0.0-rc5/introduction\""
+        ));
+
+        // A stable version publishes under its own number, dots intact.
+        assert_eq!(
+            docs_url("1.8.0"),
+            "https://maris-development.github.io/beacon/docs/1.8.0/introduction"
+        );
+        // Build metadata names no directory.
+        assert_eq!(docs_directory("2.0.0-rc.5+abc123"), "2.0.0-rc5");
+    }
+
+    /// A release bump renames the docs directory. This test holds the two
+    /// together: the page must not link a directory the repository lacks.
+    #[test]
+    fn the_repository_carries_the_docs_of_the_compiled_version() {
+        let versions = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/docs");
+        if !versions.is_dir() {
+            return; // Built outside a checkout of the repository.
+        }
+
+        let entry = versions
+            .join(docs_directory(env!("CARGO_PKG_VERSION")))
+            .join(format!("{DOCS_ENTRY}.md"));
+        assert!(entry.is_file(), "the home page links {}", entry.display());
+    }
+
+    #[test]
+    fn a_configured_title_cannot_inject_markup() {
+        let page = render("<script>alert(1)</script>", "2.0.0", "", false, false);
+        assert!(!page.contains("<script>alert"));
+        assert!(page.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
+    }
+}

--- a/beacon-server/beacon-server/src/axum/mod.rs
+++ b/beacon-server/beacon-server/src/axum/mod.rs
@@ -3,6 +3,7 @@
 mod admin;
 mod auth;
 mod client;
+mod home;
 mod router;
 
 pub use router::setup_router;

--- a/beacon-server/beacon-server/src/axum/router.rs
+++ b/beacon-server/beacon-server/src/axum/router.rs
@@ -7,7 +7,7 @@ use ::axum::{
     body::Bytes,
     extract::MatchedPath,
     http::{HeaderMap, HeaderName, HeaderValue, Method, Request},
-    response::{IntoResponse, Redirect, Response},
+    response::{Html, IntoResponse, Redirect, Response},
     routing::{any, get},
     Router,
 };
@@ -72,7 +72,6 @@ pub fn setup_router(
     // Redirect targets must be absolute and include the base path. Relative
     // targets (e.g. "./swagger") resolve against the incoming request URI, which
     // breaks once the router is nested under a non-empty base path.
-    let swagger_redirect: &'static str = format!("{base_path}/swagger").leak();
     let scalar_redirect: &'static str = format!("{base_path}/scalar/").leak();
 
     let docs = if base_path.is_empty() {
@@ -82,8 +81,8 @@ pub fn setup_router(
     };
 
     // Mount the bundled admin web UI when its build directory is present (it is in
-    // the Docker image; usually absent for a bare `cargo run`). The bare root then
-    // lands on the UI instead of the API docs.
+    // the Docker image; usually absent for a bare `cargo run`). Its absence also
+    // drops the admin card from the home page below.
     let web_ui = web_ui_router(&config.server.web_ui_dir, base_path);
 
     // MCP streamable-HTTP endpoint, gated by BEACON_MCP_ENABLED (default on). It
@@ -111,6 +110,17 @@ pub fn setup_router(
             ));
         router = router.merge(mcp_router);
     }
+    // The home page is fixed once the router is built, so it is rendered here and
+    // leaked as a constant rather than rebuilt per request.
+    let home_page: &'static str = crate::axum::home::render(
+        &config.api_docs.title,
+        BEACON_VERSION,
+        base_path,
+        web_ui.is_some(),
+        mcp_enabled,
+    )
+    .leak();
+
     let mut router = router
         .merge(Scalar::with_url("/scalar/", docs.clone()))
         .route(
@@ -118,10 +128,7 @@ pub fn setup_router(
             get(move || async move { Redirect::to(scalar_redirect) }),
         )
         .route("/api/health", get(health))
-        .route(
-            "/",
-            get(move || async move { Redirect::to(swagger_redirect) }),
-        );
+        .route("/", get(move || async move { Html(home_page) }));
 
     if let Some(web_ui) = web_ui {
         router = router.merge(web_ui);

--- a/beacon-server/beacon-server/src/axum/router.rs
+++ b/beacon-server/beacon-server/src/axum/router.rs
@@ -151,8 +151,16 @@ pub fn setup_router(
             .merge(setup_tracing_router(router))
             .merge(swagger_ui))
     } else {
+        // `nest` claims `{base_path}` and `{base_path}/{*rest}`, and that wildcard
+        // matches no empty rest. A visitor who types the trailing slash would get
+        // a 404, so that form redirects to the root the nest does serve.
+        let root: &'static str = base_path.clone().leak();
         Ok(Router::new()
             .nest(base_path, setup_tracing_router(router))
+            .route(
+                &format!("{base_path}/"),
+                get(move || async move { Redirect::to(root) }),
+            )
             .merge(swagger_ui))
     }
 }

--- a/beacon-server/beacon-server/tests/web_ui_http.rs
+++ b/beacon-server/beacon-server/tests/web_ui_http.rs
@@ -193,6 +193,12 @@ async fn the_root_serves_a_home_page_linking_to_every_surface() {
     let web = web_build();
     let (_harness, router) = app("/beacon", &web).await;
 
+    // A visitor types the base path with a trailing slash as readily as without.
+    // The nest serves the bare form, so the other one lands on it.
+    let (status, location, _) = get(&router, "/beacon/").await;
+    assert_eq!(status, StatusCode::SEE_OTHER);
+    assert_eq!(location.as_deref(), Some("/beacon"));
+
     let (status, _, body) = get(&router, "/beacon").await;
     assert_eq!(status, StatusCode::OK);
     for href in [

--- a/beacon-server/beacon-server/tests/web_ui_http.rs
+++ b/beacon-server/beacon-server/tests/web_ui_http.rs
@@ -185,3 +185,40 @@ async fn no_web_ui_directory_leaves_the_admin_path_unmounted() {
     let (status, _, _) = get(&router, "/admin").await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
+
+/// The root serves the home page itself, not a redirect to the API docs. Its
+/// links are absolute, because the root also answers without a trailing slash.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_root_serves_a_home_page_linking_to_every_surface() {
+    let web = web_build();
+    let (_harness, router) = app("/beacon", &web).await;
+
+    let (status, _, body) = get(&router, "/beacon").await;
+    assert_eq!(status, StatusCode::OK);
+    for href in [
+        "/beacon/admin/",
+        "/beacon/swagger",
+        "/beacon/scalar/",
+        "/beacon/openapi.json",
+        "/beacon/api/health",
+    ] {
+        assert!(body.contains(&format!("href=\"{href}\"")), "missing {href}");
+    }
+}
+
+/// Without an admin build there is no admin panel to offer, so the card goes.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_home_page_drops_the_admin_card_without_a_web_ui() {
+    let empty = tempfile::tempdir().expect("create temp dir");
+    let mut config = common::config(false);
+    config.server.web_ui_dir = empty.path().to_string_lossy().into_owned();
+
+    let harness = common::server_with(config).await;
+    let router = setup_router(harness.server.clone(), harness.server.config().clone())
+        .expect("router should build");
+
+    let (status, _, body) = get(&router, "/").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("href=\"/swagger\""));
+    assert!(!body.contains("href=\"/admin/\""));
+}

--- a/docs/docs/2.0.0-rc5/api/index.md
+++ b/docs/docs/2.0.0-rc5/api/index.md
@@ -10,9 +10,12 @@ URLs:
 
 | UI | URL |
 | -- | --- |
+| Home page | `/` |
 | Swagger UI | `/swagger` |
 | Scalar UI | `/scalar/` |
 | Raw spec (JSON) | `/openapi.json` |
+
+The home page links to each of these, to the admin UI and to this documentation.
 
 ## Base URL
 


### PR DESCRIPTION
## Problem

The server root redirects to the Swagger UI. A new user does not see the admin
panel or the documentation. Both need a path that nobody shows.

## Change

The root now answers with a small home page. The page links to the admin panel,
the Swagger UI, the API reference, the OpenAPI document, the documentation and
the health endpoint.

The page is a plain HTML file in `beacon-server/assets/home.html`. The build
compiles it into the binary. The server fills three placeholders at start. No
template dependency. The page fetches nothing from the network. It renders on
a server with no route out.

The admin card shows only when the admin UI is mounted. The MCP address shows
only when MCP is enabled. Every link carries `BEACON_BASE_PATH`. The
documentation link points to the docs of the compiled version. The base path root
now answers in both forms. `/prefix/` redirects to `/prefix`, which was a 404.

The colors, the type and the cards follow the documentation site.

## Tests

Five unit tests cover the page. Two HTTP tests cover the root route. All tests
pass. One test asserts that the repository holds the docs of the compiled
version.
